### PR TITLE
CXXCBC-683: Txn replace - Use CAS from given TransactionsGetResult when document is a staged insert

### DIFF
--- a/core/transactions/attempt_context_impl.cxx
+++ b/core/transactions/attempt_context_impl.cxx
@@ -670,7 +670,7 @@ attempt_context_impl::replace(const transaction_get_result& document,
                         self, "found existing INSERT of {} while replacing", document);
                       self->create_staged_insert(document.id(),
                                                  std::move(content),
-                                                 existing_sm->cas().value(),
+                                                 document.cas().value(),
                                                  exp_delay(std::chrono::milliseconds(5),
                                                            std::chrono::milliseconds(300),
                                                            self->overall()->config().timeout),

--- a/test/utils/server_version.hxx
+++ b/test/utils/server_version.hxx
@@ -304,6 +304,11 @@ struct server_version {
     // See MB-63870
     return (major == 7 && minor == 6 && micro >= 4) || (major == 7 && minor > 6) || major > 7;
   }
+
+  [[nodiscard]] auto supports_replace_body_with_xattr() const -> bool
+  {
+    return (major == 7 && minor == 1) || (major == 7 && minor > 1) || major > 7;
+  }
 };
 
 } // namespace test::utils


### PR DESCRIPTION
## Motivation

Instead of using the CAS from the existing staged mutation, we should use the CAS from the `transaction_get_result` that was given to the replace operation. The original behavior of using the CAS from the staged mutation is considered a spec bug.

A benefit of this approach is that post-ExtReplaceBodyWithXattr, the `transaction_get_result`, if fetched via a txn get operation, will come from a server read, which will include an up-to-date CAS. This means that the transaction will not fail if the document was “illegally” inserted outside the transaction after the transaction had created the staged insert.

The user will either have done a transactional get after the transactional insert to get the `transaction_get_result` passed to the replace, or have given the `transaction_get_result` that was returned by the txn insert. This means that the CAS in the `transaction_get_result` will be the one we have in the staged mutation or newer, so there’s no need to use the one from the staged mutation.

## Change
* When doing a txn replace for a document that already is a staged insert, create a staged insert with the CAS from the `transaction_get_result` passed to the `replace` operation instead of using the CAS from the existing staged mutation.

## Result
* Tests pass