### PR TITLE
CXXCBC-704: Handle document_unretrievable from get_multi individual fetch

### DIFF
--- a/core/transactions/get_multi_orchestrator.cxx
+++ b/core/transactions/get_multi_orchestrator.cxx
@@ -181,6 +181,8 @@ classify_error(const std::exception_ptr& err) -> classified_error
 {
   try {
     std::rethrow_exception(err);
+  } catch (const op_exception& e) {
+    return classified_error{ error_class_from_external_exception(e.cause()), e.cause() };
   } catch (const transaction_operation_failed& e) {
     return classified_error{ e.ec(), e.cause() };
   } catch (...) {


### PR DESCRIPTION
## Motivation
Fetching a replica now raises a document_unretrievable error that is not wrapped in a transaction_operation_failed. The get_multi error handling should be updated to handle that.

## Change

In get_multi_orchestrator's classify_error method, add handling for `op_exception`

## Results

ExtGetMultiMissingDocsTest which was previously failing now passes
