### PR TITLE
CXXCBC-552: cleanup network selection options

### DIFF
--- a/core/impl/cluster.cxx
+++ b/core/impl/cluster.cxx
@@ -140,7 +140,6 @@ options_to_origin(const std::string& connection_string,
   user_options.enable_mutation_tokens = opts.behavior.enable_mutation_tokens;
   user_options.enable_unordered_execution = opts.behavior.enable_unordered_execution;
   user_options.user_agent_extra = opts.behavior.user_agent_extra;
-  user_options.network = opts.behavior.network;
 
   user_options.server_group = opts.network.server_group;
   user_options.enable_tcp_keep_alive = opts.network.enable_tcp_keep_alive;
@@ -150,8 +149,10 @@ options_to_origin(const std::string& connection_string,
   if (opts.network.max_http_connections) {
     user_options.max_http_connections = opts.network.max_http_connections.value();
   }
-  if (!opts.network.network.empty()) {
-    user_options.network = opts.network.network;
+  user_options.network = opts.network.network;
+  if (user_options.network.empty()) {
+    // this is deprecated option, but use it in case main options is empty
+    user_options.network = opts.behavior.network;
   }
   switch (opts.network.ip_protocol) {
     case ip_protocol::any:

--- a/couchbase/behavior_options.hxx
+++ b/couchbase/behavior_options.hxx
@@ -60,16 +60,7 @@ public:
     return *this;
   }
 
-  /**
-   * Selects network to use.
-   *
-   * @param name network name as it is exposed in the configuration.
-   * @return this object for chaining purposes.
-   *
-   * @see
-   * https://docs.couchbase.com/server/current/learn/clusters-and-availability/connectivity.html#alternate-addresses
-   * @see https://docs.couchbase.com/server/current/rest-api/rest-set-up-alternate-address.html
-   */
+  [[deprecated("Use couchbase::network_options#preferred_network() instead.")]]
   auto network(std::string name) -> behavior_options&
   {
     network_ = std::move(name);

--- a/couchbase/network_options.hxx
+++ b/couchbase/network_options.hxx
@@ -35,9 +35,19 @@ public:
   static constexpr std::chrono::milliseconds default_config_poll_floor{ 50 };
   static constexpr std::chrono::milliseconds default_idle_http_connection_timeout{ 4'500 };
 
+  /**
+   * Selects network to use.
+   *
+   * @param name network name as it is exposed in the configuration.
+   * @return this object for chaining purposes.
+   *
+   * @see
+   * https://docs.couchbase.com/server/current/learn/clusters-and-availability/connectivity.html#alternate-addresses
+   * @see https://docs.couchbase.com/server/current/rest-api/rest-set-up-alternate-address.html
+   */
   auto preferred_network(std::string network_name) -> network_options&
   {
-    network_ = network_name;
+    network_ = std::move(network_name);
     return *this;
   }
 

--- a/tools/utils.cxx
+++ b/tools/utils.cxx
@@ -503,6 +503,7 @@ apply_options(couchbase::cluster_options& options, const dns_srv_options& dns_sr
 void
 apply_options(couchbase::cluster_options& options, const network_options& network)
 {
+  options.network().preferred_network(network.network);
   options.network().tcp_keep_alive_interval(network.tcp_keep_alive_interval);
   options.network().config_poll_interval(network.config_poll_interval);
   options.network().idle_http_connection_timeout(network.idle_http_connection_timeout);

--- a/tools/utils.hxx
+++ b/tools/utils.hxx
@@ -123,6 +123,7 @@ struct dns_srv_options {
 };
 
 struct network_options {
+  std::string network{};
   std::chrono::milliseconds tcp_keep_alive_interval{};
   std::chrono::milliseconds config_poll_interval{};
   std::chrono::milliseconds idle_http_connection_timeout{};


### PR DESCRIPTION
Deprecates behavior_options#network() in favor to network_options#preferred_network()