### PR TITLE
CXXCBC-588: Update timeout sent to server on each columnar query retry

### DIFF
--- a/core/columnar/error.hxx
+++ b/core/columnar/error.hxx
@@ -46,7 +46,7 @@ struct error {
   tao::json::value ctx = tao::json::empty_object;
   std::shared_ptr<error> cause{};
 
-  operator bool() const;
-  auto message_with_ctx() const -> std::string;
+  explicit operator bool() const;
+  [[nodiscard]] auto message_with_ctx() const -> std::string;
 };
 } // namespace couchbase::core::columnar

--- a/core/free_form_http_request.hxx
+++ b/core/free_form_http_request.hxx
@@ -55,7 +55,7 @@ public:
   bool is_read_only{};
   std::string unique_id{};
   std::shared_ptr<couchbase::retry_strategy> retry_strategy{};
-  std::optional<std::chrono::milliseconds> timeout{};
+  std::chrono::milliseconds timeout{};
   std::shared_ptr<couchbase::tracing::request_span> parent_span{};
 
   struct {

--- a/test/test_integration_columnar_query.cxx
+++ b/test/test_integration_columnar_query.cxx
@@ -147,7 +147,6 @@ TEST_CASE("integration: columnar query component simple request", "[integration]
   couchbase::core::columnar::agent agent{ integration.io, { { integration.cluster } } };
 
   couchbase::core::columnar::query_options options{ "FROM RANGE(0, 4999) AS i SELECT *" };
-  options.timeout = std::chrono::seconds(20);
 
   couchbase::core::columnar::query_result result;
   {
@@ -198,7 +197,6 @@ TEST_CASE("integration: columnar query component simple request - single row res
   couchbase::core::columnar::agent agent{ integration.io, { { integration.cluster } } };
 
   couchbase::core::columnar::query_options options{ "SELECT \"bar\" AS foo" };
-  options.timeout = std::chrono::seconds(20);
 
   couchbase::core::columnar::query_result result;
   {
@@ -251,7 +249,6 @@ TEST_CASE("integration: columnar query component request with database & scope n
   couchbase::core::columnar::query_options options{ "SELECT * FROM airline LIMIT 100" };
   options.database_name = "travel-sample";
   options.scope_name = "inventory";
-  options.timeout = std::chrono::seconds(20);
 
   couchbase::core::columnar::query_result result;
   {
@@ -300,7 +297,6 @@ TEST_CASE("integration: columnar query read some rows and cancel")
   couchbase::core::columnar::agent agent{ integration.io, { { integration.cluster } } };
 
   couchbase::core::columnar::query_options options{ "FROM RANGE(0, 100) AS i SELECT *" };
-  options.timeout = std::chrono::seconds(20);
 
   couchbase::core::columnar::query_result result;
   {
@@ -352,7 +348,6 @@ TEST_CASE("integration: columnar query cancel operation")
   couchbase::core::columnar::agent agent{ integration.io, { { integration.cluster } } };
 
   couchbase::core::columnar::query_options options{ "FROM RANGE(0, 10000000) AS i SELECT *" };
-  options.timeout = std::chrono::seconds(20);
 
   auto barrier = std::make_shared<std::promise<
     std::pair<couchbase::core::columnar::query_result, couchbase::core::columnar::error>>>();
@@ -398,37 +393,11 @@ TEST_CASE("integration: columnar query global timeout")
   }
 
   couchbase::core::columnar::timeout_config timeouts{};
-  timeouts.query_timeout = std::chrono::seconds(1);
+  timeouts.query_timeout = std::chrono::milliseconds(1);
   couchbase::core::columnar::agent agent{ integration.io, { { integration.cluster }, timeouts } };
 
   couchbase::core::columnar::query_options options{ "FROM RANGE(0, 200) AS i SELECT *" };
   options.read_only = true;
-
-  auto barrier = std::make_shared<std::promise<
-    std::pair<couchbase::core::columnar::query_result, couchbase::core::columnar::error>>>();
-  auto f = barrier->get_future();
-  auto resp = agent.execute_query(options, [barrier](auto res, auto err) mutable {
-    barrier->set_value({ std::move(res), err });
-  });
-  REQUIRE(resp.has_value());
-  auto [res, err] = f.get();
-  REQUIRE(err.ec == couchbase::core::columnar::errc::timeout);
-}
-
-TEST_CASE("integration: columnar query dispatch timeout")
-{
-  couchbase::core::cluster_options cluster_opts;
-  cluster_opts.dispatch_timeout =
-    std::chrono::milliseconds(5); // dispatch timeout is currently set in the cluster, not the agent
-  test::utils::integration_test_guard integration(cluster_opts);
-
-  if (!integration.cluster_version().is_columnar()) {
-    SKIP("Requires a columnar cluster");
-  }
-
-  couchbase::core::columnar::agent agent{ integration.io, { { integration.cluster } } };
-
-  couchbase::core::columnar::query_options options{ "FROM RANGE(0, 200) AS i SELECT *" };
 
   auto barrier = std::make_shared<std::promise<
     std::pair<couchbase::core::columnar::query_result, couchbase::core::columnar::error>>>();
@@ -451,7 +420,6 @@ TEST_CASE("integration: columnar query collection does not exist")
   couchbase::core::columnar::agent agent{ integration.io, { { integration.cluster } } };
 
   couchbase::core::columnar::query_options options{ "SELECT * FROM `does-not-exist`" };
-  options.timeout = std::chrono::seconds(20);
 
   auto barrier = std::make_shared<std::promise<
     std::pair<couchbase::core::columnar::query_result, couchbase::core::columnar::error>>>();
@@ -489,7 +457,6 @@ TEST_CASE("integration: columnar query positional parameters")
 
   couchbase::core::columnar::query_options options{ "SELECT $1 AS foo" };
   options.positional_parameters = { { "\"bar\"" } };
-  options.timeout = std::chrono::seconds(20);
 
   auto barrier = std::make_shared<std::promise<
     std::pair<couchbase::core::columnar::query_result, couchbase::core::columnar::error>>>();
@@ -518,7 +485,6 @@ TEST_CASE("integration: columnar query named parameters")
 
   couchbase::core::columnar::query_options options{ "SELECT $val AS foo" };
   options.named_parameters["val"] = couchbase::core::json_string{ "\"bar\"" };
-  options.timeout = std::chrono::seconds(20);
 
   auto barrier = std::make_shared<std::promise<
     std::pair<couchbase::core::columnar::query_result, couchbase::core::columnar::error>>>();
@@ -546,7 +512,6 @@ TEST_CASE("integration: closing cluster before columnar query returns")
   couchbase::core::columnar::agent agent{ integration.io, { { integration.cluster } } };
 
   couchbase::core::columnar::query_options options{ "FROM RANGE(0, 9999) AS i SELECT *" };
-  options.timeout = std::chrono::seconds(20);
 
   auto barrier = std::make_shared<std::promise<
     std::pair<couchbase::core::columnar::query_result, couchbase::core::columnar::error>>>();
@@ -578,7 +543,6 @@ TEST_CASE("integration: closing cluster while reading columnar query rows")
   couchbase::core::columnar::agent agent{ integration.io, { { integration.cluster } } };
 
   couchbase::core::columnar::query_options options{ "FROM RANGE(0, 9999) AS i SELECT *" };
-  options.timeout = std::chrono::seconds(20);
 
   auto barrier = std::make_shared<std::promise<
     std::pair<couchbase::core::columnar::query_result, couchbase::core::columnar::error>>>();


### PR DESCRIPTION
## Changes

* Update the timeout written in the query request payload when retrying, according to the time remaining until the deadline.
* Fix a bug where not setting the timeout in the options (i.e. relying on the cluster-wide default) resulted in the query timing out immediately.
  * This is because the HTTP component's timeout would not be set, which resulted in the epoch being passed on to the http_session_manager's `connect_then_send_pending_op` as the deadline.
  * The timeout is now always sent to the HTTP component.
* Remove the dispatch timeout test which was succeeding because of the bug above. Dispatching appears to succeed very quickly, so even with a timeout 1ms the test was not consistently passing - we probably need to find another way to test it.
* Use the default timeouts in tests that don't need a specific timeout value (this was previously hiding the bug)