### PR TITLE
CXXCBC-531: Transfer ownership of range_scan_orchestrator_impl to scan_result

### DIFF
--- a/core/impl/collection.cxx
+++ b/core/impl/collection.cxx
@@ -905,12 +905,12 @@ public:
                                                               core_scan_type,
                                                               orchestrator_opts);
             return orchestrator.scan(
-              [handler = std::move(handler), orchestrator](auto ec, auto core_scan_result) mutable {
+              [handler = std::move(handler)](auto ec, auto core_scan_result) mutable {
                 if (ec) {
                   return handler(error(ec, "Error while starting the range scan"), {});
                 }
-                auto internal_result = std::make_shared<internal_scan_result>(
-                  std::move(orchestrator), std::move(core_scan_result));
+                auto internal_result =
+                  std::make_shared<internal_scan_result>(std::move(core_scan_result));
                 return handler({}, scan_result{ internal_result });
               });
           });

--- a/core/impl/internal_scan_result.hxx
+++ b/core/impl/internal_scan_result.hxx
@@ -27,7 +27,7 @@ class internal_scan_result
 {
 
 public:
-  internal_scan_result(core::range_scan_orchestrator orchestrator, core::scan_result core_result);
+  explicit internal_scan_result(core::scan_result core_result);
   internal_scan_result(const internal_scan_result&) = delete;
   internal_scan_result(internal_scan_result&&) noexcept = default;
   auto operator=(const internal_scan_result&) -> internal_scan_result& = delete;
@@ -38,7 +38,6 @@ public:
   void cancel();
 
 private:
-  core::range_scan_orchestrator orchestrator_;
   core::scan_result core_result_;
 };
 } // namespace couchbase

--- a/core/impl/scan_result.cxx
+++ b/core/impl/scan_result.cxx
@@ -50,10 +50,8 @@ to_scan_result_item(core::range_scan_item core_item) -> scan_result_item
 }
 } // namespace
 
-internal_scan_result::internal_scan_result(core::range_scan_orchestrator orchestrator,
-                                           core::scan_result core_result)
-  : orchestrator_{ std::move(orchestrator) }
-  , core_result_{ std::move(core_result) }
+internal_scan_result::internal_scan_result(core::scan_result core_result)
+  : core_result_{ std::move(core_result) }
 {
 }
 

--- a/core/scan_result.hxx
+++ b/core/scan_result.hxx
@@ -41,7 +41,7 @@ class scan_result
 {
 public:
   scan_result() = default;
-  explicit scan_result(std::weak_ptr<range_scan_item_iterator> iterator);
+  explicit scan_result(std::shared_ptr<range_scan_item_iterator> iterator);
   [[nodiscard]] auto next() const -> tl::expected<range_scan_item, std::error_code>;
   void next(utils::movable_function<void(range_scan_item, std::error_code)> callback) const;
   void cancel();


### PR DESCRIPTION
When the `range_scan_orchestrator.scan()` method returns, ownership of `range_scan_orchestrator_impl` is transferred from the `range_scan_orchestrator` to the `scan_result`. This avoids the need to keep a reference to the `range_scan_orchestrator` while fetching items from the `scan_result`.

Each `range_scan_orchestrator` instance is only for a single scan, so no subsequent `scan()` calls will need to be made.