### PR TITLE
CXXCBC-646: add feature flag for FIT performer

### DIFF
--- a/core/meta/features.hxx
+++ b/core/meta/features.hxx
@@ -213,3 +213,8 @@
  * to pass into couchbase::cluster_options
  */
 #define COUCHBASE_CXX_CLIENT_SUPPORTS_APP_TELEMETRY 1
+
+/**
+ * core API like with_bucket_configuration() yields shared_ptr instead of configuration copy
+ */
+#define COUCHBASE_CXX_CLIENT_CORE_RETURNS_POINTER_TO_CONFIG 1


### PR DESCRIPTION
FIT performer need it to compile, as it must support both old and new version of the core