### PR TITLE
CXXCBC-704: Return unwrapped document_unretrievable error from get_replica_from_preferred_server_group

### DIFF
--- a/core/transactions/attempt_context_impl.cxx
+++ b/core/transactions/attempt_context_impl.cxx
@@ -450,10 +450,8 @@ attempt_context_impl::get_replica_from_preferred_server_group(
                     .no_rollback());
               case FAIL_OTHER:
                 if (cause == DOCUMENT_UNRETRIEVABLE_EXCEPTION) {
-                  return self->op_completed_with_callback(
-                    std::move(cb),
-                    transaction_operation_failed(FAIL_OTHER, cause, "failed to retrieve document"),
-                    std::move(res));
+                  return self->op_completed_with_error(
+                    std::move(cb), document_unretrievable("failed to retrieve document"));
                 }
                 [[fallthrough]];
               default: {

--- a/core/transactions/exceptions.hxx
+++ b/core/transactions/exceptions.hxx
@@ -235,6 +235,17 @@ public:
   }
 };
 
+class document_unretrievable : public op_exception
+{
+public:
+  explicit document_unretrievable(const std::string& what)
+    : op_exception({ errc::transaction_op::document_unretrievable },
+                   what,
+                   DOCUMENT_UNRETRIEVABLE_EXCEPTION)
+  {
+  }
+};
+
 class query_attempt_not_found : public op_exception
 {
 public:


### PR DESCRIPTION
## Motivation

According to the [specification](https://github.com/couchbaselabs/couchbase-transactions-specs/blob/dd156f0a0ecbfc78d7c442433932c390ccf61892/transactions-stages.md?plain=1#L867), the SDK shouldn't wrap `document_unretrievable` errors in a `transaction_operation_failed` error:
> If lookupInAnyReplica() raises `DocumentUnretrievableException` or `FeatureNotAvailable`, this is raised directly to the lambda.  E.g. this joins the very small list of cases where failures to not set internal state that guarantees this attempt will fail, and allows the user to catch and ignore the error (and more usefully - to fallback to a regular ctx.get()).

Currently, we correctly don't cache the error internally, which allows users to 'catch' it, but we still wrap it in `transaction_operation_failed`. The convention we must follow is that `transaction_operation_failed` always sets internal state and indicates the error cannot be handled to prevent a rollback.

## Change

When the replica get fails with `document_unretrievable` return it without wrapping it in a `transaction_operation_failed` error.

## Results

Relevant FIT tests in `ExtReplicaFromPreferredServerGroupTest` pass – `docDoesNotExist` and `canContinueAfterDocUnretrievable` 