### PR TITLE
CXXCBC-665: Always return partial results for all_replica ops if some get_replica reqs succeeded

### DIFF
--- a/core/operations/document_get_all_replicas.hxx
+++ b/core/operations/document_get_all_replicas.hxx
@@ -131,7 +131,11 @@ struct get_all_replicas_request {
                   }
                 }
                 if (local_handler) {
-                  return local_handler({ std::move(resp.ctx), std::move(ctx->result_) });
+                  if (ctx->result_.empty()) {
+                    // Return an error only when we have no results from any replica.
+                    return local_handler({ std::move(resp.ctx), {} });
+                  }
+                  return local_handler({ {}, std::move(ctx->result_) });
                 }
               });
           } else {
@@ -158,7 +162,11 @@ struct get_all_replicas_request {
                 }
               }
               if (local_handler) {
-                return local_handler({ std::move(resp.ctx), std::move(ctx->result_) });
+                if (ctx->result_.empty()) {
+                  // Return an error only when we have no results from any replica.
+                  return local_handler({ std::move(resp.ctx), {} });
+                }
+                return local_handler({ {}, std::move(ctx->result_) });
               }
             });
           }

--- a/core/operations/document_lookup_in_all_replicas.hxx
+++ b/core/operations/document_lookup_in_all_replicas.hxx
@@ -187,7 +187,11 @@ struct lookup_in_all_replicas_request {
                       }
                     }
                     if (local_handler) {
-                      return local_handler({ std::move(resp.ctx), std::move(ctx->result_) });
+                      if (ctx->result_.empty()) {
+                        // Return an error only when we have no results from any replica.
+                        return local_handler({ std::move(resp.ctx), {} });
+                      }
+                      return local_handler({ {}, std::move(ctx->result_) });
                     }
                   });
               } else {
@@ -231,7 +235,11 @@ struct lookup_in_all_replicas_request {
                       }
                     }
                     if (local_handler) {
-                      return local_handler({ std::move(resp.ctx), std::move(ctx->result_) });
+                      if (ctx->result_.empty()) {
+                        // Return an error only when we have no results from any replica.
+                        return local_handler({ std::move(resp.ctx), {} });
+                      }
+                      return local_handler({ {}, std::move(ctx->result_) });
                     }
                   });
               }


### PR DESCRIPTION
## Motivation

Currently, we only report an error if the last individual get/get_replica response to be received had an error. This means that if we have partial results, whether they are returned or not depends on the order at which we receive the responses, which is not deterministic.

## Change

If some successful replica results exist, always return them. We do this by only returning the error context of the last response (which is what we have been using to return an error from the overall operation), if there are no successful replica results.