### PR TITLE
Add labels to all tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Validate test labels
+        run: ./bin/validate-test-labels
       - name: Initialize couchbase for transactions testing
         if: ${{ matrix.suite  == 'transaction' }}
         env:

--- a/bin/validate-test-labels
+++ b/bin/validate-test-labels
@@ -1,0 +1,52 @@
+#!/usr/bin/env ruby
+
+require 'find'
+require 'set'
+
+ALLOWED_LABELS = [
+    'unit',
+    'integration',
+    'benchmark',
+    'transactions',
+].freeze
+
+test_dir = File.expand_path('../test', __dir__)
+tests_missing_label = []
+invalid_labels = Set[]
+
+Find.find(test_dir) do |path|
+    next unless File.file?(path)
+    next unless File.basename(path).start_with?('test_')
+    content = File.read(path)
+    content.delete("\n").scan(/TEST_CASE\(("(.*?)")\)/) do |match|
+        labels = match[0].scan(/\[(.*?)\]/)
+        if labels.empty?
+            tests_missing_label << "#{match[0]} (#{path})"
+        else
+            labels.flatten.each do |label|
+                unless ALLOWED_LABELS.include?(label)
+                    invalid_labels << label
+                end
+            end
+        end
+    end
+end
+
+unless tests_missing_label.empty?
+    puts "Tests missing label:"
+    tests_missing_label.each do |test|
+        puts "  #{test}"
+    end
+end
+
+unless invalid_labels.empty?
+    puts "Invalid labels found:"
+    invalid_labels.each do |label|
+        puts "  #{label}"
+    end
+end
+
+unless tests_missing_label.empty? && invalid_labels.empty?
+    puts "\nERROR: Missing or unexpected test labels found. This can result in tests not being run in CI."
+    exit 1
+end

--- a/test/test_integration_analytics.cxx
+++ b/test/test_integration_analytics.cxx
@@ -35,7 +35,7 @@
 #include "core/operations/management/collection_create.hxx"
 #include "core/operations/management/collections.hxx"
 
-TEST_CASE("integration: analytics query")
+TEST_CASE("integration: analytics query", "[integration]")
 {
   test::utils::integration_test_guard integration;
 
@@ -208,7 +208,7 @@ TEST_CASE("integration: analytics query")
   }
 }
 
-TEST_CASE("integration: analytics scope query")
+TEST_CASE("integration: analytics scope query", "[integration]")
 {
   test::utils::integration_test_guard integration;
 
@@ -304,7 +304,7 @@ make_http_context()
   return ctx;
 }
 
-TEST_CASE("unit: analytics query")
+TEST_CASE("unit: analytics query", "[unit]")
 {
   SECTION("priority true")
   {
@@ -331,7 +331,7 @@ TEST_CASE("unit: analytics query")
   }
 }
 
-TEST_CASE("integration: public API analytics query")
+TEST_CASE("integration: public API analytics query", "[integration]")
 {
   test::utils::integration_test_guard integration;
 
@@ -540,7 +540,7 @@ TEST_CASE("integration: public API analytics query")
   }
 }
 
-TEST_CASE("integration: public API analytics scope query")
+TEST_CASE("integration: public API analytics scope query", "[integration]")
 {
   test::utils::integration_test_guard integration;
 

--- a/test/test_integration_columnar_query.cxx
+++ b/test/test_integration_columnar_query.cxx
@@ -339,7 +339,7 @@ TEST_CASE("integration: columnar query component request with database & scope n
   REQUIRE(row_count == 100);
 }
 
-TEST_CASE("integration: columnar query read some rows and cancel")
+TEST_CASE("integration: columnar query read some rows and cancel", "[integration]")
 {
   test::utils::integration_test_guard integration;
   if (!integration.cluster_version().is_columnar()) {
@@ -390,7 +390,7 @@ TEST_CASE("integration: columnar query read some rows and cancel")
   REQUIRE_FALSE(result.metadata().has_value());
 }
 
-TEST_CASE("integration: columnar query cancel operation")
+TEST_CASE("integration: columnar query cancel operation", "[integration]")
 {
   test::utils::integration_test_guard integration;
   if (!integration.cluster_version().is_columnar()) {
@@ -413,7 +413,7 @@ TEST_CASE("integration: columnar query cancel operation")
   REQUIRE(err.ec == couchbase::core::columnar::client_errc::canceled);
 }
 
-TEST_CASE("integration: columnar query operation timeout")
+TEST_CASE("integration: columnar query operation timeout", "[integration]")
 {
   test::utils::integration_test_guard integration;
   if (!integration.cluster_version().is_columnar()) {
@@ -437,7 +437,7 @@ TEST_CASE("integration: columnar query operation timeout")
   REQUIRE(err.ec == couchbase::core::columnar::errc::timeout);
 }
 
-TEST_CASE("integration: columnar query global timeout")
+TEST_CASE("integration: columnar query global timeout", "[integration]")
 {
   test::utils::integration_test_guard integration;
   if (!integration.cluster_version().is_columnar()) {
@@ -462,7 +462,7 @@ TEST_CASE("integration: columnar query global timeout")
   REQUIRE(err.ec == couchbase::core::columnar::errc::timeout);
 }
 
-TEST_CASE("integration: columnar query collection does not exist")
+TEST_CASE("integration: columnar query collection does not exist", "[integration]")
 {
   test::utils::integration_test_guard integration;
   if (!integration.cluster_version().is_columnar()) {
@@ -498,7 +498,7 @@ TEST_CASE("integration: columnar query collection does not exist")
   REQUIRE(err.message_with_ctx().find("\"code\":24045") != std::string::npos);
 }
 
-TEST_CASE("integration: columnar query positional parameters")
+TEST_CASE("integration: columnar query positional parameters", "[integration]")
 {
   test::utils::integration_test_guard integration;
   if (!integration.cluster_version().is_columnar()) {
@@ -526,7 +526,7 @@ TEST_CASE("integration: columnar query positional parameters")
           tao::json::value{ { "foo", "bar" } });
 }
 
-TEST_CASE("integration: columnar query named parameters")
+TEST_CASE("integration: columnar query named parameters", "[integration]")
 {
   test::utils::integration_test_guard integration;
   if (!integration.cluster_version().is_columnar()) {
@@ -554,7 +554,7 @@ TEST_CASE("integration: columnar query named parameters")
           tao::json::value{ { "foo", "bar" } });
 }
 
-TEST_CASE("integration: closing cluster before columnar query returns")
+TEST_CASE("integration: closing cluster before columnar query returns", "[integration]")
 {
   test::utils::integration_test_guard integration;
   if (!integration.cluster_version().is_columnar()) {
@@ -585,7 +585,7 @@ TEST_CASE("integration: closing cluster before columnar query returns")
   REQUIRE(err.ec == couchbase::core::columnar::client_errc::canceled);
 }
 
-TEST_CASE("integration: closing cluster while reading columnar query rows")
+TEST_CASE("integration: closing cluster while reading columnar query rows", "[integration]")
 {
   test::utils::integration_test_guard integration;
   if (!integration.cluster_version().is_columnar()) {

--- a/test/test_integration_query.cxx
+++ b/test/test_integration_query.cxx
@@ -513,7 +513,7 @@ TEST_CASE("integration: sticking query to the service node", "[integration]")
   }
 }
 
-TEST_CASE("analytics create dataset")
+TEST_CASE("integration: analytics create dataset", "[integration]")
 {
   test::utils::integration_test_guard integration;
 

--- a/test/test_integration_search.cxx
+++ b/test/test_integration_search.cxx
@@ -44,7 +44,7 @@
 
 using Catch::Matchers::StartsWith;
 
-TEST_CASE("integration: search query")
+TEST_CASE("integration: search query", "[integration]")
 {
   test::utils::integration_test_guard integration;
 
@@ -506,7 +506,7 @@ TEST_CASE("integration: search query consistency", "[integration]")
   }
 }
 
-TEST_CASE("integration: search query collections")
+TEST_CASE("integration: search query collections", "[integration]")
 {
   test::utils::integration_test_guard integration;
 

--- a/test/test_integration_subdoc.cxx
+++ b/test/test_integration_subdoc.cxx
@@ -1007,7 +1007,7 @@ TEST_CASE("integration: subdoc multi mutation", "[integration]")
   }
 }
 
-TEST_CASE("integration: subdoc expiry")
+TEST_CASE("integration: subdoc expiry", "[integration]")
 {
   test::utils::integration_test_guard integration;
 

--- a/test/test_unit_management_search_index.cxx
+++ b/test/test_unit_management_search_index.cxx
@@ -19,7 +19,7 @@
 
 #include "core/management/search_index.hxx"
 
-TEST_CASE("unit: can determine if an index is a vector index")
+TEST_CASE("unit: can determine if an index is a vector index", "[unit]")
 {
   SECTION("vector index")
   {

--- a/test/test_unit_query.cxx
+++ b/test/test_unit_query.cxx
@@ -78,7 +78,7 @@ TEST_CASE("unit: query with read from replica", "[unit]")
   }
 }
 
-TEST_CASE("unit: Public API query options - add/clear parameters")
+TEST_CASE("unit: Public API query options - add/clear parameters", "[unit]")
 {
   SECTION("positional parameters")
   {


### PR DESCRIPTION
Some of our tests didn't have an 'integration' or 'unit' label. On GitHub Actions we use these labels to filter tests, which means that tests without a label weren't running on GHA.

Also added a script to verify that all tests have one of the known labels, to prevent any tests without a label from being added in the future.