### PR TITLE
Add helper method for serializing ctx into columnar error msg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,6 +422,7 @@ set(couchbase_cxx_client_FILES
     core/http_component.cxx
     core/columnar/agent.cxx
     core/columnar/agent_config.cxx
+    core/columnar/error.cxx
     core/columnar/error_codes.cxx
     core/columnar/query_component.cxx
     core/columnar/query_result.cxx

--- a/core/columnar/error.cxx
+++ b/core/columnar/error.cxx
@@ -15,37 +15,31 @@
  *   limitations under the License.
  */
 
-#pragma once
+#include "error.hxx"
 
-#include <cstdint>
-#include <map>
-#include <memory>
+#include <tao/json/to_string.hpp>
+
 #include <string>
-#include <system_error>
-#include <variant>
-
-#include <tao/json/value.hpp>
 
 namespace couchbase::core::columnar
 {
-/**
- * Properties specific to query errors. Will only be set if the error code is
- * columnar::errc::query_error
- */
-struct query_error_properties {
-  std::int32_t code{};
-  std::string server_message{};
-};
-
-using error_properties = std::variant<std::monostate, query_error_properties>;
-
-struct error {
-  std::error_code ec{};
-  std::string message{};
-  error_properties properties{};
-  tao::json::value ctx = tao::json::empty_object;
-  std::shared_ptr<error> cause{};
-
-  auto message_with_ctx() -> std::string;
-};
+auto
+error::message_with_ctx() -> std::string
+{
+  std::string serialized_ctx{};
+  if (!ctx.get_object().empty()) {
+    serialized_ctx = tao::json::to_string(ctx);
+  }
+  std::string res{};
+  if (!message.empty()) {
+    res += message;
+  }
+  if (!serialized_ctx.empty()) {
+    if (!res.empty()) {
+      res += ' ';
+    }
+    res += serialized_ctx;
+  }
+  return res;
+}
 } // namespace couchbase::core::columnar

--- a/test/test_integration_columnar.cxx
+++ b/test/test_integration_columnar.cxx
@@ -396,7 +396,8 @@ TEST_CASE("integration: columnar query collection does not exist")
   REQUIRE(std::get<couchbase::core::columnar::query_error_properties>(err.properties)
             .server_message.find("does-not-exist") != std::string::npos);
 
-  REQUIRE(err.ctx.count("errors") == 1);
+  REQUIRE(err.ctx.find("errors") != nullptr);
   REQUIRE(err.ctx["errors"].get_array().size() == 1);
   REQUIRE(err.ctx["errors"].get_array().at(0).get_object().at("code").get_signed() == 24045);
+  REQUIRE(err.message_with_ctx().find("\"code\":24045") != std::string::npos);
 }


### PR DESCRIPTION
## Changes

* The error context is now represented by a `tao::json::value` instead of `std::map<std::string, tao::json::value>`
* Add `message_with_ctx()` helper for getting the error message that includes the serialized error context, as that's the only way the error context will be exposed from the wrappers.