### PR TITLE
CXXCBC-557: Add global columnar timeout config

### DIFF
--- a/core/columnar/agent.cxx
+++ b/core/columnar/agent.cxx
@@ -38,8 +38,8 @@ public:
   agent_impl(asio::io_context& io, agent_config config)
     : io_{ io }
     , config_{ std::move(config) }
-    , http_{ io_, config_.shim, config_.default_retry_strategy }
-    , query_{ io_, http_ }
+    , http_{ io_, config_.shim }
+    , query_{ io_, http_, config_.timeouts.query_timeout }
   {
     CB_LOG_DEBUG("creating new columnar cluster agent: {}", config_.to_string());
   }

--- a/core/columnar/agent_config.cxx
+++ b/core/columnar/agent_config.cxx
@@ -17,6 +17,7 @@
 
 #include "agent_config.hxx"
 
+#include <fmt/chrono.h>
 #include <fmt/core.h>
 
 #include <string>
@@ -26,13 +27,21 @@ namespace couchbase::core::columnar
 auto
 agent_config::to_string() const -> std::string
 {
+  return fmt::format(R"(#<columnar_agent_config:{} shim={}, user_agent="{}", timeouts={}>)",
+                     static_cast<const void*>(this),
+                     shim.to_string(),
+                     user_agent,
+                     timeouts.to_string());
+}
+
+auto
+timeout_config::to_string() const -> std::string
+{
   return fmt::format(
-    R"(#<cluster_agent_config:{} shim={}, user_agent="{}", default_retry_strategy={}, seed={}, key_value={}>)",
+    R"(#<timeout_config:{} connect_timeout={}, dispatch_timeout={}, query_timeout={}>)",
     static_cast<const void*>(this),
-    shim.to_string(),
-    user_agent,
-    default_retry_strategy ? default_retry_strategy->to_string() : "(none)",
-    seed.to_string(),
-    key_value.to_string());
+    connect_timeout,
+    dispatch_timeout,
+    query_timeout);
 }
 } // namespace couchbase::core::columnar

--- a/core/columnar/agent_config.hxx
+++ b/core/columnar/agent_config.hxx
@@ -31,14 +31,26 @@ class retry_strategy;
 
 namespace couchbase::core::columnar
 {
+struct timeout_config {
+  static constexpr std::chrono::milliseconds default_connect_timeout{ 10'000 };
+  static constexpr std::chrono::milliseconds default_dispatch_timeout{ 30'000 };
+  static constexpr std::chrono::milliseconds default_query_timeout{ 600'000 };
+
+  // TODO(DC): Use connect_timeout and dispatch_timeout once the agent provides an entry point for
+  // opening the cluster
+  std::chrono::milliseconds connect_timeout{ default_connect_timeout };   // Not currently used
+  std::chrono::milliseconds dispatch_timeout{ default_dispatch_timeout }; // Not currently used
+
+  std::chrono::milliseconds query_timeout{ default_query_timeout };
+
+  [[nodiscard]] auto to_string() const -> std::string;
+};
+
 struct agent_config {
   core_sdk_shim shim; // TODO: remove once refactoring will be finished.
 
+  timeout_config timeouts{};
   std::string user_agent{};
-  std::shared_ptr<retry_strategy> default_retry_strategy{};
-
-  seed_config seed{};
-  key_value_config key_value{};
 
   [[nodiscard]] auto to_string() const -> std::string;
 };

--- a/core/columnar/query_component.hxx
+++ b/core/columnar/query_component.hxx
@@ -42,7 +42,9 @@ class query_component_impl;
 class query_component
 {
 public:
-  query_component(asio::io_context& io, http_component http);
+  query_component(asio::io_context& io,
+                  http_component http,
+                  std::chrono::milliseconds default_timeout);
 
   auto execute_query(const query_options& options, query_callback&& callback)
     -> tl::expected<std::shared_ptr<pending_operation>, error>;

--- a/core/http_component.hxx
+++ b/core/http_component.hxx
@@ -46,7 +46,7 @@ class http_component
 public:
   http_component(asio::io_context& io,
                  core_sdk_shim shim,
-                 std::shared_ptr<retry_strategy> default_retry_strategy);
+                 std::shared_ptr<retry_strategy> default_retry_strategy = {});
 
   auto do_http_request(const http_request& request, free_form_http_request_callback&& callback)
     -> tl::expected<std::shared_ptr<pending_operation>, std::error_code>;


### PR DESCRIPTION
Add timeout options to the `columnar::agent_config`. Currently only the `query_timeout` is used, as the cluster is opened separately outside the agent. When we create an entry point for opening the cluster through `columnar::agent` we will use the other timeouts as well.