### PR TITLE
CXXCBC-672: Add `add_named_parameter` and `add_positional_parameter` to query/analytics options

### DIFF
--- a/core/meta/features.hxx
+++ b/core/meta/features.hxx
@@ -223,3 +223,12 @@
  * bucket_settings in both the public and core management APIs have a num_vbuckets attribute
  */
 #define COUCHBASE_CXX_CLIENT_HAS_BUCKET_SETTINGS_NUM_VBUCKETS 1
+
+/**
+ * couchbase::query_options and couchbase::analytics_options provide the methods:
+ *   - add_positional_parameter
+ *   - add_named_parameter
+ *   - clear_positional_parameters
+ *   - clear_named_parameters
+ */
+#define COUCHBASE_CXX_CLIENT_QUERY_OPTIONS_HAVE_ADD_PARAMETER 1

--- a/couchbase/analytics_options.hxx
+++ b/couchbase/analytics_options.hxx
@@ -288,6 +288,73 @@ struct analytics_options : public common_options<analytics_options> {
   }
 
   /**
+   * Adds a positional parameter to the current list of positional parameters.
+   *
+   * @tparam Parameter type for the parameter.
+   * @param parameter the positional parameter. It will be encoded into JSON.
+   * @return this options builder for chaining purposes.
+   *
+   * @since 1.1.0
+   * @committed
+   */
+  template<typename Serializer = codec::tao_json_serializer,
+           typename Parameter,
+           std::enable_if_t<codec::is_serializer_v<Serializer>, bool> = true>
+  auto add_positional_parameter(const Parameter& parameter) -> analytics_options&
+  {
+    encode_positional_parameters<Serializer>(parameter);
+    return self();
+  }
+
+  /**
+   * Adds a named parameter to the current list of named parameters.
+   *
+   * @tparam Value type for the named parameter's value.
+   * @param name the named parameter's name
+   * @param value the named parameter's value. It will be encoded into JSON.
+   * @return this options builder for chaining purposes.
+   *
+   * @since 1.1.0
+   * @committed
+   */
+  template<typename Serializer = codec::tao_json_serializer,
+           typename Value,
+           std::enable_if_t<codec::is_serializer_v<Serializer>, bool> = true>
+  auto add_named_parameter(const std::string& name, const Value& value) -> analytics_options&
+  {
+    encode_named_parameters<Serializer>(std::make_pair(name, value));
+    return self();
+  }
+
+  /**
+   * Clears the list of positional parameters.
+   *
+   * @return this options builder for chaining purposes.
+   *
+   * @since 1.1.0
+   * @committed
+   */
+  auto clear_positional_parameters() -> analytics_options&
+  {
+    positional_parameters_.clear();
+    return self();
+  }
+
+  /**
+   * Clears the list of named parameters.
+   *
+   * @return this options builder for chaining purposes.
+   *
+   * @since 1.1.0
+   * @committed
+   */
+  auto clear_named_parameters() -> analytics_options&
+  {
+    named_parameters_.clear();
+    return self();
+  }
+
+  /**
    * Set map of raw options for a query.
    *
    * This function expects that all parameters encoded into pairs containing mapping names of the

--- a/couchbase/query_options.hxx
+++ b/couchbase/query_options.hxx
@@ -492,6 +492,73 @@ struct query_options : public common_options<query_options> {
   }
 
   /**
+   * Adds a positional parameter to the current list of positional parameters.
+   *
+   * @tparam Parameter type for the parameter.
+   * @param parameter the positional parameter. It will be encoded into JSON.
+   * @return this options builder for chaining purposes.
+   *
+   * @since 1.1.0
+   * @committed
+   */
+  template<typename Serializer = codec::tao_json_serializer,
+           typename Parameter,
+           std::enable_if_t<codec::is_serializer_v<Serializer>, bool> = true>
+  auto add_positional_parameter(const Parameter& parameter) -> query_options&
+  {
+    encode_positional_parameters<Serializer>(parameter);
+    return self();
+  }
+
+  /**
+   * Adds a named parameter to the current list of named parameters.
+   *
+   * @tparam Value type for the named parameter's value.
+   * @param name the named parameter's name
+   * @param value the named parameter's value. It will be encoded into JSON.
+   * @return this options builder for chaining purposes.
+   *
+   * @since 1.1.0
+   * @committed
+   */
+  template<typename Serializer = codec::tao_json_serializer,
+           typename Value,
+           std::enable_if_t<codec::is_serializer_v<Serializer>, bool> = true>
+  auto add_named_parameter(const std::string& name, const Value& value) -> query_options&
+  {
+    encode_named_parameters<Serializer>(std::make_pair(name, value));
+    return self();
+  }
+
+  /**
+   * Clears the list of positional parameters.
+   *
+   * @return this options builder for chaining purposes.
+   *
+   * @since 1.1.0
+   * @committed
+   */
+  auto clear_positional_parameters() -> query_options&
+  {
+    positional_parameters_.clear();
+    return self();
+  }
+
+  /**
+   * Clears the list of named parameters.
+   *
+   * @return this options builder for chaining purposes.
+   *
+   * @since 1.1.0
+   * @committed
+   */
+  auto clear_named_parameters() -> query_options&
+  {
+    named_parameters_.clear();
+    return self();
+  }
+
+  /**
    * Set map of raw options for a query.
    *
    * This function expects that all parameters encoded into pairs containing mapping names of the


### PR DESCRIPTION
## Motivation

Our existing high-level `positional_parameters` and `named_parameters` setters require the number of parameters to be known at compile time. While `encoded_positional_parameters` and `encoded_named_parameters` can be used if the number of parameters is not known at compile time, that's a low-level uncommitted API, so we should provide a high-level alternative.

## Changes

Add new methods to `analytics_options` & `query_options` – `add_named_parameter`, `add_positional_parameter`, `clear_positional_parameters`, and `clear_named_parameters`.

These allow any number of parameters to be set even when that's not known at compile time, without the user having to serialize them.