### PR TITLE
CXXCBC-627: Performance degradation after couchbase::error changes

### DIFF
--- a/core/impl/error.cxx
+++ b/core/impl/error.cxx
@@ -115,59 +115,80 @@ namespace core::impl
 auto
 make_error(const core::error_context::query& core_ctx) -> error
 {
+  if (!core_ctx.ec) {
+    return {};
+  }
   return { core_ctx.ec, {}, internal_error_context::build_error_context(core_ctx) };
 }
 
 auto
 make_error(const query_error_context& core_ctx) -> error
 {
+  if (!core_ctx.ec()) {
+    return {};
+  }
   return { core_ctx.ec(), {}, internal_error_context::build_error_context(core_ctx) };
 }
 
 auto
 make_error(const core::error_context::search& core_ctx) -> error
 {
+  if (!core_ctx.ec) {
+    return {};
+  }
   return { core_ctx.ec, {}, internal_error_context::build_error_context(core_ctx) };
 }
 
 auto
 make_error(const core::error_context::analytics& core_ctx) -> error
 {
+  if (!core_ctx.ec) {
+    return {};
+  }
   return { core_ctx.ec, {}, internal_error_context::build_error_context(core_ctx) };
 }
 
 auto
 make_error(const core::error_context::http& core_ctx) -> error
 {
+  if (!core_ctx.ec) {
+    return {};
+  }
   return { core_ctx.ec, {}, internal_error_context::build_error_context(core_ctx) };
 }
 
 auto
 make_error(const couchbase::core::key_value_error_context& core_ctx) -> error
 {
+  if (!core_ctx.ec()) {
+    return {};
+  }
   return { core_ctx.ec(), {}, internal_error_context::build_error_context(core_ctx) };
 }
 
 auto
 make_error(const couchbase::core::subdocument_error_context& core_ctx) -> error
 {
+  if (!core_ctx.ec()) {
+    return {};
+  }
   return { core_ctx.ec(), {}, internal_error_context::build_error_context(core_ctx) };
 }
 
 auto
 make_error(const couchbase::core::transaction_error_context& ctx) -> error
 {
-  return { ctx.ec(), "", {}, { ctx.cause() } };
+  return { ctx.ec(), {}, {}, { ctx.cause() } };
 }
 
 auto
 make_error(const couchbase::core::transaction_op_error_context& ctx) -> error
 {
   if (std::holds_alternative<key_value_error_context>(ctx.cause())) {
-    return { ctx.ec(), "", {}, make_error(std::get<key_value_error_context>(ctx.cause())) };
+    return { ctx.ec(), {}, {}, make_error(std::get<key_value_error_context>(ctx.cause())) };
   }
   if (std::holds_alternative<query_error_context>(ctx.cause())) {
-    return { ctx.ec(), "", {}, make_error(std::get<query_error_context>(ctx.cause())) };
+    return { ctx.ec(), {}, {}, make_error(std::get<query_error_context>(ctx.cause())) };
   }
   return ctx.ec();
 }

--- a/test/test_integration_analytics.cxx
+++ b/test/test_integration_analytics.cxx
@@ -508,6 +508,10 @@ TEST_CASE("integration: public API analytics query")
        * "errors": [{"code": 23027, "msg": "Bucket default on link Default.Local is not connected"}
        * ],
        */
+
+      if (!error.ec()) {
+        return true;
+      }
       return error.ctx().impl()->as<couchbase::core::error_context::analytics>().first_error_code !=
              23027;
     }));

--- a/test/test_integration_management.cxx
+++ b/test/test_integration_management.cxx
@@ -261,7 +261,6 @@ TEST_CASE("integration: bucket management", "[integration]")
       std::uint64_t old_quota_mb{ 0 };
       {
         auto [error, buckets] = c.buckets().get_all_buckets({}).get();
-        INFO(error.ctx().impl()->as<couchbase::core::error_context::http>().http_body);
         REQUIRE_SUCCESS(error.ec());
         bool found = false;
         for (const auto& bucket : buckets) {
@@ -2778,7 +2777,6 @@ TEST_CASE("integration: query index management", "[integration]")
       {
         auto error = c.query_indexes().drop_index(integration.ctx.bucket, index_name, {}).get();
         couchbase::core::operations::management::query_index_drop_request req{};
-        INFO(error.ctx().impl()->as<couchbase::core::error_context::http>().http_body);
         REQUIRE_SUCCESS(error.ec());
       }
     }

--- a/test/test_integration_transcoders.cxx
+++ b/test/test_integration_transcoders.cxx
@@ -582,8 +582,6 @@ TEST_CASE("integration: subdoc with public API", "[integration]")
                    {})
         .get();
     REQUIRE_SUCCESS(err.ec());
-    auto ctx = err.ctx().impl()->as<tao::json::value>();
-    REQUIRE(ctx.find("first_error_index") == nullptr);
     REQUIRE_FALSE(resp.cas().empty());
     REQUIRE(resp.has_value(0));
     REQUIRE(resp.has_value("views"));
@@ -606,10 +604,7 @@ TEST_CASE("integration: subdoc with public API", "[integration]")
           },
           {})
         .get();
-    auto ctx = err.ctx().impl()->as<tao::json::value>();
     REQUIRE_SUCCESS(err.ec());
-    REQUIRE(ctx.find("first_error_index") == nullptr);
-    REQUIRE(ctx.find("first_error_path") == nullptr);
     REQUIRE_FALSE(resp.cas().empty());
     cas = resp.cas();
   }


### PR DESCRIPTION
Changes:

- Only run `build_error_context` if the `std::error_code` is non-zero
