### PR TITLE
CXXCBC-668: ensure random generator is initialized in websocket_codec

### DIFF
--- a/core/websocket_codec.cxx
+++ b/core/websocket_codec.cxx
@@ -86,6 +86,7 @@ generate_masking_key() -> std::array<std::byte, 4>
 auto
 generate_session_key() -> std::string
 {
+  const couchbase::core::RandomGenerator randomGenerator;
   std::array<std::byte, 16> key{};
   if (!core::RandomGenerator::getBytes(key.data(), key.size())) {
     throw std::bad_alloc();


### PR DESCRIPTION
In some cases, when websocket_code is the first ever to touch RandomGenerator, the library might crash trying to dereference null pointer. It does not happen often, but in case of the one-shot applications it might happen (for example 'cbc get' from the tools)