### PR TITLE
CXXCBC-675: Support vector search prefilter

### DIFF
--- a/core/impl/vector_query.cxx
+++ b/core/impl/vector_query.cxx
@@ -26,6 +26,14 @@ vector_query::encode() const -> encoded_search_query
 {
   encoded_search_query built;
   built.query = tao::json::empty_object;
+  if (prefilter_) {
+    auto [ec, encoded_prefilter] = prefilter_->encode();
+    if (ec) {
+      built.ec = ec;
+      return built;
+    }
+    built.query["filter"] = encoded_prefilter;
+  }
   if (boost_) {
     built.query["boost"] = boost_.value();
   }

--- a/core/meta/features.hxx
+++ b/core/meta/features.hxx
@@ -248,3 +248,8 @@
  * couchbase::transactions::transaction_query_options has a flex_index option
  */
 #define COUCHBASE_CXX_CLIENT_TRANSACTION_QUERY_OPTIONS_HAVE_FLEX_INDEX 1
+
+/**
+ * couchbase::vector_query has a prefilter option.
+ */
+#define COUCHBASE_CXX_CLIENT_HAS_VECTOR_SEARCH_PREFILTER 1

--- a/couchbase/vector_query.hxx
+++ b/couchbase/vector_query.hxx
@@ -1,5 +1,3 @@
-#include <utility>
-
 /* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
 /*
  *   Copyright 2023-Present Couchbase, Inc.
@@ -18,6 +16,12 @@
  */
 
 #pragma once
+
+#include <couchbase/search_query.hxx>
+
+#include <memory>
+#include <optional>
+#include <string>
 
 namespace couchbase
 {
@@ -102,6 +106,24 @@ public:
   }
 
   /**
+   * Sets a prefilter, which allows defining a subset of the vector index, over which the vector
+   * search will be executed.
+   *
+   * @param prefilter the prefilter search query
+   *
+   * @return this vector_query for chaining purposes.
+   *
+   * @since 1.2.0
+   * @committed
+   */
+  template<typename SearchQuery>
+  auto prefilter(SearchQuery prefilter) -> vector_query&
+  {
+    prefilter_ = std::make_shared<SearchQuery>(std::move(prefilter));
+    return *this;
+  }
+
+  /**
    * @return encoded representation of the query.
    *
    * @since 1.0.0
@@ -115,5 +137,6 @@ private:
   std::optional<std::vector<double>> vector_query_{};
   std::optional<std::string> base64_vector_query_{};
   std::optional<double> boost_{};
+  std::shared_ptr<search_query> prefilter_{};
 };
 } // namespace couchbase


### PR DESCRIPTION
## Motivation

Pre-filters allows users to run vector queries on a subset of the vector index.

## Change

Add a prefilter option on `couchbase::vector_query` allowing users to specify the search query that defines the filter.

## Results

All tests in FIT's `VectorSearchPrefilterTest` pass