### PR TITLE
CXXCBC-547: Add initial columnar query core implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,6 +371,7 @@ set(couchbase_cxx_client_FILES
     core/range_scan_options.cxx
     core/range_scan_orchestrator.cxx
     core/retry_orchestrator.cxx
+    core/row_streamer.cxx
     core/scan_result.cxx
     core/search_query_options.cxx
     core/seed_config.cxx
@@ -409,6 +410,13 @@ set(couchbase_cxx_client_FILES
     core/utils/split_string.cxx
     core/utils/url_codec.cxx
     core/view_query_options.cxx
+    core/http_component.cxx
+    core/io/http_streaming_parser.cxx
+    core/io/http_streaming_response.cxx
+    core/columnar/agent.cxx
+    core/columnar/agent_config.cxx
+    core/columnar/query_component.cxx
+    core/columnar/query_result.cxx
 )
 
 if(COUCHBASE_CXX_CLIENT_BUILD_SHARED OR BUILD_SHARED_LIBS)

--- a/core/agent_group.cxx
+++ b/core/agent_group.cxx
@@ -33,13 +33,14 @@ public:
   agent_group_impl(asio::io_context& io, agent_group_config config)
     : io_{ io }
     , config_(std::move(config))
-    , cluster_agent_({
-        config_.shim,
-        config_.user_agent,
-        config_.default_retry_strategy,
-        config_.seed,
-        config_.key_value,
-      })
+    , cluster_agent_(io,
+                     {
+                       config_.shim,
+                       config_.user_agent,
+                       config_.default_retry_strategy,
+                       config_.seed,
+                       config_.key_value,
+                     })
   {
     CB_LOG_DEBUG("SDK version: {}", meta::sdk_id());
     CB_LOG_DEBUG("creating new agent group: {}", config_.to_string());
@@ -110,11 +111,10 @@ public:
     return {};
   }
 
-  auto free_form_http_request(http_request /* request */,
-                              free_form_http_request_callback&& /* callback */)
+  auto free_form_http_request(http_request request, free_form_http_request_callback&& callback)
     -> tl::expected<std::shared_ptr<pending_operation>, std::error_code>
   {
-    return {};
+    return cluster_agent_.free_form_http_request(std::move(request), std::move(callback));
   }
 
   auto wait_until_ready(

--- a/core/cluster.cxx
+++ b/core/cluster.cxx
@@ -837,6 +837,15 @@ public:
     return {};
   }
 
+  auto http_session_manager()
+    -> std::pair<std::error_code, std::shared_ptr<io::http_session_manager>>
+  {
+    if (stopped_) {
+      return { errc::network::cluster_closed, {} };
+    }
+    return { {}, session_manager_ };
+  }
+
 private:
   std::string id_{ uuid::to_string(uuid::random()) };
   asio::io_context& ctx_;
@@ -1916,6 +1925,13 @@ cluster::execute(impl::lookup_in_replica_request request,
                  utils::movable_function<void(impl::lookup_in_replica_response)>&& handler) const
 {
   return impl_->execute(std::move(request), std::move(handler));
+}
+
+auto
+cluster::http_session_manager() const
+  -> std::pair<std::error_code, std::shared_ptr<io::http_session_manager>>
+{
+  return impl_->http_session_manager();
 }
 
 auto

--- a/core/cluster.hxx
+++ b/core/cluster.hxx
@@ -43,6 +43,11 @@ namespace mcbp
 class queue_request;
 } // namespace mcbp
 
+namespace io
+{
+class http_session_manager;
+} // namespace io
+
 namespace o = operations;
 namespace om = operations::management;
 template<typename T>
@@ -297,6 +302,9 @@ public:
   [[nodiscard]] auto direct_re_queue(const std::string& bucket_name,
                                      std::shared_ptr<mcbp::queue_request> req,
                                      bool is_retry) const -> std::error_code;
+
+  [[nodiscard]] auto http_session_manager() const
+    -> std::pair<std::error_code, std::shared_ptr<io::http_session_manager>>;
 
   [[nodiscard]] auto to_string() const -> std::string;
 

--- a/core/cluster_agent.hxx
+++ b/core/cluster_agent.hxx
@@ -16,8 +16,18 @@
 #pragma once
 
 #include "cluster_agent_config.hxx"
+#include "free_form_http_request.hxx"
+#include "pending_operation.hxx"
+
+#include <tl/expected.hpp>
 
 #include <memory>
+#include <system_error>
+
+namespace asio
+{
+class io_context;
+} // namespace asio
 
 namespace couchbase::core
 {
@@ -26,7 +36,10 @@ class cluster_agent_impl;
 class cluster_agent
 {
 public:
-  explicit cluster_agent(cluster_agent_config config);
+  explicit cluster_agent(asio::io_context& io, cluster_agent_config config);
+
+  auto free_form_http_request(http_request request, free_form_http_request_callback&& callback)
+    -> tl::expected<std::shared_ptr<pending_operation>, std::error_code>;
 
 private:
   std::shared_ptr<cluster_agent_impl> impl_;

--- a/core/columnar/agent.cxx
+++ b/core/columnar/agent.cxx
@@ -1,0 +1,84 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "agent.hxx"
+
+#include "agent_config.hxx"
+#include "core/free_form_http_request.hxx"
+#include "core/http_component.hxx"
+#include "core/logger/logger.hxx"
+#include "query_component.hxx"
+#include "query_options.hxx"
+
+#include <asio/io_context.hpp>
+#include <system_error>
+#include <tl/expected.hpp>
+
+#include <utility>
+
+namespace couchbase::core::columnar
+{
+class agent_impl
+{
+public:
+  agent_impl(asio::io_context& io, agent_config config)
+    : io_{ io }
+    , config_{ std::move(config) }
+    , http_{ io_, config_.shim, config_.default_retry_strategy }
+    , query_{ io_, http_, config_.default_retry_strategy }
+  {
+    CB_LOG_DEBUG("creating new columnar cluster agent: {}", config_.to_string());
+  }
+
+  auto free_form_http_request(http_request request, free_form_http_request_callback&& callback)
+    -> tl::expected<std::shared_ptr<pending_operation>, std::error_code>
+  {
+    return http_.do_http_request(std::move(request), std::move(callback));
+  }
+
+  auto execute_query(query_options options, query_callback&& callback)
+    -> tl::expected<std::shared_ptr<pending_operation>, std::error_code>
+  {
+    return query_.execute_query(std::move(options), std::move(callback));
+  }
+
+private:
+  asio::io_context& io_;
+  const agent_config config_;
+  http_component http_;
+  query_component query_;
+};
+
+agent::agent(asio::io_context& io, couchbase::core::columnar::agent_config config)
+  : impl_{ std::make_shared<agent_impl>(io, std::move(config)) }
+{
+}
+
+auto
+agent::free_form_http_request(http_request request, free_form_http_request_callback&& callback)
+  -> tl::expected<std::shared_ptr<pending_operation>, std::error_code>
+{
+  return impl_->free_form_http_request(std::move(request), std::move(callback));
+}
+
+auto
+agent::execute_query(query_options options, query_callback&& callback)
+  -> tl::expected<std::shared_ptr<pending_operation>, std::error_code>
+{
+  return impl_->execute_query(std::move(options), std::move(callback));
+}
+} // namespace couchbase::core::columnar

--- a/core/columnar/agent.hxx
+++ b/core/columnar/agent.hxx
@@ -1,0 +1,54 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include "agent_config.hxx"
+#include "core/free_form_http_request.hxx"
+#include "core/pending_operation.hxx"
+#include "query_options.hxx"
+
+#include <asio/io_context.hpp>
+#include <tl/expected.hpp>
+
+#include <memory>
+#include <system_error>
+
+namespace couchbase
+{
+class retry_strategy;
+} // namespace couchbase
+
+namespace couchbase::core::columnar
+{
+class agent_impl;
+
+class agent
+{
+public:
+  explicit agent(asio::io_context& io, agent_config config);
+
+  auto free_form_http_request(http_request request, free_form_http_request_callback&& callback)
+    -> tl::expected<std::shared_ptr<pending_operation>, std::error_code>;
+
+  auto execute_query(query_options options, query_callback&& callback)
+    -> tl::expected<std::shared_ptr<pending_operation>, std::error_code>;
+
+private:
+  std::shared_ptr<agent_impl> impl_;
+};
+} // namespace couchbase::core::columnar

--- a/core/columnar/agent_config.cxx
+++ b/core/columnar/agent_config.cxx
@@ -1,0 +1,38 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "agent_config.hxx"
+
+#include <fmt/core.h>
+
+#include <string>
+
+namespace couchbase::core::columnar
+{
+auto
+agent_config::to_string() const -> std::string
+{
+  return fmt::format(
+    R"(#<cluster_agent_config:{} shim={}, user_agent="{}", default_retry_strategy={}, seed={}, key_value={}>)",
+    static_cast<const void*>(this),
+    shim.to_string(),
+    user_agent,
+    default_retry_strategy ? default_retry_strategy->to_string() : "(none)",
+    seed.to_string(),
+    key_value.to_string());
+}
+} // namespace couchbase::core::columnar

--- a/core/columnar/agent_config.hxx
+++ b/core/columnar/agent_config.hxx
@@ -1,0 +1,45 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include "core/core_sdk_shim.hxx"
+#include "core/key_value_config.hxx"
+#include "core/seed_config.hxx"
+
+#include <memory>
+#include <string>
+
+namespace couchbase
+{
+class retry_strategy;
+} // namespace couchbase
+
+namespace couchbase::core::columnar
+{
+struct agent_config {
+  core_sdk_shim shim; // TODO: remove once refactoring will be finished.
+
+  std::string user_agent{};
+  std::shared_ptr<retry_strategy> default_retry_strategy{};
+
+  seed_config seed{};
+  key_value_config key_value{};
+
+  [[nodiscard]] auto to_string() const -> std::string;
+};
+} // namespace couchbase::core::columnar

--- a/core/columnar/query_component.cxx
+++ b/core/columnar/query_component.cxx
@@ -1,0 +1,179 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "query_component.hxx"
+
+#include <couchbase/error_codes.hxx>
+#include <couchbase/retry_strategy.hxx>
+
+#include "core/free_form_http_request.hxx"
+#include "core/http_component.hxx"
+#include "core/logger/logger.hxx"
+#include "core/row_streamer.hxx"
+#include "core/service_type.hxx"
+#include "core/utils/json.hxx"
+#include "query_result.hxx"
+
+#include <fmt/format.h>
+#include <tao/json/value.hpp>
+
+#include <chrono>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace couchbase::core::columnar
+{
+class query_component_impl : public std::enable_shared_from_this<query_component_impl>
+{
+public:
+  query_component_impl(asio::io_context& io,
+                       http_component http,
+                       std::shared_ptr<retry_strategy> default_retry_strategy)
+    : io_{ io }
+    , http_{ std::move(http) }
+    , default_retry_strategy_{ std::move(default_retry_strategy) }
+  {
+  }
+
+  auto execute_query(query_options options, query_callback&& callback)
+    -> tl::expected<std::shared_ptr<pending_operation>, std::error_code>
+  {
+    auto req = build_query_request(options);
+    auto op = http_.do_http_request(
+      std::move(req),
+      [self = shared_from_this(), cb = std::move(callback)](auto resp, auto ec) mutable {
+        if (ec) {
+          cb({}, ec);
+          return;
+        }
+        auto streamer = std::make_shared<row_streamer>(self->io_, resp.body(), "/results/^");
+        return streamer->start([self, streamer, resp = std::move(resp), cb = std::move(cb)](
+                                 auto metadata_header, auto ec) mutable {
+          if (ec) {
+            cb({}, ec);
+            return;
+          }
+          auto query_ec =
+            self->parse_query_error(resp.status_code(), utils::json::parse(metadata_header));
+          if (query_ec) {
+            cb({}, query_ec);
+            return;
+          }
+          cb(query_result{ std::move(*streamer) }, {});
+        });
+      });
+    return op;
+  }
+
+private:
+  static auto parse_query_error(const std::uint32_t& http_status_code,
+                                const tao::json::value& /* metadata_header */) -> std::error_code
+  {
+    // TODO(dimitris): Handle errors
+    if (http_status_code != 200) {
+      return errc::common::internal_server_failure;
+    }
+    return {};
+  }
+
+  static auto build_query_payload(const query_options& options) -> tao::json::value
+  {
+    tao::json::value payload{ { "statement", options.statement } };
+    if (options.database_name.has_value() && options.scope_name.has_value()) {
+      payload["query_context"] =
+        fmt::format("default:`{}`.`{}`", options.database_name.value(), options.scope_name.value());
+    }
+    if (!options.positional_parameters.empty()) {
+      std::vector<tao::json::value> params_json;
+      params_json.reserve(options.positional_parameters.size());
+      for (const auto& val : options.positional_parameters) {
+        params_json.emplace_back(utils::json::parse(val));
+      }
+    }
+    for (const auto& [name, val] : options.named_parameters) {
+      std::string key = name;
+      if (key[0] != '$') {
+        key.insert(key.begin(), '$');
+      }
+      payload[key] = utils::json::parse(val);
+    }
+    if (options.read_only.has_value()) {
+      payload["readonly"] = options.read_only.value();
+    }
+    if (options.scan_consistency.has_value()) {
+      switch (options.scan_consistency.value()) {
+        case query_scan_consistency::not_bounded:
+          payload["scan_consistency"] = "not_bounded";
+          break;
+        case query_scan_consistency::request_plus:
+          payload["scan_consistency"] = "request_plus";
+          break;
+      }
+    }
+    for (const auto& [key, val] : options.raw) {
+      payload[key] = utils::json::parse(val);
+    }
+    if (options.timeout.has_value()) {
+      std::chrono::milliseconds timeout = options.timeout.value() + std::chrono::seconds(5);
+      payload["timeout"] = fmt::format("{}ms", timeout.count());
+    }
+
+    return payload;
+  }
+
+  static auto build_query_request(const query_options& options) -> http_request
+  {
+    http_request req{ service_type::analytics, "POST" };
+    req.path = "/analytics/service";
+    req.body = utils::json::generate(build_query_payload(options));
+    if (options.timeout.has_value()) {
+      req.timeout = options.timeout.value();
+    }
+    req.headers["connection"] = "keep-alive";
+    req.headers["content-type"] = "application/json";
+    if (options.priority.has_value() && options.priority.value()) {
+      req.headers["analytics-priority"] = "-1";
+    }
+    if (options.read_only.has_value()) {
+      req.is_read_only = options.read_only.value();
+    }
+    return req;
+  }
+
+  asio::io_context& io_;
+  http_component http_;
+  std::shared_ptr<retry_strategy> default_retry_strategy_;
+};
+
+query_component::query_component(asio::io_context& io,
+                                 core::http_component http,
+                                 std::shared_ptr<retry_strategy> default_retry_strategy)
+  : impl_{
+    std::make_shared<query_component_impl>(io, std::move(http), std::move(default_retry_strategy))
+  }
+{
+}
+
+auto
+query_component::execute_query(query_options options, query_callback&& callback)
+  -> tl::expected<std::shared_ptr<pending_operation>, std::error_code>
+{
+  return impl_->execute_query(std::move(options), std::move(callback));
+}
+
+} // namespace couchbase::core::columnar

--- a/core/columnar/query_component.hxx
+++ b/core/columnar/query_component.hxx
@@ -1,0 +1,55 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include "core/pending_operation.hxx"
+#include "query_options.hxx"
+
+#include <memory>
+#include <system_error>
+
+#include <tl/expected.hpp>
+
+namespace asio
+{
+class io_context;
+} // namespace asio
+
+namespace couchbase::core
+{
+class http_component;
+
+namespace columnar
+{
+class query_component_impl;
+
+class query_component
+{
+public:
+  query_component(asio::io_context& io,
+                  http_component http,
+                  std::shared_ptr<retry_strategy> default_retry_strategy);
+
+  auto execute_query(query_options options, query_callback&& callback)
+    -> tl::expected<std::shared_ptr<pending_operation>, std::error_code>;
+
+private:
+  std::shared_ptr<query_component_impl> impl_;
+};
+} // namespace columnar
+} // namespace couchbase::core

--- a/core/columnar/query_options.hxx
+++ b/core/columnar/query_options.hxx
@@ -1,0 +1,63 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include "query_result.hxx"
+
+#include "core/json_string.hxx"
+#include "core/utils/movable_function.hxx"
+
+#include <chrono>
+#include <map>
+#include <optional>
+#include <string>
+#include <system_error>
+#include <vector>
+
+namespace couchbase
+{
+class retry_strategy;
+} // namespace couchbase
+
+namespace couchbase::core::columnar
+{
+enum class query_scan_consistency : std::uint8_t {
+  not_bounded,
+  request_plus,
+};
+
+struct query_options {
+  // Required
+  std::string statement;
+
+  // Optional - should be set if query is at scope-level
+  std::optional<std::string> database_name{};
+  std::optional<std::string> scope_name{};
+
+  // Optional - not sent on the wire if unset
+  std::optional<bool> priority{};
+  std::vector<couchbase::core::json_string> positional_parameters{};
+  std::map<std::string, couchbase::core::json_string> named_parameters{};
+  std::optional<bool> read_only{};
+  std::optional<query_scan_consistency> scan_consistency{};
+  std::map<std::string, couchbase::core::json_string> raw{};
+  std::optional<std::chrono::milliseconds> timeout{};
+};
+
+using query_callback = utils::movable_function<void(query_result result, std::error_code ec)>;
+} // namespace couchbase::core::columnar

--- a/core/columnar/query_result.cxx
+++ b/core/columnar/query_result.cxx
@@ -1,0 +1,125 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "query_result.hxx"
+
+#include "core/utils/duration_parser.hxx"
+#include "core/utils/json.hxx"
+
+#include <optional>
+
+namespace couchbase::core::columnar
+{
+class query_result_impl
+{
+public:
+  query_result_impl(row_streamer rows)
+    : rows_{ std::move(rows) }
+  {
+  }
+
+  void next_row(
+    utils::movable_function<void(std::variant<std::monostate, query_result_row, query_result_end>,
+                                 std::error_code)> handler)
+  {
+    return rows_.next_row([handler = std::move(handler)](std::string content, std::error_code ec) {
+      if (ec) {
+        return handler({}, ec);
+      }
+      if (content.empty()) {
+        return handler(query_result_end{}, {});
+      }
+      handler(query_result_row{ content }, {});
+    });
+  }
+
+  auto metadata() -> std::optional<query_metadata>
+  {
+    // Metadata are available and have already been decoded
+    if (metadata_.has_value()) {
+      return metadata_;
+    }
+    auto raw = rows_.metadata();
+
+    // Metadata is not available yet
+    if (!raw.has_value()) {
+      return {};
+    }
+
+    // Metadata are available but we need to decode them
+    // TODO(dimitris): Handle gracefully the case where the encoded metadata is not well-formed,
+    // maybe we need to return an error?
+    auto meta_json = utils::json::parse(raw.value());
+    const auto& metrics_json = meta_json.at("metrics");
+
+    query_metadata meta{ meta_json.at("requestID").get_string() };
+    meta.metrics.elapsed_time = utils::parse_duration(metrics_json.at("elapsedTime").get_string());
+    meta.metrics.execution_time =
+      utils::parse_duration(metrics_json.at("executionTime").get_string());
+    meta.metrics.result_count = metrics_json.at("resultCount").get_unsigned();
+    meta.metrics.result_size = metrics_json.at("resultSize").get_unsigned();
+    meta.metrics.processed_objects = metrics_json.at("processedObjects").get_unsigned();
+
+    if (const auto* w = meta_json.find("warnings"); w != nullptr) {
+      for (const auto& warn_json : w->get_array()) {
+        query_warning warn{
+          static_cast<std::int32_t>(warn_json.at("code").get_signed()),
+          warn_json.at("msg").get_string(),
+        };
+        meta.warnings.emplace_back(std::move(warn));
+      }
+    }
+
+    metadata_ = meta;
+    return meta;
+  }
+
+  void cancel()
+  {
+    rows_.cancel();
+  }
+
+private:
+  row_streamer rows_;
+  std::optional<query_metadata> metadata_;
+};
+
+query_result::query_result(row_streamer rows)
+  : impl_{ std::make_shared<query_result_impl>(std::move(rows)) }
+{
+}
+
+void
+query_result::next_row(
+  utils::movable_function<void(std::variant<std::monostate, query_result_row, query_result_end>,
+                               std::error_code)> handler)
+{
+  impl_->next_row(std::move(handler));
+}
+
+void
+query_result::cancel()
+{
+  impl_->cancel();
+}
+
+auto
+query_result::metadata() -> std::optional<query_metadata>
+{
+  return impl_->metadata();
+}
+} // namespace couchbase::core::columnar

--- a/core/columnar/query_result.hxx
+++ b/core/columnar/query_result.hxx
@@ -1,0 +1,77 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include "core/row_streamer.hxx"
+#include "core/utils/movable_function.hxx"
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <system_error>
+#include <variant>
+#include <vector>
+
+namespace couchbase::core::columnar
+{
+struct query_warning {
+  std::int32_t code;
+  std::string message;
+};
+
+struct query_metrics {
+  std::chrono::nanoseconds elapsed_time{};
+  std::chrono::nanoseconds execution_time{};
+  std::uint64_t result_count{};
+  std::uint64_t result_size{};
+  std::uint64_t processed_objects{};
+};
+
+struct query_metadata {
+  std::string request_id{};
+  std::vector<query_warning> warnings{};
+  query_metrics metrics{};
+};
+
+struct query_result_row {
+  std::string content;
+};
+
+struct query_result_end {
+};
+
+class query_result_impl;
+
+class query_result
+{
+public:
+  query_result() = default;
+  explicit query_result(row_streamer rows);
+
+  void next_row(
+    utils::movable_function<void(std::variant<std::monostate, query_result_row, query_result_end>,
+                                 std::error_code)> handler);
+  void cancel();
+  auto metadata() -> std::optional<query_metadata>;
+
+private:
+  std::shared_ptr<query_result_impl> impl_{};
+};
+} // namespace couchbase::core::columnar

--- a/core/http_component.cxx
+++ b/core/http_component.cxx
@@ -1,0 +1,220 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "http_component.hxx"
+#include "free_form_http_request.hxx"
+#include "io/http_session_manager.hxx"
+#include "pending_operation.hxx"
+
+#include <asio/error.hpp>
+#include <tl/expected.hpp>
+
+#include <memory>
+#include <utility>
+
+namespace couchbase::core
+{
+class pending_http_operation
+  : public std::enable_shared_from_this<pending_http_operation>
+  , public pending_operation
+{
+public:
+  pending_http_operation(asio::io_context& io, http_request request)
+    : deadline_{ io }
+    , request_{ std::move(request) }
+    , encoded_{ io::http_request{
+        request_.service,
+        request_.method,
+        request_.path,
+        request_.headers,
+        request_.body,
+        {},
+        {},
+        request_.timeout,
+      } }
+  {
+  }
+
+  ~pending_http_operation() override = default;
+
+  void start(free_form_http_request_callback&& callback,
+             utils::movable_function<void()>&& stream_end_callback)
+  {
+    callback_ = std::move(callback);
+    stream_end_callback_ = std::move(stream_end_callback);
+    deadline_.expires_after(request_.timeout);
+    deadline_.async_wait([self = shared_from_this()](auto ec) {
+      if (ec == asio::error::operation_aborted) {
+        return;
+      }
+      self->trigger_timeout();
+      if (self->session_) {
+        self->session_->stop();
+      }
+    });
+  }
+
+  void cancel() override
+  {
+    if (session_) {
+      session_->stop();
+    }
+    invoke_response_handler(errc::common::request_canceled, {});
+  }
+
+  void invoke_response_handler(std::error_code ec, io::http_streaming_response resp)
+  {
+    deadline_.cancel();
+    std::scoped_lock lock(callback_mutex_);
+    if (callback_) {
+      callback_(http_response{ std::move(resp) }, ec);
+    }
+    callback_ = nullptr;
+  }
+
+  void send_to(std::shared_ptr<io::http_session> session)
+  {
+    if (!callback_) {
+      return;
+    }
+    session_ = std::move(session);
+
+    auto start_op = [self = shared_from_this()]() {
+      self->session_->write_and_stream(
+        self->encoded_,
+        [self](std::error_code ec, io::http_streaming_response resp) {
+          if (ec == asio::error::operation_aborted) {
+            return;
+          }
+          self->invoke_response_handler(ec, std::move(resp));
+        },
+        [self]() {
+          self->stream_end_callback_();
+        });
+    };
+
+    // TODO(dimitris): Connecting should be retried.
+    if (!session_->is_connected()) {
+      session_->connect([self = shared_from_this(), start_op = std::move(start_op)]() {
+        if (!self->session_->is_connected()) {
+          self->invoke_response_handler(couchbase::errc::common::request_canceled, {});
+          return;
+        }
+        start_op();
+      });
+    } else {
+      start_op();
+    }
+  }
+
+private:
+  void trigger_timeout()
+  {
+    auto ec =
+      request_.is_read_only ? errc::common::unambiguous_timeout : errc::common::ambiguous_timeout;
+    invoke_response_handler(ec, {});
+  }
+
+  asio::steady_timer deadline_;
+  http_request request_;
+  io::http_request encoded_;
+  free_form_http_request_callback callback_;
+  utils::movable_function<void()> stream_end_callback_;
+  std::shared_ptr<io::http_session> session_;
+  std::mutex callback_mutex_;
+};
+
+class http_component_impl
+{
+public:
+  http_component_impl(asio::io_context& io,
+                      core_sdk_shim shim,
+                      std::shared_ptr<retry_strategy> default_retry_strategy)
+    : io_{ io }
+    , shim_{ std::move(shim) }
+    , default_retry_strategy_{ std::move(default_retry_strategy) }
+  {
+  }
+
+  auto do_http_request(http_request request, free_form_http_request_callback&& callback)
+    -> tl::expected<std::shared_ptr<pending_operation>, std::error_code>
+  {
+    std::shared_ptr<io::http_session_manager> session_manager;
+    {
+      auto [ec, sm] = shim_.cluster.http_session_manager();
+      if (ec) {
+        return tl::unexpected(ec);
+      }
+      session_manager = std::move(sm);
+    }
+
+    cluster_credentials credentials;
+    if (request.username.empty() && request.password.empty()) {
+      auto [ec, origin] = shim_.cluster.origin();
+      if (ec) {
+        return tl::unexpected(ec);
+      }
+      credentials = origin.credentials();
+    } else {
+      credentials = cluster_credentials{ request.username, request.password };
+    }
+
+    std::shared_ptr<io::http_session> session;
+    {
+      auto [ec, s] = session_manager->check_out(request.service, credentials, request.endpoint);
+      if (ec) {
+        return tl::unexpected(ec);
+      }
+      session = std::move(s);
+    }
+
+    auto op = std::make_shared<pending_http_operation>(io_, request);
+    op->start(
+      [callback = std::move(callback)](auto resp, auto ec) mutable {
+        callback(std::move(resp), ec);
+      },
+      [session_manager, session, service = request.service]() mutable {
+        session_manager->check_in(service, session);
+      });
+    op->send_to(session);
+
+    return op;
+  }
+
+private:
+  asio::io_context& io_;
+  core_sdk_shim shim_;
+  std::shared_ptr<retry_strategy> default_retry_strategy_;
+};
+
+http_component::http_component(asio::io_context& io,
+                               core_sdk_shim shim,
+                               std::shared_ptr<retry_strategy> default_retry_strategy)
+  : impl_{
+    std::make_shared<http_component_impl>(io, std::move(shim), std::move(default_retry_strategy))
+  }
+{
+}
+
+auto
+http_component::do_http_request(http_request request, free_form_http_request_callback&& callback)
+  -> tl::expected<std::shared_ptr<pending_operation>, std::error_code>
+{
+  return impl_->do_http_request(std::move(request), std::move(callback));
+}
+
+} // namespace couchbase::core

--- a/core/http_component.hxx
+++ b/core/http_component.hxx
@@ -1,0 +1,57 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include "core_sdk_shim.hxx"
+#include "free_form_http_request.hxx"
+#include "pending_operation.hxx"
+
+#include <tl/expected.hpp>
+
+#include <memory>
+#include <system_error>
+
+namespace asio
+{
+class io_context;
+} // namespace asio
+
+namespace couchbase
+{
+class retry_strategy;
+} // namespace couchbase
+
+namespace couchbase::core
+{
+class http_session_manager;
+class http_component_impl;
+
+class http_component
+{
+public:
+  http_component(asio::io_context& io,
+                 core_sdk_shim shim,
+                 std::shared_ptr<retry_strategy> default_retry_strategy);
+
+  auto do_http_request(http_request request, free_form_http_request_callback&& callback)
+    -> tl::expected<std::shared_ptr<pending_operation>, std::error_code>;
+
+private:
+  std::shared_ptr<http_component_impl> impl_;
+};
+} // namespace couchbase::core

--- a/core/io/http_message.hxx
+++ b/core/io/http_message.hxx
@@ -19,6 +19,7 @@
 
 #include "core/service_type.hxx"
 #include "core/utils/json_streaming_lexer.hxx"
+#include "core/utils/movable_function.hxx"
 
 #include <chrono>
 #include <map>
@@ -45,6 +46,7 @@ struct http_request {
                                       user's request */
   std::chrono::milliseconds
     timeout{}; /* effective timeout, service default or provided in user's request */
+  bool stream_response{};
 };
 
 class http_response_body
@@ -117,4 +119,5 @@ struct http_response {
     return false;
   }
 };
+
 } // namespace couchbase::core::io

--- a/core/io/http_streaming_parser.cxx
+++ b/core/io/http_streaming_parser.cxx
@@ -1,0 +1,164 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "http_streaming_parser.hxx"
+
+#include <llhttp.h>
+
+#include <algorithm>
+#include <cctype>
+#include <memory>
+#include <utility>
+
+namespace
+{
+inline int
+static_on_status(llhttp_t* parser, const char* at, std::size_t length)
+{
+  auto* wrapper = static_cast<couchbase::core::io::http_streaming_parser*>(parser->data);
+  wrapper->status_message.assign(at, length);
+  wrapper->status_code = parser->status_code;
+  return 0;
+}
+
+inline int
+static_on_header_field(llhttp_t* parser, const char* at, std::size_t length)
+{
+  auto* wrapper = static_cast<couchbase::core::io::http_streaming_parser*>(parser->data);
+  wrapper->header_field.assign(at, length);
+  std::transform(wrapper->header_field.begin(),
+                 wrapper->header_field.end(),
+                 wrapper->header_field.begin(),
+                 [](unsigned char c) {
+                   return std::tolower(c);
+                 });
+  return 0;
+}
+
+inline int
+static_on_header_value(llhttp_t* parser, const char* at, std::size_t length)
+{
+  auto* wrapper = static_cast<couchbase::core::io::http_streaming_parser*>(parser->data);
+  wrapper->headers[wrapper->header_field] = std::string(at, length);
+  return 0;
+}
+
+inline int
+static_on_headers_complete(llhttp_t* parser)
+{
+  auto* wrapper = static_cast<couchbase::core::io::http_streaming_parser*>(parser->data);
+  wrapper->headers_complete = true;
+  return 0;
+}
+
+inline int
+static_on_body(llhttp_t* parser, const char* at, std::size_t length)
+{
+  auto* wrapper = static_cast<couchbase::core::io::http_streaming_parser*>(parser->data);
+  wrapper->body_chunk.append(std::string_view{ at, length });
+  return 0;
+}
+
+inline int
+static_on_message_complete(llhttp_t* parser)
+{
+  auto* wrapper = static_cast<couchbase::core::io::http_streaming_parser*>(parser->data);
+  wrapper->complete = true;
+  return 0;
+}
+} // namespace
+
+namespace couchbase::core::io
+{
+struct http_streaming_parser_state {
+  llhttp_settings_t settings{};
+  llhttp_t parser{};
+};
+
+http_streaming_parser::http_streaming_parser()
+{
+  state_ = std::make_shared<http_streaming_parser_state>();
+  llhttp_settings_init(&state_->settings);
+  state_->settings.on_status = static_on_status;
+  state_->settings.on_header_field = static_on_header_field;
+  state_->settings.on_header_value = static_on_header_value;
+  state_->settings.on_headers_complete = static_on_headers_complete;
+  state_->settings.on_body = static_on_body;
+  state_->settings.on_message_complete = static_on_message_complete;
+  llhttp_init(&state_->parser, HTTP_RESPONSE, &state_->settings);
+  state_->parser.data = this;
+}
+
+http_streaming_parser::http_streaming_parser(http_streaming_parser&& other) noexcept
+  : status_code{ std::move(other.status_code) }
+  , status_message{ std::move(other.status_message) }
+  , headers{ std::move(other.headers) }
+  , body_chunk{ std::move(other.body_chunk) }
+  , header_field{ std::move(other.header_field) }
+  , headers_complete{ other.headers_complete }
+  , complete{ other.complete }
+{
+  if (state_) {
+    state_->parser.data = this;
+  }
+}
+
+http_streaming_parser&
+http_streaming_parser::operator=(couchbase::core::io::http_streaming_parser&& other) noexcept
+{
+  status_code = std::move(other.status_code);
+  status_message = std::move(other.status_message);
+  headers = std::move(other.headers);
+  body_chunk = std::move(other.body_chunk);
+  header_field = std::move(other.header_field);
+  headers_complete = other.headers_complete;
+  complete = other.complete;
+  if (state_) {
+    state_->parser.data = this;
+  }
+  return *this;
+}
+
+void
+http_streaming_parser::reset()
+{
+  status_code = {};
+  status_message = {};
+  headers = {};
+  body_chunk = {};
+  header_field = {};
+  headers_complete = false;
+  complete = false;
+  llhttp_init(&state_->parser, HTTP_RESPONSE, &state_->settings);
+}
+
+const char*
+http_streaming_parser::error_message() const
+{
+  return llhttp_errno_name(llhttp_get_errno(&state_->parser));
+}
+
+http_streaming_parser::feeding_result
+http_streaming_parser::feed(const char* data, std::size_t data_len) const
+{
+  auto error = llhttp_execute(&state_->parser, data, data_len);
+  if (error != HPE_OK) {
+    return { true, complete, headers_complete, error_message() };
+  }
+  return { false, complete, headers_complete };
+}
+} // namespace couchbase::core::io

--- a/core/io/http_streaming_parser.hxx
+++ b/core/io/http_streaming_parser.hxx
@@ -1,0 +1,62 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include "http_message.hxx"
+
+#include <map>
+#include <memory>
+#include <string>
+
+namespace couchbase::core::io
+{
+struct http_streaming_parser_state;
+
+struct http_streaming_parser {
+  struct feeding_result {
+    bool failure{ false };
+    bool complete{ false };
+    bool headers_complete{ false };
+    std::string error{};
+  };
+
+  std::uint32_t status_code{};
+  std::string status_message{};
+  std::map<std::string, std::string> headers{};
+  std::string body_chunk{};
+
+  std::string header_field{};
+  bool headers_complete{ false };
+  bool complete{ false };
+
+  http_streaming_parser();
+  http_streaming_parser(http_streaming_parser&& other) noexcept;
+  http_streaming_parser& operator=(http_streaming_parser&& other) noexcept;
+  http_streaming_parser(const http_streaming_parser& other) = delete;
+  http_streaming_parser& operator=(const http_streaming_parser& other) = delete;
+
+  void reset();
+
+  [[nodiscard]] const char* error_message() const;
+
+  feeding_result feed(const char* data, std::size_t data_len) const;
+
+private:
+  std::shared_ptr<http_streaming_parser_state> state_{};
+};
+} // namespace couchbase::core::io

--- a/core/io/http_streaming_response.cxx
+++ b/core/io/http_streaming_response.cxx
@@ -1,0 +1,224 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+#include "http_streaming_response.hxx"
+#include "http_session.hxx"
+
+#include "core/utils/json.hxx"
+#include "core/utils/movable_function.hxx"
+
+#include <couchbase/codec/tao_json_serializer.hxx>
+#include <couchbase/error_codes.hxx>
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <system_error>
+#include <utility>
+
+namespace couchbase::core::io
+{
+class http_streaming_response_body_impl
+  : public std::enable_shared_from_this<http_streaming_response_body_impl>
+{
+public:
+  http_streaming_response_body_impl(asio::io_context& io,
+                                    std::shared_ptr<http_session> session,
+                                    std::string cached_data)
+    : session_{ std::move(session) }
+    , cached_data_{ std::move(cached_data) }
+    , deadline_{ io }
+  {
+  }
+
+  auto close(std::error_code ec)
+  {
+    if (session_) {
+      session_->stop();
+    }
+    session_ = nullptr;
+    final_ec_ = ec;
+  }
+
+  void next(utils::movable_function<void(std::string, std::error_code)>&& callback)
+  {
+    if (!cached_data_.empty()) {
+      // Return the cached data & clear the cache
+      std::string data;
+      std::swap(data, cached_data_);
+      callback(std::move(data), {});
+      return;
+    }
+    if (completed_) {
+      callback({}, {});
+      return;
+    }
+    if (session_) {
+      session_->read_some([self = shared_from_this(), cb = std::move(callback)](
+                            std::string data, bool has_more, std::error_code ec) mutable {
+        if (!has_more || ec) {
+          self->close({});
+          if (!ec) {
+            self->completed_ = true;
+          }
+        }
+        cb(std::move(data), ec);
+      });
+      return;
+    }
+    callback({}, final_ec_);
+  }
+
+  void set_deadline(std::chrono::time_point<std::chrono::steady_clock> deadline_tp)
+  {
+    deadline_.expires_at(deadline_tp);
+    deadline_.async_wait([self = shared_from_this()](auto ec) {
+      if (ec == asio::error::operation_aborted) {
+        return;
+      }
+      self->close(errc::common::ambiguous_timeout);
+    });
+  }
+
+private:
+  std::shared_ptr<http_session> session_;
+  std::string cached_data_;
+  std::error_code final_ec_;
+  asio::steady_timer deadline_;
+  std::atomic_bool completed_{ false };
+};
+
+http_streaming_response_body::http_streaming_response_body(asio::io_context& io,
+                                                           std::shared_ptr<http_session> session,
+                                                           std::string cached_data)
+  : impl_{ std::make_shared<http_streaming_response_body_impl>(io,
+                                                               std::move(session),
+                                                               std::move(cached_data)) }
+{
+}
+
+void
+http_streaming_response_body::next(
+  utils::movable_function<void(std::string, std::error_code)>&& callback)
+{
+  impl_->next(std::move(callback));
+}
+
+void
+http_streaming_response_body::close(std::error_code ec)
+{
+  impl_->close(ec);
+}
+
+void
+http_streaming_response_body::set_deadline(
+  std::chrono::time_point<std::chrono::steady_clock> deadline_tp)
+{
+  impl_->set_deadline(deadline_tp);
+}
+
+class http_streaming_response_impl
+{
+public:
+  http_streaming_response_impl(std::uint32_t status_code,
+                               std::string status_message,
+                               std::map<std::string, std::string> headers,
+                               http_streaming_response_body body)
+    : status_code_{ status_code }
+    , status_message_{ std::move(status_message) }
+    , headers_{ std::move(headers) }
+    , body_{ std::move(body) }
+  {
+  }
+
+  [[nodiscard]] auto status_code() const -> const std::uint32_t&
+  {
+    return status_code_;
+  }
+
+  [[nodiscard]] auto status_message() const -> const std::string&
+  {
+    return status_message_;
+  }
+
+  [[nodiscard]] auto headers() const -> const std::map<std::string, std::string>&
+  {
+    return headers_;
+  }
+
+  [[nodiscard]] auto body() -> http_streaming_response_body&
+  {
+    return body_;
+  }
+
+  [[nodiscard]] auto must_close_connection() const -> bool
+  {
+    if (const auto it = headers_.find("connection"); it != headers_.end()) {
+      return it->second == "close";
+    }
+    return false;
+  }
+
+private:
+  std::uint32_t status_code_;
+  std::string status_message_;
+  std::map<std::string, std::string> headers_;
+  http_streaming_response_body body_;
+};
+
+http_streaming_response::http_streaming_response(
+  asio::io_context& io,
+  const couchbase::core::io::http_streaming_parser& parser,
+  std::shared_ptr<http_session> session)
+  : impl_{ std::make_shared<http_streaming_response_impl>(
+      parser.status_code,
+      parser.status_message,
+      parser.headers,
+      http_streaming_response_body{ io, std::move(session), parser.body_chunk }) }
+{
+}
+
+auto
+http_streaming_response::status_code() const -> const std::uint32_t&
+{
+  return impl_->status_code();
+}
+
+auto
+http_streaming_response::status_message() const -> const std::string&
+{
+  return impl_->status_message();
+}
+
+auto
+http_streaming_response::headers() const -> const std::map<std::string, std::string>&
+{
+  return impl_->headers();
+}
+
+auto
+http_streaming_response::body() -> http_streaming_response_body&
+{
+  return impl_->body();
+}
+
+auto
+http_streaming_response::must_close_connection() const -> bool
+{
+  return impl_->must_close_connection();
+}
+} // namespace couchbase::core::io

--- a/core/io/http_streaming_response.hxx
+++ b/core/io/http_streaming_response.hxx
@@ -1,0 +1,72 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+#pragma once
+
+#include <couchbase/error_codes.hxx>
+
+#include "core/utils/movable_function.hxx"
+
+#include <asio/steady_timer.hpp>
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <system_error>
+
+namespace couchbase::core::io
+{
+class http_session;
+struct http_streaming_parser;
+class http_streaming_response_body_impl;
+
+class http_streaming_response_body
+{
+public:
+  http_streaming_response_body() = default;
+  http_streaming_response_body(asio::io_context& io,
+                               std::shared_ptr<http_session> session,
+                               std::string cached_data = {});
+
+  void set_deadline(std::chrono::time_point<std::chrono::steady_clock> deadline_tp);
+  void next(utils::movable_function<void(std::string, std::error_code)>&& callback);
+  void close(std::error_code ec = couchbase::errc::common::request_canceled);
+
+private:
+  std::shared_ptr<http_streaming_response_body_impl> impl_;
+};
+
+class http_streaming_response_impl;
+
+class http_streaming_response
+{
+public:
+  http_streaming_response() = default;
+  http_streaming_response(asio::io_context& io,
+                          const http_streaming_parser& parser,
+                          std::shared_ptr<http_session> session);
+
+  [[nodiscard]] auto status_code() const -> const std::uint32_t&;
+  [[nodiscard]] auto status_message() const -> const std::string&;
+  [[nodiscard]] auto headers() const -> const std::map<std::string, std::string>&;
+  [[nodiscard]] auto body() -> http_streaming_response_body&;
+  [[nodiscard]] auto must_close_connection() const -> bool;
+
+private:
+  std::shared_ptr<http_streaming_response_impl> impl_;
+};
+} // namespace couchbase::core::io

--- a/core/row_streamer.cxx
+++ b/core/row_streamer.cxx
@@ -1,0 +1,239 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "row_streamer.hxx"
+
+#include <couchbase/error_codes.hxx>
+
+#include "free_form_http_request.hxx"
+#include "logger/logger.hxx"
+#include "utils/json.hxx"
+#include "utils/json_stream_control.hxx"
+#include "utils/json_streaming_lexer.hxx"
+#include "utils/movable_function.hxx"
+
+#include <asio/experimental/channel_error.hpp>
+#include <asio/experimental/concurrent_channel.hpp>
+#include <asio/io_context.hpp>
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <system_error>
+#include <utility>
+#include <variant>
+
+namespace couchbase::core
+{
+struct row_stream_end_signal {
+  std::error_code ec{};
+  std::string metadata{};
+};
+
+class row_streamer_impl : public std::enable_shared_from_this<row_streamer_impl>
+{
+public:
+  static constexpr std::size_t ROW_BUFFER_SIZE{ 100 };
+  static constexpr std::size_t ROW_BUFFER_FEED_THRESHOLD{ ROW_BUFFER_SIZE * 3 / 4 };
+  static constexpr std::uint32_t LEXER_DEPTH{ 4 };
+
+  row_streamer_impl(asio::io_context& io,
+                    http_response_body body,
+                    const std::string& pointer_expression)
+    : io_{ io }
+    , body_{ std::move(body) }
+    , rows_{ io_, ROW_BUFFER_SIZE }
+    , lexer_{ pointer_expression, LEXER_DEPTH }
+  {
+  }
+
+  void start(utils::movable_function<void(std::string, std::error_code)>&& handler)
+  {
+    lexer_.on_metadata_header_complete(
+      [handler = std::move(handler)](auto ec, auto meta_header) mutable {
+        // Trim any whitespace from the end
+        meta_header.erase(meta_header.find_last_not_of(" \t\f\v\n\r") + 1);
+
+        // The metadata header can end with an open `[` (opening bracket for pointer expression
+        // array). If that's the case, close the array and the response object
+        if (meta_header[meta_header.length() - 1] == '[') {
+          meta_header.append("]}");
+        }
+        handler(meta_header, ec);
+      });
+    lexer_.on_row([self = shared_from_this()](std::string&& row) -> utils::json::stream_control {
+      self->rows_.async_send({}, std::move(row), [self](auto ec) {
+        self->buffered_row_count_++;
+        if (ec) {
+          if (ec != asio::experimental::error::channel_closed &&
+              ec != asio::experimental::error::channel_cancelled) {
+            CB_LOG_WARNING(
+              "unexpected error while sending to row channel: {} ({})", ec.value(), ec.message());
+          }
+          return;
+        }
+      });
+      return utils::json::stream_control::next_row;
+    });
+    lexer_.on_complete([self = shared_from_this()](
+                         std::error_code ec, std::size_t /*number_of_rows*/, std::string&& meta) {
+      row_stream_end_signal signal{ ec, std::move(meta) };
+      self->rows_.async_send({}, std::move(signal), [self](auto ec) {
+        if (ec) {
+          if (ec != asio::experimental::error::channel_closed &&
+              ec != asio::experimental::error::channel_cancelled) {
+            CB_LOG_WARNING(
+              "unexpected error while sending to row channel: {} ({})", ec.value(), ec.message());
+          }
+          return;
+        }
+      });
+    });
+    maybe_feed_lexer();
+  }
+
+  void next_row(utils::movable_function<void(std::string, std::error_code)>&& handler)
+  {
+    if (!rows_.is_open()) {
+      handler({}, errc::common::request_canceled);
+      return;
+    }
+    rows_.async_receive(
+      [self = shared_from_this(), handler = std::move(handler)](auto ec, auto row) mutable {
+        self->buffered_row_count_--;
+        if (ec) {
+          if (ec == asio::experimental::error::channel_closed ||
+              ec == asio::experimental::error::channel_cancelled) {
+            return handler({}, errc::common::request_canceled);
+          }
+          return handler({}, ec);
+        }
+        if (std::holds_alternative<row_stream_end_signal>(row)) {
+          auto signal = std::get<row_stream_end_signal>(row);
+          if (!signal.metadata.empty()) {
+            std::lock_guard<std::mutex> const lock{ self->metadata_mutex_ };
+            self->metadata_ = std::move(signal.metadata);
+          }
+          return handler({}, signal.ec);
+        }
+        auto row_content = std::get<std::string>(row);
+        handler(std::move(row_content), {});
+
+        // After receiving a row check if more data needs to be fed into the lexer
+        self->maybe_feed_lexer();
+        return;
+      });
+  }
+
+  void cancel()
+  {
+    body_.cancel();
+    rows_.cancel();
+    rows_.close();
+  }
+
+  auto metadata() -> std::optional<std::string>
+  {
+    std::lock_guard<std::mutex> const lock{ metadata_mutex_ };
+    return metadata_;
+  }
+
+private:
+  void maybe_feed_lexer()
+  {
+    if (feeding_ || received_all_data_ || buffered_row_count_ > ROW_BUFFER_FEED_THRESHOLD) {
+      return;
+    }
+
+    feeding_ = true;
+
+    body_.next([self = shared_from_this()](auto data, auto ec) mutable {
+      if (ec) {
+        self->received_all_data_ = true;
+        auto signal = row_stream_end_signal{ ec };
+        return self->rows_.async_send({}, std::move(signal), [self](auto ec) {
+          if (!ec || ec == asio::experimental::error::channel_cancelled ||
+              ec == asio::experimental::error::channel_closed) {
+            return;
+          }
+          CB_LOG_WARNING("unexpected error while sending row stream end signal: {} ({})",
+                         ec.value(),
+                         ec.message());
+        });
+      }
+      if (data.empty()) {
+        self->received_all_data_ = true;
+        return;
+      }
+      {
+        std::lock_guard<std::mutex> lock{ self->data_feed_mutex_ };
+        self->lexer_.feed(data);
+      }
+
+      self->feeding_ = false;
+
+      return self->maybe_feed_lexer();
+    });
+  }
+
+  asio::io_context& io_;
+  http_response_body body_;
+  asio::experimental::concurrent_channel<void(std::error_code,
+                                              std::variant<std::string, row_stream_end_signal>)>
+    rows_;
+  std::atomic_size_t buffered_row_count_{ 0 };
+  std::atomic_bool received_all_data_{ false };
+  std::atomic_bool feeding_{ false };
+  std::optional<std::string> metadata_header_;
+  std::optional<std::string> metadata_;
+  utils::json::streaming_lexer lexer_;
+  std::mutex data_feed_mutex_{};
+  std::mutex metadata_mutex_{};
+};
+
+row_streamer::row_streamer(asio::io_context& io,
+                           couchbase::core::http_response_body body,
+                           const std::string& pointer_expression)
+  : impl_{ std::make_shared<row_streamer_impl>(io, std::move(body), pointer_expression) }
+{
+}
+
+void
+row_streamer::start(utils::movable_function<void(std::string, std::error_code)>&& handler)
+{
+  impl_->start(std::move(handler));
+}
+
+void
+row_streamer::next_row(utils::movable_function<void(std::string, std::error_code)>&& handler)
+{
+  impl_->next_row(std::move(handler));
+}
+
+void
+row_streamer::cancel()
+{
+  impl_->cancel();
+}
+
+auto
+row_streamer::metadata() -> std::optional<std::string>
+{
+  return impl_->metadata();
+}
+} // namespace couchbase::core

--- a/core/row_streamer.hxx
+++ b/core/row_streamer.hxx
@@ -1,0 +1,68 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include "utils/movable_function.hxx"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <system_error>
+
+namespace asio
+{
+class io_context;
+} // namespace asio
+
+namespace couchbase::core
+{
+class row_streamer_impl;
+class http_response_body;
+
+class row_streamer
+{
+public:
+  row_streamer(asio::io_context& io,
+               http_response_body body,
+               const std::string& pointer_expression);
+
+  /**
+   *  Starts the row stream and returns all the metadata preceding the first row. This typically
+   * includes errors, if available.
+   */
+  void start(utils::movable_function<void(std::string, std::error_code)>&& handler);
+
+  /**
+   * Retrieves the next row
+   */
+  void next_row(utils::movable_function<void(std::string, std::error_code)>&& handler);
+
+  /**
+   * Cancels the row stream & closes the HTTP connection
+   */
+  void cancel();
+
+  /**
+   * If all rows have been streamed, returns the metadata encoded as JSON.
+   */
+  auto metadata() -> std::optional<std::string>;
+
+private:
+  std::shared_ptr<row_streamer_impl> impl_;
+};
+} // namespace couchbase::core

--- a/core/utils/json_streaming_lexer.hxx
+++ b/core/utils/json_streaming_lexer.hxx
@@ -21,6 +21,8 @@
 
 #include <couchbase/error_codes.hxx>
 
+#include "movable_function.hxx"
+
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -52,6 +54,8 @@ public:
 
   void feed(std::string_view data);
 
+  void on_metadata_header_complete(
+    utils::movable_function<void(std::error_code ec, std::string&& meta_header)> handler);
   void on_complete(
     std::function<void(std::error_code ec, std::size_t number_of_rows, std::string&& meta)>
       handler);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,7 @@ integration_test(search)
 integration_test(management)
 integration_test(management_eventing)
 integration_test(management_search_index)
+integration_test(columnar)
 
 unit_test(connection_string)
 unit_test(utils)

--- a/test/test_integration_columnar.cxx
+++ b/test/test_integration_columnar.cxx
@@ -1,0 +1,313 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "test_helper_integration.hxx"
+
+#include "core/columnar/agent.hxx"
+#include "core/free_form_http_request.hxx"
+#include "core/row_streamer.hxx"
+
+#include <future>
+#include <memory>
+#include <string>
+#include <variant>
+
+std::pair<std::variant<std::monostate,
+                       couchbase::core::columnar::query_result_row,
+                       couchbase::core::columnar::query_result_end>,
+          std::error_code>
+get_next_item(couchbase::core::columnar::query_result& result)
+{
+  auto barrier = std::make_shared<
+    std::promise<std::pair<std::variant<std::monostate,
+                                        couchbase::core::columnar::query_result_row,
+                                        couchbase::core::columnar::query_result_end>,
+                           std::error_code>>>();
+  auto f = barrier->get_future();
+  result.next_row([barrier](auto item, auto ec) mutable {
+    barrier->set_value({ std::move(item), ec });
+  });
+  return f.get();
+}
+
+TEST_CASE("integration: columnar http component simple request", "[integration]")
+{
+  test::utils::integration_test_guard integration;
+  if (!integration.cluster_version().is_columnar()) {
+    SKIP("Requires a columnar cluster");
+  }
+
+  auto agent = couchbase::core::columnar::agent(integration.io, { { integration.cluster } });
+
+  tao::json::value body{ { "statement", "FROM RANGE(0, 100) AS i SELECT *" } };
+
+  auto req = couchbase::core::http_request{
+    couchbase::core::service_type::analytics,     "POST", {}, "/analytics/service", {}, {},
+    couchbase::core::utils::json::generate(body),
+  };
+
+  req.timeout = std::chrono::seconds(10);
+  req.headers["content-type"] = "application/json";
+
+  couchbase::core::http_response resp;
+  {
+    auto barrier = std::make_shared<
+      std::promise<tl::expected<couchbase::core::http_response, std::error_code>>>();
+    auto f = barrier->get_future();
+    auto op = agent.free_form_http_request(std::move(req), [barrier](auto resp, auto ec) {
+      if (ec) {
+        barrier->set_value(tl::unexpected(ec));
+        return;
+      }
+      barrier->set_value(std::move(resp));
+    });
+    REQUIRE(op.has_value());
+    auto r = f.get();
+    REQUIRE(r.has_value());
+    resp = r.value();
+  }
+
+  auto code = resp.status_code();
+  REQUIRE(code == 200);
+
+  auto resp_body = resp.body();
+  std::string buffered_body{};
+  while (true) {
+    auto barrier = std::make_shared<std::promise<std::pair<std::string, std::error_code>>>();
+    auto f = barrier->get_future();
+    resp_body.next([barrier](auto s, auto ec) {
+      barrier->set_value({ std::move(s), ec });
+    });
+    auto [s, ec] = f.get();
+    REQUIRE_SUCCESS(ec);
+    if (s.empty()) {
+      break;
+    }
+    buffered_body.append(s);
+  }
+
+  auto body_json = couchbase::core::utils::json::parse(buffered_body);
+  REQUIRE(body_json.find("results") != nullptr);
+
+  auto result_array = body_json["results"].get_array();
+  REQUIRE(result_array.size() == 101);
+  for (std::size_t i = 0; i <= 100; i++) {
+    REQUIRE(result_array.at(i) == tao::json::value{ { "i", i } });
+  }
+}
+
+TEST_CASE("integration: columnar query component simple request", "[integration]")
+{
+  test::utils::integration_test_guard integration;
+  if (!integration.cluster_version().is_columnar()) {
+    SKIP("Requires a columnar cluster");
+  }
+
+  couchbase::core::columnar::agent agent{ integration.io, { { integration.cluster } } };
+
+  couchbase::core::columnar::query_options options{ "FROM RANGE(0, 4999) AS i SELECT *" };
+  options.timeout = std::chrono::seconds(20);
+
+  couchbase::core::columnar::query_result result;
+  {
+    auto barrier = std::make_shared<
+      std::promise<std::pair<couchbase::core::columnar::query_result, std::error_code>>>();
+    auto f = barrier->get_future();
+    auto resp = agent.execute_query(options, [barrier](auto res, auto ec) mutable {
+      barrier->set_value({ std::move(res), ec });
+    });
+    auto [res, ec] = f.get();
+    REQUIRE(resp.has_value());
+    REQUIRE_SUCCESS(ec);
+    REQUIRE_FALSE(res.metadata().has_value());
+    result = std::move(res);
+  }
+
+  std::size_t row_count{ 0 };
+  while (true) {
+    auto [item, ec] = get_next_item(result);
+    REQUIRE_SUCCESS(ec);
+    REQUIRE(!std::holds_alternative<std::monostate>(item));
+
+    if (std::holds_alternative<couchbase::core::columnar::query_result_end>(item)) {
+      break;
+    }
+
+    REQUIRE(std::holds_alternative<couchbase::core::columnar::query_result_row>(item));
+    auto row = std::get<couchbase::core::columnar::query_result_row>(item);
+    auto row_json = couchbase::core::utils::json::parse(row.content);
+    REQUIRE(row_json == tao::json::value{ { "i", row_count } });
+
+    row_count++;
+  }
+  REQUIRE(result.metadata().has_value());
+  REQUIRE(result.metadata()->warnings.empty());
+  REQUIRE(result.metadata()->metrics.result_count == 5000);
+  REQUIRE(row_count == 5000);
+}
+
+TEST_CASE("integration: columnar query component request with database & scope names",
+          "[integration]")
+{
+  test::utils::integration_test_guard integration;
+  if (!integration.cluster_version().is_columnar()) {
+    SKIP("Requires a columnar cluster");
+  }
+
+  couchbase::core::columnar::agent agent{ integration.io, { { integration.cluster } } };
+
+  couchbase::core::columnar::query_options options{ "SELECT * FROM airline LIMIT 100" };
+  options.database_name = "travel-sample";
+  options.scope_name = "inventory";
+  options.timeout = std::chrono::seconds(20);
+
+  couchbase::core::columnar::query_result result;
+  {
+    auto barrier = std::make_shared<
+      std::promise<std::pair<couchbase::core::columnar::query_result, std::error_code>>>();
+    auto f = barrier->get_future();
+    auto resp = agent.execute_query(options, [barrier](auto res, auto ec) mutable {
+      barrier->set_value({ std::move(res), ec });
+    });
+    auto [res, ec] = f.get();
+    REQUIRE(resp.has_value());
+    REQUIRE_SUCCESS(ec);
+    REQUIRE_FALSE(res.metadata().has_value());
+    result = std::move(res);
+  }
+
+  std::size_t row_count{ 0 };
+  while (true) {
+    auto [item, ec] = get_next_item(result);
+    REQUIRE_SUCCESS(ec);
+    REQUIRE(!std::holds_alternative<std::monostate>(item));
+
+    if (std::holds_alternative<couchbase::core::columnar::query_result_end>(item)) {
+      break;
+    }
+
+    REQUIRE(std::holds_alternative<couchbase::core::columnar::query_result_row>(item));
+    auto row = std::get<couchbase::core::columnar::query_result_row>(item);
+    REQUIRE(!row.content.empty());
+
+    row_count++;
+  }
+  REQUIRE(result.metadata().has_value());
+  REQUIRE(result.metadata()->warnings.empty());
+  REQUIRE(result.metadata()->metrics.result_count == 100);
+  REQUIRE(row_count == 100);
+}
+
+TEST_CASE("integration: columnar query read some rows and cancel")
+{
+  test::utils::integration_test_guard integration;
+  if (!integration.cluster_version().is_columnar()) {
+    SKIP("Requires a columnar cluster");
+  }
+
+  couchbase::core::columnar::agent agent{ integration.io, { { integration.cluster } } };
+
+  couchbase::core::columnar::query_options options{ "FROM RANGE(0, 100) AS i SELECT *" };
+  options.timeout = std::chrono::seconds(20);
+
+  couchbase::core::columnar::query_result result;
+  {
+    auto barrier = std::make_shared<
+      std::promise<std::pair<couchbase::core::columnar::query_result, std::error_code>>>();
+    auto f = barrier->get_future();
+    auto resp = agent.execute_query(options, [barrier](auto res, auto ec) mutable {
+      barrier->set_value({ std::move(res), ec });
+    });
+    auto [res, ec] = f.get();
+    REQUIRE(resp.has_value());
+    REQUIRE_SUCCESS(ec);
+    REQUIRE_FALSE(res.metadata().has_value());
+    result = std::move(res);
+  }
+
+  std::vector<std::string> buffered_rows{};
+  for (std::size_t i = 0; i < 2; i++) {
+    auto [item, ec] = get_next_item(result);
+    REQUIRE_SUCCESS(ec);
+    REQUIRE(!std::holds_alternative<std::monostate>(item));
+
+    if (std::holds_alternative<couchbase::core::columnar::query_result_end>(item)) {
+      break;
+    }
+    buffered_rows.emplace_back(std::get<couchbase::core::columnar::query_result_row>(item).content);
+  }
+  REQUIRE_FALSE(result.metadata().has_value());
+  REQUIRE(buffered_rows.size() == 2);
+
+  result.cancel();
+
+  for (std::size_t i = 0; i < 2; i++) {
+    auto [item, ec] = get_next_item(result);
+    REQUIRE(ec == couchbase::errc::common::request_canceled);
+    REQUIRE(std::holds_alternative<std::monostate>(item));
+  }
+
+  REQUIRE_FALSE(result.metadata().has_value());
+}
+
+TEST_CASE("integration: columnar query cancel operation")
+{
+  test::utils::integration_test_guard integration;
+  if (!integration.cluster_version().is_columnar()) {
+    SKIP("Requires a columnar cluster");
+  }
+
+  couchbase::core::columnar::agent agent{ integration.io, { { integration.cluster } } };
+
+  couchbase::core::columnar::query_options options{ "FROM RANGE(0, 10000000) AS i SELECT *" };
+  options.timeout = std::chrono::seconds(20);
+
+  auto barrier = std::make_shared<
+    std::promise<std::pair<couchbase::core::columnar::query_result, std::error_code>>>();
+  auto f = barrier->get_future();
+  auto resp = agent.execute_query(options, [barrier](auto res, auto ec) mutable {
+    barrier->set_value({ std::move(res), ec });
+  });
+  REQUIRE(resp.has_value());
+  resp.value()->cancel();
+  auto [res, ec] = f.get();
+  REQUIRE(ec == couchbase::errc::common::request_canceled);
+}
+
+TEST_CASE("integration: columnar query operation timeout")
+{
+  test::utils::integration_test_guard integration;
+  if (!integration.cluster_version().is_columnar()) {
+    SKIP("Requires a columnar cluster");
+  }
+
+  couchbase::core::columnar::agent agent{ integration.io, { { integration.cluster } } };
+
+  couchbase::core::columnar::query_options options{ "FROM RANGE(0, 10000000) AS i SELECT *" };
+  options.read_only = true;
+  options.timeout = std::chrono::seconds(1);
+
+  auto barrier = std::make_shared<
+    std::promise<std::pair<couchbase::core::columnar::query_result, std::error_code>>>();
+  auto f = barrier->get_future();
+  auto resp = agent.execute_query(options, [barrier](auto res, auto ec) mutable {
+    barrier->set_value({ std::move(res), ec });
+  });
+  REQUIRE(resp.has_value());
+  auto [res, ec] = f.get();
+  REQUIRE(ec == couchbase::errc::common::unambiguous_timeout);
+}

--- a/test/utils/server_version.cxx
+++ b/test/utils/server_version.cxx
@@ -40,6 +40,8 @@ server_version::parse(const std::string& str, const deployment_type deployment) 
             ver.edition = server_edition::enterprise;
           } else if (version_match[7] == "community") {
             ver.edition = server_edition::community;
+          } else if (version_match[7] == "columnar") {
+            ver.edition = server_edition::columnar;
           }
         }
       }

--- a/test/utils/server_version.hxx
+++ b/test/utils/server_version.hxx
@@ -26,7 +26,8 @@ namespace test::utils
 enum class server_edition {
   unknown,
   enterprise,
-  community
+  community,
+  columnar
 };
 
 enum class deployment_type {
@@ -286,6 +287,11 @@ struct server_version {
   [[nodiscard]] auto is_capella() const -> bool
   {
     return deployment == deployment_type::capella;
+  }
+
+  [[nodiscard]] auto is_columnar() const -> bool
+  {
+    return edition == server_edition::columnar;
   }
 };
 


### PR DESCRIPTION
## Motivation

Add core implementation for columnar queries

## Changes

* Add a columnar agent, providing access to all columnar-related operations. The columnar agent is the equivalent of "cluster agent" in the columnar side of things.
* Add a columnar query component, that supports executing queries and streaming the results.
* Add a high level row_streamer interface, that can be reused for different operations that stream rows (e.g. FTS, query, analytics). The row streamer allows reading the body header before returning from the operation i.e. the part of the body before the rows JSON array.
* Add an http_streaming_response that can wrap the http_session and provide access to the body using pull-based streaming. It also makes it possible to stop the HTTP session mid-stream. Add support in http_session for returning the http_streaming_response.

## Results

All tests pass

Further work is required to properly handle errors, return richer error information & add support for retries.