### PR TITLE
CXXCBC-611 & CXXCBC-612: Follow RFC naming for metric operation names

### DIFF
--- a/core/impl/get_replica.hxx
+++ b/core/impl/get_replica.hxx
@@ -41,6 +41,8 @@ struct get_replica_request {
   using encoded_response_type =
     core::protocol::client_response<core::protocol::get_replica_response_body>;
 
+  static const inline std::string observability_identifier = "get_replica";
+
   core::document_id id;
   std::optional<std::chrono::milliseconds> timeout{};
   std::uint16_t partition{};

--- a/core/impl/lookup_in_replica.hxx
+++ b/core/impl/lookup_in_replica.hxx
@@ -53,6 +53,8 @@ struct lookup_in_replica_request {
   using encoded_response_type =
     protocol::client_response<protocol::lookup_in_replica_response_body>;
 
+  static const inline std::string observability_identifier = "lookup_in_replica";
+
   document_id id;
   std::vector<couchbase::core::impl::subdoc::command> specs{};
   std::optional<std::chrono::milliseconds> timeout{};

--- a/core/impl/observe_seqno.hxx
+++ b/core/impl/observe_seqno.hxx
@@ -50,6 +50,8 @@ struct observe_seqno_request {
   using encoded_response_type =
     core::protocol::client_response<core::protocol::observe_seqno_response_body>;
 
+  static const inline std::string observability_identifier = "observe_seqno";
+
   core::document_id id;
   bool active{};
   std::uint64_t partition_uuid{};

--- a/core/io/http_command.hxx
+++ b/core/io/http_command.hxx
@@ -246,8 +246,8 @@ private:
         }
         if (self->meter_) {
           metrics::metric_attributes attrs{
-            service_type::key_value,
-            fmt::format("{}", self->encoded.path),
+            self->request.type,
+            self->request.observability_identifier,
             ec,
           };
           self->meter_->record_value(std::move(attrs), start);

--- a/core/io/mcbp_command.hxx
+++ b/core/io/mcbp_command.hxx
@@ -269,7 +269,7 @@ struct mcbp_command : public std::enable_shared_from_this<mcbp_command<Manager, 
         std::optional<key_value_error_map_info> /* error_info */) mutable {
         metrics::metric_attributes attrs{
           service_type::key_value,
-          fmt::format("{}", encoded_request_type::body_type::opcode),
+          self->request.observability_identifier,
           ec,
           self->request.id.bucket(),
           self->request.id.scope(),

--- a/core/operations/document_analytics.hxx
+++ b/core/operations/document_analytics.hxx
@@ -80,6 +80,7 @@ struct analytics_request {
   using error_context_type = error_context::analytics;
 
   static const inline service_type type = service_type::analytics;
+  static const inline std::string observability_identifier = "analytics";
 
   std::string statement;
 

--- a/core/operations/document_append.hxx
+++ b/core/operations/document_append.hxx
@@ -44,6 +44,8 @@ struct append_request {
   using encoded_request_type = protocol::client_request<protocol::append_request_body>;
   using encoded_response_type = protocol::client_response<protocol::append_response_body>;
 
+  static const inline std::string observability_identifier = "append";
+
   document_id id;
   std::vector<std::byte> value;
   std::uint16_t partition{};

--- a/core/operations/document_decrement.hxx
+++ b/core/operations/document_decrement.hxx
@@ -45,6 +45,8 @@ struct decrement_request {
   using encoded_request_type = protocol::client_request<protocol::decrement_request_body>;
   using encoded_response_type = protocol::client_response<protocol::decrement_response_body>;
 
+  static const inline std::string observability_identifier = "decrement";
+
   document_id id;
   std::uint16_t partition{};
   std::uint32_t opaque{};

--- a/core/operations/document_exists.hxx
+++ b/core/operations/document_exists.hxx
@@ -50,6 +50,8 @@ struct exists_request {
   using encoded_request_type = protocol::client_request<protocol::get_meta_request_body>;
   using encoded_response_type = protocol::client_response<protocol::get_meta_response_body>;
 
+  static const inline std::string observability_identifier = "exists";
+
   document_id id;
   std::uint16_t partition{};
   std::uint32_t opaque{};

--- a/core/operations/document_get.hxx
+++ b/core/operations/document_get.hxx
@@ -41,6 +41,8 @@ struct get_request {
   using encoded_request_type = protocol::client_request<protocol::get_request_body>;
   using encoded_response_type = protocol::client_response<protocol::get_response_body>;
 
+  static const inline std::string observability_identifier = "get";
+
   document_id id;
   std::uint16_t partition{};
   std::uint32_t opaque{};

--- a/core/operations/document_get_all_replicas.hxx
+++ b/core/operations/document_get_all_replicas.hxx
@@ -50,6 +50,8 @@ struct get_all_replicas_request {
   using encoded_response_type =
     core::protocol::client_response<core::protocol::get_replica_response_body>;
 
+  static const inline std::string observability_identifier = "get_all_replicas";
+
   core::document_id id;
   std::optional<std::chrono::milliseconds> timeout{};
   couchbase::read_preference read_preference{ couchbase::read_preference::no_preference };

--- a/core/operations/document_get_and_lock.hxx
+++ b/core/operations/document_get_and_lock.hxx
@@ -41,6 +41,8 @@ struct get_and_lock_request {
   using encoded_request_type = protocol::client_request<protocol::get_and_lock_request_body>;
   using encoded_response_type = protocol::client_response<protocol::get_and_lock_response_body>;
 
+  static const inline std::string observability_identifier = "get_and_lock";
+
   document_id id;
   std::uint16_t partition{};
   std::uint32_t opaque{};

--- a/core/operations/document_get_and_touch.hxx
+++ b/core/operations/document_get_and_touch.hxx
@@ -42,6 +42,8 @@ struct get_and_touch_request {
   using encoded_request_type = protocol::client_request<protocol::get_and_touch_request_body>;
   using encoded_response_type = protocol::client_response<protocol::get_and_touch_response_body>;
 
+  static const inline std::string observability_identifier = "get_and_touch";
+
   document_id id;
   std::uint16_t partition{};
   std::uint32_t opaque{};

--- a/core/operations/document_get_any_replica.hxx
+++ b/core/operations/document_get_any_replica.hxx
@@ -46,6 +46,8 @@ struct get_any_replica_request {
   using encoded_response_type =
     core::protocol::client_response<core::protocol::get_replica_response_body>;
 
+  static const inline std::string observability_identifier = "get_any_replica";
+
   core::document_id id;
   std::optional<std::chrono::milliseconds> timeout{};
   couchbase::read_preference read_preference{ couchbase::read_preference::no_preference };

--- a/core/operations/document_get_projected.hxx
+++ b/core/operations/document_get_projected.hxx
@@ -42,6 +42,8 @@ struct get_projected_request {
   using encoded_request_type = protocol::client_request<protocol::lookup_in_request_body>;
   using encoded_response_type = protocol::client_response<protocol::lookup_in_response_body>;
 
+  static const inline std::string observability_identifier = "get";
+
   document_id id;
   std::uint16_t partition{};
   std::uint32_t opaque{};

--- a/core/operations/document_increment.hxx
+++ b/core/operations/document_increment.hxx
@@ -45,6 +45,8 @@ struct increment_request {
   using encoded_request_type = protocol::client_request<protocol::increment_request_body>;
   using encoded_response_type = protocol::client_response<protocol::increment_response_body>;
 
+  static const inline std::string observability_identifier = "increment";
+
   document_id id;
   std::uint16_t partition{};
   std::uint32_t opaque{};

--- a/core/operations/document_insert.hxx
+++ b/core/operations/document_insert.hxx
@@ -44,6 +44,8 @@ struct insert_request {
   using encoded_request_type = protocol::client_request<protocol::insert_request_body>;
   using encoded_response_type = protocol::client_response<protocol::insert_response_body>;
 
+  static const inline std::string observability_identifier = "insert";
+
   document_id id;
   std::vector<std::byte> value;
   std::uint16_t partition{};

--- a/core/operations/document_lookup_in.hxx
+++ b/core/operations/document_lookup_in.hxx
@@ -54,6 +54,8 @@ struct lookup_in_request {
   using encoded_request_type = protocol::client_request<protocol::lookup_in_request_body>;
   using encoded_response_type = protocol::client_response<protocol::lookup_in_response_body>;
 
+  static const inline std::string observability_identifier = "lookup_in";
+
   document_id id;
   std::uint16_t partition{};
   std::uint32_t opaque{};

--- a/core/operations/document_lookup_in_all_replicas.hxx
+++ b/core/operations/document_lookup_in_all_replicas.hxx
@@ -61,6 +61,8 @@ struct lookup_in_all_replicas_request {
   using encoded_response_type =
     core::protocol::client_response<core::protocol::lookup_in_replica_response_body>;
 
+  static const inline std::string observability_identifier = "lookup_in_all_replicas";
+
   core::document_id id;
   std::vector<couchbase::core::impl::subdoc::command> specs{};
   std::optional<std::chrono::milliseconds> timeout{};

--- a/core/operations/document_lookup_in_any_replica.hxx
+++ b/core/operations/document_lookup_in_any_replica.hxx
@@ -59,6 +59,8 @@ struct lookup_in_any_replica_request {
   using encoded_response_type =
     core::protocol::client_response<core::protocol::lookup_in_replica_response_body>;
 
+  static const inline std::string observability_identifier = "lookup_in_any_replica";
+
   core::document_id id;
   std::vector<couchbase::core::impl::subdoc::command> specs{};
   std::optional<std::chrono::milliseconds> timeout{};

--- a/core/operations/document_mutate_in.hxx
+++ b/core/operations/document_mutate_in.hxx
@@ -55,6 +55,8 @@ struct mutate_in_request {
   using encoded_request_type = protocol::client_request<protocol::mutate_in_request_body>;
   using encoded_response_type = protocol::client_response<protocol::mutate_in_response_body>;
 
+  static const inline std::string observability_identifier = "mutate_in";
+
   document_id id;
   std::uint16_t partition{};
   std::uint32_t opaque{};

--- a/core/operations/document_prepend.hxx
+++ b/core/operations/document_prepend.hxx
@@ -44,6 +44,8 @@ struct prepend_request {
   using encoded_request_type = protocol::client_request<protocol::prepend_request_body>;
   using encoded_response_type = protocol::client_response<protocol::prepend_response_body>;
 
+  static const inline std::string observability_identifier = "prepend";
+
   document_id id;
   std::vector<std::byte> value;
   std::uint16_t partition{};

--- a/core/operations/document_query.hxx
+++ b/core/operations/document_query.hxx
@@ -80,6 +80,7 @@ struct query_request {
   using error_context_type = error_context::query;
 
   static const inline service_type type = service_type::query;
+  static const inline std::string observability_identifier = "query";
 
   std::string statement;
 

--- a/core/operations/document_remove.hxx
+++ b/core/operations/document_remove.hxx
@@ -44,6 +44,8 @@ struct remove_request {
   using encoded_request_type = protocol::client_request<protocol::remove_request_body>;
   using encoded_response_type = protocol::client_response<protocol::remove_response_body>;
 
+  static const inline std::string observability_identifier = "remove";
+
   document_id id;
   std::uint16_t partition{};
   std::uint32_t opaque{};

--- a/core/operations/document_replace.hxx
+++ b/core/operations/document_replace.hxx
@@ -44,6 +44,8 @@ struct replace_request {
   using encoded_request_type = protocol::client_request<protocol::replace_request_body>;
   using encoded_response_type = protocol::client_response<protocol::replace_response_body>;
 
+  static const inline std::string observability_identifier = "replace";
+
   document_id id;
   std::vector<std::byte> value;
   std::uint16_t partition{};

--- a/core/operations/document_search.hxx
+++ b/core/operations/document_search.hxx
@@ -116,6 +116,7 @@ struct search_request {
   using error_context_type = error_context::search;
 
   static const inline service_type type = service_type::search;
+  static const inline std::string observability_identifier = "search";
 
   std::string index_name;
   couchbase::core::json_string query;

--- a/core/operations/document_touch.hxx
+++ b/core/operations/document_touch.hxx
@@ -39,6 +39,8 @@ struct touch_request {
   using encoded_request_type = protocol::client_request<protocol::touch_request_body>;
   using encoded_response_type = protocol::client_response<protocol::touch_response_body>;
 
+  static const inline std::string observability_identifier = "touch";
+
   document_id id;
   std::uint16_t partition{};
   std::uint32_t opaque{};

--- a/core/operations/document_unlock.hxx
+++ b/core/operations/document_unlock.hxx
@@ -39,6 +39,8 @@ struct unlock_request {
   using encoded_request_type = protocol::client_request<protocol::unlock_request_body>;
   using encoded_response_type = protocol::client_response<protocol::unlock_response_body>;
 
+  static const inline std::string observability_identifier = "unlock";
+
   document_id id;
   std::uint16_t partition{};
   std::uint32_t opaque{};

--- a/core/operations/document_upsert.hxx
+++ b/core/operations/document_upsert.hxx
@@ -44,6 +44,8 @@ struct upsert_request {
   using encoded_request_type = protocol::client_request<protocol::upsert_request_body>;
   using encoded_response_type = protocol::client_response<protocol::upsert_response_body>;
 
+  static const inline std::string observability_identifier = "upsert";
+
   document_id id;
   std::vector<std::byte> value;
   std::uint16_t partition{};

--- a/core/operations/document_view.hxx
+++ b/core/operations/document_view.hxx
@@ -61,6 +61,7 @@ struct document_view_request {
   using error_context_type = error_context::view;
 
   static const inline service_type type = service_type::view;
+  static const inline std::string observability_identifier = "views";
 
   std::string bucket_name;
   std::string document_name;

--- a/core/operations/http_noop.hxx
+++ b/core/operations/http_noop.hxx
@@ -35,6 +35,8 @@ struct http_noop_request {
   using encoded_response_type = io::http_response;
   using error_context_type = error_context::http;
 
+  static const inline std::string observability_identifier = "noop";
+
   service_type type{};
 
   std::optional<std::string> client_context_id{};

--- a/core/operations/management/analytics_dataset_create.hxx
+++ b/core/operations/management/analytics_dataset_create.hxx
@@ -39,6 +39,7 @@ struct analytics_dataset_create_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::analytics;
+  static const inline std::string observability_identifier = "manager_analytics_create_dataset";
 
   std::string dataverse_name{ "Default" };
   std::string dataset_name;

--- a/core/operations/management/analytics_dataset_drop.hxx
+++ b/core/operations/management/analytics_dataset_drop.hxx
@@ -39,6 +39,7 @@ struct analytics_dataset_drop_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::analytics;
+  static const inline std::string observability_identifier = "manager_analytics_drop_dataset";
 
   std::string dataverse_name{ "Default" };
   std::string dataset_name;

--- a/core/operations/management/analytics_dataset_get_all.hxx
+++ b/core/operations/management/analytics_dataset_get_all.hxx
@@ -41,6 +41,7 @@ struct analytics_dataset_get_all_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::analytics;
+  static const inline std::string observability_identifier = "manager_analytics_get_all_datasets";
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};

--- a/core/operations/management/analytics_dataverse_create.hxx
+++ b/core/operations/management/analytics_dataverse_create.hxx
@@ -39,6 +39,7 @@ struct analytics_dataverse_create_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::analytics;
+  static const inline std::string observability_identifier = "manager_analytics_create_dataverse";
 
   std::string dataverse_name;
 

--- a/core/operations/management/analytics_dataverse_drop.hxx
+++ b/core/operations/management/analytics_dataverse_drop.hxx
@@ -39,6 +39,7 @@ struct analytics_dataverse_drop_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::analytics;
+  static const inline std::string observability_identifier = "manager_analytics_drop_dataverse";
 
   std::string dataverse_name;
 

--- a/core/operations/management/analytics_get_pending_mutations.hxx
+++ b/core/operations/management/analytics_get_pending_mutations.hxx
@@ -40,6 +40,8 @@ struct analytics_get_pending_mutations_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::analytics;
+  static const inline std::string observability_identifier =
+    "manager_analytics_get_pending_mutations";
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};

--- a/core/operations/management/analytics_index_create.hxx
+++ b/core/operations/management/analytics_index_create.hxx
@@ -39,6 +39,7 @@ struct analytics_index_create_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::analytics;
+  static const inline std::string observability_identifier = "manager_analytics_create_index";
 
   std::string dataverse_name{ "Default" };
   std::string dataset_name;

--- a/core/operations/management/analytics_index_drop.hxx
+++ b/core/operations/management/analytics_index_drop.hxx
@@ -39,6 +39,7 @@ struct analytics_index_drop_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::analytics;
+  static const inline std::string observability_identifier = "manager_analytics_drop_index";
 
   std::string dataverse_name{ "Default" };
   std::string dataset_name;

--- a/core/operations/management/analytics_index_get_all.hxx
+++ b/core/operations/management/analytics_index_get_all.hxx
@@ -41,6 +41,7 @@ struct analytics_index_get_all_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::analytics;
+  static const inline std::string observability_identifier = "manager_analytics_get_all_indexes";
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};

--- a/core/operations/management/analytics_link_connect.hxx
+++ b/core/operations/management/analytics_link_connect.hxx
@@ -43,6 +43,7 @@ struct analytics_link_connect_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::analytics;
+  static const inline std::string observability_identifier = "manager_analytics_connect_link";
 
   std::string dataverse_name{ "Default" };
   std::string link_name{ "Local" };

--- a/core/operations/management/analytics_link_create.hxx
+++ b/core/operations/management/analytics_link_create.hxx
@@ -51,6 +51,7 @@ struct analytics_link_create_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::analytics;
+  static const inline std::string observability_identifier = "manager_analytics_create_link";
 
   analytics_link_type link{};
   std::optional<std::string> client_context_id{};

--- a/core/operations/management/analytics_link_disconnect.hxx
+++ b/core/operations/management/analytics_link_disconnect.hxx
@@ -43,6 +43,7 @@ struct analytics_link_disconnect_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::analytics;
+  static const inline std::string observability_identifier = "manager_analytics_disconnect_link";
 
   std::string dataverse_name{ "Default" };
   std::string link_name{ "Local" };

--- a/core/operations/management/analytics_link_drop.hxx
+++ b/core/operations/management/analytics_link_drop.hxx
@@ -43,6 +43,7 @@ struct analytics_link_drop_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::analytics;
+  static const inline std::string observability_identifier = "manager_analytics_drop_link";
 
   std::string link_name{};
   std::string dataverse_name{};

--- a/core/operations/management/analytics_link_get_all.hxx
+++ b/core/operations/management/analytics_link_get_all.hxx
@@ -48,6 +48,7 @@ struct analytics_link_get_all_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::analytics;
+  static const inline std::string observability_identifier = "manager_analytics_get_links";
 
   std::optional<std::string> link_type{};
   std::optional<std::string> link_name{};

--- a/core/operations/management/analytics_link_replace.hxx
+++ b/core/operations/management/analytics_link_replace.hxx
@@ -51,6 +51,7 @@ struct analytics_link_replace_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::analytics;
+  static const inline std::string observability_identifier = "manager_analytics_replace_link";
 
   analytics_link_type link{};
 

--- a/core/operations/management/bucket_create.hxx
+++ b/core/operations/management/bucket_create.hxx
@@ -38,6 +38,7 @@ struct bucket_create_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::management;
+  static const inline std::string observability_identifier = "manager_buckets_create_bucket";
 
   couchbase::core::management::cluster::bucket_settings bucket{};
 

--- a/core/operations/management/bucket_describe.hxx
+++ b/core/operations/management/bucket_describe.hxx
@@ -76,6 +76,7 @@ struct bucket_describe_request {
   std::string name;
 
   static const inline service_type type = service_type::management;
+  static const inline std::string observability_identifier = "manager_buckets_describe_bucket";
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};

--- a/core/operations/management/bucket_drop.hxx
+++ b/core/operations/management/bucket_drop.hxx
@@ -36,6 +36,7 @@ struct bucket_drop_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::management;
+  static const inline std::string observability_identifier = "manager_buckets_drop_bucket";
 
   std::string name;
 

--- a/core/operations/management/bucket_flush.hxx
+++ b/core/operations/management/bucket_flush.hxx
@@ -36,6 +36,7 @@ struct bucket_flush_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::management;
+  static const inline std::string observability_identifier = "manager_buckets_flush_bucket";
 
   std::string name;
 

--- a/core/operations/management/bucket_get.hxx
+++ b/core/operations/management/bucket_get.hxx
@@ -38,6 +38,7 @@ struct bucket_get_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::management;
+  static const inline std::string observability_identifier = "manager_buckets_get_bucket";
 
   std::string name;
 

--- a/core/operations/management/bucket_get_all.hxx
+++ b/core/operations/management/bucket_get_all.hxx
@@ -38,6 +38,7 @@ struct bucket_get_all_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::management;
+  static const inline std::string observability_identifier = "manager_buckets_get_all_buckets";
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};

--- a/core/operations/management/bucket_update.hxx
+++ b/core/operations/management/bucket_update.hxx
@@ -39,6 +39,7 @@ struct bucket_update_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::management;
+  static const inline std::string observability_identifier = "manager_buckets_update_bucket";
 
   couchbase::core::management::cluster::bucket_settings bucket{};
 

--- a/core/operations/management/change_password.hxx
+++ b/core/operations/management/change_password.hxx
@@ -37,6 +37,7 @@ struct change_password_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::management;
+  static const inline std::string observability_identifier = "manager_users_change_password";
 
   std::string newPassword{};
 

--- a/core/operations/management/cluster_describe.hxx
+++ b/core/operations/management/cluster_describe.hxx
@@ -61,6 +61,7 @@ struct cluster_describe_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::management;
+  static const inline std::string observability_identifier = "cluster_describe";
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};

--- a/core/operations/management/cluster_developer_preview_enable.hxx
+++ b/core/operations/management/cluster_developer_preview_enable.hxx
@@ -36,6 +36,7 @@ struct cluster_developer_preview_enable_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::management;
+  static const inline std::string observability_identifier = "enable_developer_preview";
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};

--- a/core/operations/management/collection_create.hxx
+++ b/core/operations/management/collection_create.hxx
@@ -37,6 +37,8 @@ struct collection_create_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::management;
+  static const inline std::string observability_identifier =
+    "manager_collections_create_collection";
 
   std::string bucket_name;
   std::string scope_name;

--- a/core/operations/management/collection_drop.hxx
+++ b/core/operations/management/collection_drop.hxx
@@ -37,6 +37,7 @@ struct collection_drop_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::management;
+  static const inline std::string observability_identifier = "manager_collections_drop_collection";
 
   std::string bucket_name;
   std::string scope_name;

--- a/core/operations/management/collection_update.hxx
+++ b/core/operations/management/collection_update.hxx
@@ -37,6 +37,8 @@ struct collection_update_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::management;
+  static const inline std::string observability_identifier =
+    "manager_collections_update_collection";
 
   std::string bucket_name;
   std::string scope_name;

--- a/core/operations/management/collections_manifest_get.hxx
+++ b/core/operations/management/collections_manifest_get.hxx
@@ -40,6 +40,8 @@ struct collections_manifest_get_request {
   using encoded_response_type =
     protocol::client_response<protocol::get_collections_manifest_response_body>;
 
+  static const inline std::string observability_identifier = "get_collection_manifest";
+
   document_id id{};
   std::uint16_t partition{};
   std::uint32_t opaque{};

--- a/core/operations/management/eventing_deploy_function.hxx
+++ b/core/operations/management/eventing_deploy_function.hxx
@@ -38,12 +38,13 @@ struct eventing_deploy_function_request {
   using encoded_response_type = io::http_response;
   using error_context_type = error_context::http;
 
+  static const inline service_type type = service_type::eventing;
+  static const inline std::string observability_identifier = "manager_eventing_deploy_function";
+
   std::string name;
 
   std::optional<std::string> bucket_name{};
   std::optional<std::string> scope_name{};
-
-  static const inline service_type type = service_type::eventing;
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};

--- a/core/operations/management/eventing_drop_function.hxx
+++ b/core/operations/management/eventing_drop_function.hxx
@@ -38,12 +38,13 @@ struct eventing_drop_function_request {
   using encoded_response_type = io::http_response;
   using error_context_type = error_context::http;
 
+  static const inline service_type type = service_type::eventing;
+  static const inline std::string observability_identifier = "manager_eventing_drop_function";
+
   std::string name;
 
   std::optional<std::string> bucket_name{};
   std::optional<std::string> scope_name{};
-
-  static const inline service_type type = service_type::eventing;
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};

--- a/core/operations/management/eventing_get_all_functions.hxx
+++ b/core/operations/management/eventing_get_all_functions.hxx
@@ -39,10 +39,11 @@ struct eventing_get_all_functions_request {
   using encoded_response_type = io::http_response;
   using error_context_type = error_context::http;
 
+  static const inline service_type type = service_type::eventing;
+  static const inline std::string observability_identifier = "manager_eventing_drop_function";
+
   std::optional<std::string> bucket_name{};
   std::optional<std::string> scope_name{};
-
-  static const inline service_type type = service_type::eventing;
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};

--- a/core/operations/management/eventing_get_function.hxx
+++ b/core/operations/management/eventing_get_function.hxx
@@ -39,11 +39,12 @@ struct eventing_get_function_request {
   using encoded_response_type = io::http_response;
   using error_context_type = error_context::http;
 
+  static const inline service_type type = service_type::eventing;
+  static const inline std::string observability_identifier = "manager_eventing_get_function";
+
   std::string name;
   std::optional<std::string> bucket_name{};
   std::optional<std::string> scope_name{};
-
-  static const inline service_type type = service_type::eventing;
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};

--- a/core/operations/management/eventing_get_status.hxx
+++ b/core/operations/management/eventing_get_status.hxx
@@ -41,10 +41,11 @@ struct eventing_get_status_request {
   using encoded_response_type = io::http_response;
   using error_context_type = error_context::http;
 
+  static const inline service_type type = service_type::eventing;
+  static const inline std::string observability_identifier = "manager_eventing_functions_status";
+
   std::optional<std::string> bucket_name{};
   std::optional<std::string> scope_name{};
-
-  static const inline service_type type = service_type::eventing;
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};

--- a/core/operations/management/eventing_pause_function.hxx
+++ b/core/operations/management/eventing_pause_function.hxx
@@ -38,12 +38,13 @@ struct eventing_pause_function_request {
   using encoded_response_type = io::http_response;
   using error_context_type = error_context::http;
 
+  static const inline service_type type = service_type::eventing;
+  static const inline std::string observability_identifier = "manager_eventing_pause_function";
+
   std::string name;
 
   std::optional<std::string> bucket_name{};
   std::optional<std::string> scope_name{};
-
-  static const inline service_type type = service_type::eventing;
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};

--- a/core/operations/management/eventing_resume_function.hxx
+++ b/core/operations/management/eventing_resume_function.hxx
@@ -38,12 +38,13 @@ struct eventing_resume_function_request {
   using encoded_response_type = io::http_response;
   using error_context_type = error_context::http;
 
+  static const inline service_type type = service_type::eventing;
+  static const inline std::string observability_identifier = "manager_eventing_resume_function";
+
   std::string name;
 
   std::optional<std::string> bucket_name{};
   std::optional<std::string> scope_name{};
-
-  static const inline service_type type = service_type::eventing;
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};

--- a/core/operations/management/eventing_undeploy_function.hxx
+++ b/core/operations/management/eventing_undeploy_function.hxx
@@ -38,12 +38,13 @@ struct eventing_undeploy_function_request {
   using encoded_response_type = io::http_response;
   using error_context_type = error_context::http;
 
+  static const inline service_type type = service_type::eventing;
+  static const inline std::string observability_identifier = "manager_eventing_undeploy_function";
+
   std::string name;
 
   std::optional<std::string> bucket_name{};
   std::optional<std::string> scope_name{};
-
-  static const inline service_type type = service_type::eventing;
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};

--- a/core/operations/management/eventing_upsert_function.hxx
+++ b/core/operations/management/eventing_upsert_function.hxx
@@ -38,12 +38,13 @@ struct eventing_upsert_function_request {
   using encoded_response_type = io::http_response;
   using error_context_type = error_context::http;
 
+  static const inline service_type type = service_type::eventing;
+  static const inline std::string observability_identifier = "manager_eventing_upsert_function";
+
   couchbase::core::management::eventing::function function{};
 
   std::optional<std::string> bucket_name{};
   std::optional<std::string> scope_name{};
-
-  static const inline service_type type = service_type::eventing;
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};

--- a/core/operations/management/freeform.hxx
+++ b/core/operations/management/freeform.hxx
@@ -39,6 +39,8 @@ struct freeform_request {
   using encoded_response_type = io::http_response;
   using error_context_type = error_context::http;
 
+  static const inline std::string observability_identifier = "freeform_http";
+
   service_type type{};
   std::string method;
   std::string path;

--- a/core/operations/management/group_drop.hxx
+++ b/core/operations/management/group_drop.hxx
@@ -35,6 +35,7 @@ struct group_drop_request {
   using encoded_response_type = io::http_response;
   using error_context_type = error_context::http;
 
+  static const inline std::string observability_identifier = "manager_users_drop_group";
   static const inline service_type type = service_type::management;
 
   std::string name{};

--- a/core/operations/management/group_get.hxx
+++ b/core/operations/management/group_get.hxx
@@ -37,6 +37,7 @@ struct group_get_request {
   using encoded_response_type = io::http_response;
   using error_context_type = error_context::http;
 
+  static const inline std::string observability_identifier = "manager_users_get_group";
   static const inline service_type type = service_type::management;
 
   std::string name{};

--- a/core/operations/management/group_get_all.hxx
+++ b/core/operations/management/group_get_all.hxx
@@ -37,6 +37,7 @@ struct group_get_all_request {
   using encoded_response_type = io::http_response;
   using error_context_type = error_context::http;
 
+  static const inline std::string observability_identifier = "manager_users_get_all_groups";
   static const inline service_type type = service_type::management;
 
   std::optional<std::string> client_context_id{};

--- a/core/operations/management/group_upsert.hxx
+++ b/core/operations/management/group_upsert.hxx
@@ -37,6 +37,7 @@ struct group_upsert_request {
   using encoded_response_type = io::http_response;
   using error_context_type = error_context::http;
 
+  static const inline std::string observability_identifier = "manager_users_upsert_group";
   static const inline service_type type = service_type::management;
 
   couchbase::core::management::rbac::group group{};

--- a/core/operations/management/query_index_build.hxx
+++ b/core/operations/management/query_index_build.hxx
@@ -43,6 +43,8 @@ struct query_index_build_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::query;
+  static const inline std::string observability_identifier = "manager_query_build_indexes";
+
   static constexpr auto namespace_id = "default";
 
   std::string bucket_name;

--- a/core/operations/management/query_index_build_deferred.hxx
+++ b/core/operations/management/query_index_build_deferred.hxx
@@ -44,6 +44,9 @@ struct query_index_build_deferred_request {
   using encoded_response_type = io::http_response;
   using error_context_type = error_context::http;
 
+  static const inline service_type type = service_type::query;
+  static const inline std::string observability_identifier = "manager_query_build_deferred_indexes";
+
   static constexpr auto namespace_id = "default";
 
   std::string bucket_name;

--- a/core/operations/management/query_index_create.hxx
+++ b/core/operations/management/query_index_create.hxx
@@ -43,6 +43,7 @@ struct query_index_create_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::query;
+  static const inline std::string observability_identifier = "manager_query_create_index";
 
   static constexpr auto namespace_id = "default";
   std::string bucket_name;

--- a/core/operations/management/query_index_drop.hxx
+++ b/core/operations/management/query_index_drop.hxx
@@ -43,6 +43,7 @@ struct query_index_drop_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::query;
+  static const inline std::string observability_identifier = "manager_query_drop_index";
 
   static constexpr auto namespace_id = "default";
   std::string bucket_name;

--- a/core/operations/management/query_index_get_all.hxx
+++ b/core/operations/management/query_index_get_all.hxx
@@ -40,6 +40,8 @@ struct query_index_get_all_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::query;
+  static const inline std::string observability_identifier = "manager_query_get_all_indexes";
+
   static constexpr auto namespace_id = "default";
 
   std::string bucket_name;

--- a/core/operations/management/query_index_get_all_deferred.hxx
+++ b/core/operations/management/query_index_get_all_deferred.hxx
@@ -40,6 +40,9 @@ struct query_index_get_all_deferred_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::query;
+  static const inline std::string observability_identifier =
+    "manager_query_get_all_deferred_indexes";
+
   static constexpr auto namespace_id = "default";
 
   std::string bucket_name;

--- a/core/operations/management/role_get_all.hxx
+++ b/core/operations/management/role_get_all.hxx
@@ -37,6 +37,7 @@ struct role_get_all_request {
   using encoded_response_type = io::http_response;
   using error_context_type = error_context::http;
 
+  static const inline std::string observability_identifier = "manager_users_get_roles";
   static const inline service_type type = service_type::management;
 
   std::optional<std::string> client_context_id{};

--- a/core/operations/management/scope_create.hxx
+++ b/core/operations/management/scope_create.hxx
@@ -37,6 +37,7 @@ struct scope_create_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::management;
+  static const inline std::string observability_identifier = "manager_collections_create_scope";
 
   std::string bucket_name;
   std::string scope_name;

--- a/core/operations/management/scope_drop.hxx
+++ b/core/operations/management/scope_drop.hxx
@@ -37,6 +37,7 @@ struct scope_drop_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::management;
+  static const inline std::string observability_identifier = "manager_collections_drop_scope";
 
   std::string bucket_name;
   std::string scope_name;

--- a/core/operations/management/scope_get_all.hxx
+++ b/core/operations/management/scope_get_all.hxx
@@ -38,6 +38,7 @@ struct scope_get_all_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::management;
+  static const inline std::string observability_identifier = "manager_collections_get_all_scopes";
 
   std::string bucket_name;
 

--- a/core/operations/management/search_get_stats.hxx
+++ b/core/operations/management/search_get_stats.hxx
@@ -37,6 +37,7 @@ struct search_get_stats_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::search;
+  static const inline std::string observability_identifier = "manager_search_get_stats";
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};

--- a/core/operations/management/search_index_analyze_document.hxx
+++ b/core/operations/management/search_index_analyze_document.hxx
@@ -39,6 +39,7 @@ struct search_index_analyze_document_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::search;
+  static const inline std::string observability_identifier = "manager_search_analyze_document";
 
   std::string index_name;
   std::string encoded_document;

--- a/core/operations/management/search_index_control_ingest.hxx
+++ b/core/operations/management/search_index_control_ingest.hxx
@@ -38,6 +38,7 @@ struct search_index_control_ingest_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::search;
+  static const inline std::string observability_identifier = "manager_search_control_ingest";
 
   std::string index_name;
   bool pause;

--- a/core/operations/management/search_index_control_plan_freeze.hxx
+++ b/core/operations/management/search_index_control_plan_freeze.hxx
@@ -40,6 +40,7 @@ struct search_index_control_plan_freeze_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::search;
+  static const inline std::string observability_identifier = "manager_search_control_plan_freeze";
 
   std::string index_name;
   bool freeze;

--- a/core/operations/management/search_index_control_query.hxx
+++ b/core/operations/management/search_index_control_query.hxx
@@ -38,6 +38,7 @@ struct search_index_control_query_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::search;
+  static const inline std::string observability_identifier = "manager_search_control_querying";
 
   std::string index_name;
   bool allow;

--- a/core/operations/management/search_index_drop.hxx
+++ b/core/operations/management/search_index_drop.hxx
@@ -38,6 +38,7 @@ struct search_index_drop_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::search;
+  static const inline std::string observability_identifier = "manager_search_drop_index";
 
   std::string index_name;
 

--- a/core/operations/management/search_index_get.hxx
+++ b/core/operations/management/search_index_get.hxx
@@ -40,6 +40,7 @@ struct search_index_get_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::search;
+  static const inline std::string observability_identifier = "manager_search_get_index";
 
   std::string index_name;
   std::optional<std::string> bucket_name;

--- a/core/operations/management/search_index_get_all.hxx
+++ b/core/operations/management/search_index_get_all.hxx
@@ -40,6 +40,7 @@ struct search_index_get_all_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::search;
+  static const inline std::string observability_identifier = "manager_search_get_all_indexes";
 
   std::optional<std::string> bucket_name;
   std::optional<std::string> scope_name;

--- a/core/operations/management/search_index_get_documents_count.hxx
+++ b/core/operations/management/search_index_get_documents_count.hxx
@@ -39,6 +39,8 @@ struct search_index_get_documents_count_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::search;
+  static const inline std::string observability_identifier =
+    "manager_search_get_indexed_documents_count";
 
   std::string index_name;
 

--- a/core/operations/management/search_index_get_stats.hxx
+++ b/core/operations/management/search_index_get_stats.hxx
@@ -39,6 +39,7 @@ struct search_index_get_stats_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::search;
+  static const inline std::string observability_identifier = "manager_search_get_stats";
 
   std::string index_name;
 

--- a/core/operations/management/search_index_upsert.hxx
+++ b/core/operations/management/search_index_upsert.hxx
@@ -41,6 +41,7 @@ struct search_index_upsert_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::search;
+  static const inline std::string observability_identifier = "manager_search_upsert_index";
 
   couchbase::core::management::search::index index;
 

--- a/core/operations/management/user_drop.hxx
+++ b/core/operations/management/user_drop.hxx
@@ -36,6 +36,7 @@ struct user_drop_request {
   using encoded_response_type = io::http_response;
   using error_context_type = error_context::http;
 
+  static const inline std::string observability_identifier = "manager_users_drop_user";
   static const inline service_type type = service_type::management;
 
   std::string username{};

--- a/core/operations/management/user_get.hxx
+++ b/core/operations/management/user_get.hxx
@@ -37,6 +37,7 @@ struct user_get_request {
   using encoded_response_type = io::http_response;
   using error_context_type = error_context::http;
 
+  static const inline std::string observability_identifier = "manager_users_get_user";
   static const inline service_type type = service_type::management;
 
   std::string username{};

--- a/core/operations/management/user_get_all.hxx
+++ b/core/operations/management/user_get_all.hxx
@@ -37,6 +37,7 @@ struct user_get_all_request {
   using encoded_response_type = io::http_response;
   using error_context_type = error_context::http;
 
+  static const inline std::string observability_identifier = "manager_users_get_all_users";
   static const inline service_type type = service_type::management;
 
   couchbase::core::management::rbac::auth_domain domain{

--- a/core/operations/management/user_upsert.hxx
+++ b/core/operations/management/user_upsert.hxx
@@ -37,6 +37,7 @@ struct user_upsert_request {
   using encoded_response_type = io::http_response;
   using error_context_type = error_context::http;
 
+  static const inline std::string observability_identifier = "manager_users_upsert_user";
   static const inline service_type type = service_type::management;
 
   couchbase::core::management::rbac::auth_domain domain{

--- a/core/operations/management/view_index_drop.hxx
+++ b/core/operations/management/view_index_drop.hxx
@@ -37,6 +37,7 @@ struct view_index_drop_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::view;
+  static const inline std::string observability_identifier = "manager_views_drop_design_document";
 
   std::string bucket_name;
   std::string document_name;

--- a/core/operations/management/view_index_get.hxx
+++ b/core/operations/management/view_index_get.hxx
@@ -38,6 +38,7 @@ struct view_index_get_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::view;
+  static const inline std::string observability_identifier = "manager_views_get_design_document";
 
   std::string bucket_name;
   std::string document_name;

--- a/core/operations/management/view_index_get_all.hxx
+++ b/core/operations/management/view_index_get_all.hxx
@@ -38,6 +38,8 @@ struct view_index_get_all_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::management;
+  static const inline std::string observability_identifier =
+    "manager_views_get_all_design_documents";
 
   std::string bucket_name;
   design_document_namespace ns;

--- a/core/operations/management/view_index_upsert.hxx
+++ b/core/operations/management/view_index_upsert.hxx
@@ -37,6 +37,7 @@ struct view_index_upsert_request {
   using error_context_type = error_context::http;
 
   static const inline service_type type = service_type::view;
+  static const inline std::string observability_identifier = "manager_views_upsert_design_document";
 
   std::string bucket_name;
   couchbase::core::management::views::design_document document;

--- a/test/test_integration_meter.cxx
+++ b/test/test_integration_meter.cxx
@@ -256,6 +256,9 @@ TEST_CASE("integration: use external meter", "[integration]")
   {
     SECTION("get_all_scopes")
     {
+      if (!guard.cluster_version().supports_collections()) {
+        SKIP("cluster does not support collections");
+      }
       meter->reset();
       const couchbase::core::operations::management::scope_get_all_request r{ guard.ctx.bucket };
       auto response = test::utils::execute(guard.cluster, r);

--- a/test/test_integration_meter.cxx
+++ b/test/test_integration_meter.cxx
@@ -98,10 +98,9 @@ public:
   void reset()
   {
     std::lock_guard<std::mutex> lock(mutex_);
-    for (auto v : value_recorders_) {
-      v.second->reset();
-    }
+    value_recorders_.clear();
   }
+
   std::list<std::shared_ptr<test_value_recorder>> get_recorders(const std::string& name)
   {
     std::list<std::shared_ptr<test_value_recorder>> retval;

--- a/test/test_integration_meter.cxx
+++ b/test/test_integration_meter.cxx
@@ -24,9 +24,11 @@
 #include "core/operations/document_insert.hxx"
 #include "core/operations/document_mutate_in.hxx"
 #include "core/operations/document_prepend.hxx"
+#include "core/operations/document_query.hxx"
 #include "core/operations/document_remove.hxx"
 #include "core/operations/document_replace.hxx"
 #include "core/operations/document_upsert.hxx"
+#include "core/operations/management/scope_get_all.hxx"
 #include "core/platform/uuid.h"
 
 #include <couchbase/metrics/meter.hxx>
@@ -128,12 +130,36 @@ assert_kv_recorder_tags(test::utils::integration_test_guard& guard,
   const auto& tags = recorders.front()->tags();
 
   REQUIRE(tags.at("db.couchbase.service") == "kv");
-  // db.operation always _starts_ with the op -- like '<op> 0x<NN'
-  REQUIRE(tags.at("db.operation").find(op, 0) == 0);
+  REQUIRE(tags.at("db.operation") == op);
   REQUIRE(tags.at("outcome") == expected_outcome);
   REQUIRE(tags.at("db.name") == id.bucket());
   REQUIRE(tags.at("db.couchbase.scope") == id.scope());
   REQUIRE(tags.at("db.couchbase.collection") == id.collection());
+
+  if (guard.cluster_version().supports_cluster_labels()) {
+    REQUIRE_FALSE(tags.at("db.couchbase.cluster_name").empty());
+    REQUIRE_FALSE(tags.at("db.couchbase.cluster_uuid").empty());
+  } else {
+    REQUIRE(tags.find("db.couchbase.cluster_name") == tags.end());
+    REQUIRE(tags.find("db.couchbase.cluster_uuid") == tags.end());
+  }
+}
+
+void
+assert_http_recorder_tags(test::utils::integration_test_guard& guard,
+                          std::list<std::shared_ptr<test_value_recorder>> recorders,
+                          const std::string& op,
+                          const std::string& service,
+                          [[maybe_unused]] const std::string& expected_outcome = "Success")
+{
+  REQUIRE(recorders.size() == 1);
+
+  const auto& tags = recorders.front()->tags();
+
+  REQUIRE(tags.at("db.couchbase.service") == service);
+  REQUIRE(tags.at("db.operation") == op);
+  // TODO(CXXCBC-630): Enable assertion once bug recording all HTTP operations as 'Success' is
+  // resolved. REQUIRE(tags.at("outcome") == expected_outcome);
 
   if (guard.cluster_version().supports_cluster_labels()) {
     REQUIRE_FALSE(tags.at("db.couchbase.cluster_name").empty());
@@ -164,16 +190,16 @@ TEST_CASE("integration: use external meter", "[integration]")
   auto existing_id = make_id(guard.ctx, "foo");
   SECTION("add doc 'foo'")
   {
-    couchbase::core::operations::upsert_request r{ existing_id, value };
+    const couchbase::core::operations::upsert_request r{ existing_id, value };
     auto response = test::utils::execute(guard.cluster, r);
     REQUIRE_FALSE(response.ctx.ec());
   }
-  SECTION("test KV ops")
+  SECTION("with KV ops")
   {
     SECTION("upsert")
     {
       meter->reset();
-      couchbase::core::operations::upsert_request r{ existing_id, value };
+      const couchbase::core::operations::upsert_request r{ existing_id, value };
       auto response = test::utils::execute(guard.cluster, r);
       REQUIRE_FALSE(response.ctx.ec());
       auto recorders = meter->get_recorders("db.couchbase.operations");
@@ -184,7 +210,7 @@ TEST_CASE("integration: use external meter", "[integration]")
     {
       meter->reset();
       auto new_id = make_id(guard.ctx);
-      couchbase::core::operations::insert_request r{ new_id, value };
+      const couchbase::core::operations::insert_request r{ new_id, value };
       auto response = test::utils::execute(guard.cluster, r);
       REQUIRE_FALSE(response.ctx.ec());
       auto recorders = meter->get_recorders("db.couchbase.operations");
@@ -195,7 +221,7 @@ TEST_CASE("integration: use external meter", "[integration]")
     {
       meter->reset();
       auto new_value = couchbase::core::utils::to_binary("{\"some\": \"thing else\"");
-      couchbase::core::operations::replace_request r{ existing_id, new_value };
+      const couchbase::core::operations::replace_request r{ existing_id, new_value };
       auto response = test::utils::execute(guard.cluster, r);
       REQUIRE_FALSE(response.ctx.ec());
       auto recorders = meter->get_recorders("db.couchbase.operations");
@@ -205,7 +231,7 @@ TEST_CASE("integration: use external meter", "[integration]")
     SECTION("get")
     {
       meter->reset();
-      couchbase::core::operations::get_request r{ existing_id };
+      const couchbase::core::operations::get_request r{ existing_id };
       auto response = test::utils::execute(guard.cluster, r);
       REQUIRE_FALSE(response.ctx.ec());
       auto meters = meter->get_recorders("db.couchbase.operations");
@@ -216,12 +242,51 @@ TEST_CASE("integration: use external meter", "[integration]")
     {
       meter->reset();
       auto new_id = make_id(guard.ctx);
-      couchbase::core::operations::get_request r{ new_id };
+      const couchbase::core::operations::get_request r{ new_id };
       auto response = test::utils::execute(guard.cluster, r);
       REQUIRE(response.ctx.ec() == couchbase::errc::key_value::document_not_found);
       auto meters = meter->get_recorders("db.couchbase.operations");
       REQUIRE_FALSE(meters.empty());
       assert_kv_recorder_tags(guard, meters, "get", new_id, "DocumentNotFound");
+    }
+  }
+
+  SECTION("with HTTP ops")
+  {
+    SECTION("get_all_scopes")
+    {
+      meter->reset();
+      const couchbase::core::operations::management::scope_get_all_request r{ guard.ctx.bucket };
+      auto response = test::utils::execute(guard.cluster, r);
+      REQUIRE_SUCCESS(response.ctx.ec);
+      auto meters = meter->get_recorders("db.couchbase.operations");
+      REQUIRE_FALSE(meters.empty());
+      assert_http_recorder_tags(guard, meters, "manager_collections_get_all_scopes", "management");
+    }
+
+    SECTION("query")
+    {
+      meter->reset();
+      const couchbase::core::operations::query_request r{ "SELECT 1=1" };
+      auto response = test::utils::execute(guard.cluster, r);
+      REQUIRE_SUCCESS(response.ctx.ec);
+      auto meters = meter->get_recorders("db.couchbase.operations");
+      REQUIRE_FALSE(meters.empty());
+      assert_http_recorder_tags(guard, meters, "query", "query");
+    }
+
+    SECTION("query fails with parsing_failure")
+    {
+      meter->reset();
+
+      couchbase::core::operations::query_request r{ "SELECT * FROM" };
+      r.query_context = "default:`non-existent`.`non-existent`";
+
+      auto response = test::utils::execute(guard.cluster, r);
+      REQUIRE(response.ctx.ec == couchbase::errc::common::parsing_failure);
+      auto meters = meter->get_recorders("db.couchbase.operations");
+      REQUIRE_FALSE(meters.empty());
+      assert_http_recorder_tags(guard, meters, "query", "query", "ParsingFailure");
     }
   }
 }


### PR DESCRIPTION
## Motivation

Currently we were recording operation name & code, or path for KV and HTTP operations respectively. According to the Extended Observability RFC, the `db.operation` metric field should have the same value as outer span names:
> “db.operation”: Same as the “outer span names” - for example “get”, “get_and_lock” etc.

## Changes

* Add an `observaility_identifier` static field to all requests, with the operation name specified in the RFC's outer span name table.
* Use that field to populate `db.operation` in metrics. (That field should also be used for the outer spans, will be done under a separate ticket)
* Fix bug where all HTTP operations were recorded with `db.couchbase.service` = `"kv"`
* Add tests for HTTP operation metrics