### PR TITLE
CXXCBC-580: Report last error when timing out on columnar query retries

### DIFF
--- a/core/columnar/retry_info.hxx
+++ b/core/columnar/retry_info.hxx
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "error.hxx"
+
 #include <cstddef>
 #include <string>
 
@@ -27,5 +29,6 @@ struct retry_info {
   std::string last_dispatched_to{};
   std::string last_dispatched_from{};
   std::string last_dispatched_to_host{};
+  error last_error{};
 };
 } // namespace couchbase::core::columnar

--- a/core/platform/string_hex.h
+++ b/core/platform/string_hex.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 #include <string_view>
 
 namespace couchbase::core


### PR DESCRIPTION
## Motivation

The Error/Retry handling RFC Revision 8 requires that we list the last error code & message that was retried when reporting a timeout

## Changes

* Include a `last_errors` field in the error context that lists the set of server errors that were retried, when the error is a timeout resulting from retries.
* FIX: Timeout should be initialized before the HTTP request in `pending_query_operation`

## Results

Tested with [FIT](https://review.couchbase.org/c/transactions-fit-performer/+/215117) (via Python) - test passed