### PR TITLE
CXXCBC-620: Update core analytics_link_get_all to follow RFC

### DIFF
--- a/core/operations/management/analytics_link_get_all.hxx
+++ b/core/operations/management/analytics_link_get_all.hxx
@@ -49,9 +49,9 @@ struct analytics_link_get_all_request {
 
   static const inline service_type type = service_type::analytics;
 
-  std::string link_type{};
-  std::string link_name{};
-  std::string dataverse_name{};
+  std::optional<std::string> link_type{};
+  std::optional<std::string> link_name{};
+  std::optional<std::string> dataverse_name{};
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};

--- a/test/test_integration_management.cxx
+++ b/test/test_integration_management.cxx
@@ -3932,6 +3932,13 @@ run_s3_link_test_core_api(test::utils::integration_test_guard& integration,
 
   {
     couchbase::core::operations::management::analytics_link_get_all_request req{};
+    req.link_name = link_name;
+    auto resp = test::utils::execute(integration.cluster, req);
+    REQUIRE(resp.ctx.ec == couchbase::errc::common::invalid_argument);
+  }
+
+  {
+    couchbase::core::operations::management::analytics_link_get_all_request req{};
     req.dataverse_name = dataverse_name;
     auto resp = test::utils::execute(integration.cluster, req);
     REQUIRE_SUCCESS(resp.ctx.ec);
@@ -4543,6 +4550,13 @@ run_s3_link_test_public_api(test::utils::integration_test_guard& integration,
     };
     auto error = mgr.create_link(s3_link, {}).get();
     REQUIRE(error.ec() == couchbase::errc::analytics::link_exists);
+  }
+
+  {
+    auto opts = couchbase::get_links_analytics_options().name(link_name);
+    auto [error, res] = mgr.get_links(opts).get();
+    REQUIRE(error.ec() == couchbase::errc::common::invalid_argument);
+    REQUIRE(res.empty());
   }
 
   {


### PR DESCRIPTION
Changes
=======
* Allow link_type, link_name and dataverse_name to be optional
* Raise invalid_argument if a link_name is provided but a dataverse_name is not