### PR TITLE
CXXCBC-646: Do not copy configuration when the operation depends on it

### DIFF
--- a/.github/workflows/columnar.yml
+++ b/.github/workflows/columnar.yml
@@ -2,9 +2,13 @@ name: columnar
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'release-*'
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - 'release-*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -2,9 +2,13 @@ name: linters
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - 'release-*'
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - 'release-*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -2,9 +2,13 @@ name: sanitizers
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'release-*'
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - 'release-*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,13 @@ name: tests
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'release-*'
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - 'release-*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,9 +2,13 @@ name: windows
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'release-*'
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - 'release-*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/core/bucket.hxx
+++ b/core/bucket.hxx
@@ -189,7 +189,8 @@ public:
   void update_config(topology::configuration config) override;
   void bootstrap(utils::movable_function<void(std::error_code, topology::configuration)>&& handler);
   void with_configuration(
-    utils::movable_function<void(std::error_code, topology::configuration)>&& handler);
+    utils::movable_function<void(std::error_code, std::shared_ptr<topology::configuration>)>&&
+      handler);
 
   void on_configuration_update(std::shared_ptr<config_listener> handler);
   void close();

--- a/core/cluster.hxx
+++ b/core/cluster.hxx
@@ -77,7 +77,8 @@ public:
 
   void with_bucket_configuration(
     const std::string& bucket_name,
-    utils::movable_function<void(std::error_code, topology::configuration)>&& handler) const;
+    utils::movable_function<void(std::error_code, std::shared_ptr<topology::configuration>)>&&
+      handler) const;
 
   void execute(o::analytics_request request, mf<void(o::analytics_response)>&& handler) const;
   void execute(o::append_request request, mf<void(o::append_response)>&& handler) const;

--- a/core/impl/replica_utils.cxx
+++ b/core/impl/replica_utils.cxx
@@ -25,7 +25,7 @@ namespace couchbase::core::impl
 
 auto
 effective_nodes(const document_id& id,
-                const topology::configuration& config,
+                const std::shared_ptr<topology::configuration>& config,
                 const read_preference& preference,
                 const std::string& preferred_server_group) -> std::vector<readable_node>
 {
@@ -37,12 +37,12 @@ effective_nodes(const document_id& id,
   std::vector<readable_node> available_nodes{};
   std::vector<readable_node> local_nodes{};
 
-  for (std::size_t idx = 0U; idx <= config.num_replicas.value_or(0U); ++idx) {
-    auto [vbid, server] = config.map_key(id.key(), idx);
-    if (server.has_value() && server.value() < config.nodes.size()) {
+  for (std::size_t idx = 0U; idx <= config->num_replicas.value_or(0U); ++idx) {
+    auto [vbid, server] = config->map_key(id.key(), idx);
+    if (server.has_value() && server.value() < config->nodes.size()) {
       const bool is_replica = idx != 0;
       available_nodes.emplace_back(readable_node{ is_replica, idx });
-      if (preferred_server_group == config.nodes[server.value()].server_group) {
+      if (preferred_server_group == config->nodes[server.value()].server_group) {
         local_nodes.emplace_back(readable_node{ is_replica, idx });
       }
     }

--- a/core/impl/replica_utils.hxx
+++ b/core/impl/replica_utils.hxx
@@ -23,6 +23,7 @@
 
 #include "couchbase/read_preference.hxx"
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -42,7 +43,7 @@ struct readable_node {
  */
 auto
 effective_nodes(const document_id& id,
-                const topology::configuration& config,
+                const std::shared_ptr<topology::configuration>& config,
                 const read_preference& preference,
                 const std::string& preferred_server_group) -> std::vector<readable_node>;
 } // namespace couchbase::core::impl

--- a/core/operations/document_get_all_replicas.hxx
+++ b/core/operations/document_get_all_replicas.hxx
@@ -26,7 +26,6 @@
 #include "core/utils/movable_function.hxx"
 #include "couchbase/error_codes.hxx"
 
-#include <functional>
 #include <memory>
 #include <mutex>
 
@@ -65,8 +64,8 @@ struct get_all_replicas_request {
        id = id,
        timeout = timeout,
        read_preference = read_preference,
-       h = std::forward<Handler>(handler)](std::error_code ec,
-                                           const topology::configuration& config) mutable {
+       h = std::forward<Handler>(handler)](
+        std::error_code ec, std::shared_ptr<topology::configuration> config) mutable {
         if (ec) {
           return h(response_type{ make_key_value_error_context(ec, id) });
         }
@@ -82,7 +81,7 @@ struct get_all_replicas_request {
             "Unable to retrieve replicas for \"{}\", server_group={}, number_of_replicas={}",
             id,
             origin.options().server_group,
-            config.num_replicas.value_or(0));
+            config->num_replicas.value_or(0));
           return h(response_type{
             make_key_value_error_context(errc::key_value::document_irretrievable, id) });
         }

--- a/core/operations/document_get_any_replica.hxx
+++ b/core/operations/document_get_any_replica.hxx
@@ -61,8 +61,8 @@ struct get_any_replica_request {
        id = id,
        timeout = timeout,
        read_preference = read_preference,
-       h = std::forward<Handler>(handler)](std::error_code ec,
-                                           const topology::configuration& config) mutable {
+       h = std::forward<Handler>(handler)](
+        std::error_code ec, std::shared_ptr<topology::configuration> config) mutable {
         const auto [e, origin] = core->origin();
         if (e && !ec) {
           ec = e;
@@ -75,7 +75,7 @@ struct get_any_replica_request {
             "Unable to retrieve replicas for \"{}\", server_group={}, number_of_replicas={}",
             id,
             origin.options().server_group,
-            config.num_replicas.value_or(0));
+            config->num_replicas.value_or(0));
           ec = errc::key_value::document_irretrievable;
         }
 

--- a/core/operations/document_lookup_in_all_replicas.hxx
+++ b/core/operations/document_lookup_in_all_replicas.hxx
@@ -94,8 +94,8 @@ struct lookup_in_all_replicas_request {
         core->with_bucket_configuration(
           id.bucket(),
           [core, id, timeout, specs, parent_span, read_preference, h = std::forward<Handler>(h)](
-            std::error_code ec, const topology::configuration& config) mutable {
-            if (!config.capabilities.supports_subdoc_read_replica()) {
+            std::error_code ec, std::shared_ptr<topology::configuration> config) mutable {
+            if (!config->capabilities.supports_subdoc_read_replica()) {
               ec = errc::common::feature_not_available;
             }
 
@@ -111,7 +111,7 @@ struct lookup_in_all_replicas_request {
                 "Unable to retrieve replicas for \"{}\", server_group={}, number_of_replicas={}",
                 id,
                 origin.options().server_group,
-                config.num_replicas.value_or(0));
+                config->num_replicas.value_or(0));
               ec = errc::key_value::document_irretrievable;
             }
 

--- a/core/operations/document_lookup_in_any_replica.hxx
+++ b/core/operations/document_lookup_in_any_replica.hxx
@@ -92,8 +92,8 @@ struct lookup_in_any_replica_request {
         return core->with_bucket_configuration(
           id.bucket(),
           [core, id, timeout, specs, parent_span, read_preference, h = std::forward<Handler>(h)](
-            std::error_code ec, const topology::configuration& config) mutable {
-            if (!config.capabilities.supports_subdoc_read_replica()) {
+            std::error_code ec, std::shared_ptr<topology::configuration> config) mutable {
+            if (!config->capabilities.supports_subdoc_read_replica()) {
               ec = errc::common::feature_not_available;
             }
             const auto [e, origin] = core->origin();
@@ -108,7 +108,7 @@ struct lookup_in_any_replica_request {
                 "Unable to retrieve replicas for \"{}\", server_group={}, number_of_replicas={}",
                 id,
                 origin.options().server_group,
-                config.num_replicas.value_or(0));
+                config->num_replicas.value_or(0));
               ec = errc::key_value::document_irretrievable;
             }
 


### PR DESCRIPTION
For performance reasons, store bucket configuration as shared pointer, and copy it instead. The SDK can use shared pointer here, as configuration is readonly, and only access to the pointer have to be protected by the mutex