### PR TITLE
Bump Ubuntu version used in GHA workflows

### DIFF
--- a/.github/workflows/columnar.yml
+++ b/.github/workflows/columnar.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Install build environment

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -33,7 +33,7 @@ jobs:
           CB_CLANG_FORMAT: /usr/bin/clang-format-19
 
   clang_static_analyzer:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -43,15 +43,15 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y libssl-dev cmake curl wget gnupg2
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo bash -c "echo 'deb https://apt.llvm.org/focal/ llvm-toolchain-focal-11 main' >> /etc/apt/sources.list"
+          sudo bash -c "echo 'deb https://apt.llvm.org/noble/ llvm-toolchain-noble-19 main' >> /etc/apt/sources.list"
           sudo apt-get update -y
-          sudo apt-get install -y clang-11 clang-tools-11
+          sudo apt-get install -y clang-19 clang-tools-19
       - name: Run scan build
         run: ./bin/check-clang-static-analyzer
         env:
-          CB_CC: /usr/bin/clang-11
-          CB_CXX: /usr/bin/clang++-11
-          CB_SCAN_BUILD: /usr/bin/scan-build-11
+          CB_CC: /usr/bin/clang-19
+          CB_CXX: /usr/bin/clang++-19
+          CB_SCAN_BUILD: /usr/bin/scan-build-19
       - name: Upload scan-build report
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
           - server: 6.6.6
             suite: unit
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     services:
       couchbase:
         image: couchbase:enterprise-${{ matrix.server }}


### PR DESCRIPTION
Ubuntu 20.04 runners have now been retired and removed.