### PR TITLE
CXXCBC-582: Add cluster labels, keyspace & outcome in metrics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,7 @@ set(couchbase_cxx_client_FILES
     core/mcbp/server_duration.cxx
     core/meta/version.cxx
     core/metrics/logging_meter.cxx
+    core/metrics/meter_wrapper.cxx
     core/n1ql_query_options.cxx
     core/operations/document_analytics.cxx
     core/operations/document_append.cxx

--- a/core/bucket.hxx
+++ b/core/bucket.hxx
@@ -33,10 +33,6 @@
 
 namespace couchbase
 {
-namespace metrics
-{
-class meter;
-} // namespace metrics
 namespace tracing
 {
 class request_tracer;
@@ -52,6 +48,10 @@ namespace diag
 class ping_collector;
 struct diagnostics_result;
 } // namespace diag
+namespace metrics
+{
+class meter_wrapper;
+} // namespace metrics
 namespace impl
 {
 class bootstrap_state_listener;
@@ -69,7 +69,7 @@ public:
          asio::io_context& ctx,
          asio::ssl::context& tls,
          std::shared_ptr<couchbase::tracing::request_tracer> tracer,
-         std::shared_ptr<couchbase::metrics::meter> meter,
+         std::shared_ptr<metrics::meter_wrapper> meter,
          std::string name,
          couchbase::core::origin origin,
          std::vector<protocol::hello_feature> known_features,
@@ -201,7 +201,7 @@ public:
   [[nodiscard]] auto name() const -> const std::string&;
   [[nodiscard]] auto log_prefix() const -> const std::string&;
   [[nodiscard]] auto tracer() const -> std::shared_ptr<couchbase::tracing::request_tracer>;
-  [[nodiscard]] auto meter() const -> std::shared_ptr<couchbase::metrics::meter>;
+  [[nodiscard]] auto meter() const -> std::shared_ptr<metrics::meter_wrapper>;
   [[nodiscard]] auto default_retry_strategy() const -> std::shared_ptr<couchbase::retry_strategy>;
   [[nodiscard]] auto is_closed() const -> bool;
   [[nodiscard]] auto is_configured() const -> bool;

--- a/core/io/http_session_manager.hxx
+++ b/core/io/http_session_manager.hxx
@@ -68,7 +68,7 @@ public:
     tracer_ = std::move(tracer);
   }
 
-  void set_meter(std::shared_ptr<couchbase::metrics::meter> meter)
+  void set_meter(std::shared_ptr<metrics::meter_wrapper> meter)
   {
     meter_ = std::move(meter);
   }
@@ -929,7 +929,7 @@ private:
   asio::io_context& ctx_;
   asio::ssl::context& tls_;
   std::shared_ptr<couchbase::tracing::request_tracer> tracer_{ nullptr };
-  std::shared_ptr<couchbase::metrics::meter> meter_{ nullptr };
+  std::shared_ptr<metrics::meter_wrapper> meter_{ nullptr };
   cluster_options options_{};
 
   topology::configuration config_{};

--- a/core/metrics/meter_wrapper.cxx
+++ b/core/metrics/meter_wrapper.cxx
@@ -1,0 +1,188 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "meter_wrapper.hxx"
+
+#include <couchbase/error_codes.hxx>
+
+#include <mutex>
+#include <system_error>
+
+namespace couchbase::core::metrics
+{
+namespace
+{
+auto
+snake_case_to_camel_case(const std::string& s) -> std::string
+{
+  std::string res{};
+  bool capitalize{ true }; // First letter should be capitalized
+  for (const char c : s) {
+    if (c == '_') {
+      capitalize = true; // Next letter should be capitalized
+      continue;
+    }
+    if (capitalize) {
+      res += static_cast<char>(std::toupper(c));
+      capitalize = false;
+    } else {
+      res += c;
+    }
+  }
+  return res;
+}
+
+auto
+extract_error_name(std::error_code ec) -> std::string
+{
+  const std::string::size_type pos = ec.message().find(' ');
+  if (pos != std::string::npos) {
+    return ec.message().substr(0, pos);
+  }
+  return ec.message();
+}
+
+auto
+service_to_string(service_type s) -> std::string
+{
+  switch (s) {
+    case service_type::analytics:
+      return "analytics";
+    case service_type::search:
+      return "search";
+    case service_type::key_value:
+      return "kv";
+    case service_type::management:
+      return "management";
+    case service_type::eventing:
+      return "eventing";
+    case service_type::query:
+      return "query";
+    case service_type::view:
+      return "views";
+  }
+  return {};
+}
+
+auto
+get_standardized_outcome(std::error_code ec) -> std::string
+{
+  if (!ec) {
+    return "Success";
+  }
+
+  // SDK-specific errors
+  if (ec.value() >= 1000) {
+    return "CouchbaseError";
+  }
+
+  // Errors where message and RFC-message don't match
+  if (ec == errc::field_level_encryption::generic_cryptography_failure) {
+    return "CryptoError";
+  }
+
+  return snake_case_to_camel_case(extract_error_name(ec));
+}
+} // namespace
+
+auto
+metric_attributes::encode() const -> std::map<std::string, std::string>
+{
+  std::map<std::string, std::string> tags = { { "db.couchbase.service",
+                                                service_to_string(service) },
+                                              { "db.operation", operation },
+                                              { "outcome", get_standardized_outcome(ec) } };
+
+  if (internal.cluster_name.has_value()) {
+    tags.emplace("db.couchbase.cluster_name", internal.cluster_name.value());
+  }
+  if (internal.cluster_uuid.has_value()) {
+    tags.emplace("db.couchbase.cluster_uuid", internal.cluster_uuid.value());
+  }
+  if (bucket_name) {
+    tags.emplace("db.name", bucket_name.value());
+  }
+  if (scope_name) {
+    tags.emplace("db.couchbase.scope", scope_name.value());
+  }
+  if (collection_name) {
+    tags.emplace("db.couchbase.collection", collection_name.value());
+  }
+
+  return tags;
+}
+
+meter_wrapper::meter_wrapper(std::shared_ptr<couchbase::metrics::meter> meter)
+  : meter_{ std::move(meter) }
+{
+}
+
+void
+meter_wrapper::start()
+{
+  meter_->start();
+}
+
+void
+meter_wrapper::stop()
+{
+  meter_->stop();
+}
+
+void
+meter_wrapper::record_value(metric_attributes attrs,
+                            std::chrono::steady_clock::time_point start_time)
+{
+  static const std::string meter_name{ "db.couchbase.operations" };
+
+  {
+    const std::shared_lock lock{ cluster_labels_mutex_ };
+
+    if (cluster_name_) {
+      attrs.internal.cluster_name = cluster_name_;
+    }
+    if (cluster_uuid_) {
+      attrs.internal.cluster_uuid = cluster_uuid_;
+    }
+  }
+
+  auto tags = attrs.encode();
+  meter_->get_value_recorder(meter_name, tags)
+    ->record_value(std::chrono::duration_cast<std::chrono::microseconds>(
+                     std::chrono::steady_clock::now() - start_time)
+                     .count());
+}
+
+void
+meter_wrapper::update_config(topology::configuration config)
+{
+  const std::scoped_lock<std::shared_mutex> lock{ cluster_labels_mutex_ };
+  if (config.cluster_uuid.has_value()) {
+    cluster_uuid_ = config.cluster_uuid;
+  }
+  if (config.cluster_name.has_value()) {
+    cluster_name_ = config.cluster_name;
+  }
+}
+
+auto
+meter_wrapper::create(std::shared_ptr<couchbase::metrics::meter> meter)
+  -> std::shared_ptr<meter_wrapper>
+{
+  return std::make_shared<meter_wrapper>(std::move(meter));
+}
+} // namespace couchbase::core::metrics

--- a/core/metrics/meter_wrapper.hxx
+++ b/core/metrics/meter_wrapper.hxx
@@ -1,0 +1,73 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include "core/config_listener.hxx"
+#include "core/service_type.hxx"
+#include "core/topology/configuration.hxx"
+
+#include <couchbase/metrics/meter.hxx>
+
+#include <chrono>
+#include <map>
+#include <optional>
+#include <shared_mutex>
+#include <string>
+#include <system_error>
+
+namespace couchbase::core::metrics
+{
+struct metric_attributes {
+  couchbase::core::service_type service;
+  std::string operation;
+  std::error_code ec;
+  std::optional<std::string> bucket_name{};
+  std::optional<std::string> scope_name{};
+  std::optional<std::string> collection_name{};
+
+  struct {
+    std::optional<std::string> cluster_name{};
+    std::optional<std::string> cluster_uuid{};
+  } internal{};
+
+  [[nodiscard]] auto encode() const -> std::map<std::string, std::string>;
+};
+
+class meter_wrapper : public config_listener
+{
+public:
+  explicit meter_wrapper(std::shared_ptr<couchbase::metrics::meter> meter);
+
+  void start();
+  void stop();
+
+  void record_value(metric_attributes attrs, std::chrono::steady_clock::time_point start_time);
+
+  void update_config(topology::configuration config) override;
+
+  [[nodiscard]] static auto create(std::shared_ptr<couchbase::metrics::meter> meter)
+    -> std::shared_ptr<meter_wrapper>;
+
+private:
+  std::shared_ptr<couchbase::metrics::meter> meter_{};
+
+  std::optional<std::string> cluster_name_{};
+  std::optional<std::string> cluster_uuid_{};
+  std::shared_mutex cluster_labels_mutex_{};
+};
+} // namespace couchbase::core::metrics

--- a/core/topology/configuration.hxx
+++ b/core/topology/configuration.hxx
@@ -100,6 +100,8 @@ struct configuration {
   std::optional<std::uint64_t> collections_manifest_uid{};
   configuration_capabilities capabilities{};
   node_locator_type node_locator{ node_locator_type::unknown };
+  std::optional<std::string> cluster_name{};
+  std::optional<std::string> cluster_uuid{};
   bool force{ false };
 
   auto operator==(const configuration& other) const -> bool

--- a/core/topology/configuration_json.hxx
+++ b/core/topology/configuration_json.hxx
@@ -319,6 +319,14 @@ struct traits<couchbase::core::topology::configuration> {
         }
       }
     }
+
+    if (const auto n = v.find("clusterName"); n != nullptr) {
+      result.cluster_name = n->get_string();
+    }
+    if (const auto u = v.find("clusterUUID"); u != nullptr) {
+      result.cluster_uuid = u->get_string();
+    }
+
     return result;
   }
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,7 @@ unit_test(query)
 unit_test(diagnostics)
 unit_test(management_query_index)
 unit_test(management_search_index)
+unit_test(metrics)
 unit_test(range_scan)
 target_link_libraries(test_unit_jsonsl jsonsl)
 

--- a/test/test_unit_metrics.cxx
+++ b/test/test_unit_metrics.cxx
@@ -1,0 +1,105 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "test_helper.hxx"
+
+#include "core/metrics/meter_wrapper.hxx"
+
+#include <couchbase/error_codes.hxx>
+
+TEST_CASE("unit: metric attributes encoding", "[unit]")
+{
+  SECTION("all attributes set")
+  {
+    couchbase::core::metrics::metric_attributes attrs{
+      couchbase::core::service_type::key_value,
+      "get",
+      couchbase::errc::key_value::document_not_found,
+      "test-bucket",
+      "test-scope",
+      "test-collection",
+      { "test-cluster", "d476fe9c-1f66-4bf4-9c2b-9ee866fc5251" }
+    };
+
+    auto tags = attrs.encode();
+
+    REQUIRE(tags.size() == 8);
+    REQUIRE(tags.at("db.couchbase.service") == "kv");
+    REQUIRE(tags.at("db.operation") == "get");
+    REQUIRE(tags.at("db.name") == "test-bucket");
+    REQUIRE(tags.at("db.couchbase.scope") == "test-scope");
+    REQUIRE(tags.at("db.couchbase.collection") == "test-collection");
+    REQUIRE(tags.at("outcome") == "DocumentNotFound");
+    REQUIRE(tags.at("db.couchbase.cluster_name") == "test-cluster");
+    REQUIRE(tags.at("db.couchbase.cluster_uuid") == "d476fe9c-1f66-4bf4-9c2b-9ee866fc5251");
+  }
+
+  SECTION("successful operation")
+  {
+    couchbase::core::metrics::metric_attributes attrs{ couchbase::core::service_type::key_value,
+                                                       "get",
+                                                       {},
+                                                       "test-bucket",
+                                                       "test-scope",
+                                                       "test-collection",
+                                                       { "test-cluster",
+                                                         "d476fe9c-1f66-4bf4-9c2b-9ee866fc5251" } };
+
+    auto tags = attrs.encode();
+
+    REQUIRE(tags.size() == 8);
+    REQUIRE(tags.at("outcome") == "Success");
+  }
+
+  SECTION("cluster labels missing")
+  {
+    couchbase::core::metrics::metric_attributes attrs{
+      couchbase::core::service_type::key_value,
+      "get",
+      {},
+      "test-bucket",
+      "test-scope",
+      "test-collection",
+    };
+
+    auto tags = attrs.encode();
+
+    REQUIRE(tags.size() == 6);
+    REQUIRE(tags.find("db.couchbase.cluster_uuid") == tags.end());
+    REQUIRE(tags.find("db.couchbase.cluster_name") == tags.end());
+  }
+
+  SECTION("bucket/scope/collection names missing")
+  {
+    couchbase::core::metrics::metric_attributes attrs{
+      couchbase::core::service_type::key_value,
+      "get",
+      couchbase::errc::key_value::document_not_found,
+      {},
+      {},
+      {},
+      { "test-cluster", "d476fe9c-1f66-4bf4-9c2b-9ee866fc5251" }
+    };
+
+    auto tags = attrs.encode();
+
+    REQUIRE(tags.size() == 5);
+    REQUIRE(tags.find("db.name") == tags.end());
+    REQUIRE(tags.find("db.couchbase.scope") == tags.end());
+    REQUIRE(tags.find("db.couchbase.collection") == tags.end());
+  }
+}

--- a/test/utils/server_version.hxx
+++ b/test/utils/server_version.hxx
@@ -298,6 +298,11 @@ struct server_version {
   {
     return (major == 7 && minor == 6 && micro >= 2) || (major == 7 && minor > 6) || major > 7;
   }
+
+  [[nodiscard]] auto supports_cluster_labels() const -> bool
+  {
+    return (major == 7 && minor >= 7) || major > 7;
+  }
 };
 
 } // namespace test::utils


### PR DESCRIPTION
## Motivation

The Extended Observability RFC revisions 24 & 25 require us to record additional metrics tags: bucket, scope, collection, outcome, and cluster labels (name & UUID)

## Changes

* Update config parsing to include `clusterName` & `clusterUUID`
* Create a new `core::metrics::meter_wrapper` class that watches for config updates and keeps track of cluster labels 
* Replace all meter references in the core with the meter wrapper
* The meter wrapper is responsible for encoding the metric attributes & inserts tags for the cluster labels, if those are supported by the cluster
* Add some tests for KV

## Results

Tests pass

## Known issues

Non-KV operation metrics don't currently report collection, bucket and scope names.
