### PR TITLE
CXXCBC-618: fix memory leak and data race

### DIFF
--- a/core/io/http_command.hxx
+++ b/core/io/http_command.hxx
@@ -49,13 +49,13 @@ struct http_command : public std::enable_shared_from_this<http_command<Request>>
   asio::steady_timer deadline;
   Request request;
   encoded_request_type encoded;
-  std::shared_ptr<tracing::tracer_wrapper> tracer_;
+  std::shared_ptr<tracing::tracer_wrapper> tracer_{ nullptr };
   std::shared_ptr<couchbase::tracing::request_span> span_{ nullptr };
   std::shared_ptr<metrics::meter_wrapper> meter_{};
   std::shared_ptr<io::http_session> session_{};
   http_command_handler handler_{};
   std::chrono::milliseconds timeout_{};
-  std::string client_context_id_;
+  std::string client_context_id_{};
   std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 #ifdef COUCHBASE_CXX_CLIENT_COLUMNAR
   std::chrono::milliseconds dispatch_timeout_{};

--- a/core/io/http_message.hxx
+++ b/core/io/http_message.hxx
@@ -36,9 +36,9 @@ struct streaming_settings {
 };
 
 struct http_request {
-  service_type type;
+  service_type type{};
   std::string method{};
-  std::string path;
+  std::string path{};
   std::map<std::string, std::string> headers{};
   std::string body{};
   std::optional<streaming_settings> streaming{};

--- a/core/io/http_session_manager.hxx
+++ b/core/io/http_session_manager.hxx
@@ -208,8 +208,7 @@ public:
             std::scoped_lock lock(sessions_mutex_);
             busy_sessions_[type].push_back(session);
           }
-          operations::http_noop_request request{};
-          request.type = type;
+          operations::http_noop_request request{ type };
           request.timeout = timeout;
 #ifdef COUCHBASE_CXX_CLIENT_COLUMNAR
           auto cmd = std::make_shared<operations::http_command<operations::http_noop_request>>(

--- a/core/metrics/meter_wrapper.hxx
+++ b/core/metrics/meter_wrapper.hxx
@@ -33,9 +33,9 @@
 namespace couchbase::core::metrics
 {
 struct metric_attributes {
-  couchbase::core::service_type service;
-  std::string operation;
-  std::error_code ec;
+  couchbase::core::service_type service{};
+  std::string operation{};
+  std::error_code ec{};
   std::optional<std::string> bucket_name{};
   std::optional<std::string> scope_name{};
   std::optional<std::string> collection_name{};


### PR DESCRIPTION
using `std::function` along with `std::shared_ptr` for promise might affect the lifetime of the cluster object and result in memory leak and data races during destruction