### PR TITLE
CXXCBC-682: Transaction replace/insert result should include post-op content

### DIFF
--- a/core/transactions/staged_mutation.cxx
+++ b/core/transactions/staged_mutation.cxx
@@ -480,7 +480,7 @@ staged_mutation_queue::rollback_remove_or_replace(
             }
               .specs();
           req.cas = item.doc().cas();
-          req.flags = item.doc().content().flags;
+          req.flags = item.current_user_flags();
           wrap_durable_request(req, ctx->overall()->config());
           return ctx->cluster_ref().execute(
             req,

--- a/core/transactions/staged_mutation.hxx
+++ b/core/transactions/staged_mutation.hxx
@@ -41,16 +41,19 @@ private:
   transaction_get_result doc_;
   staged_mutation_type type_;
   std::optional<codec::encoded_value> content_;
+  std::uint32_t current_user_flags_;
   std::string operation_id_;
 
 public:
   staged_mutation(transaction_get_result doc,
                   std::optional<codec::encoded_value> content,
                   staged_mutation_type type,
+                  std::uint32_t current_user_flags,
                   std::string operation_id = uid_generator::next())
     : doc_(std::move(doc))
     , type_(type)
     , content_(std::move(content))
+    , current_user_flags_(current_user_flags)
     , operation_id_(std::move(operation_id))
   {
   }
@@ -98,7 +101,7 @@ public:
    */
   [[nodiscard]] auto current_user_flags() const -> std::uint32_t
   {
-    return doc_.content().flags;
+    return current_user_flags_;
   }
 
   void content(const codec::encoded_value& content)

--- a/test/test_transaction_public_blocking_api.cxx
+++ b/test/test_transaction_public_blocking_api.cxx
@@ -156,6 +156,7 @@ TEST_CASE("transactions public blocking API: can insert", "[transactions]")
       auto [e, doc] = ctx->insert(coll, id, content);
       CHECK_FALSE(e.ec());
       CHECK(doc.id() == id);
+      CHECK(doc.content_as<tao::json::value>() == content);
       auto [e2, inserted_doc] = ctx->get(coll, id);
       CHECK_FALSE(e2.ec());
       CHECK(inserted_doc.content_as<tao::json::value>() == content);
@@ -223,8 +224,7 @@ TEST_CASE("transactions public blocking API: can replace", "[transactions]")
       CHECK_FALSE(e.ec());
       CHECK(doc.id() == replaced_doc.id());
       CHECK(doc.content_as<tao::json::value>() == content);
-      // FIXME(JCBC-2152)
-      // CHECK(replaced_doc.content<tao::json::value>() == new_content);
+      CHECK(replaced_doc.content_as<tao::json::value>() == new_content);
       return {};
     },
     txn_opts());


### PR DESCRIPTION
## Motivation

The `transaction_get_result` returned from `ctx.replace()` or `ctx.insert()` does not include the post-operation content. Instead it includes the pre-replace content or an empty content respectively. The specification expects that the post-operation content is returned.

## Changes

* Update insert/replace results in the create staged replace/insert methods to include the post-operation content.
* Store the pre-transaction user flags in the staged mutation, so they can be accessed when rolling back replace or remove operations via `staged_mutation::current_user_flags()`
* Add assertions to the relevant tests checking that the updated body was returned.

