### PR TITLE
Bump up minimum required CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 3.17)
-# node.js uses cmake 3.17
+cmake_minimum_required(VERSION 3.19)
 message(STATUS "CMake version ${CMAKE_VERSION}")
 
 set(couchbase_cxx_client_BUILD_NUMBER 0)


### PR DESCRIPTION
Restrictions on interface property names were removed in CMake 3.19