### PR TITLE
CXXCBC-543: Add retries for columnar query

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,6 +426,7 @@ set(couchbase_cxx_client_FILES
     core/columnar/error_codes.cxx
     core/columnar/query_component.cxx
     core/columnar/query_result.cxx
+    core/columnar/backoff_calculator.cxx
 )
 
 if(COUCHBASE_CXX_CLIENT_BUILD_SHARED OR BUILD_SHARED_LIBS)

--- a/core/columnar/agent.cxx
+++ b/core/columnar/agent.cxx
@@ -39,7 +39,7 @@ public:
     : io_{ io }
     , config_{ std::move(config) }
     , http_{ io_, config_.shim, config_.default_retry_strategy }
-    , query_{ io_, http_, config_.default_retry_strategy }
+    , query_{ io_, http_ }
   {
     CB_LOG_DEBUG("creating new columnar cluster agent: {}", config_.to_string());
   }

--- a/core/columnar/backoff_calculator.cxx
+++ b/core/columnar/backoff_calculator.cxx
@@ -1,0 +1,62 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "backoff_calculator.hxx"
+
+#include <random>
+
+namespace couchbase::core::columnar
+{
+auto
+exponential_backoff_with_full_jitter(std::chrono::milliseconds min_backoff,
+                                     std::chrono::milliseconds max_backoff,
+                                     double backoff_factor) -> backoff_calculator
+{
+
+  double min = 100;   // 100 milliseconds
+  double max = 60000; // 1 minute
+  double factor = 2;
+
+  if (min_backoff > std::chrono::milliseconds::zero()) {
+    min = static_cast<double>(min_backoff.count());
+  }
+  if (max_backoff > std::chrono::milliseconds::zero()) {
+    max = static_cast<double>(max_backoff.count());
+  }
+  if (backoff_factor > 0) {
+    factor = backoff_factor;
+  }
+
+  return [min, max, factor](std::size_t retry_attempts) -> std::chrono::milliseconds {
+    const std::int32_t max_backoff =
+      static_cast<std::int32_t>(std::round(std::min(max, min * std::pow(factor, retry_attempts))));
+
+    std::mt19937 gen(std::random_device{}());
+    std::uniform_int_distribution<std::int32_t> distrib(0, max_backoff);
+
+    return std::chrono::milliseconds(distrib(gen));
+  };
+}
+
+auto
+default_backoff_calculator(std::size_t retry_attempts) -> std::chrono::milliseconds
+{
+  auto calculator = exponential_backoff_with_full_jitter(
+    std::chrono::milliseconds(100), std::chrono::minutes(1), 2);
+  return calculator(retry_attempts);
+}
+} // namespace couchbase::core::columnar

--- a/core/columnar/backoff_calculator.hxx
+++ b/core/columnar/backoff_calculator.hxx
@@ -15,36 +15,20 @@
  *   limitations under the License.
  */
 
-#include "error.hxx"
+#pragma once
 
-#include <tao/json/to_string.hpp>
-
-#include <string>
+#include <chrono>
+#include <functional>
 
 namespace couchbase::core::columnar
 {
-error::operator bool() const
-{
-  return ec.operator bool();
-}
+using backoff_calculator = std::function<std::chrono::milliseconds(std::size_t retry_attempts)>;
 
 auto
-error::message_with_ctx() const -> std::string
-{
-  std::string serialized_ctx{};
-  if (!ctx.get_object().empty()) {
-    serialized_ctx = tao::json::to_string(ctx);
-  }
-  std::string res{};
-  if (!message.empty()) {
-    res += message;
-  }
-  if (!serialized_ctx.empty()) {
-    if (!res.empty()) {
-      res += ' ';
-    }
-    res += serialized_ctx;
-  }
-  return res;
-}
+exponential_backoff_with_full_jitter(std::chrono::milliseconds min_backoff,
+                                     std::chrono::milliseconds max_backoff,
+                                     double backoff_factor) -> backoff_calculator;
+
+auto
+default_backoff_calculator(std::size_t retry_attempts) -> std::chrono::milliseconds;
 } // namespace couchbase::core::columnar

--- a/core/columnar/error.hxx
+++ b/core/columnar/error.hxx
@@ -46,6 +46,7 @@ struct error {
   tao::json::value ctx = tao::json::empty_object;
   std::shared_ptr<error> cause{};
 
+  operator bool() const;
   auto message_with_ctx() const -> std::string;
 };
 } // namespace couchbase::core::columnar

--- a/core/columnar/query_component.cxx
+++ b/core/columnar/query_component.cxx
@@ -87,6 +87,7 @@ public:
           auto op_info = std::dynamic_pointer_cast<pending_operation_connection_info>(op);
           self->retry_info_.last_dispatched_from = op_info->dispatched_from();
           self->retry_info_.last_dispatched_to = op_info->dispatched_to();
+          self->retry_info_.last_dispatched_to_host = op_info->dispatched_to_host();
         }
 
         if (ec) {
@@ -180,6 +181,7 @@ private:
         return;
       }
       self->retry_info_.retry_attempts++;
+      self->http_req_.internal.undesired_endpoint = self->retry_info_.last_dispatched_to;
       auto err = self->dispatch();
       if (err) {
         self->invoke_callback({}, std::move(err));

--- a/core/columnar/query_component.cxx
+++ b/core/columnar/query_component.cxx
@@ -18,96 +18,271 @@
 #include "query_component.hxx"
 
 #include <couchbase/error_codes.hxx>
-#include <couchbase/retry_strategy.hxx>
 
+#include "backoff_calculator.hxx"
 #include "core/free_form_http_request.hxx"
 #include "core/http_component.hxx"
 #include "core/logger/logger.hxx"
+#include "core/pending_operation_connection_info.hxx"
+#include "core/platform/uuid.h"
 #include "core/row_streamer.hxx"
 #include "core/service_type.hxx"
 #include "core/utils/json.hxx"
 #include "error.hxx"
 #include "error_codes.hxx"
 #include "query_result.hxx"
+#include "retry_info.hxx"
 
+#include <asio/io_context.hpp>
+#include <asio/steady_timer.hpp>
 #include <fmt/format.h>
 #include <gsl/util>
 #include <tao/json/value.hpp>
 #include <tl/expected.hpp>
 
-#include <chrono>
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <system_error>
 #include <utility>
 #include <vector>
 
 namespace couchbase::core::columnar
 {
-class query_component_impl : public std::enable_shared_from_this<query_component_impl>
+class pending_query_operation
+  : public std::enable_shared_from_this<pending_query_operation>
+  , public pending_operation
 {
 public:
-  query_component_impl(asio::io_context& io,
-                       http_component http,
-                       std::shared_ptr<retry_strategy> default_retry_strategy)
-    : io_{ io }
-    , http_{ std::move(http) }
-    , default_retry_strategy_{ std::move(default_retry_strategy) }
+  pending_query_operation(const query_options& options, asio::io_context& io, http_component& http)
+    : http_req_{ build_query_request(options) }
+    , timeout_{ options.timeout.value_or(std::chrono::minutes(10)) }
+    // TODO(CXXCBC-557): Replace with global timeout
+    , io_{ io }
+    , deadline_{ io_ }
+    , retry_timer_{ io_ }
+    , http_{ http }
   {
   }
 
-  auto execute_query(const query_options& options, query_callback&& callback)
-    -> tl::expected<std::shared_ptr<pending_operation>, error>
+  auto invoke_callback(query_result res, error err)
   {
-    auto req = build_query_request(options);
-    auto op = http_.do_http_request(
-      req, [self = shared_from_this(), cb = std::move(callback)](auto resp, auto ec) mutable {
+    const std::scoped_lock lock{ callback_mutex_ };
+    if (auto cb = std::move(callback_); cb) {
+      cb(std::move(res), std::move(err));
+    }
+  }
+
+  auto dispatch() -> error
+  {
+    auto op =
+      http_.do_http_request(http_req_, [self = shared_from_this()](auto resp, auto ec) mutable {
+        std::shared_ptr<pending_operation> op;
+        {
+          const std::scoped_lock lock{ self->pending_op_mutex_ };
+          std::swap(op, self->pending_op_);
+        }
+        // op can be null if the pending_query_operation was cancelled.
+        if (op) {
+          auto op_info = std::dynamic_pointer_cast<pending_operation_connection_info>(op);
+          self->retry_info_.last_dispatched_from = op_info->dispatched_from();
+          self->retry_info_.last_dispatched_to = op_info->dispatched_to();
+        }
+
         if (ec) {
           if (ec == couchbase::errc::common::request_canceled) {
-            cb({},
-               { couchbase::core::columnar::errc::generic, "The query operation was canceled." });
+            self->invoke_callback(
+              {},
+              { couchbase::core::columnar::errc::generic, "The query operation was canceled." });
             return;
           }
-          cb({}, { maybe_convert_error_code(ec) });
+          self->invoke_callback({}, { maybe_convert_error_code(ec) });
           return;
         }
         auto streamer = std::make_shared<row_streamer>(self->io_, resp.body(), "/results/^");
-        return streamer->start([self, streamer, resp = std::move(resp), cb = std::move(cb)](
-                                 auto metadata_header, auto ec) mutable {
-          if (ec) {
-            cb({}, { maybe_convert_error_code(ec) });
-            return;
-          }
-          auto error_parse_res =
-            parse_error(resp.status_code(), utils::json::parse(metadata_header));
-          if (error_parse_res.err.ec) {
-            cb({}, { error_parse_res.err });
-            return;
-          }
-          cb(query_result{ std::move(*streamer) }, {});
-        });
+        return streamer->start(
+          [self, streamer, resp = std::move(resp)](auto metadata_header, auto ec) mutable {
+            if (ec) {
+              self->invoke_callback({}, { maybe_convert_error_code(ec) });
+              return;
+            }
+            auto error_parse_res =
+              self->parse_error(resp.status_code(), utils::json::parse(metadata_header));
+
+            if (error_parse_res.retriable) {
+              return self->maybe_retry();
+            }
+
+            if (error_parse_res.err) {
+              self->invoke_callback({}, { error_parse_res.err });
+              return;
+            }
+            self->invoke_callback(query_result{ std::move(*streamer) }, {});
+          });
       });
 
-    if (!op.has_value()) {
-      return tl::unexpected<error>({ op.error() });
+    if (op.has_value()) {
+      const std::scoped_lock lock{ pending_op_mutex_ };
+      pending_op_ = op.value();
+      return {};
     }
-    return { op.value() };
+    return error{ op.error() };
+  }
+
+  auto start(query_callback&& callback) -> error
+  {
+    callback_ = std::move(callback);
+
+    deadline_.expires_after(timeout_);
+    deadline_.async_wait([self = shared_from_this()](auto ec) {
+      if (ec == asio::error::operation_aborted) {
+        return;
+      }
+      CB_LOG_DEBUG(R"(Columnar Query request timed out: retry_attempts={})",
+                   self->retry_info_.retry_attempts);
+      self->trigger_timeout();
+    });
+
+    return dispatch();
+  }
+
+  void cancel() override
+  {
+    cancelled_ = true;
+    retry_timer_.cancel();
+    std::shared_ptr<pending_operation> op;
+    {
+      const std::scoped_lock lock{ pending_op_mutex_ };
+      std::swap(op, pending_op_);
+    }
+    if (op) {
+      op->cancel();
+    }
+    // This will only call the callback if it has not already been called.
+    invoke_callback(
+      {}, { couchbase::core::columnar::errc::generic, "The query operation was canceled." });
   }
 
 private:
+  void maybe_retry()
+  {
+    if (cancelled_) {
+      return;
+    }
+    auto backoff = backoff_calculator_(retry_info_.retry_attempts);
+    if (std::chrono::steady_clock::now() + backoff >= deadline_.expiry()) {
+      // Retrying will exceed the deadline, time out immediately instead.
+      return trigger_timeout();
+    }
+    retry_timer_.expires_after(backoff);
+    retry_timer_.async_wait([self = shared_from_this()](auto ec) {
+      if (ec == asio::error::operation_aborted) {
+        return;
+      }
+      self->retry_info_.retry_attempts++;
+      auto err = self->dispatch();
+      if (err) {
+        self->invoke_callback({}, std::move(err));
+      }
+    });
+  }
+
+  void trigger_timeout()
+  {
+    error err{ errc::timeout };
+    enhance_error(err);
+    invoke_callback({}, err);
+    cancel();
+  }
+
+  auto build_query_payload(const query_options& options) -> tao::json::value
+  {
+    tao::json::value payload{ { "statement", options.statement },
+                              { "client_context_id", client_context_id_ } };
+    if (options.database_name.has_value() && options.scope_name.has_value()) {
+      payload["query_context"] =
+        fmt::format("default:`{}`.`{}`", options.database_name.value(), options.scope_name.value());
+    }
+    if (!options.positional_parameters.empty()) {
+      std::vector<tao::json::value> params_json;
+      params_json.reserve(options.positional_parameters.size());
+      for (const auto& val : options.positional_parameters) {
+        params_json.emplace_back(utils::json::parse(val));
+      }
+      payload["args"] = std::move(params_json);
+    }
+    for (const auto& [name, val] : options.named_parameters) {
+      std::string key = name;
+      if (key[0] != '$') {
+        key.insert(key.begin(), '$');
+      }
+      payload[key] = utils::json::parse(val);
+    }
+    if (options.read_only.has_value()) {
+      payload["readonly"] = options.read_only.value();
+    }
+    if (options.scan_consistency.has_value()) {
+      switch (options.scan_consistency.value()) {
+        case query_scan_consistency::not_bounded:
+          payload["scan_consistency"] = "not_bounded";
+          break;
+        case query_scan_consistency::request_plus:
+          payload["scan_consistency"] = "request_plus";
+          break;
+      }
+    }
+    for (const auto& [key, val] : options.raw) {
+      payload[key] = utils::json::parse(val);
+    }
+    const std::chrono::milliseconds server_timeout = timeout_ + std::chrono::seconds(5);
+    payload["timeout"] = fmt::format("{}ms", server_timeout.count());
+
+    return payload;
+  }
+
+  auto build_query_request(const query_options& options) -> http_request
+  {
+    http_request req{ service_type::analytics, "POST" };
+    req.path = "/api/v1/request";
+    req.body = utils::json::generate(build_query_payload(options));
+    if (options.timeout.has_value()) {
+      req.timeout = options.timeout.value();
+    }
+    req.client_context_id = client_context_id_;
+    req.headers["connection"] = "keep-alive";
+    req.headers["content-type"] = "application/json";
+    if (options.priority.has_value() && options.priority.value()) {
+      req.headers["analytics-priority"] = "-1";
+    }
+    if (options.read_only.has_value()) {
+      req.is_read_only = options.read_only.value();
+    }
+    CB_LOG_DEBUG("QUERY REQUEST: client_context_id={}, body={}.", client_context_id_, req.body);
+    return req;
+  }
+
   struct error_parse_result {
     error err{};
     bool retriable{ false };
   };
 
-  static auto parse_error(const std::uint32_t& http_status_code,
-                          const tao::json::value& metadata_header) -> error_parse_result
+  void enhance_error(error& err)
+  {
+    err.ctx["retry_attempts"] = retry_info_.retry_attempts;
+    err.ctx["last_dispatched_to"] = retry_info_.last_dispatched_to;
+    err.ctx["last_dispatched_from"] = retry_info_.last_dispatched_from;
+  }
+
+  auto parse_error(const std::uint32_t& http_status_code,
+                   const tao::json::value& metadata_header) -> error_parse_result
   {
     const auto* errors_json = metadata_header.find("errors");
     if (errors_json == nullptr) {
       return {};
     }
-    CB_LOG_DEBUG("QUERY ERROR: {}.", utils::json::generate(errors_json));
+    CB_LOG_DEBUG("QUERY ERROR (client_context_id={}): {}.",
+                 client_context_id_,
+                 utils::json::generate(errors_json));
     if (!errors_json->is_array()) {
       return { { errc::generic,
                  "Could not parse errors from server response - expected JSON array" } };
@@ -120,6 +295,7 @@ private:
     res.retriable = true;
     res.err.ctx["http_status"] = std::to_string(http_status_code);
     res.err.ctx["errors"] = std::vector<tao::json::value>{};
+    enhance_error(res.err);
 
     if (http_status_code == 401) {
       res.err.ec = errc::invalid_credential;
@@ -198,85 +374,49 @@ private:
     return res;
   }
 
-  static auto build_query_payload(const query_options& options) -> tao::json::value
-  {
-    tao::json::value payload{ { "statement", options.statement } };
-    if (options.database_name.has_value() && options.scope_name.has_value()) {
-      payload["query_context"] =
-        fmt::format("default:`{}`.`{}`", options.database_name.value(), options.scope_name.value());
-    }
-    if (!options.positional_parameters.empty()) {
-      std::vector<tao::json::value> params_json;
-      params_json.reserve(options.positional_parameters.size());
-      for (const auto& val : options.positional_parameters) {
-        params_json.emplace_back(utils::json::parse(val));
-      }
-      if (!params_json.empty()) {
-        payload["args"] = std::move(params_json);
-      }
-    }
-    for (const auto& [name, val] : options.named_parameters) {
-      std::string key = name;
-      if (key[0] != '$') {
-        key.insert(key.begin(), '$');
-      }
-      payload[key] = utils::json::parse(val);
-    }
-    if (options.read_only.has_value()) {
-      payload["readonly"] = options.read_only.value();
-    }
-    if (options.scan_consistency.has_value()) {
-      switch (options.scan_consistency.value()) {
-        case query_scan_consistency::not_bounded:
-          payload["scan_consistency"] = "not_bounded";
-          break;
-        case query_scan_consistency::request_plus:
-          payload["scan_consistency"] = "request_plus";
-          break;
-      }
-    }
-    for (const auto& [key, val] : options.raw) {
-      payload[key] = utils::json::parse(val);
-    }
-    if (options.timeout.has_value()) {
-      const std::chrono::milliseconds timeout = options.timeout.value() + std::chrono::seconds(5);
-      payload["timeout"] = fmt::format("{}ms", timeout.count());
-    }
-
-    return payload;
-  }
-
-  static auto build_query_request(const query_options& options) -> http_request
-  {
-    http_request req{ service_type::analytics, "POST" };
-    req.path = "/api/v1/request";
-    req.body = utils::json::generate(build_query_payload(options));
-    if (options.timeout.has_value()) {
-      req.timeout = options.timeout.value();
-    }
-    req.headers["connection"] = "keep-alive";
-    req.headers["content-type"] = "application/json";
-    if (options.priority.has_value() && options.priority.value()) {
-      req.headers["analytics-priority"] = "-1";
-    }
-    if (options.read_only.has_value()) {
-      req.is_read_only = options.read_only.value();
-    }
-    CB_LOG_DEBUG("QUERY REQUEST: body={}.", req.body);
-    return req;
-  }
-
+  http_request http_req_;
+  std::chrono::milliseconds timeout_;
   asio::io_context& io_;
-  http_component http_;
-  std::shared_ptr<retry_strategy> default_retry_strategy_;
+  asio::steady_timer deadline_;
+  asio::steady_timer retry_timer_;
+  http_component& http_;
+  query_callback callback_{};
+  std::mutex callback_mutex_{};
+  std::shared_ptr<pending_operation> pending_op_{};
+  std::mutex pending_op_mutex_{};
+  std::atomic_bool cancelled_{ false };
+  backoff_calculator backoff_calculator_{ default_backoff_calculator };
+  retry_info retry_info_{};
+  std::string client_context_id_{ uuid::to_string(uuid::random()) };
 };
 
-query_component::query_component(asio::io_context& io,
-                                 core::http_component http,
-                                 std::shared_ptr<retry_strategy> default_retry_strategy)
-  : impl_{
-    std::make_shared<query_component_impl>(io, std::move(http), std::move(default_retry_strategy))
+class query_component_impl : public std::enable_shared_from_this<query_component_impl>
+{
+public:
+  query_component_impl(asio::io_context& io, http_component http)
+    : io_{ io }
+    , http_{ std::move(http) }
+  {
   }
+
+  auto execute_query(const query_options& options, query_callback&& callback)
+    -> tl::expected<std::shared_ptr<pending_operation>, error>
+  {
+    auto op = std::make_shared<pending_query_operation>(options, io_, http_);
+    auto err = op->start(std::move(callback));
+    if (err) {
+      return tl::unexpected<error>(err);
+    }
+    return op;
+  }
+
+private:
+  asio::io_context& io_;
+  http_component http_;
+};
+
+query_component::query_component(asio::io_context& io, core::http_component http)
+  : impl_{ std::make_shared<query_component_impl>(io, std::move(http)) }
 {
 }
 

--- a/core/columnar/query_component.hxx
+++ b/core/columnar/query_component.hxx
@@ -42,9 +42,7 @@ class query_component_impl;
 class query_component
 {
 public:
-  query_component(asio::io_context& io,
-                  http_component http,
-                  std::shared_ptr<retry_strategy> default_retry_strategy);
+  query_component(asio::io_context& io, http_component http);
 
   auto execute_query(const query_options& options, query_callback&& callback)
     -> tl::expected<std::shared_ptr<pending_operation>, error>;

--- a/core/columnar/retry_info.hxx
+++ b/core/columnar/retry_info.hxx
@@ -26,5 +26,6 @@ struct retry_info {
   std::size_t retry_attempts{ 0 };
   std::string last_dispatched_to{};
   std::string last_dispatched_from{};
+  std::string last_dispatched_to_host{};
 };
 } // namespace couchbase::core::columnar

--- a/core/columnar/retry_info.hxx
+++ b/core/columnar/retry_info.hxx
@@ -15,36 +15,16 @@
  *   limitations under the License.
  */
 
-#include "error.hxx"
+#pragma once
 
-#include <tao/json/to_string.hpp>
-
+#include <cstddef>
 #include <string>
 
 namespace couchbase::core::columnar
 {
-error::operator bool() const
-{
-  return ec.operator bool();
-}
-
-auto
-error::message_with_ctx() const -> std::string
-{
-  std::string serialized_ctx{};
-  if (!ctx.get_object().empty()) {
-    serialized_ctx = tao::json::to_string(ctx);
-  }
-  std::string res{};
-  if (!message.empty()) {
-    res += message;
-  }
-  if (!serialized_ctx.empty()) {
-    if (!res.empty()) {
-      res += ' ';
-    }
-    res += serialized_ctx;
-  }
-  return res;
-}
+struct retry_info {
+  std::size_t retry_attempts{ 0 };
+  std::string last_dispatched_to{};
+  std::string last_dispatched_from{};
+};
 } // namespace couchbase::core::columnar

--- a/core/free_form_http_request.hxx
+++ b/core/free_form_http_request.hxx
@@ -60,6 +60,7 @@ public:
 
   struct {
     std::string user{};
+    std::string undesired_endpoint{};
   } internal{};
 };
 

--- a/core/free_form_http_request.hxx
+++ b/core/free_form_http_request.hxx
@@ -22,6 +22,7 @@
 #include <cinttypes>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <system_error>
 #include <vector>
@@ -49,11 +50,12 @@ public:
   std::string body{};
   std::map<std::string, std::string> headers{};
   std::string content_type{};
+  std::string client_context_id{};
   bool is_idempotent{};
   bool is_read_only{};
   std::string unique_id{};
   std::shared_ptr<couchbase::retry_strategy> retry_strategy{};
-  std::chrono::milliseconds timeout{};
+  std::optional<std::chrono::milliseconds> timeout{};
   std::shared_ptr<couchbase::tracing::request_span> parent_span{};
 
   struct {

--- a/core/http_component.cxx
+++ b/core/http_component.cxx
@@ -202,6 +202,11 @@ public:
     return session_->local_address();
   }
 
+  [[nodiscard]] auto dispatched_to_host() const -> std::string override
+  {
+    return fmt::format("{}:{}", session_->hostname(), session_->port());
+  }
+
 private:
   void trigger_timeout()
   {
@@ -272,7 +277,8 @@ public:
 
     std::shared_ptr<io::http_session> session;
     {
-      auto [ec, s] = session_manager->check_out(request.service, credentials, request.endpoint);
+      auto [ec, s] = session_manager->check_out(
+        request.service, credentials, request.endpoint, request.internal.undesired_endpoint);
       if (ec) {
         return tl::unexpected(ec);
       }
@@ -333,8 +339,10 @@ private:
         }
         std::shared_ptr<io::http_session> session;
         {
-          auto [ec, s] =
-            session_manager->check_out(op->request().service, credentials, op->request().endpoint);
+          auto [ec, s] = session_manager->check_out(op->request().service,
+                                                    credentials,
+                                                    op->request().endpoint,
+                                                    op->request().internal.undesired_endpoint);
           if (ec) {
             return op->invoke_response_handler(ec, {});
           }

--- a/core/pending_operation_connection_info.hxx
+++ b/core/pending_operation_connection_info.hxx
@@ -26,6 +26,7 @@ class pending_operation_connection_info
 public:
   virtual ~pending_operation_connection_info() = default;
   [[nodiscard]] virtual auto dispatched_to() const -> std::string = 0;
+  [[nodiscard]] virtual auto dispatched_to_host() const -> std::string = 0;
   [[nodiscard]] virtual auto dispatched_from() const -> std::string = 0;
 };
 } // namespace couchbase::core

--- a/core/pending_operation_connection_info.hxx
+++ b/core/pending_operation_connection_info.hxx
@@ -15,36 +15,17 @@
  *   limitations under the License.
  */
 
-#include "error.hxx"
-
-#include <tao/json/to_string.hpp>
+#pragma once
 
 #include <string>
 
-namespace couchbase::core::columnar
+namespace couchbase::core
 {
-error::operator bool() const
+class pending_operation_connection_info
 {
-  return ec.operator bool();
-}
-
-auto
-error::message_with_ctx() const -> std::string
-{
-  std::string serialized_ctx{};
-  if (!ctx.get_object().empty()) {
-    serialized_ctx = tao::json::to_string(ctx);
-  }
-  std::string res{};
-  if (!message.empty()) {
-    res += message;
-  }
-  if (!serialized_ctx.empty()) {
-    if (!res.empty()) {
-      res += ' ';
-    }
-    res += serialized_ctx;
-  }
-  return res;
-}
-} // namespace couchbase::core::columnar
+public:
+  virtual ~pending_operation_connection_info() = default;
+  [[nodiscard]] virtual auto dispatched_to() const -> std::string = 0;
+  [[nodiscard]] virtual auto dispatched_from() const -> std::string = 0;
+};
+} // namespace couchbase::core

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,7 @@ integration_test(search)
 integration_test(management)
 integration_test(management_eventing)
 integration_test(management_search_index)
+integration_test(http_session_manager)
 
 unit_test(connection_string)
 unit_test(utils)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,7 +19,6 @@ integration_test(search)
 integration_test(management)
 integration_test(management_eventing)
 integration_test(management_search_index)
-integration_test(columnar)
 
 unit_test(connection_string)
 unit_test(utils)
@@ -51,3 +50,6 @@ unit_test(waitable_op_list)
 
 integration_test(examples)
 transaction_test(examples)
+
+integration_test(columnar_query)
+unit_test(columnar_retry)

--- a/test/test_integration_http_session_manager.cxx
+++ b/test/test_integration_http_session_manager.cxx
@@ -1,0 +1,64 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "test_helper_integration.hxx"
+
+#include "core/io/http_session_manager.hxx"
+
+#include <couchbase/build_config.hxx>
+
+TEST_CASE("integration: random node selection with analytics service", "[integration]")
+{
+  test::utils::integration_test_guard integration;
+  if (!integration.has_analytics_service()) {
+    SKIP("Requires analytics service");
+  }
+
+  auto [mgr_ec, session_mgr] = integration.cluster.http_session_manager();
+  REQUIRE_SUCCESS(mgr_ec);
+
+#ifdef COUCHBASE_CXX_CLIENT_COLUMNAR
+  auto barrier = std::make_shared<std::promise<bool>>();
+  session_mgr->add_to_deferred_queue([barrier]() mutable {
+    barrier->set_value(true);
+  });
+  auto fut = barrier->get_future();
+  fut.get();
+#endif
+
+  auto [origin_ec, origin] = integration.cluster.origin();
+  REQUIRE_SUCCESS(origin_ec);
+
+  auto [session_ec, session] =
+    session_mgr->check_out(couchbase::core::service_type::analytics, origin.credentials(), "");
+  REQUIRE_SUCCESS(session_ec);
+
+  auto last_addr = fmt::format("{}:{}", session->hostname(), session->port());
+
+  session_mgr->check_in(couchbase::core::service_type::analytics, session);
+  auto [session2_ec, session2] = session_mgr->check_out(
+    couchbase::core::service_type::analytics, origin.credentials(), "", last_addr);
+  REQUIRE_SUCCESS(session2_ec);
+
+  auto new_addr = fmt::format("{}:{}", session2->hostname(), session2->port());
+
+  if (integration.number_of_analytics_nodes() > 1) {
+    REQUIRE(new_addr != last_addr);
+  } else {
+    REQUIRE(new_addr == last_addr);
+  }
+}

--- a/test/utils/integration_test_guard.cxx
+++ b/test/utils/integration_test_guard.cxx
@@ -208,11 +208,11 @@ integration_test_guard::load_pools_info(bool refresh) -> pools_response
 }
 
 auto
-integration_test_guard::number_of_query_nodes() -> std::size_t
+integration_test_guard::number_of_nodes_with_service(std::string type) -> std::size_t
 {
   const auto& ci = load_cluster_info();
-  const auto result = std::count_if(ci.nodes.begin(), ci.nodes.end(), [](const auto& node) {
-    return std::find(node.services.begin(), node.services.end(), "n1ql") != node.services.end();
+  const auto result = std::count_if(ci.nodes.begin(), ci.nodes.end(), [type](const auto& node) {
+    return std::find(node.services.begin(), node.services.end(), type) != node.services.end();
   });
   return static_cast<std::size_t>(result);
 }

--- a/test/utils/integration_test_guard.hxx
+++ b/test/utils/integration_test_guard.hxx
@@ -113,7 +113,17 @@ public:
     return has_service(couchbase::core::service_type::analytics);
   }
 
-  auto number_of_query_nodes() -> std::size_t;
+  auto number_of_nodes_with_service(std::string type) -> std::size_t;
+
+  auto number_of_query_nodes() -> std::size_t
+  {
+    return number_of_nodes_with_service("n1ql");
+  }
+
+  auto number_of_analytics_nodes() -> std::size_t
+  {
+    return number_of_nodes_with_service("cbas");
+  }
 
   [[nodiscard]] auto transactions() const
     -> std::shared_ptr<couchbase::core::transactions::transactions>;


### PR DESCRIPTION
* Refactor columnar query execution into a `pending_query_operation` in query_component, to enable handling retries
* Implement exponential backoff with full jitter and use it for columnar query retries if all errors have `is_retriable == true`
* Add a randomly generated client-context-id to the query request (include in payload & logging)
* Extend `session_manager->check_out()` to allow specifying an 'undesired' node. If other nodes for the required service exist, any other node will be selected at random. This is used for columnar query retries.
