### PR TITLE
CXXCBC-622: Update OpenTelemetry metrics integration to use GA Metrics API

### DIFF
--- a/core/meta/features.hxx
+++ b/core/meta/features.hxx
@@ -195,3 +195,9 @@
  * encode document content or decode results.
  */
 #define COUCHBASE_CXX_CLIENT_PUBLIC_API_USES_TAO_JSON_ONLY_FOR_CONTENT
+
+/**
+ * couchbase::metrics::otel_meter uses the GA version of the OpenTelemetry Metrics API.
+ * The Metrics API for OpenTelemetry was GA'd in version 1.7.0.
+ */
+#define COUCHBASE_CXX_CLIENT_OTEL_METER_USES_GA_METRICS_API 1


### PR DESCRIPTION
## Motivation

The integration with the OpenTelemetry Metrics API was written before the Otel Metrics API was GA'd (< 1.7.0). Update it to support the latest Metrics API that is now stable.

## Change

* Replace usage of `opentelemetry::metrics::Meter::CreateLongHistogram` with `opentelemetry::metrics::Meter::CreateUint64Histogram`