### PR TITLE
CXXCBC-562: (Columnar) Provide HTTP session manager with updated cluster

### DIFF
--- a/core/cluster.cxx
+++ b/core/cluster.cxx
@@ -1000,7 +1000,9 @@ public:
   void create_cluster_sessions()
   {
     config_tracker_->create_sessions(
-      [self = shared_from_this()](std::error_code ec, const topology::configuration& cfg) mutable {
+      [self = shared_from_this()](std::error_code ec,
+                                  const topology::configuration& cfg,
+                                  const cluster_options& options) mutable {
         if (ec) {
           auto backoff = std::chrono::milliseconds(500);
           CB_LOG_DEBUG("[{}] Waiting for {}ms before retrying to create cluster sessions.",
@@ -1010,7 +1012,7 @@ public:
             self->create_cluster_sessions();
           });
         } else {
-          self->session_manager_->set_configuration(cfg, self->origin_.options());
+          self->session_manager_->set_configuration(cfg, options);
           self->config_tracker_->on_configuration_update(self->session_manager_);
           self->config_tracker_->register_state_listener();
         }

--- a/core/io/config_tracker.cxx
+++ b/core/io/config_tracker.cxx
@@ -94,7 +94,8 @@ public:
   }
 
   void create_sessions(
-    utils::movable_function<void(std::error_code, topology::configuration cfg)>&& handler)
+    utils::movable_function<
+      void(std::error_code, const topology::configuration&, const cluster_options&)>&& handler)
   {
     io::mcbp_session new_session =
       origin_.options().enable_tls
@@ -153,7 +154,7 @@ public:
         }
 #endif
       }
-      h(ec, cfg);
+      h(ec, cfg, self->origin_.options());
     });
   }
 
@@ -611,7 +612,8 @@ cluster_config_tracker::close()
 
 void
 cluster_config_tracker::create_sessions(
-  utils::movable_function<void(std::error_code, topology::configuration cfg)>&& handler)
+  utils::movable_function<
+    void(std::error_code, const topology::configuration&, const cluster_options&)>&& handler)
 {
   return impl_->create_sessions(std::move(handler));
 }

--- a/core/io/config_tracker.hxx
+++ b/core/io/config_tracker.hxx
@@ -42,6 +42,7 @@ class context;
 
 namespace couchbase::core
 {
+struct cluster_options;
 struct origin;
 
 namespace protocol
@@ -94,7 +95,9 @@ public:
   ~cluster_config_tracker() override;
 
   void create_sessions(
-    utils::movable_function<void(std::error_code, topology::configuration cfg)>&& handler);
+    utils::movable_function<void(std::error_code,
+                                 const topology::configuration&,
+                                 const couchbase::core::cluster_options&)>&& handler);
   void on_configuration_update(std::shared_ptr<config_listener> handler);
   void close();
   void register_state_listener();


### PR DESCRIPTION
Motivation
==========
After bootstrap completes, for alternate addressing, cluster options can be updated.  However, currently for the Columnar connection path those cluster options are not propagated to the HTTP session manager.  The lack of propagation means HTTP connections are not able to connect when using alternate addressing because the external hostname and/or port is not used.

Changes
=======
* For Columnar connections, pass the updated cluster options back in the create_sessions() callback so that the options can be propagated to the HTTP session manager.