### PR TITLE
CXXCBC-420: external_exception NOT_SET should not set to generic error code

### DIFF
--- a/core/impl/error.cxx
+++ b/core/impl/error.cxx
@@ -218,8 +218,7 @@ make_error(const couchbase::core::transactions::transaction_operation_failed& co
   return { couchbase::errc::transaction_op::transaction_op_failed,
            core_tof.what(),
            internal_error_context::build_error_context(tao::json::empty_object, core_tof),
-           error(errc::make_error_code(
-             transaction_op_errc_from_external_exception(core_tof.cause()))) };
+           error(transaction_op_errc_from_external_exception(core_tof.cause())) };
 }
 } // namespace core::impl
 } // namespace couchbase

--- a/core/transactions/exceptions.cxx
+++ b/core/transactions/exceptions.cxx
@@ -112,12 +112,13 @@ transaction_exception::transaction_exception(const std::runtime_error& cause,
 }
 
 auto
-transaction_op_errc_from_external_exception(external_exception e) -> errc::transaction_op
+transaction_op_errc_from_external_exception(external_exception e) -> std::error_code
 {
   switch (e) {
+    case external_exception::NOT_SET:
+      return {};
     case external_exception::UNKNOWN:
     case external_exception::COUCHBASE_EXCEPTION:
-    case external_exception::NOT_SET:
       return errc::transaction_op::generic;
     case external_exception::ACTIVE_TRANSACTION_RECORD_ENTRY_NOT_FOUND:
       return errc::transaction_op::active_transaction_record_entry_not_found;

--- a/core/transactions/exceptions.hxx
+++ b/core/transactions/exceptions.hxx
@@ -67,8 +67,7 @@ enum external_exception {
 };
 
 auto
-transaction_op_errc_from_external_exception(external_exception e)
-  -> couchbase::errc::transaction_op;
+transaction_op_errc_from_external_exception(external_exception e) -> std::error_code;
 
 auto
 external_exception_from_transaction_op_errc(couchbase::errc::transaction_op ec)

--- a/core/transactions/internal/exceptions_internal.hxx
+++ b/core/transactions/internal/exceptions_internal.hxx
@@ -290,7 +290,7 @@ public:
 
   [[nodiscard]] transaction_op_error_context get_error_ctx() const
   {
-    errc::transaction_op ec = transaction_op_errc_from_external_exception(cause_);
+    std::error_code ec = transaction_op_errc_from_external_exception(cause_);
     return { ec };
   }
 


### PR DESCRIPTION
Motivation
----------
Exception propagation FIT tests were failing, which uncovered that we were setting the NOT_SET external exception to a generic error code

Changes
-------
Change NOT_SET to return an unset error code, including the conversion function