### PR TITLE
CXXCBC-609: Expose `parent_span` in Public API options

### DIFF
--- a/core/impl/analytics.cxx
+++ b/core/impl/analytics.cxx
@@ -167,6 +167,7 @@ build_analytics_request(std::string statement,
     std::move(options.client_context_id),
     options.timeout,
   };
+  request.parent_span = options.parent_span;
   if (!options.raw.empty()) {
     for (auto& [name, value] : options.raw) {
       request.raw[name] = std::move(value);

--- a/core/impl/collection.cxx
+++ b/core/impl/collection.cxx
@@ -149,6 +149,7 @@ public:
           {},
           options.timeout,
           { options.retry_strategy },
+          options.parent_span,
         },
         [handler = std::move(handler)](auto resp) mutable {
           return handler(core::impl::make_error(std::move(resp.ctx)),
@@ -166,6 +167,7 @@ public:
         false,
         options.timeout,
         { options.retry_strategy },
+        options.parent_span,
       },
       [handler = std::move(handler)](auto resp) mutable {
         std::optional<std::chrono::system_clock::time_point> expiry_time{};
@@ -190,6 +192,7 @@ public:
         expiry,
         options.timeout,
         { options.retry_strategy },
+        options.parent_span,
       },
       [handler = std::move(handler)](auto resp) mutable {
         return handler(core::impl::make_error(std::move(resp.ctx)),
@@ -210,6 +213,7 @@ public:
         expiry,
         options.timeout,
         { options.retry_strategy },
+        options.parent_span,
       },
       [handler = std::move(handler)](const auto& resp) mutable {
         return handler(core::impl::make_error(std::move(resp.ctx)), result{ resp.cas });
@@ -279,6 +283,7 @@ public:
           options.durability_level,
           options.timeout,
           { options.retry_strategy },
+          options.parent_span,
         },
         [handler = std::move(handler)](auto resp) mutable {
           if (resp.ctx.ec()) {
@@ -290,7 +295,14 @@ public:
     }
 
     core::operations::remove_request request{
-      id, {}, {}, options.cas, durability_level::none, options.timeout, { options.retry_strategy },
+      id,
+      {},
+      {},
+      options.cas,
+      durability_level::none,
+      options.timeout,
+      { options.retry_strategy },
+      options.parent_span,
     };
     return core_.execute(std::move(request),
                          [core = core_, id = std::move(id), options, handler = std::move(handler)](
@@ -332,6 +344,7 @@ public:
         static_cast<uint32_t>(lock_duration.count()),
         options.timeout,
         { options.retry_strategy },
+        options.parent_span,
       },
       [handler = std::move(handler)](auto&& resp) mutable {
         return handler(core::impl::make_error(std::move(resp.ctx)),
@@ -352,6 +365,7 @@ public:
         cas,
         options.timeout,
         { options.retry_strategy },
+        options.parent_span,
       },
       [handler = std::move(handler)](auto&& resp) mutable {
         return handler(core::impl::make_error(std::move(resp.ctx)));
@@ -369,6 +383,7 @@ public:
         {},
         options.timeout,
         { options.retry_strategy },
+        options.parent_span,
       },
       [handler = std::move(handler)](auto&& resp) mutable {
         return handler(core::impl::make_error(std::move(resp.ctx)),
@@ -395,6 +410,7 @@ public:
         specs,
         options.timeout,
         { options.retry_strategy },
+        options.parent_span,
       },
       [handler = std::move(handler)](auto resp) mutable {
         if (resp.ctx.ec()) {
@@ -427,7 +443,7 @@ public:
         core::document_id{ bucket_name_, scope_name_, name_, std::move(document_key) },
         specs,
         options.timeout,
-        {},
+        options.parent_span,
         options.read_preference,
       },
       [handler = std::move(handler)](auto resp) mutable {
@@ -465,7 +481,7 @@ public:
         core::document_id{ bucket_name_, scope_name_, name_, std::move(document_key) },
         specs,
         options.timeout,
-        {},
+        options.parent_span,
         options.read_preference,
       },
       [handler = std::move(handler)](auto resp) mutable {
@@ -514,6 +530,7 @@ public:
           options.timeout,
           { options.retry_strategy },
           options.preserve_expiry,
+          options.parent_span,
         },
         [handler = std::move(handler)](auto resp) mutable {
           if (resp.ctx.ec()) {
@@ -548,6 +565,7 @@ public:
       options.timeout,
       { options.retry_strategy },
       options.preserve_expiry,
+      options.parent_span,
     };
     return core_.execute(
       std::move(request),
@@ -611,6 +629,7 @@ public:
           options.timeout,
           { options.retry_strategy },
           options.preserve_expiry,
+          options.parent_span,
         },
         [handler = std::move(handler)](auto resp) mutable {
           return handler(core::impl::make_error(std::move(resp.ctx)),
@@ -629,6 +648,7 @@ public:
       options.timeout,
       { options.retry_strategy },
       options.preserve_expiry,
+      options.parent_span,
     };
     return core_.execute(
       std::move(request),
@@ -681,6 +701,7 @@ public:
           options.durability_level,
           options.timeout,
           { options.retry_strategy },
+          options.parent_span,
         },
         [handler = std::move(handler)](auto&& resp) mutable {
           if (resp.ctx.ec()) {
@@ -701,6 +722,7 @@ public:
       durability_level::none,
       options.timeout,
       { options.retry_strategy },
+      options.parent_span,
     };
     return core_.execute(
       std::move(request),
@@ -754,6 +776,7 @@ public:
           options.timeout,
           { options.retry_strategy },
           options.preserve_expiry,
+          options.parent_span,
         },
         [handler = std::move(handler)](auto resp) mutable {
           if (resp.ctx.ec()) {
@@ -776,6 +799,7 @@ public:
       options.timeout,
       { options.retry_strategy },
       options.preserve_expiry,
+      options.parent_span,
     };
     return core_.execute(std::move(request),
                          [core = core_, id = std::move(id), options, handler = std::move(handler)](

--- a/core/impl/query.cxx
+++ b/core/impl/query.cxx
@@ -180,6 +180,7 @@ build_query_request(std::string statement,
     std::move(query_context), std::move(options.client_context_id),
     options.timeout,          options.profile,
   };
+  request.parent_span = options.parent_span;
   if (!options.raw.empty()) {
     for (auto& [name, value] : options.raw) {
       request.raw[name] = std::move(value);

--- a/core/impl/search.cxx
+++ b/core/impl/search.cxx
@@ -165,6 +165,7 @@ build_search_request(std::string index_name,
     options.client_context_id,
     options.timeout,
   };
+  request.parent_span = options.parent_span;
   return request;
 }
 
@@ -207,6 +208,7 @@ build_search_request(std::string index_name,
     options.client_context_id,
     options.timeout,
   };
+  core_request.parent_span = options.parent_span;
 
   if (auto vector_search = request.vector_search(); vector_search.has_value()) {
     core_request.vector_search = core::utils::json::generate_binary(vector_search->query);

--- a/core/meta/features.hxx
+++ b/core/meta/features.hxx
@@ -201,3 +201,8 @@
  * The Metrics API for OpenTelemetry was GA'd in version 1.7.0.
  */
 #define COUCHBASE_CXX_CLIENT_OTEL_METER_USES_GA_METRICS_API 1
+
+/**
+ * All options classes in the Public API expose the parent_span option.
+ */
+#define COUCHBASE_CXX_CLIENT_PUBLIC_API_PARENT_SPAN 1

--- a/couchbase/common_options.hxx
+++ b/couchbase/common_options.hxx
@@ -76,9 +76,9 @@ public:
    * @since 1.0.4
    * @volatile
    */
-  auto parent_span(const std::shared_ptr<tracing::request_span>& span) -> derived_class&
+  auto parent_span(std::shared_ptr<tracing::request_span> span) -> derived_class&
   {
-    parent_span_ = span;
+    parent_span_ = std::move(span);
     return self();
   }
 

--- a/couchbase/common_options.hxx
+++ b/couchbase/common_options.hxx
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <couchbase/retry_strategy.hxx>
+#include <couchbase/tracing/request_span.hxx>
 
 #include <chrono>
 #include <memory>
@@ -70,6 +71,18 @@ public:
   }
 
   /**
+   * @param span
+   *
+   * @since 1.0.4
+   * @volatile
+   */
+  auto parent_span(const std::shared_ptr<tracing::request_span>& span) -> derived_class&
+  {
+    parent_span_ = span;
+    return self();
+  }
+
+  /**
    * Immutable value object representing consistent options.
    *
    * @since 1.0.0
@@ -78,6 +91,7 @@ public:
   struct built {
     const std::optional<std::chrono::milliseconds> timeout;
     const std::shared_ptr<couchbase::retry_strategy> retry_strategy;
+    const std::shared_ptr<tracing::request_span> parent_span;
   };
 
 protected:
@@ -88,7 +102,7 @@ protected:
    */
   [[nodiscard]] auto build_common_options() const -> built
   {
-    return { timeout_, retry_strategy_ };
+    return { timeout_, retry_strategy_, parent_span_ };
   }
 
   /**
@@ -107,6 +121,7 @@ protected:
 private:
   std::optional<std::chrono::milliseconds> timeout_{};
   std::shared_ptr<couchbase::retry_strategy> retry_strategy_{ nullptr };
+  std::shared_ptr<tracing::request_span> parent_span_{ nullptr };
 };
 
 } // namespace couchbase


### PR DESCRIPTION
## Changes

* Add a `parent_span` setter to all Public API options classes (by adding it to the `common_options` base class) – at 'volatile' stability
* Map the option to the corresponding Core API field where it is available