### PR TITLE
Revert 13186f3 for 0001-fix-build-for-mingw-w64-ucrt-x86_64-toolchain.patch

### DIFF
--- a/cmake/0001-fix-build-for-mingw-w64-ucrt-x86_64-toolchain.patch
+++ b/cmake/0001-fix-build-for-mingw-w64-ucrt-x86_64-toolchain.patch
@@ -28,11 +28,12 @@ index 0cd1a12aa..ab33badc0 100644
 --- a/src/crypto/curve25519/internal.h
 +++ b/src/crypto/curve25519/internal.h
 @@ -32,7 +32,7 @@ void x25519_NEON(uint8_t out[32], const uint8_t scalar[32],
-#endif
+ #endif
 
-#if !defined(OPENSSL_NO_ASM) && !defined(OPENSSL_SMALL) && -defined(__GNUC__) && defined(__x86_64__)
+ #if !defined(OPENSSL_NO_ASM) && !defined(OPENSSL_SMALL) && \
+-    defined(__GNUC__) && defined(__x86_64__)
 +    defined(__GNUC__) && defined(__x86_64__) && !defined(__MINGW32__)
-#define BORINGSSL_FE25519_ADX
+ #define BORINGSSL_FE25519_ADX
 
  // fiat_curve25519_adx_mul is defined in
 --


### PR DESCRIPTION
This is necessary to fix Ruby build on Windows