### PR TITLE
Include `<string>` in string_hex.h

### DIFF
--- a/core/platform/string_hex.h
+++ b/core/platform/string_hex.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 #include <string_view>
 
 namespace couchbase::core


### PR DESCRIPTION
`std::string` is used in this header. We should add `#include <string>`