### PR TITLE
CXXCBC-569: resolve cycle in shared pointers for transaction_context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /out/
+/CPTCMakeBuild
 /build/
 /cmake-build-*/
 /cmake-build-report.tar.gz

--- a/core/transactions/atr_cleanup_entry.cxx
+++ b/core/transactions/atr_cleanup_entry.cxx
@@ -20,6 +20,7 @@
 #include "durability_level.hxx"
 #include "forward_compat.hxx"
 
+#include "core/operations.hxx"
 #include "core/transactions.hxx"
 #include "internal/atr_cleanup_entry.hxx"
 #include "internal/doc_record_fmt.hxx"
@@ -63,7 +64,6 @@ atr_cleanup_entry::atr_cleanup_entry(const atr_entry& entry,
                                      core::document_id atr_id,
                                      const transactions_cleanup& cleanup,
                                      bool check_if_expired)
-  //  : atr_id_(atr_id.bucket(), atr_id.scope(), atr_id.collection(), atr_id.key())
   : atr_id_(std::move(atr_id))
   , attempt_id_(entry.attempt_id())
   , check_if_expired_(check_if_expired)
@@ -90,7 +90,7 @@ atr_cleanup_entry::atr_cleanup_entry(const std::shared_ptr<attempt_context>& ctx
     };
   }
   attempt_id_ = ctx_impl->id();
-  cleanup_ = &ctx_impl->overall_->cleanup();
+  cleanup_ = &ctx_impl->overall()->cleanup();
 }
 
 void

--- a/core/transactions/attempt_context_impl.hxx
+++ b/core/transactions/attempt_context_impl.hxx
@@ -75,7 +75,7 @@ class attempt_context_impl
   , public std::enable_shared_from_this<attempt_context_impl>
 {
 private:
-  std::shared_ptr<transaction_context> overall_;
+  std::weak_ptr<transaction_context> overall_;
   std::optional<core::document_id> atr_id_;
   bool is_done_{ false };
   std::unique_ptr<staged_mutation_queue> staged_mutations_;
@@ -288,10 +288,10 @@ private:
 
   [[nodiscard]] auto cluster_ref() const -> const core::cluster&;
 
-  explicit attempt_context_impl(std::shared_ptr<transaction_context> transaction_ctx);
+  explicit attempt_context_impl(const std::shared_ptr<transaction_context>& transaction_ctx);
 
 public:
-  static auto create(std::shared_ptr<transaction_context> transaction_ctx)
+  static auto create(const std::shared_ptr<transaction_context>& transaction_ctx)
     -> std::shared_ptr<attempt_context_impl>;
 
   ~attempt_context_impl() override;
@@ -364,23 +364,23 @@ public:
 
   [[nodiscard]] auto is_done() const -> bool;
 
-  [[nodiscard]] auto overall() -> std::shared_ptr<transaction_context>;
+  [[nodiscard]] auto overall() const -> std::shared_ptr<transaction_context>;
 
   [[nodiscard]] auto transaction_id() const -> const std::string&;
 
   [[nodiscard]] auto id() const -> const std::string&;
 
-  [[nodiscard]] auto state() -> attempt_state;
+  [[nodiscard]] auto state() const -> attempt_state;
 
-  void state(attempt_state s);
+  void state(attempt_state s) const;
 
   [[nodiscard]] auto atr_id() const -> const std::string&;
 
-  void atr_id(const std::string& atr_id);
+  void atr_id(const std::string& atr_id) const;
 
   [[nodiscard]] auto atr_collection() const -> const std::string&;
 
-  void atr_collection_name(const std::string& coll);
+  void atr_collection_name(const std::string& coll) const;
 
   auto has_expired_client_side(std::string place, std::optional<const std::string> doc_id) -> bool;
 

--- a/core/transactions/document_metadata.hxx
+++ b/core/transactions/document_metadata.hxx
@@ -98,9 +98,9 @@ public:
   }
 
 private:
-  const std::optional<std::string> cas_;
-  const std::optional<std::string> revid_;
-  const std::optional<std::uint32_t> exptime_;
-  const std::optional<std::string> crc32_;
+  std::optional<std::string> cas_;
+  std::optional<std::string> revid_;
+  std::optional<std::uint32_t> exptime_;
+  std::optional<std::string> crc32_;
 };
 } // namespace couchbase::core::transactions

--- a/core/transactions/internal/transaction_context.hxx
+++ b/core/transactions/internal/transaction_context.hxx
@@ -49,6 +49,7 @@ public:
                      const couchbase::transactions::transaction_options& config = {})
     -> std::shared_ptr<transaction_context>;
 
+  ~transaction_context();
   transaction_context(const transaction_context&) = delete;
   transaction_context(transaction_context&&) = delete;
   auto operator=(transaction_context&&) -> transaction_context& = delete;
@@ -70,7 +71,7 @@ public:
 
   auto cleanup() -> transactions_cleanup&;
 
-  [[nodiscard]] bool has_expired_client_side();
+  [[nodiscard]] auto has_expired_client_side() -> bool;
 
   void after_delay(std::chrono::milliseconds delay, const std::function<void()>& fn);
 

--- a/core/transactions/internal/transactions_cleanup.hxx
+++ b/core/transactions/internal/transactions_cleanup.hxx
@@ -43,32 +43,38 @@ private:
   attempt_state state_;
 
 public:
-  transactions_cleanup_attempt(const atr_cleanup_entry&);
+  explicit transactions_cleanup_attempt(const atr_cleanup_entry&);
 
-  [[nodiscard]] bool success() const
+  [[nodiscard]] auto success() const -> bool
   {
     return success_;
   }
+
   void success(bool success)
   {
     success_ = success;
   }
-  [[nodiscard]] const core::document_id& atr_id() const
+
+  [[nodiscard]] auto atr_id() const -> const core::document_id&
   {
     return atr_id_;
   }
-  [[nodiscard]] const std::string attempt_id() const
+
+  [[nodiscard]] auto attempt_id() const -> std::string
   {
     return attempt_id_;
   }
-  [[nodiscard]] const std::string atr_bucket_name() const
+
+  [[nodiscard]] auto atr_bucket_name() const -> std::string
   {
     return atr_bucket_name_;
   }
-  [[nodiscard]] attempt_state state() const
+
+  [[nodiscard]] auto state() const -> attempt_state
   {
     return state_;
   }
+
   void state(attempt_state state)
   {
     state_ = state;
@@ -76,14 +82,8 @@ public:
 };
 
 struct atr_cleanup_stats {
-  bool exists;
-  std::size_t num_entries;
-
-  atr_cleanup_stats()
-    : exists(false)
-    , num_entries(0)
-  {
-  }
+  bool exists{};
+  std::size_t num_entries{};
 };
 
 class transactions_cleanup
@@ -93,16 +93,16 @@ public:
                        couchbase::transactions::transactions_config::built config);
   ~transactions_cleanup();
 
-  [[nodiscard]] const core::cluster& cluster_ref() const
+  [[nodiscard]] auto cluster_ref() const -> const core::cluster&
   {
     return cluster_;
   };
 
-  [[nodiscard]] const couchbase::transactions::transactions_config::built& config() const
+  [[nodiscard]] auto config() const -> const couchbase::transactions::transactions_config::built&
   {
     return config_;
   }
-  [[nodiscard]] couchbase::transactions::transactions_config::built& config()
+  [[nodiscard]] auto config() -> couchbase::transactions::transactions_config::built&
   {
     return config_;
   };
@@ -110,13 +110,13 @@ public:
   // Add an attempt cleanup later.
   void add_attempt(const std::shared_ptr<attempt_context>& ctx);
 
-  std::size_t cleanup_queue_length() const
+  auto cleanup_queue_length() const -> std::size_t
   {
     return atr_queue_.size();
   }
 
-  void add_collection(couchbase::transactions::transaction_keyspace keyspace);
-  std::list<couchbase::transactions::transaction_keyspace> collections()
+  void add_collection(const couchbase::transactions::transaction_keyspace& keyspace);
+  auto collections() -> std::list<couchbase::transactions::transaction_keyspace>
   {
     std::lock_guard<std::mutex> lock(mutex_);
     return collections_;
@@ -152,14 +152,14 @@ private:
 
   void attempts_loop();
 
-  bool is_running()
+  auto is_running() -> bool
   {
     std::unique_lock<std::mutex> lock(mutex_);
     return running_;
   }
 
   template<class R, class P>
-  bool interruptable_wait(std::chrono::duration<R, P> time);
+  auto interruptable_wait(std::chrono::duration<R, P> time) -> bool;
 
   void lost_attempts_loop();
   void clean_collection(const couchbase::transactions::transaction_keyspace& keyspace);

--- a/core/transactions/staged_mutation.hxx
+++ b/core/transactions/staged_mutation.hxx
@@ -16,12 +16,12 @@
 
 #pragma once
 
-#include <couchbase/codec/encoded_value.hxx>
-
 #include "attempt_context_impl.hxx"
 #include "internal/utils.hxx"
 #include "transaction_get_result.hxx"
 #include "uid_generator.hxx"
+
+#include <couchbase/codec/encoded_value.hxx>
 
 #include <mutex>
 #include <string>
@@ -55,10 +55,11 @@ public:
   {
   }
 
-  staged_mutation(const staged_mutation& o) = default;
-  staged_mutation(staged_mutation&& o) = default;
-  auto operator=(const staged_mutation& o) -> staged_mutation& = default;
-  auto operator=(staged_mutation&& o) -> staged_mutation& = default;
+  ~staged_mutation() = default;
+  staged_mutation(const staged_mutation&) = delete;
+  staged_mutation(staged_mutation&&) = default;
+  auto operator=(const staged_mutation&) -> staged_mutation& = delete;
+  auto operator=(staged_mutation&&) -> staged_mutation& = default;
 
   [[nodiscard]] auto id() const -> const core::document_id&
   {
@@ -125,7 +126,7 @@ public:
 };
 
 struct unstaging_state {
-  static const size_t MAX_PARALLELISM = 1000;
+  static constexpr std::size_t MAX_PARALLELISM{ 1000 };
 
   std::shared_ptr<attempt_context_impl> ctx_;
   std::mutex mutex_{};
@@ -209,7 +210,7 @@ private:
 
 public:
   auto empty() -> bool;
-  void add(const staged_mutation& mutation);
+  void add(staged_mutation&& mutation);
   void extract_to(const std::string& prefix, core::operations::mutate_in_request& req);
   void commit(const std::shared_ptr<attempt_context_impl>& ctx);
   void rollback(const std::shared_ptr<attempt_context_impl>& ctx);

--- a/core/transactions/transaction_context.cxx
+++ b/core/transactions/transaction_context.cxx
@@ -71,6 +71,8 @@ transaction_context::transaction_context(transactions& txns,
   }
 }
 
+transaction_context::~transaction_context() = default;
+
 void
 transaction_context::add_attempt()
 {

--- a/core/transactions/transaction_get_result.cxx
+++ b/core/transactions/transaction_get_result.cxx
@@ -15,8 +15,12 @@
  */
 
 #include "transaction_get_result.hxx"
-#include "couchbase/codec/codec_flags.hxx"
+
 #include "result.hxx"
+
+#include "core/operations.hxx"
+
+#include <couchbase/codec/codec_flags.hxx>
 
 namespace couchbase::core::transactions
 {

--- a/core/transactions/transaction_get_result.hxx
+++ b/core/transactions/transaction_get_result.hxx
@@ -15,16 +15,17 @@
  */
 
 #pragma once
+
 #include "core/document_id.hxx"
-#include "core/operations.hxx"
+#include "core/operations_fwd.hxx"
 #include "core/utils/json.hxx"
-#include "couchbase/codec/encoded_value.hxx"
 #include "document_metadata.hxx"
 #include "transaction_links.hxx"
+
+#include <couchbase/codec/encoded_value.hxx>
 #include <couchbase/fmt/cas.hxx>
 #include <couchbase/transactions/transaction_get_result.hxx>
 
-#include <ostream>
 #include <utility>
 
 namespace couchbase::core::transactions
@@ -57,6 +58,8 @@ public:
   /** @internal */
   transaction_get_result(const transaction_get_result& doc) = default;
   transaction_get_result(transaction_get_result&& doc) noexcept = default;
+  auto operator=(const transaction_get_result&) -> transaction_get_result& = delete;
+  auto operator=(transaction_get_result&&) -> transaction_get_result& = default;
 
   /*
   transaction_get_result(const transaction_op_error_context& ctx)
@@ -82,7 +85,7 @@ public:
     : cas_(res.cas())
     , document_id_(res.bucket(), res.scope(), res.collection(), res.id())
     , links_(res.base_->links())
-    , content_(std::move(res.content()))
+    , content_(res.content())
     , metadata_(res.base_->metadata_)
   {
   }
@@ -111,20 +114,9 @@ public:
     }
   }
 
-  auto operator=(const transaction_get_result& o) -> transaction_get_result&
-  {
-    if (this != &o) {
-      document_id_ = o.document_id_;
-      content_ = o.content_;
-      cas_ = o.cas_;
-      links_ = o.links_;
-    }
-    return *this;
-  }
-
   /** @internal */
-  static transaction_get_result create_from(const transaction_get_result& document,
-                                            codec::encoded_value content);
+  static auto create_from(const transaction_get_result& document,
+                          codec::encoded_value content) -> transaction_get_result;
 
   /** @internal */
   static auto create_from(const core::operations::lookup_in_response& resp)

--- a/core/transactions/transaction_links.cxx
+++ b/core/transactions/transaction_links.cxx
@@ -16,9 +16,12 @@
 
 #include "transaction_links.hxx"
 
+#include <utility>
+
+namespace couchbase::core::transactions
+{
 auto
-couchbase::core::transactions::operator<<(std::ostream& os,
-                                          const transaction_links& links) -> std::ostream&
+operator<<(std::ostream& os, const transaction_links& links) -> std::ostream&
 {
   os << "transaction_links{atr: " << links.atr_id_.value_or("none")
      << ", atr_bkt: " << links.atr_bucket_name_.value_or("none")
@@ -29,3 +32,85 @@ couchbase::core::transactions::operator<<(std::ostream& os,
      << ", crc32_of_staging:" << links.crc32_of_staging_.value_or("none") << "}";
   return os;
 }
+
+void
+transaction_links::append_to_json(tao::json::value& obj) const
+{
+  if (staged_attempt_id_) {
+    obj["txnMeta"]["atmpt"] = staged_attempt_id_.value();
+  }
+  if (staged_transaction_id_) {
+    obj["txnMeta"]["txn"] = staged_transaction_id_.value();
+  }
+  if (staged_operation_id_) {
+    obj["txnMeta"]["txn"] = staged_operation_id_.value();
+  }
+  if (atr_id_) {
+    obj["txnMeta"]["atr"]["key"] = atr_id_.value();
+  }
+  if (atr_bucket_name_) {
+    obj["txnMeta"]["atr"]["bkt"] = atr_bucket_name_.value();
+  }
+  if (atr_scope_name_) {
+    obj["txnMeta"]["atr"]["scp"] = atr_scope_name_.value();
+  }
+  if (atr_collection_name_) {
+    obj["txnMeta"]["atr"]["coll"] = atr_collection_name_.value();
+  }
+}
+
+transaction_links::transaction_links(const tao::json::value& json)
+{
+  if (const auto* meta = json.find("txnMeta"); meta != nullptr && meta->is_object()) {
+    for (const auto& [key, value] : meta->get_object()) {
+      if (key == "atmpt") {
+        staged_attempt_id_ = value.get_string();
+      }
+      if (key == "txn") {
+        staged_transaction_id_ = value.get_string();
+      }
+      if (key == "atr" && value.is_object()) {
+        atr_id_ = value.at("key").get_string();
+        atr_bucket_name_ = value.at("bkt").get_string();
+        atr_scope_name_ = value.at("scp").get_string();
+        atr_collection_name_ = value.at("coll").get_string();
+      }
+    }
+  }
+}
+
+transaction_links::transaction_links(std::optional<std::string> atr_id,
+                                     std::optional<std::string> atr_bucket_name,
+                                     std::optional<std::string> atr_scope_name,
+                                     std::optional<std::string> atr_collection_name,
+                                     std::optional<std::string> staged_transaction_id,
+                                     std::optional<std::string> staged_attempt_id,
+                                     std::optional<std::string> staged_operation_id,
+                                     std::optional<codec::encoded_value> staged_content_json,
+                                     std::optional<codec::encoded_value> staged_content_binary,
+                                     std::optional<std::string> cas_pre_txn,
+                                     std::optional<std::string> revid_pre_txn,
+                                     std::optional<std::uint32_t> exptime_pre_txn,
+                                     std::optional<std::string> crc32_of_staging,
+                                     std::optional<std::string> op,
+                                     std::optional<tao::json::value> forward_compat,
+                                     bool is_deleted)
+  : atr_id_(std::move(atr_id))
+  , atr_bucket_name_(std::move(atr_bucket_name))
+  , atr_scope_name_(std::move(atr_scope_name))
+  , atr_collection_name_(std::move(atr_collection_name))
+  , staged_transaction_id_(std::move(staged_transaction_id))
+  , staged_attempt_id_(std::move(staged_attempt_id))
+  , staged_operation_id_(std::move(staged_operation_id))
+  , staged_content_json_(std::move(staged_content_json))
+  , staged_content_binary_(std::move(staged_content_binary))
+  , cas_pre_txn_(std::move(cas_pre_txn))
+  , revid_pre_txn_(std::move(revid_pre_txn))
+  , exptime_pre_txn_(exptime_pre_txn)
+  , crc32_of_staging_(std::move(crc32_of_staging))
+  , op_(std::move(op))
+  , forward_compat_(std::move(forward_compat))
+  , is_deleted_(is_deleted)
+{
+}
+} // namespace couchbase::core::transactions

--- a/core/transactions/transaction_links.hxx
+++ b/core/transactions/transaction_links.hxx
@@ -68,74 +68,15 @@ public:
                     std::optional<std::string> crc32_of_staging,
                     std::optional<std::string> op,
                     std::optional<tao::json::value> forward_compat,
-                    bool is_deleted)
-    : atr_id_(std::move(atr_id))
-    , atr_bucket_name_(std::move(atr_bucket_name))
-    , atr_scope_name_(std::move(atr_scope_name))
-    , atr_collection_name_(std::move(atr_collection_name))
-    , staged_transaction_id_(std::move(staged_transaction_id))
-    , staged_attempt_id_(std::move(staged_attempt_id))
-    , staged_operation_id_(std::move(staged_operation_id))
-    , staged_content_json_(std::move(staged_content_json))
-    , staged_content_binary_(std::move(staged_content_binary))
-    , cas_pre_txn_(std::move(cas_pre_txn))
-    , revid_pre_txn_(std::move(revid_pre_txn))
-    , exptime_pre_txn_(exptime_pre_txn)
-    , crc32_of_staging_(std::move(crc32_of_staging))
-    , op_(std::move(op))
-    , forward_compat_(forward_compat)
-    , is_deleted_(is_deleted)
-  {
-  }
+                    bool is_deleted);
 
   /** @brief create links from query result
    *
    * @param json the returned row object from a txn query response.
    */
-  explicit transaction_links(const tao::json::value& json)
-  {
-    if (const auto* meta = json.find("txnMeta"); meta != nullptr && meta->is_object()) {
-      for (const auto& [key, value] : meta->get_object()) {
-        if (key == "atmpt") {
-          staged_attempt_id_ = value.get_string();
-        }
-        if (key == "txn") {
-          staged_transaction_id_ = value.get_string();
-        }
-        if (key == "atr" && value.is_object()) {
-          atr_id_ = value.at("key").get_string();
-          atr_bucket_name_ = value.at("bkt").get_string();
-          atr_scope_name_ = value.at("scp").get_string();
-          atr_collection_name_ = value.at("coll").get_string();
-        }
-      }
-    }
-  }
+  explicit transaction_links(const tao::json::value& json);
 
-  void append_to_json(tao::json::value& obj) const
-  {
-    if (staged_attempt_id_) {
-      obj["txnMeta"]["atmpt"] = staged_attempt_id_.value();
-    }
-    if (staged_transaction_id_) {
-      obj["txnMeta"]["txn"] = staged_transaction_id_.value();
-    }
-    if (staged_operation_id_) {
-      obj["txnMeta"]["txn"] = staged_operation_id_.value();
-    }
-    if (atr_id_) {
-      obj["txnMeta"]["atr"]["key"] = atr_id_.value();
-    }
-    if (atr_bucket_name_) {
-      obj["txnMeta"]["atr"]["bkt"] = atr_bucket_name_.value();
-    }
-    if (atr_scope_name_) {
-      obj["txnMeta"]["atr"]["scp"] = atr_scope_name_.value();
-    }
-    if (atr_collection_name_) {
-      obj["txnMeta"]["atr"]["coll"] = atr_collection_name_.value();
-    }
-  }
+  void append_to_json(tao::json::value& obj) const;
 
   /**
    * Note this doesn't guarantee an active transaction, as it may have expired
@@ -226,17 +167,17 @@ public:
     return staged_content_json_ || staged_content_binary_;
   }
 
-  [[nodiscard]] codec::encoded_value staged_content_json_or_binary() const
+  [[nodiscard]] auto staged_content_json_or_binary() const -> codec::encoded_value
   {
     return staged_content_json_.value_or(staged_content_binary_.value_or(codec::encoded_value{}));
   }
 
-  [[nodiscard]] codec::encoded_value staged_content_json() const
+  [[nodiscard]] auto staged_content_json() const -> codec::encoded_value
   {
     return staged_content_json_.value_or(codec::encoded_value{});
   }
 
-  [[nodiscard]] codec::encoded_value staged_content_binary() const
+  [[nodiscard]] auto staged_content_binary() const -> codec::encoded_value
   {
     return staged_content_binary_.value_or(codec::encoded_value{});
   }

--- a/core/transactions/transactions_cleanup.cxx
+++ b/core/transactions/transactions_cleanup.cxx
@@ -26,6 +26,7 @@
 #include "internal/transactions_cleanup.hxx"
 #include "internal/utils.hxx"
 
+#include "core/operations.hxx"
 #include "core/utils/byteswap.hxx"
 
 #include <couchbase/fmt/transaction_keyspace.hxx>
@@ -577,7 +578,7 @@ transactions_cleanup::add_attempt(const std::shared_ptr<attempt_context>& ctx)
 }
 
 void
-transactions_cleanup::add_collection(couchbase::transactions::transaction_keyspace keyspace)
+transactions_cleanup::add_collection(const couchbase::transactions::transaction_keyspace& keyspace)
 {
 
   if (keyspace.valid() && config_.cleanup_config.cleanup_lost_attempts) {
@@ -585,7 +586,7 @@ transactions_cleanup::add_collection(couchbase::transactions::transaction_keyspa
 
     auto it = std::find(collections_.begin(), collections_.end(), keyspace);
     if (it == collections_.end()) {
-      collections_.emplace_back(std::move(keyspace));
+      collections_.emplace_back(keyspace);
       // start cleaning right away
       lost_attempt_cleanup_workers_.emplace_back([this, keyspace = collections_.back()]() {
         this->clean_collection(keyspace);

--- a/test/test_transaction_context.cxx
+++ b/test/test_transaction_context.cxx
@@ -18,6 +18,7 @@
 
 #include "core/transactions/attempt_context_impl.hxx"
 
+#include "core/operations.hxx"
 #include "core/transactions.hxx"
 #include "core/transactions/internal/transaction_context.hxx"
 #include "core/transactions/internal/utils.hxx"

--- a/test/test_transaction_simple.cxx
+++ b/test/test_transaction_simple.cxx
@@ -18,6 +18,7 @@
 
 #include "simple_object.hxx"
 
+#include "core/operations.hxx"
 #include "core/transactions.hxx"
 #include "core/transactions/atr_ids.hxx"
 

--- a/test/test_transaction_simple_async.cxx
+++ b/test/test_transaction_simple_async.cxx
@@ -16,6 +16,7 @@
 
 #include "test_helper_integration.hxx"
 
+#include "core/operations.hxx"
 #include "core/transactions.hxx"
 #include "core/transactions/attempt_context_impl.hxx"
 #include "simple_object.hxx"


### PR DESCRIPTION
The attempt object does not own the transaction context, so it should use weak_ptr instead.