### PR TITLE
CXXCBC-700: update wan_develpment profile for public API

### DIFF
--- a/couchbase/wan_development_configuration_profile.hxx
+++ b/couchbase/wan_development_configuration_profile.hxx
@@ -21,7 +21,6 @@
 #include <couchbase/configuration_profile.hxx>
 
 #include <chrono>
-#include <string>
 
 namespace couchbase
 {
@@ -39,6 +38,8 @@ public:
     timeouts.analytics_timeout(std::chrono::minutes(2));
     timeouts.search_timeout(std::chrono::minutes(2));
     timeouts.management_timeout(std::chrono::minutes(2));
+    timeouts.resolve_timeout(std::chrono::seconds(20));  // timeout to resolve hostnames
+    timeouts.bootstrap_timeout(std::chrono::minutes(2)); // overall timeout to bootstrab
   }
 };
 } // namespace couchbase


### PR DESCRIPTION
Also this patch avoids to reuse connection timer for resolve and connect timeouts. With clean separation it is now easier to trace these events.