### PR TITLE
CXXCBC-651: Preserve cached node labels after generating report in app telemetry meter

### DIFF
--- a/core/app_telemetry_meter.hxx
+++ b/core/app_telemetry_meter.hxx
@@ -20,6 +20,7 @@
 #include <chrono>
 #include <cstdint>
 #include <memory>
+#include <shared_mutex>
 #include <string>
 #include <vector>
 
@@ -175,9 +176,9 @@ class app_telemetry_meter
 {
 public:
   app_telemetry_meter();
-  app_telemetry_meter(app_telemetry_meter&&) = default;
+  app_telemetry_meter(app_telemetry_meter&&) = delete;
   app_telemetry_meter(const app_telemetry_meter&) = delete;
-  auto operator=(app_telemetry_meter&&) -> app_telemetry_meter& = default;
+  auto operator=(app_telemetry_meter&&) -> app_telemetry_meter& = delete;
   auto operator=(const app_telemetry_meter&) -> app_telemetry_meter& = delete;
   ~app_telemetry_meter();
 
@@ -193,6 +194,7 @@ public:
 private:
   std::string agent_;
   std::unique_ptr<app_telemetry_meter_impl> impl_;
+  std::shared_mutex impl_mutex_{};
 };
 
 } // namespace couchbase::core


### PR DESCRIPTION
## Motivation

When a report is generated, we replace the existing `app_telemetry_meter_impl` with a new instance of a `default_app_telemetry_meter_impl`. This means that the existing node labels cache will be empty, until a new config is seen, and any subsequent reports will possibly have empty `node` and `alt_node` attributes.

## Changes

* When creating the new `default_app_telemetry_meter_impl` instance, set its node labels cache to the value it had in the old `app_telemetry_meter_impl` instance.
* Add a shared lock to protect the `impl_` pointer, as it can be modified and accessed from different threads at the same time.

## Results

ApplicationTelemetrySocketTest in FIT now passes, with the exception of some assertions failing due to [CXXCBC-650](https://jira.issues.couchbase.com/browse/CXXCBC-650).

[CXXCBC-650]: https://couchbasecloud.atlassian.net/browse/CXXCBC-650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ