### PR TITLE
[backport] CXXCBC-660: Fix potential race condition in the logger

### DIFF
--- a/core/logger/logger.cxx
+++ b/core/logger/logger.cxx
@@ -322,7 +322,7 @@ create_file_logger(const configuration& logger_settings) -> std::optional<std::s
   if (error) {
     return error;
   }
-  file_logger = std::move(logger);
+  update_file_logger(logger);
   return {};
 }
 


### PR DESCRIPTION
All code paths must use update_file_logger to ensure thread safety. The create_file_logger just updated the logger pointer without incrementing version.

Backport of #722 