### PR TITLE
CXXCBC-674: Set cluster name in init-cluster if supported & not already set

### DIFF
--- a/bin/init-cluster
+++ b/bin/init-cluster
@@ -162,3 +162,14 @@ if options[:sample_buckets].include?("travel-sample") && services.include?("fts"
   index_definition_path = File.join(__dir__, "travel-sample-index#{"-v6" if has_v6_nodes}.json")
   ensure_search_index_created(index_definition_path, options.merge(service_address))
 end
+
+current_cluster_name = api.get("/pools/default")["clusterName"]
+if current_cluster_name == ""
+  new_name = "test-cluster"
+  api.post_form("/pools/default", {"clusterName" => new_name})
+  puts "Cluster name set to \"test-cluster\""
+elsif current_cluster_name != nil
+  puts "Cluster name is already set to \"#{current_cluster_name}\""
+else
+  puts "Server version does not support setting cluster name"
+end


### PR DESCRIPTION
We have some failing tests on Jenkins because cbdyncluster clusters don't have a cluster name set by default. The relevant tests are:
* integration: enable external tracer.integration: enable external tracer
* integration: use external meter.integration: use external 

They are failing because they expect the `db.couchbase.cluster_name` field to be populated for server versions where the cluster name is reported in the config.

We should set it in init-cluster if it's not already set.