### PR TITLE
CXXCBC-684: Allow setting both named and positional parameters for queries

### DIFF
--- a/core/meta/features.hxx
+++ b/core/meta/features.hxx
@@ -223,3 +223,9 @@
  * bucket_settings in both the public and core management APIs have a num_vbuckets attribute
  */
 #define COUCHBASE_CXX_CLIENT_HAS_BUCKET_SETTINGS_NUM_VBUCKETS 1
+
+/**
+ * couchbase::query_options and couchbase::analytics_options allow setting both positional and named
+ * parameters.
+ */
+#define COUCHBASE_CXX_CLIENT_QUERY_SUPPORTS_BOTH_POSITIONAL_NAMED_PARAMETERS 1

--- a/core/operations/document_analytics.cxx
+++ b/core/operations/document_analytics.cxx
@@ -35,16 +35,16 @@ analytics_request::encode_to(analytics_request::encoded_request_type& encoded,
   tao::json::value body{ { "statement", statement },
                          { "client_context_id", encoded.client_context_id },
                          { "timeout", fmt::format("{}ms", encoded.timeout.count()) } };
-  if (positional_parameters.empty()) {
-    for (const auto& [name, value] : named_parameters) {
-      Expects(name.empty() == false);
-      std::string key = name;
-      if (key[0] != '$') {
-        key.insert(key.begin(), '$');
-      }
-      body[key] = utils::json::parse(value);
+
+  for (const auto& [name, value] : named_parameters) {
+    Expects(name.empty() == false);
+    std::string key = name;
+    if (key[0] != '$') {
+      key.insert(key.begin(), '$');
     }
-  } else {
+    body[key] = utils::json::parse(value);
+  }
+  if (!positional_parameters.empty()) {
     std::vector<tao::json::value> parameters;
     parameters.reserve(positional_parameters.size());
     for (const auto& value : positional_parameters) {

--- a/core/operations/document_query.cxx
+++ b/core/operations/document_query.cxx
@@ -64,16 +64,16 @@ query_request::encode_to(query_request::encoded_request_type& encoded,
     timeout_for_service -= std::chrono::milliseconds(500);
   }
   body["timeout"] = fmt::format("{}ms", timeout_for_service.count());
-  if (positional_parameters.empty()) {
-    for (const auto& [name, value] : named_parameters) {
-      Expects(name.empty() == false);
-      std::string key = name;
-      if (key[0] != '$') {
-        key.insert(key.begin(), '$');
-      }
-      body[key] = utils::json::parse(value);
+
+  for (const auto& [name, value] : named_parameters) {
+    Expects(name.empty() == false);
+    std::string key = name;
+    if (key[0] != '$') {
+      key.insert(key.begin(), '$');
     }
-  } else {
+    body[key] = utils::json::parse(value);
+  }
+  if (!positional_parameters.empty()) {
     std::vector<tao::json::value> parameters;
     parameters.reserve(positional_parameters.size());
     for (const auto& value : positional_parameters) {

--- a/couchbase/analytics_options.hxx
+++ b/couchbase/analytics_options.hxx
@@ -246,7 +246,8 @@ struct analytics_options : public common_options<analytics_options> {
   }
 
   /**
-   * Set list of positional parameters for a query.
+   * Set list of positional parameters for a query. Any existing positional parameters will be
+   * overridden.
    *
    * @tparam Parameters types for the parameters
    * @param parameters the sequence of positional parameters. Each entry will be encoded into JSON.
@@ -260,14 +261,13 @@ struct analytics_options : public common_options<analytics_options> {
            std::enable_if_t<codec::is_serializer_v<Serializer>, bool> = true>
   auto positional_parameters(const Parameters&... parameters) -> analytics_options&
   {
-    named_parameters_.clear();
     positional_parameters_.clear();
     encode_positional_parameters<Serializer>(parameters...);
     return self();
   }
 
   /**
-   * Set list of named parameters for a query.
+   * Set list of named parameters for a query. Any existing named parameters will be overridden.
    *
    * @tparam Parameters types for the parameter pairs
    * @param parameters the sequence of name-value pairs. Each value will be encoded into JSON.
@@ -282,7 +282,6 @@ struct analytics_options : public common_options<analytics_options> {
   auto named_parameters(const Parameters&... parameters) -> analytics_options&
   {
     named_parameters_.clear();
-    positional_parameters_.clear();
     encode_named_parameters<Serializer>(parameters...);
     return self();
   }
@@ -325,7 +324,6 @@ struct analytics_options : public common_options<analytics_options> {
    */
   auto encoded_positional_parameters(std::vector<codec::binary> parameters) -> analytics_options&
   {
-    named_parameters_.clear();
     positional_parameters_ = std::move(parameters);
     return self();
   }
@@ -348,7 +346,6 @@ struct analytics_options : public common_options<analytics_options> {
     -> analytics_options&
   {
     named_parameters_ = std::move(parameters);
-    positional_parameters_.clear();
     return self();
   }
 

--- a/couchbase/query_options.hxx
+++ b/couchbase/query_options.hxx
@@ -450,7 +450,8 @@ struct query_options : public common_options<query_options> {
   }
 
   /**
-   * Set list of positional parameters for a query.
+   * Set list of positional parameters for a query. Any existing positional parameters will be
+   * overridden.
    *
    * @tparam Parameters types for the parameters
    * @param parameters the sequence of positional parameters. Each entry will be encoded into JSON.
@@ -464,14 +465,13 @@ struct query_options : public common_options<query_options> {
            std::enable_if_t<codec::is_serializer_v<Serializer>, bool> = true>
   auto positional_parameters(const Parameters&... parameters) -> query_options&
   {
-    named_parameters_.clear();
     positional_parameters_.clear();
     encode_positional_parameters<Serializer>(parameters...);
     return self();
   }
 
   /**
-   * Set list of named parameters for a query.
+   * Set list of named parameters for a query. Any existing named parameters will be overridden.
    *
    * @tparam Parameters types for the parameter pairs
    * @param parameters the sequence of name-value pairs. Each value will be encoded into JSON.
@@ -486,7 +486,6 @@ struct query_options : public common_options<query_options> {
   auto named_parameters(const Parameters&... parameters) -> query_options&
   {
     named_parameters_.clear();
-    positional_parameters_.clear();
     encode_named_parameters<Serializer>(parameters...);
     return self();
   }
@@ -529,7 +528,6 @@ struct query_options : public common_options<query_options> {
    */
   auto encoded_positional_parameters(std::vector<codec::binary> parameters) -> query_options&
   {
-    named_parameters_.clear();
     positional_parameters_ = std::move(parameters);
     return self();
   }
@@ -552,7 +550,6 @@ struct query_options : public common_options<query_options> {
     -> query_options&
   {
     named_parameters_ = std::move(parameters);
-    positional_parameters_.clear();
     return self();
   }
 

--- a/test/test_integration_query.cxx
+++ b/test/test_integration_query.cxx
@@ -722,3 +722,32 @@ TEST_CASE("integration: query from scope with public API", "[integration]")
     REQUIRE(rows[0][collection_name] == value);
   }
 }
+
+TEST_CASE("integration: public API query using both named and positional parameters",
+          "[integration]")
+{
+  test::utils::integration_test_guard integration;
+
+  if (!integration.cluster_version().supports_query()) {
+    SKIP("cluster does not support query");
+  }
+
+  auto cluster = integration.public_cluster();
+
+  auto opts = couchbase::query_options().positional_parameters(20, "foo").named_parameters(
+    std::pair{ "x", 10 });
+
+  auto [err, res] = cluster.query("SELECT $x fieldA, $1 fieldB, $2 fieldC", opts).get();
+  if (err) {
+    fmt::println("{}", err.ctx().to_json());
+  }
+  REQUIRE_SUCCESS(err.ec());
+
+  auto rows = res.rows_as<couchbase::codec::tao_json_serializer, tao::json::value>();
+  REQUIRE(rows.size() == 1);
+
+  auto row = rows[0].get_object();
+  REQUIRE(row["fieldA"].as<std::uint32_t>() == 10);
+  REQUIRE(row["fieldB"].as<std::uint32_t>() == 20);
+  REQUIRE(row["fieldC"].as<std::string>() == "foo");
+}


### PR DESCRIPTION
## Motivation

The query and analytics services allow queries that have named and positional parameters in the same request. We should allow users to make queries with both types of parameters.

## Changes

**Public API:**
* Update `query_options` & `analytics_options` so that setting named parameters doesn't clear any existing positional parameters and vice versa.
* Document the fact that setting positional parameters overrides existing positional parameters, and setting named parameters overrides existing named parameters.

**Core API:**
* Update encoding of query/analytics_query requests so both named and positional parameters are included in the payload if both have been set.