### PR TITLE
CXXCBC-694: Handle case where requestID is missing from query response payload

### DIFF
--- a/core/operations/document_query.cxx
+++ b/core/operations/document_query.cxx
@@ -237,7 +237,9 @@ query_request::make_response(error_context::query&& ctx,
       response.ctx.ec = errc::common::parsing_failure;
       return response;
     }
-    response.meta.request_id = payload.at("requestID").get_string();
+    if (const auto* i = payload.find("requestID"); i != nullptr) {
+      response.meta.request_id = i->get_string();
+    }
 
     if (const auto* i = payload.find("clientContextID"); i != nullptr) {
       response.meta.client_context_id = i->get_string();

--- a/test/test_integration_query.cxx
+++ b/test/test_integration_query.cxx
@@ -59,6 +59,12 @@ TEST_CASE("integration: trivial non-data query", "[integration]")
     couchbase::core::operations::query_request req{ R"(SELECT "ruby rules" AS greeting)" };
     auto resp = test::utils::execute(integration.cluster, req);
     REQUIRE_SUCCESS(resp.ctx.ec);
+    REQUIRE(resp.rows.size() == 1);
+    REQUIRE(tao::json::from_string(resp.rows[0]) ==
+            tao::json::value{ { "greeting", "ruby rules" } });
+    REQUIRE_FALSE(resp.meta.client_context_id.empty());
+    REQUIRE_FALSE(resp.meta.request_id.empty());
+    REQUIRE(resp.meta.status == "success");
   }
 }
 


### PR DESCRIPTION
## Motivation

We noticed in a FIT run on CI that the SDK throws an exception in situations when an error was returned and requestID was missing. We should just leave it unset to prevent an out_of_range exception from being raised.

## Change

* Don't set request_id in query response if it's not present in the response payload.
* Update test to expect request_id to be non-empty so we catch any situations where an error hasn't occurred but request_id is missing (which would be a server bug)

