### PR TITLE
CXXCBC-615: Expose insert_raw & replace_raw in core txns attempt ctx

### DIFF
--- a/core/transactions/attempt_context_impl.hxx
+++ b/core/transactions/attempt_context_impl.hxx
@@ -92,36 +92,35 @@ private:
   // transaction_context needs access to the two functions below
   friend class transaction_context;
 
+  void insert(const core::document_id& id,
+              codec::encoded_value content,
+              core::transactions::async_attempt_context::Callback&& cb) override;
+
+  auto insert(const core::document_id& id,
+              codec::encoded_value content) -> core::transactions::transaction_get_result override;
+
+  void replace(const transaction_get_result& document,
+               codec::encoded_value content,
+               core::transactions::async_attempt_context::Callback&& cb) override;
+
+  auto replace(const transaction_get_result& document,
+               codec::encoded_value content) -> transaction_get_result override;
+
   auto insert_raw(const collection& coll, const std::string& id, codec::encoded_value content)
     -> std::pair<couchbase::error, couchbase::transactions::transaction_get_result> override;
-  auto insert_raw(const core::document_id& id, codec::encoded_value content)
-    -> core::transactions::transaction_get_result override;
 
   void insert_raw(const collection& coll,
                   std::string id,
                   codec::encoded_value content,
                   couchbase::transactions::async_result_handler&& handler) override;
 
-  void insert_raw(
-    const core::document_id& id,
-    codec::encoded_value content,
-    std::function<void(std::exception_ptr, std::optional<transaction_get_result>)>&& cb) override;
-
   auto replace_raw(const couchbase::transactions::transaction_get_result& doc,
                    codec::encoded_value content)
     -> std::pair<couchbase::error, couchbase::transactions::transaction_get_result> override;
 
-  auto replace_raw(const transaction_get_result& document,
-                   codec::encoded_value content) -> transaction_get_result override;
-
   void replace_raw(couchbase::transactions::transaction_get_result doc,
                    codec::encoded_value content,
                    couchbase::transactions::async_result_handler&& handler) override;
-
-  void replace_raw(
-    const transaction_get_result& document,
-    codec::encoded_value content,
-    std::function<void(std::exception_ptr, std::optional<transaction_get_result>)>&& cb) override;
 
   void remove_staged_insert(const core::document_id& id, VoidCallback&& cb);
 
@@ -200,7 +199,7 @@ private:
                                std::exception_ptr&& err)
   {
     try {
-      std::rethrow_exception(std::move(err));
+      std::rethrow_exception(err);
     } catch (const transaction_operation_failed& e) {
       // if this is a transaction_operation_failed, we need to cache it before
       // moving on...

--- a/core/transactions/transaction_context.cxx
+++ b/core/transactions/transaction_context.cxx
@@ -180,7 +180,7 @@ transaction_context::insert(const core::document_id& id,
                             async_attempt_context::Callback&& cb)
 {
   if (current_attempt_context_) {
-    return current_attempt_context_->insert_raw(id, std::move(content), std::move(cb));
+    return current_attempt_context_->insert(id, std::move(content), std::move(cb));
   }
   throw transaction_operation_failed(FAIL_OTHER, "no current attempt context");
 }
@@ -191,7 +191,7 @@ transaction_context::replace(const transaction_get_result& doc,
                              async_attempt_context::Callback&& cb)
 {
   if (current_attempt_context_) {
-    return current_attempt_context_->replace_raw(doc, std::move(content), std::move(cb));
+    return current_attempt_context_->replace(doc, std::move(content), std::move(cb));
   }
   throw transaction_operation_failed(FAIL_OTHER, "no current attempt context");
 }

--- a/core/transactions/transaction_get_result.hxx
+++ b/core/transactions/transaction_get_result.hxx
@@ -200,26 +200,6 @@ public:
   }
 
   /**
-   * Content of the document.
-   *
-   * @return content of the document.
-   */
-  template<typename Document,
-           typename Transcoder = codec::default_json_transcoder,
-           std::enable_if_t<!codec::is_transcoder_v<Document>, bool> = true,
-           std::enable_if_t<codec::is_transcoder_v<Transcoder>, bool> = true>
-  [[nodiscard]] auto content() const -> Document
-  {
-    return Transcoder::template decode<Document>(content_);
-  }
-
-  template<typename Transcoder, std::enable_if_t<codec::is_transcoder_v<Transcoder>, bool> = true>
-  [[nodiscard]] auto content() const -> typename Transcoder::document_type
-  {
-    return Transcoder::decode(content_);
-  }
-
-  /**
    * Content of the document as raw byte vector
    *
    * @return content

--- a/test/test_transaction_context.cxx
+++ b/test/test_transaction_context.cxx
@@ -429,7 +429,8 @@ TEST_CASE("transactions: RYOW get after insert", "[transactions]")
         CHECK(res);
         tx->get(id, [barrier](std::exception_ptr err, std::optional<transaction_get_result> res) {
           CHECK_FALSE(err);
-          CHECK(res->content<tao::json::value>() == tx_content);
+          CHECK(couchbase::codec::default_json_transcoder::decode<tao::json::value>(
+                  res->content()) == tx_content);
           barrier->set_value();
         });
       });


### PR DESCRIPTION
* Expose `insert_raw` and `replace_raw` in the core txns attempt context APIs, which have now been renamed to `insert` and `replace`.
* Remove the variants of `insert` and `replace` that use transcoders from the core API, as well as the overloads of `core::transactions::transaction_get_result::content()` that use transcoders
   * The C++ Public API, as well as the wrappers, have their own transcoder support, which makes these redundant.