### PR TITLE
CXXCBC-519 Check vector queries are not empty when constructing vector search

### DIFF
--- a/couchbase/vector_query.hxx
+++ b/couchbase/vector_query.hxx
@@ -50,7 +50,7 @@ class vector_query
      * Creates a vector query
      *
      * @param vector_field_name the document field that contains the vector
-     * @param base64_vector_query the base64 encoded vector query to run. Cannot be empty.
+     * @param base64_vector_query a base64-encoded sequence of little-endian IEEE 754 floats
      *
      * @snippet test/test_unit_search.cxx base64-vector-query
      * @since 1.0.0

--- a/couchbase/vector_search.hxx
+++ b/couchbase/vector_search.hxx
@@ -44,10 +44,13 @@ class vector_search
       : vector_queries_{ std::move(vector_queries) }
       , options_{ options.build() }
     {
+        if (vector_queries_.empty()) {
+            throw std::invalid_argument("At least one vector query must be specified");
+        }
     }
 
     /**
-     * Will execute a singe vector_query, using default options
+     * Will execute a single vector_query, using default options
      *
      * @param query the query to be run
      *


### PR DESCRIPTION
Changes:

- Added invalid argument check when constructing a vector search
- Improved some codedocs.
