### PR TITLE
Fix behaviour when reading is complete before returning HTTP streaming resp

### DIFF
--- a/core/io/http_session.cxx
+++ b/core/io/http_session.cxx
@@ -681,7 +681,7 @@ http_session::do_read()
             std::scoped_lock lock(self->current_response_mutex_);
             std::swap(self->current_streaming_response_, ctx);
           } else {
-            if (auto handler = std::move(ctx.stream_end_handler)) {
+            if (auto handler = std::move(ctx.stream_end_handler); handler) {
               handler();
             }
           }

--- a/core/io/http_session.cxx
+++ b/core/io/http_session.cxx
@@ -501,6 +501,9 @@ http_session::read_some(
           std::scoped_lock lock(self->current_response_mutex_);
           std::swap(self->current_streaming_response_, ctx);
         }
+        if (ctx.stream_end_handler) {
+          ctx.stream_end_handler();
+        }
         if (ctx.resp->must_close_connection()) {
           self->keep_alive_ = false;
         }
@@ -677,6 +680,10 @@ http_session::do_read()
           if (!res.complete) {
             std::scoped_lock lock(self->current_response_mutex_);
             std::swap(self->current_streaming_response_, ctx);
+          } else {
+            if (auto handler = std::move(ctx.stream_end_handler)) {
+              handler();
+            }
           }
           return;
         }

--- a/core/io/http_streaming_response.hxx
+++ b/core/io/http_streaming_response.hxx
@@ -40,7 +40,8 @@ public:
   http_streaming_response_body() = default;
   http_streaming_response_body(asio::io_context& io,
                                std::shared_ptr<http_session> session,
-                               std::string cached_data = {});
+                               std::string cached_data = {},
+                               bool reading_complete = false);
 
   void set_deadline(std::chrono::time_point<std::chrono::steady_clock> deadline_tp);
   void next(utils::movable_function<void(std::string, std::error_code)>&& callback);


### PR DESCRIPTION
## Motivation

If the entire HTTP body has been read in the initial read before returning the HTTP streaming response, any subsequent attempt to read from the TCP socket will never return.

## Changes

* Set `reading_complete` when initializing `http_streaming_response_body` with the value of `http_streaming_parser`'s `complete` field.
* Call the `stream_end_handler` when the entire HTTP message has been read successfully (not only on cancellation).