### PR TITLE
CXXCBC-709: Fix exists() in transactions get_multi result

### DIFF
--- a/core/transactions/transaction_get_multi_replicas_from_preferred_server_group_result.hxx
+++ b/core/transactions/transaction_get_multi_replicas_from_preferred_server_group_result.hxx
@@ -52,7 +52,8 @@ public:
 
   [[nodiscard]] auto exists(std::size_t spec_index) const -> bool
   {
-    return spec_index >= content_.size() && content_[spec_index].has_value();
+    Expects(spec_index < content_.size());
+    return content_[spec_index].has_value();
   }
 
   [[nodiscard]] auto content() const -> const std::vector<std::optional<codec::encoded_value>>&

--- a/core/transactions/transaction_get_multi_result.hxx
+++ b/core/transactions/transaction_get_multi_result.hxx
@@ -47,7 +47,8 @@ public:
 
   [[nodiscard]] auto exists(std::size_t spec_index) const -> bool
   {
-    return spec_index >= content_.size() && content_[spec_index].has_value();
+    Expects(spec_index < content_.size());
+    return content_[spec_index].has_value();
   }
 
   [[nodiscard]] auto content() const -> const std::vector<std::optional<codec::encoded_value>>&

--- a/couchbase/transactions/transaction_get_multi_replicas_from_preferred_server_group_result.hxx
+++ b/couchbase/transactions/transaction_get_multi_replicas_from_preferred_server_group_result.hxx
@@ -91,7 +91,10 @@ public:
    */
   [[nodiscard]] auto exists(std::size_t spec_index) const -> bool
   {
-    return spec_index >= content_.size() && content_[spec_index].has_value();
+    if (spec_index >= content_.size()) {
+      throw std::invalid_argument("spec index " + std::to_string(spec_index) + " is not valid");
+    }
+    return content_[spec_index].has_value();
   }
 
 private:

--- a/couchbase/transactions/transaction_get_multi_result.hxx
+++ b/couchbase/transactions/transaction_get_multi_result.hxx
@@ -85,7 +85,10 @@ public:
    */
   [[nodiscard]] auto exists(std::size_t spec_index) const -> bool
   {
-    return spec_index >= content_.size() && content_[spec_index].has_value();
+    if (spec_index >= content_.size()) {
+      throw std::invalid_argument("spec index " + std::to_string(spec_index) + " is not valid");
+    }
+    return content_[spec_index].has_value();
   }
 
 private:


### PR DESCRIPTION
The `exists` method in transactions get_multi results is always returning `false`, as `spec_index >= content_.size()` is _always_ false for valid spec indexes.