### PR TITLE
[backport] CXXCBC-693: Handle empty/null indexDefs

### DIFF
--- a/core/operations/management/search_index_get_all.cxx
+++ b/core/operations/management/search_index_get_all.cxx
@@ -71,8 +71,8 @@ search_index_get_all_request::make_response(error_context::http&& ctx,
         for (const auto& [name, index] : indexes->get_object()) {
           response.indexes.emplace_back(index.as<couchbase::core::management::search::index>());
         }
-        return response;
       }
+      return response;
     } else if (encoded.status_code == 404) {
       tao::json::value payload{};
       try {


### PR DESCRIPTION
Changes
=======
* Do not return an error if/when indexDefs are empty/null. Instead return w/ an empty list of index definitions.