### PR TITLE
[backport] CXXCBC-715: Hard Failover Intermittent Crash

### DIFF
--- a/core/io/http_session_manager.hxx
+++ b/core/io/http_session_manager.hxx
@@ -114,8 +114,11 @@ public:
   void update_config(topology::configuration config) override
   {
     {
-      std::scoped_lock config_lock(config_mutex_, sessions_mutex_);
+      std::scoped_lock config_lock(config_mutex_, sessions_mutex_, next_index_mutex_);
       config_ = std::move(config);
+      if (!config_.nodes.empty() && next_index_ >= config_.nodes.size()) {
+        next_index_ = 0;
+      }
       for (auto& [type, sessions] : idle_sessions_) {
         sessions.remove_if([&opts = options_, &cfg = config_](const auto& session) {
           return session && !cfg.has_node(opts.network,

--- a/tools/analytics.cxx
+++ b/tools/analytics.cxx
@@ -170,18 +170,14 @@ public:
                                   : do_analytics(cluster, statement, analytics_options))
                              .get();
 
+      auto ctx = error.ctx() && error.ctx().impl()
+                   ? error.ctx().impl()->as<couchbase::core::error_context::analytics>()
+                   : couchbase::core::error_context::analytics{};
+
       if (json_lines_) {
-        print_result_json_line(scope_id,
-                               statement,
-                               error.ctx().impl()->as<couchbase::core::error_context::analytics>(),
-                               resp,
-                               analytics_options);
+        print_result_json_line(scope_id, statement, ctx, resp, analytics_options);
       } else {
-        print_result(scope_id,
-                     statement,
-                     error.ctx().impl()->as<couchbase::core::error_context::analytics>(),
-                     resp,
-                     analytics_options);
+        print_result(scope_id, statement, ctx, resp, analytics_options);
       }
     }
 


### PR DESCRIPTION
Motivation
===========
An HTTP workload can potentially use an invalid node index to access a node in the config in scenarios to where a node in the cluster has been failed over.

Changes
=======
* Upon updating the config w/in the HTTP Session manager, reset the next node index if its current value is greater than or equal to the number of nodes in the new config
* Update analytics tool to only populate error context if the analytics operation has an error