### PR TITLE
[release-1.1] GHA: Remove windows-2019 & add windows-2025

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, windows-2019]
+        os: [windows-2025, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install dependencies


### PR DESCRIPTION
Windows Server 2019 runners have been retired