### PR TITLE
CXXCBC-692: Operational SDK prevent connection to Analytics 2.0 Cluster

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,6 +405,7 @@ set(couchbase_cxx_client_FILES
     core/scan_result.cxx
     core/search_query_options.cxx
     core/seed_config.cxx
+    core/topology/capabilities.cxx
     core/topology/configuration.cxx
     core/tracing/threshold_logging_tracer.cxx
     core/tracing/tracer_wrapper.cxx

--- a/core/cluster_options.hxx
+++ b/core/cluster_options.hxx
@@ -108,6 +108,7 @@ public:
     timeout_defaults::app_telemetry_backoff_interval
   };
   bool preserve_bootstrap_nodes_order{ false };
+  bool allow_enterprise_analytics{ false };
 };
 
 } // namespace couchbase::core

--- a/core/topology/capabilities.cxx
+++ b/core/topology/capabilities.cxx
@@ -1,0 +1,51 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2022-present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "capabilities.hxx"
+
+#include "core/logger/logger.hxx"
+
+namespace couchbase::core
+{
+auto
+configuration_capabilities::supports_operational_client(const cluster_options& options) const
+  -> bool
+{
+  if (options.allow_enterprise_analytics) {
+    CB_LOG_DEBUG("Bypassing cluster prod_name check as allow_enterprise_analytics is enabled");
+    return true;
+  }
+
+  if (!prod_name.has_value()) {
+    return true;
+  }
+
+  if (prod_name.value().rfind("Couchbase Server", 0) == 0) {
+    return true;
+  }
+
+  std::string msg = fmt::format("This {} cluster cannot be used with this SDK, which is intended "
+                                "for use with operational clusters. ",
+                                prod_name.value());
+  if (prod_name.value().rfind("Enterprise Analytics", 0) == 0) {
+    msg.append("For this cluster, an Enterprise Analytics SDK should be used.");
+  }
+  CB_LOG_ERROR(msg);
+
+  return false;
+}
+} // namespace couchbase::core

--- a/core/topology/capabilities.hxx
+++ b/core/topology/capabilities.hxx
@@ -19,6 +19,8 @@
 
 #include <set>
 
+#include "core/cluster_options.hxx"
+
 namespace couchbase::core
 {
 enum class bucket_capability {
@@ -59,6 +61,7 @@ enum class cluster_capability {
 struct configuration_capabilities {
   std::set<bucket_capability> bucket{};
   std::set<cluster_capability> cluster{};
+  std::optional<std::string> prod_name{};
 
   [[nodiscard]] auto has_cluster_capability(cluster_capability cap) const -> bool
   {
@@ -111,6 +114,8 @@ struct configuration_capabilities {
   {
     return has_cluster_capability(cluster_capability::search_vector_search);
   }
+
+  [[nodiscard]] auto supports_operational_client(const cluster_options& options) const -> bool;
 };
 
 } // namespace couchbase::core

--- a/core/topology/configuration.hxx
+++ b/core/topology/configuration.hxx
@@ -102,6 +102,7 @@ struct configuration {
   node_locator_type node_locator{ node_locator_type::unknown };
   std::optional<std::string> cluster_name{};
   std::optional<std::string> cluster_uuid{};
+  std::optional<std::string> prod_name{};
   bool force{ false };
 
   auto operator==(const configuration& other) const -> bool

--- a/core/topology/configuration_json.hxx
+++ b/core/topology/configuration_json.hxx
@@ -332,6 +332,10 @@ struct traits<couchbase::core::topology::configuration> {
     if (const auto u = v.find("clusterUUID"); u != nullptr) {
       result.cluster_uuid = u->get_string();
     }
+    if (const auto n = v.find("prodName"); n != nullptr) {
+      result.prod_name = n->get_string();
+      result.capabilities.prod_name = result.prod_name;
+    }
 
     return result;
   }

--- a/core/utils/connection_string.cxx
+++ b/core/utils/connection_string.cxx
@@ -588,6 +588,8 @@ extract_options(connection_string& connstr)
       parse_option(connstr.options.app_telemetry_endpoint, name, value, connstr.warnings);
     } else if (name == "preserve_bootstrap_nodes_order") {
       parse_option(connstr.options.preserve_bootstrap_nodes_order, name, value, connstr.warnings);
+    } else if (name == "allow_enterprise_analytics") {
+      parse_option(connstr.options.allow_enterprise_analytics, name, value, connstr.warnings);
     } else {
       connstr.warnings.push_back(
         fmt::format(R"(unknown parameter "{}" in connection string (value "{}"))", name, value));


### PR DESCRIPTION
Changes:
- Add prodName cluster config field
- Add config prodName check to config capabilities to block the SDK from connecting to Analytics2