### PR TITLE
CXXCBC-636: Expose preferred server group replica reads in transaction_context

### DIFF
--- a/core/transactions/internal/transaction_context.hxx
+++ b/core/transactions/internal/transaction_context.hxx
@@ -98,6 +98,9 @@ public:
   // These functions just delegate to the current_attempt_context_
   void get(const core::document_id& id, async_attempt_context::Callback&& cb);
 
+  void get_replica_from_preferred_server_group(const core::document_id& id,
+                                               async_attempt_context::Callback&& cb);
+
   void get_optional(const core::document_id& id, async_attempt_context::Callback&& cb);
 
   void insert(const core::document_id& id,

--- a/core/transactions/transaction_context.cxx
+++ b/core/transactions/transaction_context.cxx
@@ -166,6 +166,16 @@ transaction_context::get(const core::document_id& id, async_attempt_context::Cal
 }
 
 void
+transaction_context::get_replica_from_preferred_server_group(const core::document_id& id,
+                                                             async_attempt_context::Callback&& cb)
+{
+  if (current_attempt_context_) {
+    return current_attempt_context_->get_replica_from_preferred_server_group(id, std::move(cb));
+  }
+  throw transaction_operation_failed(FAIL_OTHER, "no current attempt context");
+}
+
+void
 transaction_context::get_optional(const core::document_id& id, async_attempt_context::Callback&& cb)
 {
   if (current_attempt_context_) {


### PR DESCRIPTION
- Exposed `get_replica_from_preferred_server_group` in `transaction_context`