### PR TITLE
CXXCBC-593: apply configuration profile as the last step

### DIFF
--- a/docs/cbc-analytics.md
+++ b/docs/cbc-analytics.md
@@ -48,7 +48,7 @@ Execute one or more Analytics queries and print results to standard output.
 <dt>`--certificate-path=STRING`</dt><dd>Path to the certificate.</dd>
 <dt>`--key-path=STRING`</dt><dd>Path to the key.</dd>
 <dt>`--ldap-compatible`</dt><dd>Whether to select authentication mechanism that is compatible with LDAP.</dd>
-<dt>`--configuration-profile=STRING`</dt><dd>Apply configuration profile. (available profiles: `wan_development`)</dd>
+<dt>`--configuration-profile=STRING`</dt><dd>Apply configuration profile (might override other switches). (available profiles: `wan_development`)</dd>
 </dl>
 
 ### SECURITY OPTIONS

--- a/docs/cbc-get.md
+++ b/docs/cbc-get.md
@@ -48,7 +48,7 @@ Retrieve one or more documents from the server and print them to standard output
 <dt>`--certificate-path=STRING`</dt><dd>Path to the certificate.</dd>
 <dt>`--key-path=STRING`</dt><dd>Path to the key.</dd>
 <dt>`--ldap-compatible`</dt><dd>Whether to select authentication mechanism that is compatible with LDAP.</dd>
-<dt>`--configuration-profile=STRING`</dt><dd>Apply configuration profile. (available profiles: `wan_development`)</dd>
+<dt>`--configuration-profile=STRING`</dt><dd>Apply configuration profile (might override other switches). (available profiles: `wan_development`)</dd>
 </dl>
 
 ### SECURITY OPTIONS

--- a/docs/cbc-pillowfight.md
+++ b/docs/cbc-pillowfight.md
@@ -51,7 +51,7 @@ Run simple workload generator that sends GET/UPSERT requests with optional N1QL 
 <dt>`--certificate-path=STRING`</dt><dd>Path to the certificate.</dd>
 <dt>`--key-path=STRING`</dt><dd>Path to the key.</dd>
 <dt>`--ldap-compatible`</dt><dd>Whether to select authentication mechanism that is compatible with LDAP.</dd>
-<dt>`--configuration-profile=STRING`</dt><dd>Apply configuration profile. (available profiles: `wan_development`)</dd>
+<dt>`--configuration-profile=STRING`</dt><dd>Apply configuration profile (might override other switches). (available profiles: `wan_development`)</dd>
 </dl>
 
 ### SECURITY OPTIONS

--- a/docs/cbc-query.md
+++ b/docs/cbc-query.md
@@ -56,7 +56,7 @@ Execute one or more N1QL queries and print results to standard output.
 <dt>`--certificate-path=STRING`</dt><dd>Path to the certificate.</dd>
 <dt>`--key-path=STRING`</dt><dd>Path to the key.</dd>
 <dt>`--ldap-compatible`</dt><dd>Whether to select authentication mechanism that is compatible with LDAP.</dd>
-<dt>`--configuration-profile=STRING`</dt><dd>Apply configuration profile. (available profiles: `wan_development`)</dd>
+<dt>`--configuration-profile=STRING`</dt><dd>Apply configuration profile (might override other switches). (available profiles: `wan_development`)</dd>
 </dl>
 
 ### SECURITY OPTIONS

--- a/tools/utils.cxx
+++ b/tools/utils.cxx
@@ -88,8 +88,9 @@ add_options(CLI::App* app, connection_options& options)
                   options.ldap_compatible,
                   "Whether to select authentication mechanism that is compatible with LDAP.");
   group
-    ->add_option(
-      "--configuration-profile", options.configuration_profile, "Apply configuration profile.")
+    ->add_option("--configuration-profile",
+                 options.configuration_profile,
+                 "Apply configuration profile (might override other switches).")
     ->transform(CLI::IsMember(couchbase::configuration_profiles_registry::available_profiles()));
 }
 
@@ -633,10 +634,6 @@ build_cluster_options(const common_options& options) -> couchbase::cluster_optio
 {
   auto cluster_options = create_cluster_options(options.connection);
 
-  if (!options.connection.configuration_profile.empty()) {
-    cluster_options.apply_profile(options.connection.configuration_profile);
-  }
-
   apply_options(cluster_options, options.security);
   apply_options(cluster_options, options.timeouts);
   apply_options(cluster_options, options.compression);
@@ -646,6 +643,10 @@ build_cluster_options(const common_options& options) -> couchbase::cluster_optio
   apply_options(cluster_options, options.metrics);
   apply_options(cluster_options, options.tracing);
   apply_options(cluster_options, options.behavior);
+
+  if (!options.connection.configuration_profile.empty()) {
+    cluster_options.apply_profile(options.connection.configuration_profile);
+  }
 
   return cluster_options;
 }


### PR DESCRIPTION
To ensure that profile works, we must apply it the options as the very last step, because the way how CLI parser works, the switches are always populated, either by user value or by default. And being --configuration-profile switch itself, we cannot update defaults for other switches at before the parsing stage, therefore we left with the only option to defer profile application to the very last step.