### PR TITLE
CXXCBC-707: update network selection heuristic

### DIFF
--- a/core/topology/configuration.cxx
+++ b/core/topology/configuration.cxx
@@ -196,14 +196,13 @@ auto
 configuration::select_network(const std::string& bootstrap_hostname) const -> std::string
 {
   for (const auto& n : nodes) {
-    if (n.this_node) {
-      if (n.hostname == bootstrap_hostname) {
-        return "default";
-      }
-      for (const auto& [network, address] : n.alt) {
-        if (address.hostname == bootstrap_hostname) {
-          return network;
-        }
+    if (n.hostname == bootstrap_hostname) {
+      return "default";
+    }
+
+    if (auto network = n.alt.find("external"); network != n.alt.end()) {
+      if (network->second.hostname == bootstrap_hostname) {
+        return "external";
       }
     }
   }


### PR DESCRIPTION
* check all nodes, not just node marked with 'thisNode=true' property when selecting the network

* only check default and "external" networks