### PR TITLE
CXXCBC-576: Ensure all HTTP sessions are stopped when closing the core cluster

### DIFF
--- a/core/cluster.cxx
+++ b/core/cluster.cxx
@@ -19,10 +19,6 @@
 
 #include "cluster.hxx"
 
-#ifdef COUCHBASE_CXX_CLIENT_COLUMNAR
-#include "core/io/config_tracker.hxx"
-#endif
-
 #include "bucket.hxx"
 #include "capella_ca.hxx"
 #include "core/diagnostics.hxx"
@@ -33,6 +29,9 @@
 #include "core/io/http_message.hxx"
 #include "core/io/http_session_manager.hxx"
 #include "core/io/mcbp_session.hxx"
+#ifdef COUCHBASE_CXX_CLIENT_COLUMNAR
+#include "core/io/config_tracker.hxx"
+#endif
 #include "core/logger/logger.hxx"
 #include "core/management/analytics_link_azure_blob_external.hxx"
 #include "core/management/analytics_link_couchbase_remote.hxx"

--- a/core/columnar/error_codes.cxx
+++ b/core/columnar/error_codes.cxx
@@ -27,7 +27,7 @@ namespace couchbase::core::columnar
 struct columnar_error_category : std::error_category {
   [[nodiscard]] auto name() const noexcept -> const char* override
   {
-    return "couchbase.core.columnar";
+    return "couchbase.core.columnar.errc";
   }
 
   [[nodiscard]] auto message(int ev) const noexcept -> std::string override
@@ -42,17 +42,48 @@ struct columnar_error_category : std::error_category {
       case errc::query_error:
         return "query_error";
     }
-    return "FIXME: unknown error code (recompile with newer library): couchbase.core.columnar." +
+    return "FIXME: unknown error code (recompile with newer library): "
+           "couchbase.core.columnar.errc." +
            std::to_string(ev);
   }
 };
 
-const inline static columnar_error_category category_instance;
+const inline static columnar_error_category columnar_category_instance;
 
 auto
 columnar_category() noexcept -> const std::error_category&
 {
-  return category_instance;
+  return columnar_category_instance;
+}
+
+struct columnar_client_error_category : std::error_category {
+  [[nodiscard]] auto name() const noexcept -> const char* override
+  {
+    return "couchbase.core.columnar.client_errc";
+  }
+
+  [[nodiscard]] auto message(int ev) const noexcept -> std::string override
+  {
+    switch (static_cast<client_errc>(ev)) {
+      case client_errc::canceled:
+        return "canceled";
+      case client_errc::cluster_closed:
+        return "cluster_closed";
+      case client_errc::invalid_argument:
+        return "invalid_argument";
+    }
+    return "FIXME: unknown error code (recompile with newer library): "
+           "couchbase.core.columnar.client_errc" +
+           std::to_string(ev);
+  }
+};
+
+const inline static columnar_client_error_category columnar_client_category_instance;
+
+auto
+columnar_client_category() noexcept -> const std::error_category&
+{
+  return columnar_client_category_instance;
 }
 
 auto
@@ -62,7 +93,15 @@ maybe_convert_error_code(std::error_code e) -> std::error_code
       e == couchbase::errc::common::ambiguous_timeout) {
     return errc::timeout;
   }
+  if (e == couchbase::errc::common::request_canceled) {
+    return client_errc::canceled;
+  }
+  if (e == couchbase::errc::network::cluster_closed) {
+    return client_errc::cluster_closed;
+  }
+  if (e == couchbase::errc::common::invalid_argument) {
+    return client_errc::invalid_argument;
+  }
   return e;
 }
-
 } // namespace couchbase::core::columnar

--- a/core/columnar/error_codes.hxx
+++ b/core/columnar/error_codes.hxx
@@ -25,6 +25,10 @@ namespace couchbase::core::columnar
 auto
 columnar_category() noexcept -> const std::error_category&;
 
+/**
+ * Error codes used when the error is the result of an unsuccessful client-server interaction.
+ * Wrapper SDKs should expose them as an error that extends ColumnarError.
+ */
 enum class errc : std::uint8_t {
   generic = 1,
   invalid_credential = 2,
@@ -39,9 +43,33 @@ make_error_code(errc e) noexcept -> std::error_code
 }
 
 auto
+columnar_client_category() noexcept -> const std::error_category&;
+
+/**
+ * Error codes used for client-side errors.
+ * Wrapper SDKs should expose them using platform-idiomatic error types that do _not_ extend
+ * ColumnarError.
+ */
+enum class client_errc : std::uint8_t {
+  canceled = 1,
+  invalid_argument = 2,
+  cluster_closed = 3,
+};
+
+inline auto
+make_error_code(client_errc e) noexcept -> std::error_code
+{
+  return { static_cast<int>(e), columnar_client_category() };
+}
+
+auto
 maybe_convert_error_code(std::error_code e) -> std::error_code;
 } // namespace couchbase::core::columnar
 
 template<>
 struct std::is_error_code_enum<couchbase::core::columnar::errc> : std::true_type {
+};
+
+template<>
+struct std::is_error_code_enum<couchbase::core::columnar::client_errc> : std::true_type {
 };

--- a/core/columnar/query_result.cxx
+++ b/core/columnar/query_result.cxx
@@ -43,9 +43,6 @@ public:
     return rows_.next_row(
       [handler = std::move(handler)](const std::string& content, std::error_code ec) {
         if (ec) {
-          if (ec == couchbase::errc::common::request_canceled) {
-            return handler(query_result_end{}, {});
-          }
           return handler({}, { maybe_convert_error_code(ec) });
         }
         if (content.empty()) {

--- a/core/io/http_session.hxx
+++ b/core/io/http_session.hxx
@@ -177,6 +177,7 @@ private:
   void write(const std::string_view& buf);
   void flush();
   void cancel_current_response(std::error_code ec);
+  void invoke_connect_callback();
 
   service_type type_{};
   std::string client_id_;
@@ -199,6 +200,7 @@ private:
   std::atomic_bool reading_{ false };
 
   utils::movable_function<void()> connect_callback_{};
+  std::mutex connect_callback_mutex_{};
   std::function<void()> on_stop_handler_{ nullptr };
 
   response_context current_response_{};


### PR DESCRIPTION
## Motivation

When `cluster.close()` is called, all in-progress HTTP operations should be cancelled.

## Changes

* Add `pending_sessions_` in the HTTP session manager to ensure that it has a reference to sessions created by it at all stages of their lifetime. Pending operations are the sessions that are currently connecting (i.e. after they have been removed from `idle_sessions_` or created and before being added to `busy_sessions_`)
* Fix issue where the callback was not called in the case of a timeout (dispatch timeout or overall timeout) while a session is connecting.
* In an HTTP session that is connecting, call the connect callback if it is stopped before it has connected.
* Add the `couchbase::core::columnar::client_errc` error codes to represent errors that are not the result of a client-server interaction. These are the errors that should be exposed in a platform-idiomatic way in the wrappers, not as 
`ColumnarError`s - one example is cancellation which happens on the client-side.
* In `pending_query_operation` replace the use of `columnar::errc::generic` for cancellations with the new `columnar::client_errc::canceled`
* When `http_session_manager.close()` is called, force all the sessions owned by the manager to stop, not just discarding the pointers.
* Fix seg fault when accessing `retry_info_` for a `pending_query_operation` where the session wrapped by it is `nullptr` (e.g. in the case of a dispatch timeout)
* Add tests for closing the cluster before columnar `execute_query` has returned & for closing the cluster while rows are being iterated
* Add test for the dispatch timeout with a columnar query

## Results

All tests pass