### PR TITLE
CXXCBC-646: Do not copy configuration when the operation depends on it

### DIFF
--- a/core/bucket.cxx
+++ b/core/bucket.cxx
@@ -368,7 +368,7 @@ public:
   void restart_sessions()
   {
     const std::scoped_lock lock(config_mutex_, sessions_mutex_);
-    if (!config_.has_value()) {
+    if (!config_) {
       return;
     }
 
@@ -532,38 +532,39 @@ public:
   }
 
   void with_configuration(
-    utils::movable_function<void(std::error_code, topology::configuration)>&& handler)
+    utils::movable_function<void(std::error_code, std::shared_ptr<topology::configuration>)>&&
+      handler)
   {
     if (closed_) {
-      return handler(errc::network::configuration_not_available, topology::configuration{});
+      return handler(errc::network::configuration_not_available, nullptr);
     }
     if (configured_) {
-      std::optional<topology::configuration> config{};
+      std::shared_ptr<topology::configuration> config{};
       {
         const std::scoped_lock config_lock(config_mutex_);
         config = config_;
       }
       if (config) {
-        return handler({}, config.value());
+        return handler({}, config);
       }
-      return handler(errc::network::configuration_not_available, topology::configuration{});
+      return handler(errc::network::configuration_not_available, nullptr);
     }
     const std::scoped_lock lock(deferred_commands_mutex_);
     deferred_commands_.emplace(
       [self = shared_from_this(), handler = std::move(handler)](std::error_code ec) mutable {
         if (ec == errc::common::request_canceled || self->closed_ || !self->configured_) {
-          return handler(errc::network::configuration_not_available, topology::configuration{});
+          return handler(errc::network::configuration_not_available, nullptr);
         }
 
-        std::optional<topology::configuration> config{};
+        std::shared_ptr<topology::configuration> config{};
         {
           const std::scoped_lock config_lock(self->config_mutex_);
           config = self->config_;
         }
         if (config) {
-          return handler({}, config.value());
+          return handler({}, config);
         }
-        return handler(errc::network::configuration_not_available, topology::configuration{});
+        return handler(errc::network::configuration_not_available, nullptr);
       });
   }
 
@@ -736,7 +737,7 @@ public:
                      config_->rev_str(),
                      config.rev_str());
         return;
-      } else if (config_ < config) {
+      } else if (*config_ < config) {
         CB_LOG_DEBUG("{} will update the configuration old={} -> new={}",
                      log_prefix_,
                      config_->rev_str(),
@@ -763,7 +764,7 @@ public:
         added = config.nodes;
       }
       config_.reset();
-      config_ = config;
+      config_ = std::make_shared<topology::configuration>(config);
       configured_ = true;
 
       {
@@ -998,7 +999,7 @@ private:
   std::atomic_bool closed_{ false };
   std::atomic_bool configured_{ false };
 
-  std::optional<topology::configuration> config_{};
+  std::shared_ptr<topology::configuration> config_{};
   mutable std::mutex config_mutex_{};
 
   std::vector<std::shared_ptr<config_listener>> config_listeners_{};
@@ -1123,7 +1124,8 @@ bucket::bootstrap(utils::movable_function<void(std::error_code, topology::config
 
 void
 bucket::with_configuration(
-  utils::movable_function<void(std::error_code, topology::configuration)>&& handler)
+  utils::movable_function<void(std::error_code, std::shared_ptr<topology::configuration>)>&&
+    handler)
 {
   return impl_->with_configuration(std::move(handler));
 }

--- a/core/bucket.hxx
+++ b/core/bucket.hxx
@@ -196,7 +196,8 @@ public:
   void update_config(topology::configuration config) override;
   void bootstrap(utils::movable_function<void(std::error_code, topology::configuration)>&& handler);
   void with_configuration(
-    utils::movable_function<void(std::error_code, topology::configuration)>&& handler);
+    utils::movable_function<void(std::error_code, std::shared_ptr<topology::configuration>)>&&
+      handler);
 
   void on_configuration_update(std::shared_ptr<config_listener> handler);
   void close();

--- a/core/cluster.cxx
+++ b/core/cluster.cxx
@@ -589,12 +589,12 @@ public:
         return self->with_bucket_configuration(
           bucket_name,
           [self, cap, request = std::move(request), handler = std::forward<Handler>(handler)](
-            std::error_code ec, const topology::configuration& config) mutable {
+            std::error_code ec, const std::shared_ptr<topology::configuration>& config) mutable {
             if (ec) {
               handler(request.make_response({ ec }, {}));
               return;
             }
-            if (!config.capabilities.has_bucket_capability(cap)) {
+            if (!config->capabilities.has_bucket_capability(cap)) {
               handler(request.make_response({ errc::common::feature_not_available }, {}));
               return;
             }
@@ -997,10 +997,11 @@ public:
 
   void with_bucket_configuration(
     const std::string& bucket_name,
-    utils::movable_function<void(std::error_code, topology::configuration)>&& handler)
+    utils::movable_function<void(std::error_code, std::shared_ptr<topology::configuration>)>&&
+      handler)
   {
     if (stopped_) {
-      return handler(errc::network::cluster_closed, {});
+      return handler(errc::network::cluster_closed, nullptr);
     }
     if (auto bucket = find_bucket_by_name(bucket_name); bucket != nullptr) {
       return bucket->with_configuration(std::move(handler));
@@ -1009,13 +1010,13 @@ public:
       bucket_name,
       [self = shared_from_this(), bucket_name, handler = std::move(handler)](auto ec) mutable {
         if (ec) {
-          return handler(ec, {});
+          return handler(ec, nullptr);
         }
 
         if (auto bucket = self->find_bucket_by_name(bucket_name); bucket != nullptr) {
           return bucket->with_configuration(std::move(handler));
         }
-        return handler(errc::common::bucket_not_found, {});
+        return handler(errc::common::bucket_not_found, nullptr);
       });
   }
 
@@ -1364,7 +1365,8 @@ cluster::ping(std::optional<std::string> report_id,
 void
 cluster::with_bucket_configuration(
   const std::string& bucket_name,
-  utils::movable_function<void(std::error_code, topology::configuration)>&& handler) const
+  utils::movable_function<void(std::error_code, std::shared_ptr<topology::configuration>)>&&
+    handler) const
 {
   if (impl_) {
     impl_->with_bucket_configuration(bucket_name, std::move(handler));

--- a/core/cluster.hxx
+++ b/core/cluster.hxx
@@ -77,7 +77,8 @@ public:
 
   void with_bucket_configuration(
     const std::string& bucket_name,
-    utils::movable_function<void(std::error_code, topology::configuration)>&& handler) const;
+    utils::movable_function<void(std::error_code, std::shared_ptr<topology::configuration>)>&&
+      handler) const;
 
   void execute(o::analytics_request request, mf<void(o::analytics_response)>&& handler) const;
   void execute(o::append_request request, mf<void(o::append_response)>&& handler) const;

--- a/core/impl/replica_utils.cxx
+++ b/core/impl/replica_utils.cxx
@@ -25,7 +25,7 @@ namespace couchbase::core::impl
 
 auto
 effective_nodes(const document_id& id,
-                const topology::configuration& config,
+                const std::shared_ptr<topology::configuration>& config,
                 const read_preference& preference,
                 const std::string& preferred_server_group) -> std::vector<readable_node>
 {
@@ -37,12 +37,12 @@ effective_nodes(const document_id& id,
   std::vector<readable_node> available_nodes{};
   std::vector<readable_node> local_nodes{};
 
-  for (std::size_t idx = 0U; idx <= config.num_replicas.value_or(0U); ++idx) {
-    auto [vbid, server] = config.map_key(id.key(), idx);
-    if (server.has_value() && server.value() < config.nodes.size()) {
+  for (std::size_t idx = 0U; idx <= config->num_replicas.value_or(0U); ++idx) {
+    auto [vbid, server] = config->map_key(id.key(), idx);
+    if (server.has_value() && server.value() < config->nodes.size()) {
       const bool is_replica = idx != 0;
       available_nodes.emplace_back(readable_node{ is_replica, idx });
-      if (preferred_server_group == config.nodes[server.value()].server_group) {
+      if (preferred_server_group == config->nodes[server.value()].server_group) {
         local_nodes.emplace_back(readable_node{ is_replica, idx });
       }
     }

--- a/core/impl/replica_utils.hxx
+++ b/core/impl/replica_utils.hxx
@@ -23,6 +23,7 @@
 
 #include "couchbase/read_preference.hxx"
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -42,7 +43,7 @@ struct readable_node {
  */
 auto
 effective_nodes(const document_id& id,
-                const topology::configuration& config,
+                const std::shared_ptr<topology::configuration>& config,
                 const read_preference& preference,
                 const std::string& preferred_server_group) -> std::vector<readable_node>;
 } // namespace couchbase::core::impl

--- a/core/operations/document_get_all_replicas.hxx
+++ b/core/operations/document_get_all_replicas.hxx
@@ -26,7 +26,6 @@
 #include "core/utils/movable_function.hxx"
 #include "couchbase/error_codes.hxx"
 
-#include <functional>
 #include <memory>
 #include <mutex>
 
@@ -65,8 +64,8 @@ struct get_all_replicas_request {
        id = id,
        timeout = timeout,
        read_preference = read_preference,
-       h = std::forward<Handler>(handler)](std::error_code ec,
-                                           const topology::configuration& config) mutable {
+       h = std::forward<Handler>(handler)](
+        std::error_code ec, std::shared_ptr<topology::configuration> config) mutable {
         if (ec) {
           return h(response_type{ make_key_value_error_context(ec, id) });
         }
@@ -82,7 +81,7 @@ struct get_all_replicas_request {
             "Unable to retrieve replicas for \"{}\", server_group={}, number_of_replicas={}",
             id,
             origin.options().server_group,
-            config.num_replicas.value_or(0));
+            config->num_replicas.value_or(0));
           return h(response_type{
             make_key_value_error_context(errc::key_value::document_irretrievable, id) });
         }

--- a/core/operations/document_get_any_replica.hxx
+++ b/core/operations/document_get_any_replica.hxx
@@ -61,8 +61,8 @@ struct get_any_replica_request {
        id = id,
        timeout = timeout,
        read_preference = read_preference,
-       h = std::forward<Handler>(handler)](std::error_code ec,
-                                           const topology::configuration& config) mutable {
+       h = std::forward<Handler>(handler)](
+        std::error_code ec, std::shared_ptr<topology::configuration> config) mutable {
         const auto [e, origin] = core->origin();
         if (e && !ec) {
           ec = e;
@@ -75,7 +75,7 @@ struct get_any_replica_request {
             "Unable to retrieve replicas for \"{}\", server_group={}, number_of_replicas={}",
             id,
             origin.options().server_group,
-            config.num_replicas.value_or(0));
+            config->num_replicas.value_or(0));
           ec = errc::key_value::document_irretrievable;
         }
 

--- a/core/operations/document_lookup_in_all_replicas.hxx
+++ b/core/operations/document_lookup_in_all_replicas.hxx
@@ -94,8 +94,8 @@ struct lookup_in_all_replicas_request {
         core->with_bucket_configuration(
           id.bucket(),
           [core, id, timeout, specs, parent_span, read_preference, h = std::forward<Handler>(h)](
-            std::error_code ec, const topology::configuration& config) mutable {
-            if (!config.capabilities.supports_subdoc_read_replica()) {
+            std::error_code ec, std::shared_ptr<topology::configuration> config) mutable {
+            if (!config->capabilities.supports_subdoc_read_replica()) {
               ec = errc::common::feature_not_available;
             }
 
@@ -111,7 +111,7 @@ struct lookup_in_all_replicas_request {
                 "Unable to retrieve replicas for \"{}\", server_group={}, number_of_replicas={}",
                 id,
                 origin.options().server_group,
-                config.num_replicas.value_or(0));
+                config->num_replicas.value_or(0));
               ec = errc::key_value::document_irretrievable;
             }
 

--- a/core/operations/document_lookup_in_any_replica.hxx
+++ b/core/operations/document_lookup_in_any_replica.hxx
@@ -92,8 +92,8 @@ struct lookup_in_any_replica_request {
         return core->with_bucket_configuration(
           id.bucket(),
           [core, id, timeout, specs, parent_span, read_preference, h = std::forward<Handler>(h)](
-            std::error_code ec, const topology::configuration& config) mutable {
-            if (!config.capabilities.supports_subdoc_read_replica()) {
+            std::error_code ec, std::shared_ptr<topology::configuration> config) mutable {
+            if (!config->capabilities.supports_subdoc_read_replica()) {
               ec = errc::common::feature_not_available;
             }
             const auto [e, origin] = core->origin();
@@ -108,7 +108,7 @@ struct lookup_in_any_replica_request {
                 "Unable to retrieve replicas for \"{}\", server_group={}, number_of_replicas={}",
                 id,
                 origin.options().server_group,
-                config.num_replicas.value_or(0));
+                config->num_replicas.value_or(0));
               ec = errc::key_value::document_irretrievable;
             }
 


### PR DESCRIPTION
For performance reasons, store bucket configuration as shared pointer, and copy it instead. The SDK can use shared pointer here, as configuration is readonly, and only access to the pointer have to be protected by the mutex