### PR TITLE
CXXCBC-699: Allow to randomize list of bootstrap nodes

### DIFF
--- a/core/cluster.cxx
+++ b/core/cluster.cxx
@@ -350,9 +350,10 @@ public:
     }
 
     origin_ = std::move(origin);
-    CB_LOG_DEBUG(R"(open cluster, id: "{}", core version: "{}", {})",
+    CB_LOG_DEBUG(R"(open cluster, id: "{}", core version: "{}", connection string: {}, {})",
                  id_,
                  couchbase::core::meta::sdk_semver(),
+                 origin_.connection_string(),
                  origin_.to_json());
     setup_observability();
     if (origin_.options().enable_dns_srv) {

--- a/core/cluster_options.hxx
+++ b/core/cluster_options.hxx
@@ -107,6 +107,7 @@ public:
   std::chrono::milliseconds app_telemetry_backoff_interval{
     timeout_defaults::app_telemetry_backoff_interval
   };
+  bool preserve_bootstrap_nodes_order{ false };
 };
 
 } // namespace couchbase::core

--- a/core/impl/cluster.cxx
+++ b/core/impl/cluster.cxx
@@ -140,6 +140,7 @@ options_to_origin(const std::string& connection_string, const couchbase::cluster
   user_options.enable_mutation_tokens = opts.behavior.enable_mutation_tokens;
   user_options.enable_unordered_execution = opts.behavior.enable_unordered_execution;
   user_options.user_agent_extra = opts.behavior.user_agent_extra;
+  user_options.preserve_bootstrap_nodes_order = opts.behavior.preserve_bootstrap_nodes_order;
 
   user_options.server_group = opts.network.server_group;
   user_options.enable_tcp_keep_alive = opts.network.enable_tcp_keep_alive;

--- a/core/origin.hxx
+++ b/core/origin.hxx
@@ -55,29 +55,31 @@ struct origin {
          const std::string& port,
          cluster_options options);
   origin(cluster_credentials auth, const utils::connection_string& connstr);
-  origin& operator=(origin&& other) = default;
-  origin& operator=(const origin& other);
+  auto operator=(origin&& other) -> origin& = default;
+  auto operator=(const origin& other) -> origin&;
 
-  [[nodiscard]] const std::string& username() const;
-  [[nodiscard]] const std::string& password() const;
-  [[nodiscard]] const std::string& certificate_path() const;
-  [[nodiscard]] const std::string& key_path() const;
+  [[nodiscard]] auto connection_string() const -> const std::string&;
+  [[nodiscard]] auto username() const -> const std::string&;
+  [[nodiscard]] auto password() const -> const std::string&;
+  [[nodiscard]] auto certificate_path() const -> const std::string&;
+  [[nodiscard]] auto key_path() const -> const std::string&;
 
-  [[nodiscard]] std::vector<std::string> get_hostnames() const;
-  [[nodiscard]] std::vector<std::string> get_nodes() const;
+  [[nodiscard]] auto get_hostnames() const -> std::vector<std::string>;
+  [[nodiscard]] auto get_nodes() const -> std::vector<std::string>;
 
+  void shuffle_nodes();
   void set_nodes(node_list nodes);
   void set_nodes_from_config(const topology::configuration& config);
 
-  [[nodiscard]] std::pair<std::string, std::string> next_address();
+  [[nodiscard]] auto next_address() -> std::pair<std::string, std::string>;
 
-  [[nodiscard]] bool exhausted() const;
+  [[nodiscard]] auto exhausted() const -> bool;
 
   void restart();
 
-  [[nodiscard]] const couchbase::core::cluster_options& options() const;
-  [[nodiscard]] couchbase::core::cluster_options& options();
-  [[nodiscard]] const couchbase::core::cluster_credentials& credentials() const;
+  [[nodiscard]] auto options() const -> const couchbase::core::cluster_options&;
+  [[nodiscard]] auto options() -> couchbase::core::cluster_options&;
+  [[nodiscard]] auto credentials() const -> const couchbase::core::cluster_credentials&;
   [[nodiscard]] auto to_json() const -> std::string;
 
 private:
@@ -86,6 +88,7 @@ private:
   node_list nodes_{};
   node_list::iterator next_node_{};
   bool exhausted_{ false };
+  std::string connection_string_{};
 };
 
 } // namespace couchbase::core

--- a/core/utils/connection_string.cxx
+++ b/core/utils/connection_string.cxx
@@ -586,6 +586,8 @@ extract_options(connection_string& connstr)
       parse_option(connstr.options.enable_app_telemetry, name, value, connstr.warnings);
     } else if (name == "app_telemetry_endpoint") {
       parse_option(connstr.options.app_telemetry_endpoint, name, value, connstr.warnings);
+    } else if (name == "preserve_bootstrap_nodes_order") {
+      parse_option(connstr.options.preserve_bootstrap_nodes_order, name, value, connstr.warnings);
     } else {
       connstr.warnings.push_back(
         fmt::format(R"(unknown parameter "{}" in connection string (value "{}"))", name, value));
@@ -598,6 +600,7 @@ auto
 parse_connection_string(const std::string& input, cluster_options options) -> connection_string
 {
   connection_string res{};
+  res.input = input;
   res.options = std::move(options);
 
   if (input.empty()) {

--- a/core/utils/connection_string.hxx
+++ b/core/utils/connection_string.hxx
@@ -57,6 +57,7 @@ struct connection_string {
     }
   };
 
+  std::string input;
   std::string scheme{ "couchbase" };
   bool tls{ false };
   std::map<std::string, std::string> params{};

--- a/couchbase/behavior_options.hxx
+++ b/couchbase/behavior_options.hxx
@@ -67,6 +67,12 @@ public:
     return *this;
   }
 
+  auto preserve_bootstrap_nodes_order(bool enable) -> behavior_options&
+  {
+    preserve_bootstrap_nodes_order_ = enable;
+    return *this;
+  }
+
   struct built {
     std::string user_agent_extra;
     bool show_queries;
@@ -75,6 +81,7 @@ public:
     bool enable_unordered_execution;
     bool dump_configuration;
     std::string network;
+    bool preserve_bootstrap_nodes_order;
   };
 
   [[nodiscard]] auto build() const -> built
@@ -87,6 +94,7 @@ public:
       enable_unordered_execution_,
       dump_configuration_,
       network_,
+      preserve_bootstrap_nodes_order_,
     };
   }
 
@@ -98,5 +106,6 @@ private:
   bool enable_unordered_execution_{ true };
   bool dump_configuration_{ false };
   std::string network_{ "auto" };
+  bool preserve_bootstrap_nodes_order_{ false };
 };
 } // namespace couchbase


### PR DESCRIPTION
By default the SDK would shuffle node list (including list received via DNS-SRV request). To disable this behavior use `preserve_bootstrap_nodes_order` option.