### PR TITLE
CXXCBC-577: Add columnar database mangement operations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ set(couchbase_cxx_client_FILES
     core/columnar/backoff_calculator.cxx
     core/columnar/error.cxx
     core/columnar/error_codes.cxx
+    core/columnar/management_component.cxx
     core/columnar/query_component.cxx
     core/columnar/query_result.cxx
     core/config_profiles.cxx

--- a/core/columnar/agent_config.cxx
+++ b/core/columnar/agent_config.cxx
@@ -38,10 +38,11 @@ auto
 timeout_config::to_string() const -> std::string
 {
   return fmt::format(
-    R"(#<timeout_config:{} connect_timeout={}, dispatch_timeout={}, query_timeout={}>)",
+    R"(#<timeout_config:{} connect_timeout={}, dispatch_timeout={}, query_timeout={}, management_timeout={}>)",
     static_cast<const void*>(this),
     connect_timeout,
     dispatch_timeout,
-    query_timeout);
+    query_timeout,
+    management_timeout);
 }
 } // namespace couchbase::core::columnar

--- a/core/columnar/agent_config.hxx
+++ b/core/columnar/agent_config.hxx
@@ -35,6 +35,7 @@ struct timeout_config {
   static constexpr std::chrono::milliseconds default_connect_timeout{ 10'000 };
   static constexpr std::chrono::milliseconds default_dispatch_timeout{ 30'000 };
   static constexpr std::chrono::milliseconds default_query_timeout{ 600'000 };
+  static constexpr std::chrono::milliseconds default_management_timeout{ 30'000 };
 
   // TODO(DC): Use connect_timeout and dispatch_timeout once the agent provides an entry point for
   // opening the cluster
@@ -42,6 +43,7 @@ struct timeout_config {
   std::chrono::milliseconds dispatch_timeout{ default_dispatch_timeout }; // Not currently used
 
   std::chrono::milliseconds query_timeout{ default_query_timeout };
+  std::chrono::milliseconds management_timeout{ default_management_timeout };
 
   [[nodiscard]] auto to_string() const -> std::string;
 };

--- a/core/columnar/database_management_options.hxx
+++ b/core/columnar/database_management_options.hxx
@@ -1,0 +1,56 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <chrono>
+#include <optional>
+#include <vector>
+
+#include "core/utils/movable_function.hxx"
+#include "error.hxx"
+
+namespace couchbase::core::columnar
+{
+struct fetch_all_databases_options {
+  std::optional<std::chrono::milliseconds> timeout{};
+};
+
+struct drop_database_options {
+  std::string name;
+
+  bool ignore_if_not_exists{};
+  std::optional<std::chrono::milliseconds> timeout{};
+};
+
+struct create_database_options {
+  std::string name;
+
+  bool ignore_if_exists{};
+  std::optional<std::chrono::milliseconds> timeout{};
+};
+
+struct database_metadata {
+  std::string name;
+  bool is_system_database;
+};
+
+using fetch_all_databases_callback =
+  utils::movable_function<void(std::vector<database_metadata>, error)>;
+using drop_database_callback = utils::movable_function<void(error)>;
+using create_database_callback = utils::movable_function<void(error)>;
+} // namespace couchbase::core::columnar

--- a/core/columnar/management_component.cxx
+++ b/core/columnar/management_component.cxx
@@ -1,0 +1,300 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "management_component.hxx"
+
+#include "core/http_component.hxx"
+#include "core/logger/logger.hxx"
+#include "core/platform/uuid.h"
+#include "core/utils/json.hxx"
+#include "core/utils/movable_function.hxx"
+#include "error.hxx"
+#include "error_codes.hxx"
+
+#include <chrono>
+#include <optional>
+#include <string>
+
+#include <gsl/narrow>
+#include <tao/json/value.hpp>
+#include <tl/expected.hpp>
+
+namespace couchbase::core::columnar
+{
+struct query_based_management_request {
+  std::string statement;
+  std::optional<std::chrono::milliseconds> timeout{};
+  std::string client_context_id{ uuid::to_string(uuid::random()) };
+};
+
+class pending_management_operation
+  : public std::enable_shared_from_this<pending_management_operation>
+  , public pending_operation
+{
+public:
+  pending_management_operation(http_request req, http_component& http)
+    : req_{ std::move(req) }
+    , http_{ http }
+  {
+  }
+
+  auto parse_management_error(const std::uint32_t& http_status,
+                              const tao::json::value& body) -> error
+  {
+    const auto* errors_json = body.find("errors");
+    if (errors_json == nullptr) {
+      return {};
+    }
+    if (!errors_json->is_array()) {
+      return { errc::generic, "Could not parse errors from server response - expected JSON array" };
+    }
+    if (errors_json->get_array().empty()) {
+      return {};
+    }
+
+    CB_LOG_DEBUG("MANAGEMENT OPERATION ERROR (client_context_id={}, http_status={}): {}.",
+                 req_.client_context_id,
+                 http_status,
+                 utils::json::generate(errors_json));
+
+    error err{ errc::generic };
+    err.ctx["http_status"] = std::to_string(http_status);
+    err.ctx["errors"] = std::vector<tao::json::value>{};
+
+    if (http_status == 401) {
+      err.ec = errc::invalid_credential;
+    }
+
+    for (auto error_json : errors_json->get_array()) {
+      auto* msg = error_json.find("msg");
+      if (msg == nullptr) {
+        return { errc::generic,
+                 "Could not parse error from server response - could not find 'msg' field" };
+      }
+      if (!msg->is_string()) {
+        return { errc::generic,
+                 "Could not parse error from server response - 'msg' field was not string" };
+      }
+
+      auto* c = error_json.find("code");
+      if (c == nullptr) {
+        return { errc::generic,
+                 "Could not parse error from server response - could not find 'code' field" };
+      }
+      if (!(c->is_unsigned() || c->is_signed())) {
+        return { errc::generic,
+                 "Could not parse error from server response - 'code' field was not an integer" };
+      }
+
+      std::int32_t code = c->is_signed() ? gsl::narrow_cast<std::int32_t>(c->get_signed())
+                                         : gsl::narrow_cast<std::int32_t>(c->get_unsigned());
+
+      tao::json::value error = {
+        { "code", code },
+        { "msg", msg->get_string() },
+      };
+      err.ctx["errors"].get_array().emplace_back(std::move(error));
+
+      switch (code) {
+        case 20000:
+          err.ec = errc::invalid_credential;
+          break;
+        case 21002:
+          err.ec = errc::timeout;
+          break;
+        default:
+          break;
+      }
+    }
+
+    return err;
+  }
+
+  auto execute(core::utils::movable_function<void(std::vector<tao::json::value>, error)>&& callback)
+    -> error
+  {
+    auto op = http_.do_http_request_buffered(
+      req_,
+      [self = shared_from_this(), cb = std::move(callback)](buffered_http_response resp, auto ec) {
+        if (ec) {
+          return cb(
+            {}, { maybe_convert_error_code(ec), "Failed to execute management HTTP operation" });
+        }
+        auto body_json = utils::json::parse(std::string_view{ resp.body() });
+        auto err = self->parse_management_error(resp.status_code(), body_json);
+        if (err) {
+          return cb({}, err);
+        }
+        const auto* results_json = body_json.find("results");
+        if (results_json == nullptr) {
+          return cb({}, {});
+        }
+        if (!results_json->is_array()) {
+          return cb({},
+                    { errc::generic,
+                      "Could not parse results from server response - expected JSON array" });
+        }
+        cb(results_json->get_array(), {});
+      });
+
+    if (op.has_value()) {
+      http_op_ = std::move(op.value());
+      return {};
+    }
+    return error{ maybe_convert_error_code(op.error()),
+                  "Failed do dispatch management HTTP operation" };
+  }
+
+  void cancel() override
+  {
+    if (http_op_) {
+      http_op_->cancel();
+    }
+  }
+
+private:
+  http_request req_;
+  http_component& http_;
+  std::shared_ptr<pending_operation> http_op_{};
+};
+
+class management_component_impl
+{
+public:
+  management_component_impl(http_component http, std::chrono::milliseconds default_timeout)
+    : http_{ std::move(http) }
+    , default_timeout_{ default_timeout }
+  {
+  }
+
+  auto database_fetch_all(const fetch_all_databases_options& options,
+                          fetch_all_databases_callback&& callback)
+    -> tl::expected<std::shared_ptr<pending_operation>, error>
+  {
+    query_based_management_request req{
+      "SELECT d.* FROM `System`.`Metadata`.`Database` AS d",
+      options.timeout,
+    };
+    return execute(std::move(req), [cb = std::move(callback)](auto raw_res, auto err) {
+      if (err) {
+        cb({}, std::move(err));
+        return;
+      }
+      std::vector<database_metadata> res{};
+      res.reserve(raw_res.size());
+      for (tao::json::value raw_metadata : raw_res) {
+        res.emplace_back(database_metadata{
+          raw_metadata["DatabaseName"].get_string(),
+          raw_metadata["SystemDatabase"].get_boolean(),
+        });
+      }
+      cb(std::move(res), {});
+    });
+  }
+
+  auto database_create(const create_database_options& options, create_database_callback&& callback)
+    -> tl::expected<std::shared_ptr<pending_operation>, error>
+  {
+    query_based_management_request req{
+      fmt::format("CREATE DATABASE `{}`", options.name),
+      options.timeout,
+    };
+    if (options.ignore_if_exists) {
+      req.statement += " IF NOT EXISTS";
+    }
+    return execute(std::move(req), [cb = std::move(callback)](auto /*raw_res*/, auto err) {
+      cb(std::move(err));
+    });
+  }
+
+  auto database_drop(const drop_database_options& options, drop_database_callback&& callback)
+    -> tl::expected<std::shared_ptr<pending_operation>, error>
+  {
+    query_based_management_request req{
+      fmt::format("DROP DATABASE `{}`", options.name),
+      options.timeout,
+    };
+    if (options.ignore_if_not_exists) {
+      req.statement += " IF EXISTS";
+    }
+    return execute(std::move(req), [cb = std::move(callback)](auto /*raw_res*/, auto err) {
+      cb(std::move(err));
+    });
+  }
+
+private:
+  auto execute(query_based_management_request req,
+               core::utils::movable_function<void(std::vector<tao::json::value>, error)>&& callback)
+    -> tl::expected<std::shared_ptr<pending_management_operation>, error>
+  {
+    const std::chrono::milliseconds timeout = req.timeout.value_or(default_timeout_);
+    const std::chrono::milliseconds server_timeout = timeout + std::chrono::seconds(5);
+
+    const tao::json::value body{
+      { "statement", std::move(req.statement) },
+      { "client_context_id", req.client_context_id },
+      { "timeout", fmt::format("{}ms", server_timeout.count()) },
+    };
+
+    http_request http_req{ service_type::analytics, "POST", {}, "/api/v1/request" };
+    http_req.body = utils::json::generate(body);
+    http_req.headers["content-type"] = "application/json";
+    http_req.client_context_id = std::move(req.client_context_id);
+    http_req.timeout = timeout;
+
+    auto op = std::make_shared<pending_management_operation>(std::move(http_req), http_);
+    auto err = op->execute(std::move(callback));
+    if (err) {
+      return tl::unexpected{ err };
+    }
+    return op;
+  }
+
+  http_component http_;
+  std::chrono::milliseconds default_timeout_;
+};
+
+management_component::management_component(http_component http,
+                                           std::chrono::milliseconds default_timeout)
+  : impl_{ std::make_shared<management_component_impl>(std::move(http), default_timeout) }
+{
+}
+
+auto
+management_component::database_fetch_all(const fetch_all_databases_options& options,
+                                         fetch_all_databases_callback&& callback)
+  -> tl::expected<std::shared_ptr<pending_operation>, error>
+{
+  return impl_->database_fetch_all(options, std::move(callback));
+}
+
+auto
+management_component::database_create(const create_database_options& options,
+                                      create_database_callback&& callback)
+  -> tl::expected<std::shared_ptr<pending_operation>, error>
+{
+  return impl_->database_create(options, std::move(callback));
+}
+
+auto
+management_component::database_drop(const drop_database_options& options,
+                                    drop_database_callback&& callback)
+  -> tl::expected<std::shared_ptr<pending_operation>, error>
+{
+  return impl_->database_drop(options, std::move(callback));
+}
+} // namespace couchbase::core::columnar

--- a/core/columnar/management_component.hxx
+++ b/core/columnar/management_component.hxx
@@ -17,43 +17,27 @@
 
 #pragma once
 
-#include "agent_config.hxx"
-#include "core/free_form_http_request.hxx"
 #include "core/pending_operation.hxx"
 #include "database_management_options.hxx"
 #include "error.hxx"
-#include "query_options.hxx"
 
-#include <asio/io_context.hpp>
+#include <chrono>
+#include <memory>
+
 #include <tl/expected.hpp>
 
-#include <memory>
-#include <system_error>
-
-namespace couchbase
+namespace couchbase::core
 {
-class retry_strategy;
-} // namespace couchbase
+class http_component;
 
-namespace couchbase::core::columnar
+namespace columnar
 {
-class agent_impl;
+class management_component_impl;
 
-class agent
+class management_component
 {
 public:
-  explicit agent(asio::io_context& io, agent_config config);
-
-  auto free_form_http_request(const http_request& request,
-                              free_form_http_request_callback&& callback)
-    -> tl::expected<std::shared_ptr<pending_operation>, std::error_code>;
-
-  auto free_form_http_request_buffered(const http_request& request,
-                                       buffered_free_form_http_request_callback&& callback)
-    -> tl::expected<std::shared_ptr<pending_operation>, std::error_code>;
-
-  auto execute_query(const query_options& options, query_callback&& callback)
-    -> tl::expected<std::shared_ptr<pending_operation>, error>;
+  management_component(http_component http, std::chrono::milliseconds default_timeout);
 
   auto database_fetch_all(const fetch_all_databases_options& options,
                           fetch_all_databases_callback&& callback)
@@ -66,6 +50,7 @@ public:
     -> tl::expected<std::shared_ptr<pending_operation>, error>;
 
 private:
-  std::shared_ptr<agent_impl> impl_;
+  std::shared_ptr<management_component_impl> impl_;
 };
-} // namespace couchbase::core::columnar
+} // namespace columnar
+} // namespace couchbase::core

--- a/core/columnar/query_component.hxx
+++ b/core/columnar/query_component.hxx
@@ -21,8 +21,8 @@
 #include "error.hxx"
 #include "query_options.hxx"
 
+#include <chrono>
 #include <memory>
-#include <system_error>
 
 #include <tl/expected.hpp>
 

--- a/core/columnar/query_options.hxx
+++ b/core/columnar/query_options.hxx
@@ -30,11 +30,6 @@
 #include <system_error>
 #include <vector>
 
-namespace couchbase
-{
-class retry_strategy;
-} // namespace couchbase
-
 namespace couchbase::core::columnar
 {
 enum class query_scan_consistency : std::uint8_t {

--- a/core/free_form_http_request.hxx
+++ b/core/free_form_http_request.hxx
@@ -67,6 +67,7 @@ public:
 namespace io
 {
 class http_streaming_response;
+struct http_response;
 } // namespace io
 
 class http_response_impl;
@@ -74,7 +75,7 @@ class http_response_impl;
 class http_response_body
 {
 public:
-  http_response_body(std::shared_ptr<http_response_impl> impl);
+  explicit http_response_body(std::shared_ptr<http_response_impl> impl);
 
   void next(utils::movable_function<void(std::string, std::error_code)> callback);
   void cancel();
@@ -87,13 +88,13 @@ class http_response
 {
 public:
   http_response() = default;
-  http_response(io::http_streaming_response resp);
+  explicit http_response(io::http_streaming_response resp);
 
-  auto endpoint() const -> std::string;
-  auto status_code() const -> std::uint32_t;
-  auto content_length() const -> std::size_t;
+  [[nodiscard]] auto endpoint() const -> std::string;
+  [[nodiscard]] auto status_code() const -> std::uint32_t;
+  [[nodiscard]] auto content_length() const -> std::size_t;
 
-  auto body() const -> http_response_body;
+  [[nodiscard]] auto body() const -> http_response_body;
   void close();
 
 private:
@@ -103,4 +104,24 @@ private:
 using free_form_http_request_callback =
   utils::movable_function<void(http_response response, std::error_code ec)>;
 
+class buffered_http_response_impl;
+
+class buffered_http_response
+{
+public:
+  buffered_http_response() = default;
+  explicit buffered_http_response(io::http_response resp);
+
+  [[nodiscard]] auto endpoint() const -> std::string;
+  [[nodiscard]] auto status_code() const -> std::uint32_t;
+  [[nodiscard]] auto content_length() const -> std::size_t;
+
+  [[nodiscard]] auto body() -> std::string;
+
+private:
+  std::shared_ptr<buffered_http_response_impl> impl_;
+};
+
+using buffered_free_form_http_request_callback =
+  utils::movable_function<void(buffered_http_response response, std::error_code ec)>;
 } // namespace couchbase::core

--- a/core/http_component.hxx
+++ b/core/http_component.hxx
@@ -51,6 +51,10 @@ public:
   auto do_http_request(const http_request& request, free_form_http_request_callback&& callback)
     -> tl::expected<std::shared_ptr<pending_operation>, std::error_code>;
 
+  auto do_http_request_buffered(const http_request& request,
+                                buffered_free_form_http_request_callback&& callback)
+    -> tl::expected<std::shared_ptr<pending_operation>, std::error_code>;
+
 private:
   std::shared_ptr<http_component_impl> impl_;
 };

--- a/core/io/http_streaming_response.cxx
+++ b/core/io/http_streaming_response.cxx
@@ -16,6 +16,7 @@
  */
 
 #include "http_streaming_response.hxx"
+
 #include "core/utils/movable_function.hxx"
 #include "http_session.hxx"
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -53,4 +53,5 @@ integration_test(examples)
 transaction_test(examples)
 
 integration_test(columnar_query)
+integration_test(columnar_management)
 unit_test(columnar_retry)

--- a/test/test_integration_columnar_management.cxx
+++ b/test/test_integration_columnar_management.cxx
@@ -1,0 +1,146 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "test_helper_integration.hxx"
+
+#include "core/columnar/agent.hxx"
+#include "core/columnar/error_codes.hxx"
+
+TEST_CASE("integration: columnar database management", "[integration]")
+{
+  test::utils::integration_test_guard integration;
+  if (!integration.cluster_version().is_columnar()) {
+    SKIP("Requires a columnar cluster");
+  }
+
+  auto agent = couchbase::core::columnar::agent(integration.io, { { integration.cluster } });
+
+  SECTION("Creating database")
+  {
+    const couchbase::core::columnar::create_database_options options{ "test-database" };
+
+    auto barrier = std::make_shared<std::promise<couchbase::core::columnar::error>>();
+    auto f = barrier->get_future();
+    auto op = agent.database_create(options, [barrier](auto err) {
+      barrier->set_value(std::move(err));
+    });
+
+    REQUIRE(op.has_value());
+    auto err = f.get();
+    REQUIRE_SUCCESS(err.ec);
+  }
+
+  SECTION("Creating database that already exists")
+  {
+    const couchbase::core::columnar::create_database_options options{ "test-database" };
+
+    auto barrier = std::make_shared<std::promise<couchbase::core::columnar::error>>();
+    auto f = barrier->get_future();
+    auto op = agent.database_create(options, [barrier](auto err) mutable {
+      barrier->set_value(std::move(err));
+    });
+
+    REQUIRE(op.has_value());
+    auto err = f.get();
+    REQUIRE(err.ec == couchbase::core::columnar::errc::generic);
+  }
+
+  SECTION("Create database with ignore if exists")
+  {
+    const couchbase::core::columnar::create_database_options options{ "test-database", true };
+
+    auto barrier = std::make_shared<std::promise<couchbase::core::columnar::error>>();
+    auto f = barrier->get_future();
+    auto op = agent.database_create(options, [barrier](auto err) mutable {
+      barrier->set_value(std::move(err));
+    });
+
+    REQUIRE(op.has_value());
+    auto err = f.get();
+    REQUIRE_SUCCESS(err.ec);
+  }
+
+  SECTION("Fetch all databases")
+  {
+    const couchbase::core::columnar::fetch_all_databases_options options{};
+
+    auto barrier = std::make_shared<
+      std::promise<std::pair<std::vector<couchbase::core::columnar::database_metadata>,
+                             couchbase::core::columnar::error>>>();
+    auto f = barrier->get_future();
+    auto op = agent.database_fetch_all(options, [barrier](auto databases, auto err) mutable {
+      barrier->set_value({ std::move(databases), std::move(err) });
+    });
+    auto [databases, err] = f.get();
+
+    REQUIRE_SUCCESS(err.ec);
+
+    bool found{ false };
+    for (const auto& db : databases) {
+      if (db.name == "test-database") {
+        found = true;
+        REQUIRE(!db.is_system_database);
+      }
+    }
+    REQUIRE(found);
+  }
+
+  SECTION("Drop database")
+  {
+    const couchbase::core::columnar::drop_database_options options{ "test-database" };
+
+    auto barrier = std::make_shared<std::promise<couchbase::core::columnar::error>>();
+    auto f = barrier->get_future();
+    auto op = agent.database_drop(options, [barrier](auto err) mutable {
+      barrier->set_value(std::move(err));
+    });
+
+    REQUIRE(op.has_value());
+    auto err = f.get();
+    REQUIRE_SUCCESS(err.ec);
+  }
+
+  SECTION("Drop database that does not exist")
+  {
+    const couchbase::core::columnar::drop_database_options options{ "test-database" };
+
+    auto barrier = std::make_shared<std::promise<couchbase::core::columnar::error>>();
+    auto f = barrier->get_future();
+    auto op = agent.database_drop(options, [barrier](auto err) mutable {
+      barrier->set_value(std::move(err));
+    });
+
+    REQUIRE(op.has_value());
+    auto err = f.get();
+    REQUIRE(err.ec == couchbase::core::columnar::errc::generic);
+  }
+
+  SECTION("Drop database with ignore if not exists")
+  {
+    const couchbase::core::columnar::drop_database_options options{ "test-database", true };
+
+    auto barrier = std::make_shared<std::promise<couchbase::core::columnar::error>>();
+    auto f = barrier->get_future();
+    auto op = agent.database_drop(options, [barrier](auto err) mutable {
+      barrier->set_value(std::move(err));
+    });
+
+    REQUIRE(op.has_value());
+    auto err = f.get();
+    REQUIRE_SUCCESS(err.ec);
+  }
+}


### PR DESCRIPTION
* Add a `buffered_http_request` option in the HTTP component, that we can use for management operations that don't require streaming
* Add a columnar management component, that currently has support for all database management operations listed in the RFC