### PR TITLE
CXXCBC-654: Add num_vbuckets to bucket_settings

### DIFF
--- a/core/impl/bucket_manager.cxx
+++ b/core/impl/bucket_manager.cxx
@@ -61,6 +61,7 @@ map_bucket_settings(const couchbase::core::management::cluster::bucket_settings&
   bucket_settings.flush_enabled = bucket.flush_enabled;
   bucket_settings.history_retention_bytes = bucket.history_retention_bytes;
   bucket_settings.history_retention_duration = bucket.history_retention_duration;
+  bucket_settings.num_vbuckets = bucket.num_vbuckets;
   switch (bucket.conflict_resolution_type) {
     case core::management::cluster::bucket_conflict_resolution::unknown:
       bucket_settings.conflict_resolution_type =
@@ -169,6 +170,7 @@ map_bucket_settings(const couchbase::management::cluster::bucket_settings& bucke
     bucket.history_retention_collection_default;
   bucket_settings.history_retention_bytes = bucket.history_retention_bytes;
   bucket_settings.history_retention_duration = bucket.history_retention_duration;
+  bucket_settings.num_vbuckets = bucket.num_vbuckets;
   switch (bucket.conflict_resolution_type) {
     case management::cluster::bucket_conflict_resolution::unknown:
       bucket_settings.conflict_resolution_type =

--- a/core/management/bucket_settings.hxx
+++ b/core/management/bucket_settings.hxx
@@ -136,6 +136,7 @@ struct bucket_settings {
   std::optional<bool> history_retention_collection_default{};
   std::optional<std::uint32_t> history_retention_bytes{};
   std::optional<std::uint32_t> history_retention_duration{};
+  std::optional<std::uint16_t> num_vbuckets{};
 
   /**
    * UNCOMMITTED: This API may change in the future

--- a/core/management/bucket_settings_json.hxx
+++ b/core/management/bucket_settings_json.hxx
@@ -56,6 +56,10 @@ struct traits<couchbase::core::management::cluster::bucket_settings> {
         history_retention_duration->template as<std::optional<std::uint32_t>>();
     }
 
+    if (auto* num_vbuckets = v.find("numVBuckets"); num_vbuckets != nullptr) {
+      result.num_vbuckets = num_vbuckets->template as<std::optional<std::uint16_t>>();
+    }
+
     if (auto& str = v.at("bucketType").get_string(); str == "couchbase" || str == "membase") {
       result.bucket_type = couchbase::core::management::cluster::bucket_type::couchbase;
     } else if (str == "ephemeral") {

--- a/core/meta/features.hxx
+++ b/core/meta/features.hxx
@@ -218,3 +218,8 @@
  * core API like with_bucket_configuration() yields shared_ptr instead of configuration copy
  */
 #define COUCHBASE_CXX_CLIENT_CORE_RETURNS_POINTER_TO_CONFIG 1
+
+/**
+ * bucket_settings in both the public and core management APIs have a num_vbuckets attribute
+ */
+#define COUCHBASE_CXX_CLIENT_HAS_BUCKET_SETTINGS_NUM_VBUCKETS 1

--- a/core/operations/management/bucket_create.cxx
+++ b/core/operations/management/bucket_create.cxx
@@ -86,6 +86,9 @@ bucket_create_request::encode_to(encoded_request_type& encoded,
   if (bucket.flush_enabled.has_value()) {
     encoded.body.append(fmt::format("&flushEnabled={}", bucket.flush_enabled.value() ? "1" : "0"));
   }
+  if (bucket.num_vbuckets.has_value()) {
+    encoded.body.append(fmt::format("&numVBuckets={}", bucket.num_vbuckets.value()));
+  }
 
   switch (bucket.eviction_policy) {
     case couchbase::core::management::cluster::bucket_eviction_policy::full:

--- a/core/operations/management/bucket_update.cxx
+++ b/core/operations/management/bucket_update.cxx
@@ -69,6 +69,9 @@ bucket_update_request::encode_to(encoded_request_type& encoded,
   if (bucket.flush_enabled.has_value()) {
     encoded.body.append(fmt::format("&flushEnabled={}", bucket.flush_enabled.value() ? "1" : "0"));
   }
+  if (bucket.num_vbuckets.has_value()) {
+    encoded.body.append(fmt::format("&numVBuckets={}", bucket.num_vbuckets.value()));
+  }
 
   switch (bucket.eviction_policy) {
     case couchbase::core::management::cluster::bucket_eviction_policy::full:

--- a/couchbase/management/bucket_settings.hxx
+++ b/couchbase/management/bucket_settings.hxx
@@ -126,6 +126,7 @@ struct bucket_settings {
   std::optional<bool> history_retention_collection_default{};
   std::optional<std::uint32_t> history_retention_bytes;
   std::optional<std::uint32_t> history_retention_duration{};
+  std::optional<std::uint16_t> num_vbuckets{};
 
   /**
    * UNCOMMITTED: This API may change in the future


### PR DESCRIPTION
## Motivation

From Morpheus, the server is adding support for creating Magma buckets with 128 vBuckets. We are adding a `num_vbuckets` parameter to `bucket_settings` to allow configuring the number of vbuckets to either 128 or 1024.

## Changes

Add `num_vbuckets` to `bucket_settings` in both the core and public APIs

## Results

All FIT tests pass