### PR TITLE
CXXCBC-692: Add way to disable enterprise analytics check programmatically

### DIFF
--- a/core/cluster.cxx
+++ b/core/cluster.cxx
@@ -272,6 +272,9 @@ is_feature_supported(const operations::analytics_request& /*request*/,
                      const configuration_capabilities& capabilities,
                      const cluster_options& options) -> bool
 {
+  if (operations::analytics_request::allow_enterprise_analytics) {
+    return true;
+  }
   return !capabilities.is_analytics_cluster(options);
 }
 

--- a/core/operations/document_analytics.hxx
+++ b/core/operations/document_analytics.hxx
@@ -82,6 +82,8 @@ struct analytics_request {
   static const inline service_type type = service_type::analytics;
   static const inline std::string observability_identifier = "analytics";
 
+  static inline bool allow_enterprise_analytics = false;
+
   std::string statement;
 
   bool readonly{ false };


### PR DESCRIPTION
This makes it possible to disable the EA check application-wide. Similarly to what has been implemented in the [JVM SDKs](https://github.com/couchbase/couchbase-jvm-clients/blob/ecbd12d73847b5da76055f46c19ddb07257f6938/core-io/src/main/java/com/couchbase/client/core/classic/analytics/AnalyticsHelper.java#L35-L43):

```cpp
#include <core/operations/document_analytics.hxx>

core::operations::analytics_request::allow_enterprise_analytics = true;
```