### PR TITLE
CXXCBC-718: Use cbdinocluster for GitHub Actions

### DIFF
--- a/.github/actions/create-cluster/action.yml
+++ b/.github/actions/create-cluster/action.yml
@@ -1,0 +1,77 @@
+name: create-cluster
+description: Sets up a Couchbase cluster using cbdinocluster
+inputs:
+  version:
+    description: 'Couchbase Server version to use'
+    required: true
+  suite:
+    description: 'Test suite the cluster is being created for'
+    required: true
+outputs:
+  ip:
+    description: 'The IP address of a node of the cluster'
+    value: ${{ steps.start-cluster.outputs.ip }}
+  connstr:
+    description: 'Connection string to connect to the cluster'
+    value: ${{ steps.start-cluster.outputs.connstr }}
+  tls-connstr:
+    description: 'Connection string to connect to the cluster over TLS'
+    value: ${{ steps.start-cluster.outputs.tls-connstr }}
+  id:
+    description: 'The cbdinocluster ID of the created cluster'
+    value: ${{ steps.start-cluster.outputs.id }}
+runs:
+  using: composite
+  steps:
+    - name: Install cbdinocluster
+      shell: bash
+      run: |
+        mkdir -p "$HOME/bin"
+        wget -nv -O $HOME/bin/cbdinocluster https://github.com/couchbaselabs/cbdinocluster/releases/download/v0.0.86/cbdinocluster-linux-amd64
+        chmod +x $HOME/bin/cbdinocluster
+        echo "$HOME/bin" >> $GITHUB_PATH
+    - name: Initialize cbdinocluster
+      shell: bash
+      run: |
+        cbdinocluster -v init --auto
+    - name: Start Couchbase cluster
+      id: start-cluster
+      shell: bash
+      env:
+        CLUSTER_CONFIG: |
+          nodes:
+            - count: 1
+              version: ${{ inputs.version }}
+              services: [kv, n1ql, index]
+            - count: 1
+              version: ${{ inputs.version }}
+              services: [kv, fts]
+            - count: 1
+              version: ${{ inputs.version }}
+              services: [kv, cbas, eventing]
+          docker:
+            kv-memory: 2048
+            fts-memory: 2048
+          expiry: 4h
+      run: |
+        CBDC_ID=$(cbdinocluster -v alloc --def="${CLUSTER_CONFIG}")
+        echo "CBDC_ID=$CBDC_ID" >> "$GITHUB_ENV"
+        echo "ip=$(cbdinocluster -v ip $CBDC_ID)" >> "$GITHUB_OUTPUT"
+        echo "connstr=$(cbdinocluster -v connstr --no-tls $CBDC_ID)" >> "$GITHUB_OUTPUT"
+        echo "tls-connstr=$(cbdinocluster -v connstr --tls $CBDC_ID)" >> "$GITHUB_OUTPUT"
+        echo "id=$CBDC_ID" >> "$GITHUB_OUTPUT"
+        cbdinocluster certificates get-ca $CBDC_ID >> "$GITHUB_WORKSPACE/cluster.crt"
+    - name: Add default bucket
+      shell: bash
+      run: |
+        cbdinocluster buckets add $CBDC_ID default --ram-quota-mb 100
+    - name: Add second bucket for transactions
+      shell: bash
+      if: ${{ inputs.suite == 'transaction' }}
+      run: |
+        cbdinocluster buckets add $CBDC_ID secBucket --ram-quota-mb 100
+    - name: Load travel-sample bucket
+      shell: bash
+      if: ${{ inputs.suite == 'unit' }}
+      run: |
+        cbdinocluster buckets load-sample $CBDC_ID travel-sample

--- a/.github/actions/remove-cluster/action.yml
+++ b/.github/actions/remove-cluster/action.yml
@@ -1,0 +1,13 @@
+name: remove-cluster
+description: Removes a cbdinocluster cluster
+inputs:
+  id:
+    description: 'cbdinocluster ID'
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Remove cbdinocluster cluster
+      shell: bash
+      run: |
+        cbdinocluster -v rm ${{ inputs.id }}

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         server:
-          - 7.6.5
+          - 7.6.7
         sanitizer:
           - asan
           - lsan
@@ -32,14 +32,6 @@ jobs:
           - tls
           - plain
     runs-on: ubuntu-24.04
-    services:
-      couchbase:
-        image: couchbase:enterprise-${{ matrix.server }}
-        ports:
-          - 8091-8096:8091-8096
-          - 11210:11210
-          - 18091-18096:18091-18096
-          - 11207:11207
     steps:
       - name: Install dependencies
         run: |
@@ -48,10 +40,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Initialize couchbase
-        env:
-          CB_TRAVEL_SAMPLE: yes
-        run: ./bin/init-cluster
+      - name: Create Couchbase cluster with cbdinocluster
+        id: cbdino
+        uses: ./.github/actions/create-cluster
+        with:
+          version: ${{ matrix.server }}
+          suite: unit
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
@@ -64,15 +58,21 @@ jobs:
           CB_BORINGSSL: OFF
         run: ./bin/build-tests
       - name: Check couchbase
+        env:
+          HOST: ${{ steps.cbdino.outputs.ip }}
         run: ./bin/check-cluster
       - name: Run tests
         timeout-minutes: 120
         env:
           CB_SANITIZER: ${{ matrix.sanitizer }}
           TEST_SERVER_VERSION: ${{ matrix.server }}
-          TEST_CONNECTION_STRING: ${{ matrix.tls == 'tls' && 'couchbases://127.0.0.1?trust_certificate=cluster.crt' || 'couchbase://127.0.0.1' }}
+          TEST_CONNECTION_STRING: ${{ matrix.tls == 'tls' && format('{0}?trust_certificate=cluster.crt', steps.cbdino.outputs.tls-connstr) || steps.cbdino.outputs.connstr }}
           TEST_LOG_LEVEL: trace
         run: ./bin/run-unit-tests
+      - name: Remove Couchbase cluster
+        uses: ./.github/actions/remove-cluster
+        with:
+          id: ${{ steps.cbdino.outputs.id }}
       - name: Upload report
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,8 +21,8 @@ jobs:
       fail-fast: false
       matrix:
         server:
-          - 7.6.5
-          - 7.2.7
+          - 7.6.7
+          - 7.2.8
           - 7.1.6
           - 7.0.5
         suite:
@@ -33,14 +33,6 @@ jobs:
             suite: unit
 
     runs-on: ubuntu-24.04
-    services:
-      couchbase:
-        image: couchbase:enterprise-${{ matrix.server }}
-        ports:
-          - 8091-8096:8091-8096
-          - 11210:11210
-          - 18091-18096:18091-18096
-          - 11207:11207
     steps:
       - name: Install build environment
         run: |
@@ -51,16 +43,12 @@ jobs:
           submodules: recursive
       - name: Validate test labels
         run: ./bin/validate-test-labels
-      - name: Initialize couchbase for transactions testing
-        if: ${{ matrix.suite  == 'transaction' }}
-        env:
-          CB_SEC_BUCKET: 'secBucket'
-        run: ./bin/init-cluster
-      - name: Initialize couchbase for non-transactions testing
-        if: ${{ matrix.suite != 'transaction' }}
-        env:
-          CB_TRAVEL_SAMPLE: yes
-        run: ./bin/init-cluster
+      - name: Create Couchbase cluster with cbdinocluster
+        id: cbdino
+        uses: ./.github/actions/create-cluster
+        with:
+          version: ${{ matrix.server }}
+          suite: ${{ matrix.suite }}
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
@@ -71,11 +59,17 @@ jobs:
           CB_TEST_SUITE: ${{ matrix.suite }}
         run: ./bin/build-tests
       - name: Check couchbase
+        env:
+          HOST: ${{ steps.cbdino.outputs.ip }}
         run: ./bin/check-cluster
       - name: Run tests
         timeout-minutes: 40
         env:
           TEST_SERVER_VERSION: ${{ matrix.server }}
-          TEST_CONNECTION_STRING: couchbase://127.0.0.1
+          TEST_CONNECTION_STRING: ${{ steps.cbdino.outputs.connstr }}
           TEST_LOG_LEVEL: trace
         run: ./bin/run-${{ matrix.suite }}-tests
+      - name: Remove Couchbase cluster
+        uses: ./.github/actions/remove-cluster
+        with:
+          id: ${{ steps.cbdino.outputs.id }}

--- a/test/test_integration_analytics.cxx
+++ b/test/test_integration_analytics.cxx
@@ -343,12 +343,8 @@ TEST_CASE("integration: public API analytics query", "[integration]")
     SKIP("cluster does not support analytics");
   }
 
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
-  auto bucket = cluster.bucket(integration.ctx.bucket);
-  auto collection = bucket.default_collection();
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
 
   auto dataset_name = test::utils::uniq_id("dataset");
 
@@ -555,10 +551,7 @@ TEST_CASE("integration: public API analytics scope query", "[integration]")
     SKIP("cluster does not support collections");
   }
 
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto cluster = integration.public_cluster();
   auto bucket = cluster.bucket(integration.ctx.bucket);
 
   auto scope_name = test::utils::uniq_id("scope");

--- a/test/test_integration_arithmetic.cxx
+++ b/test/test_integration_arithmetic.cxx
@@ -83,14 +83,8 @@ TEST_CASE("integration: increment with public API", "[integration]")
 {
   test::utils::integration_test_guard integration;
 
-  auto test_ctx = integration.ctx;
-  auto [e, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
-
-  auto collection = cluster.bucket(integration.ctx.bucket)
-                      .scope(couchbase::scope::default_name)
-                      .collection(couchbase::collection::default_name);
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
 
   auto id = test::utils::uniq_id("counter");
 
@@ -188,14 +182,8 @@ TEST_CASE("integration: decrement with public API", "[integration]")
 {
   test::utils::integration_test_guard integration;
 
-  auto test_ctx = integration.ctx;
-  auto [e, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
-
-  auto collection = cluster.bucket(integration.ctx.bucket)
-                      .scope(couchbase::scope::default_name)
-                      .collection(couchbase::collection::default_name);
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
 
   auto id = test::utils::uniq_id("counter");
 

--- a/test/test_integration_connect.cxx
+++ b/test/test_integration_connect.cxx
@@ -165,6 +165,10 @@ TEST_CASE("integration: destroy cluster without waiting for close completion", "
 
   auto origin = couchbase::core::origin(
     ctx.build_auth(), couchbase::core::utils::parse_connection_string(ctx.connection_string));
+  if (ctx.use_wan_development_profile) {
+    origin.options().apply_profile("wan_development");
+  }
+
   test::utils::open_cluster(cluster, origin);
   test::utils::open_bucket(cluster, ctx.bucket);
 
@@ -203,6 +207,10 @@ TEST_CASE("integration: connecting with a custom transactions metadata collectio
   auto ctx = test::utils::test_context::load_from_environment();
 
   auto opts = couchbase::cluster_options(ctx.username, ctx.password);
+  if (ctx.use_wan_development_profile) {
+    opts.apply_profile("wan_development");
+  }
+
   opts.transactions().metadata_collection(couchbase::transactions::transaction_keyspace{
     "nonexistent",
     "_default",

--- a/test/test_integration_crud.cxx
+++ b/test/test_integration_crud.cxx
@@ -720,7 +720,7 @@ TEST_CASE("integration: multi-threaded open/close bucket", "[integration]")
         integration.ctx.bucket, "_default", "_default", test::utils::uniq_id("foo")
       };
       couchbase::core::operations::upsert_request req{ id, basic_doc_json };
-      req.timeout = std::chrono::seconds{ 10 };
+      req.timeout = std::chrono::seconds{ 20 };
       if (auto resp = test::utils::execute(integration.cluster, req); resp.ctx.ec()) {
         if (resp.ctx.ec() != couchbase::errc::common::ambiguous_timeout) {
           throw std::system_error(resp.ctx.ec());
@@ -873,10 +873,7 @@ TEST_CASE("integration: extract core from public API cluster", "[integration]")
 {
   test::utils::integration_test_guard integration;
 
-  auto test_ctx = integration.ctx;
-  auto [e, public_api_cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
+  auto public_api_cluster = integration.public_cluster();
 
   auto id = test::utils::uniq_id("counter");
 
@@ -903,14 +900,9 @@ TEST_CASE("integration: pessimistic locking with public API", "[integration]")
 {
   test::utils::integration_test_guard integration;
 
-  auto test_ctx = integration.ctx;
-  auto [e, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
+  auto cluster = integration.public_cluster();
 
-  auto collection = cluster.bucket(integration.ctx.bucket)
-                      .scope(couchbase::scope::default_name)
-                      .collection(couchbase::collection::default_name);
+  auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
 
   auto id = test::utils::uniq_id("counter");
   std::chrono::seconds lock_time{ 10 };
@@ -1003,14 +995,8 @@ TEST_CASE("integration: exists with public API", "[integration]")
 {
   test::utils::integration_test_guard integration;
 
-  auto test_ctx = integration.ctx;
-  auto [e, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
-
-  auto collection = cluster.bucket(integration.ctx.bucket)
-                      .scope(couchbase::scope::default_name)
-                      .collection(couchbase::collection::default_name);
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
 
   auto id = test::utils::uniq_id("exists");
 
@@ -1050,14 +1036,8 @@ TEST_CASE("integration: get with expiry with public API", "[integration]")
 {
   test::utils::integration_test_guard integration;
 
-  auto test_ctx = integration.ctx;
-  auto [e, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
-
-  auto collection = cluster.bucket(integration.ctx.bucket)
-                      .scope(couchbase::scope::default_name)
-                      .collection(couchbase::collection::default_name);
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
 
   auto id = test::utils::uniq_id("get_expiry");
 

--- a/test/test_integration_diagnostics.cxx
+++ b/test/test_integration_diagnostics.cxx
@@ -65,10 +65,7 @@ TEST_CASE("integration: fetch diagnostics after N1QL query", "[integration]")
 
   SECTION("Public API")
   {
-    auto test_ctx = integration.ctx;
-    auto [e, cluster] =
-      couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-    REQUIRE_SUCCESS(e.ec());
+    auto cluster = integration.public_cluster();
 
     {
       auto [ctx, res] = cluster.query("SELECT 'hello, couchbase' AS greetings", {}).get();
@@ -143,10 +140,7 @@ TEST_CASE("integration: ping", "[integration]")
 
   SECTION("Public API")
   {
-    auto test_ctx = integration.ctx;
-    auto [e, cluster] =
-      couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-    REQUIRE_SUCCESS(e.ec());
+    auto cluster = integration.public_cluster();
 
     auto [err, res] = cluster.ping(couchbase::ping_options().report_id("my_report_id")).get();
     REQUIRE(res.endpoints().size() > 0);
@@ -214,10 +208,7 @@ TEST_CASE("integration: ping allows to select services", "[integration]")
 
   SECTION("Public API")
   {
-    auto test_ctx = integration.ctx;
-    auto [e, cluster] =
-      couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-    REQUIRE_SUCCESS(e.ec());
+    auto cluster = integration.public_cluster();
 
     auto opts = couchbase::ping_options().service_types(
       { couchbase::service_type::key_value, couchbase::service_type::query });
@@ -260,10 +251,7 @@ TEST_CASE("integration: ping allows to select bucket and opens it automatically"
 
   SECTION("Public API")
   {
-    auto test_ctx = integration.ctx;
-    auto [e, cluster] =
-      couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-    REQUIRE_SUCCESS(e.ec());
+    auto cluster = integration.public_cluster();
 
     auto bucket = cluster.bucket(integration.ctx.bucket);
 
@@ -350,10 +338,7 @@ TEST_CASE("integration: ping allows setting timeout", "[integration]")
 
   SECTION("Public API")
   {
-    auto test_ctx = integration.ctx;
-    auto [e, cluster] =
-      couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-    REQUIRE_SUCCESS(e.ec());
+    auto cluster = integration.public_cluster();
 
     auto [err, res] =
       cluster.ping(couchbase::ping_options().timeout(std::chrono::milliseconds(0))).get();

--- a/test/test_integration_durability.cxx
+++ b/test/test_integration_durability.cxx
@@ -111,15 +111,9 @@ TEST_CASE("integration: legacy durability persist to active and replicate to one
                      integration.number_of_replicas()));
   }
 
-  test::utils::open_bucket(integration.cluster, integration.ctx.bucket);
-
   std::string key = test::utils::uniq_id("upsert_legacy");
 
-  auto test_ctx = integration.ctx;
-  auto [e, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
-
+  auto cluster = integration.public_cluster();
   auto collection = cluster.bucket(integration.ctx.bucket)
                       .scope(couchbase::scope::default_name)
                       .collection(couchbase::collection::default_name);

--- a/test/test_integration_management.cxx
+++ b/test/test_integration_management.cxx
@@ -231,10 +231,7 @@ TEST_CASE("integration: bucket management", "[integration]")
     }
     SECTION("public API")
     {
-      auto test_ctx = integration.ctx;
-      auto [err, c] =
-        couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-      REQUIRE_SUCCESS(err.ec());
+      auto c = integration.public_cluster();
 
       couchbase::management::cluster::bucket_settings bucket_settings;
       bucket_settings.name = bucket_name;
@@ -447,10 +444,7 @@ TEST_CASE("integration: bucket management", "[integration]")
     }
     SECTION("public API")
     {
-      auto test_ctx = integration.ctx;
-      auto [err, c] =
-        couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-      REQUIRE_SUCCESS(err.ec());
+      auto c = integration.public_cluster();
 
       SECTION("flush item")
       {
@@ -546,10 +540,7 @@ TEST_CASE("integration: bucket management", "[integration]")
     }
     SECTION("public api")
     {
-      auto test_ctx = integration.ctx;
-      auto [err, c] =
-        couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-      REQUIRE_SUCCESS(err.ec());
+      auto c = integration.public_cluster();
 
       {
         couchbase::management::cluster::bucket_settings bucket_settings;
@@ -648,10 +639,7 @@ TEST_CASE("integration: bucket management", "[integration]")
     }
     SECTION("public api")
     {
-      auto test_ctx = integration.ctx;
-      auto [err, c] =
-        couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-      REQUIRE_SUCCESS(err.ec());
+      auto c = integration.public_cluster();
 
       couchbase::management::cluster::bucket_settings bucket_settings;
       bucket_settings.name = bucket_name;
@@ -813,10 +801,7 @@ TEST_CASE("integration: bucket management", "[integration]")
     }
     SECTION("public api")
     {
-      auto test_ctx = integration.ctx;
-      auto [err, c] =
-        couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-      REQUIRE_SUCCESS(err.ec());
+      auto c = integration.public_cluster();
 
       couchbase::management::cluster::bucket_settings bucket_settings;
       bucket_settings.name = bucket_name;
@@ -917,10 +902,7 @@ TEST_CASE("integration: bucket management", "[integration]")
     }
     SECTION("public api")
     {
-      auto test_ctx = integration.ctx;
-      auto [err, c] =
-        couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-      REQUIRE_SUCCESS(err.ec());
+      auto c = integration.public_cluster();
 
       couchbase::management::cluster::bucket_settings bucket_settings;
       bucket_settings.name = bucket_name;
@@ -977,10 +959,7 @@ TEST_CASE("integration: bucket management", "[integration]")
       }
       SECTION("public api")
       {
-        auto test_ctx = integration.ctx;
-        auto [err, c] =
-          couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-        REQUIRE_SUCCESS(err.ec());
+        auto c = integration.public_cluster();
 
         couchbase::management::cluster::bucket_settings bucket_settings;
         bucket_settings.name = bucket_name;
@@ -1356,10 +1335,7 @@ TEST_CASE("integration: collection management", "[integration]")
   }
   SECTION("public API")
   {
-    auto test_ctx = integration.ctx;
-    auto [err, c] =
-      couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-    REQUIRE_SUCCESS(err.ec());
+    auto c = integration.public_cluster();
 
     auto manager = c.bucket(integration.ctx.bucket).collections();
     {
@@ -1468,10 +1444,7 @@ TEST_CASE("integration: collection management create collection with max expiry"
   auto scope_name = "_default";
   auto collection_name = test::utils::uniq_id("collection");
 
-  auto test_ctx = integration.ctx;
-  auto [err, c] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto c = integration.public_cluster();
 
   auto manager = c.bucket(integration.ctx.bucket).collections();
 
@@ -1634,10 +1607,7 @@ TEST_CASE("integration: collection management update collection with max expiry"
     REQUIRE_SUCCESS(ec);
   }
 
-  auto test_ctx = integration.ctx;
-  auto [err, c] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto c = integration.public_cluster();
 
   auto manager = c.bucket(integration.ctx.bucket).collections();
 
@@ -1812,10 +1782,7 @@ TEST_CASE("integration: collection management history retention not supported in
 
     SECTION("public API")
     {
-      auto test_ctx = integration.ctx;
-      auto [err, cluster] =
-        couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-      REQUIRE_SUCCESS(err.ec());
+      auto cluster = integration.public_cluster();
 
       auto manager = cluster.bucket(integration.ctx.bucket).collections();
 
@@ -1849,10 +1816,7 @@ TEST_CASE("integration: collection management history retention not supported in
 
     SECTION("public API")
     {
-      auto test_ctx = integration.ctx;
-      auto [err, cluster] =
-        couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-      REQUIRE_SUCCESS(err.ec());
+      auto cluster = integration.public_cluster();
 
       auto manager = cluster.bucket(integration.ctx.bucket).collections();
 
@@ -2317,8 +2281,6 @@ TEST_CASE("integration: user management", "[integration]")
     {
       auto user_name = test::utils::uniq_id("newUser");
       // Create options
-      auto options_original =
-        couchbase::cluster_options(integration.ctx.username, integration.ctx.password);
       auto options_outdated = couchbase::cluster_options(user_name, integration.ctx.password);
       auto options_updated = couchbase::cluster_options(user_name, "newPassword");
 
@@ -2330,27 +2292,24 @@ TEST_CASE("integration: user management", "[integration]")
         new_user.roles = {
           couchbase::core::management::rbac::role{ "admin" },
         };
-        auto [err, cluster] =
-          couchbase::cluster::connect(integration.ctx.connection_string, options_original).get();
-        couchbase::core::operations::management::user_upsert_request upsertReq{};
-        upsertReq.user = new_user;
-        auto upsertResp = test::utils::execute(couchbase::extract_core_cluster(cluster), upsertReq);
+        couchbase::core::operations::management::user_upsert_request upsert_req{};
+        upsert_req.user = new_user;
+        auto upsertResp = test::utils::execute(integration.cluster, upsert_req);
         REQUIRE_SUCCESS(upsertResp.ctx.ec);
         test::utils::wait_until_user_present(integration.cluster, user_name);
-        cluster.close().get();
       }
 
       {
         // Connect with new credentials and change password
         auto [ec_new, cluster_new] =
           couchbase::cluster::connect(integration.ctx.connection_string, options_outdated).get();
-        couchbase::core::operations::management::change_password_request changePasswordReq{};
-        changePasswordReq.newPassword = "newPassword";
-        auto changePasswordResp =
-          test::utils::execute(couchbase::extract_core_cluster(cluster_new), changePasswordReq);
-        REQUIRE_SUCCESS(changePasswordResp.ctx.ec);
+        couchbase::core::operations::management::change_password_request change_password_req{};
+        change_password_req.newPassword = "newPassword";
+        auto change_password_resp =
+          test::utils::execute(couchbase::extract_core_cluster(cluster_new), change_password_req);
+        REQUIRE_SUCCESS(change_password_resp.ctx.ec);
         test::utils::wait_until_cluster_connected(
-          user_name, changePasswordReq.newPassword, integration.ctx.connection_string);
+          user_name, change_password_req.newPassword, integration.ctx.connection_string);
         cluster_new.close().get();
       }
 
@@ -2519,10 +2478,7 @@ TEST_CASE("integration: query index management", "[integration]")
       }
       SECTION("public api")
       {
-        auto test_ctx = integration.ctx;
-        auto [err, c] =
-          couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-        REQUIRE_SUCCESS(err.ec());
+        auto c = integration.public_cluster();
 
         {
           std::error_code ec;
@@ -2646,10 +2602,7 @@ TEST_CASE("integration: query index management", "[integration]")
     }
     SECTION("public API")
     {
-      auto test_ctx = integration.ctx;
-      auto [err, c] =
-        couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-      REQUIRE_SUCCESS(err.ec());
+      auto c = integration.public_cluster();
 
       auto index_name = test::utils::uniq_id("index");
       {
@@ -2742,10 +2695,7 @@ TEST_CASE("integration: query index management", "[integration]")
   {
     SECTION("public API")
     {
-      auto test_ctx = integration.ctx;
-      auto [e, c] =
-        couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-      REQUIRE_SUCCESS(e.ec());
+      auto c = integration.public_cluster();
 
       auto index_name = test::utils::uniq_id("index");
       {
@@ -2779,9 +2729,7 @@ TEST_CASE("integration: query index management", "[integration]")
       }
 
       {
-        auto [err, cluster] =
-          couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-        REQUIRE_SUCCESS(err.ec());
+        auto cluster = integration.public_cluster();
 
         auto manager = cluster.query_indexes();
         auto error = manager.build_deferred_indexes(integration.ctx.bucket, {}).get();
@@ -2872,10 +2820,7 @@ TEST_CASE("integration: query index management", "[integration]")
     }
     SECTION("public API")
     {
-      auto test_ctx = integration.ctx;
-      auto [err, c] =
-        couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-      REQUIRE_SUCCESS(err.ec());
+      auto c = integration.public_cluster();
 
       auto error = c.query_indexes().create_primary_index("missing_bucket", {}).get();
       REQUIRE(error.ec() == couchbase::errc::common::bucket_not_found);
@@ -2894,10 +2839,7 @@ TEST_CASE("integration: query index management", "[integration]")
     }
     SECTION("public API")
     {
-      auto test_ctx = integration.ctx;
-      auto [err, c] =
-        couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-      REQUIRE_SUCCESS(err.ec());
+      auto c = integration.public_cluster();
 
       auto [error, indexes] = c.query_indexes().get_all_indexes("missing_bucket", {}).get();
       REQUIRE_SUCCESS(error.ec());
@@ -2917,10 +2859,7 @@ TEST_CASE("integration: query index management", "[integration]")
     }
     SECTION("public API")
     {
-      auto test_ctx = integration.ctx;
-      auto [err, c] =
-        couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-      REQUIRE_SUCCESS(err.ec());
+      auto c = integration.public_cluster();
 
       auto error = c.query_indexes().drop_primary_index("missing_bucket", {}).get();
       REQUIRE(error.ec() == couchbase::errc::common::bucket_not_found);
@@ -2931,10 +2870,7 @@ TEST_CASE("integration: query index management", "[integration]")
   {
     SECTION("public API")
     {
-      auto test_ctx = integration.ctx;
-      auto [err, c] =
-        couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-      REQUIRE_SUCCESS(err.ec());
+      auto c = integration.public_cluster();
 
       auto error = c.query_indexes()
                      .watch_indexes(integration.ctx.bucket,
@@ -2950,10 +2886,7 @@ TEST_CASE("integration: query index management", "[integration]")
   {
     SECTION("public API")
     {
-      auto test_ctx = integration.ctx;
-      auto [err, c] =
-        couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-      REQUIRE_SUCCESS(err.ec());
+      auto c = integration.public_cluster();
 
       auto error = c.query_indexes()
                      .watch_indexes("missing_buckeet",
@@ -3006,10 +2939,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
     REQUIRE(created);
   }
 
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto cluster = integration.public_cluster();
 
   auto manager = cluster.bucket(integration.ctx.bucket)
                    .scope(scope_name)
@@ -3426,9 +3356,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
     }
     SECTION("public API")
     {
-      auto [e, c] =
-        couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-      REQUIRE_SUCCESS(e.ec());
+      auto c = integration.public_cluster();
 
       auto coll =
         c.bucket(integration.ctx.bucket).scope(scope_name).collection("missing_collection");
@@ -3451,9 +3379,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
     }
     SECTION("public API")
     {
-      auto [e, c] =
-        couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-      REQUIRE_SUCCESS(e.ec());
+      auto c = integration.public_cluster();
 
       auto coll =
         c.bucket(integration.ctx.bucket).scope("missing scope").collection(collection_name);
@@ -3476,9 +3402,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
     }
     SECTION("public API")
     {
-      auto [e, c] =
-        couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-      REQUIRE_SUCCESS(e.ec());
+      auto c = integration.public_cluster();
 
       auto coll =
         c.bucket(integration.ctx.bucket).scope(scope_name).collection("missing_collection");
@@ -3501,9 +3425,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
     }
     SECTION("public API")
     {
-      auto [e, c] =
-        couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-      REQUIRE_SUCCESS(e.ec());
+      auto c = integration.public_cluster();
 
       auto coll =
         c.bucket(integration.ctx.bucket).scope("missing_scope").collection(collection_name);
@@ -3527,9 +3449,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
     }
     SECTION("public API")
     {
-      auto [e, c] =
-        couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-      REQUIRE_SUCCESS(e.ec());
+      auto c = integration.public_cluster();
 
       auto coll =
         c.bucket(integration.ctx.bucket).scope(scope_name).collection("missing_collection");
@@ -3551,9 +3471,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
     }
     SECTION("public API")
     {
-      auto [e, c] =
-        couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-      REQUIRE_SUCCESS(e.ec());
+      auto c = integration.public_cluster();
 
       auto coll =
         c.bucket(integration.ctx.bucket).scope("missing_scope").collection(collection_name);
@@ -3565,9 +3483,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
   {
     SECTION("public API")
     {
-      auto [e, c] =
-        couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-      REQUIRE_SUCCESS(e.ec());
+      auto c = integration.public_cluster();
 
       auto coll =
         c.bucket(integration.ctx.bucket).scope("missing_scope").collection(collection_name);
@@ -3583,9 +3499,7 @@ TEST_CASE("integration: collections query index management", "[integration]")
   {
     SECTION("public API")
     {
-      auto [e, c] =
-        couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-      REQUIRE_SUCCESS(e.ec());
+      auto c = integration.public_cluster();
 
       auto coll =
         c.bucket(integration.ctx.bucket).scope(scope_name).collection("missing_collection");
@@ -4291,10 +4205,7 @@ TEST_CASE("integration: analytics index management with public API", "[integrati
     SKIP("analytics does not work with magma storage backend, see MB-47718");
   }
 
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto cluster = integration.public_cluster();
 
   auto mgr = cluster.analytics_indexes();
 
@@ -4549,10 +4460,7 @@ run_s3_link_test_public_api(test::utils::integration_test_guard& integration,
                             const std::string& dataverse_name,
                             const std::string& link_name)
 {
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto cluster = integration.public_cluster();
 
   auto mgr = cluster.analytics_indexes();
 
@@ -4675,10 +4583,7 @@ run_azure_link_test_public_api(test::utils::integration_test_guard& integration,
                                const std::string& dataverse_name,
                                const std::string& link_name)
 {
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto cluster = integration.public_cluster();
 
   auto mgr = cluster.analytics_indexes();
 
@@ -4805,10 +4710,7 @@ TEST_CASE("integration: analytics external link management with public API", "[i
          "MB-40198");
   }
 
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto cluster = integration.public_cluster();
 
   auto mgr = cluster.analytics_indexes();
 

--- a/test/test_integration_management_search_index.cxx
+++ b/test/test_integration_management_search_index.cxx
@@ -316,10 +316,7 @@ TEST_CASE("integration: search index management public API", "[integration]")
     test::utils::open_bucket(integration.cluster, integration.ctx.bucket);
   }
 
-  auto test_ctx = integration.ctx;
-  auto [e, c] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
+  auto c = integration.public_cluster();
 
   auto index_name = test::utils::uniq_id("index");
 
@@ -487,10 +484,7 @@ TEST_CASE("integration: search index management analyze document public API", "[
   auto index_name = test::utils::uniq_id("index");
 
   {
-    auto test_ctx = integration.ctx;
-    auto [e, c] =
-      couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-    REQUIRE_SUCCESS(e.ec());
+    auto c = integration.public_cluster();
 
     {
       couchbase::management::search::index index;
@@ -533,10 +527,7 @@ TEST_CASE("integration: scope search index management public API", "[integration
     test::utils::open_bucket(integration.cluster, integration.ctx.bucket);
   }
 
-  auto test_ctx = integration.ctx;
-  auto [e, c] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
+  auto c = integration.public_cluster();
 
   auto manager = c.bucket(integration.ctx.bucket).scope("_default").search_indexes();
   auto index_name = test::utils::uniq_id("index");
@@ -637,10 +628,7 @@ TEST_CASE("integration: scope search index management analyze document public AP
     SKIP("Wait for search pindexes ready is used in this test, which doesn't work against Capella");
   }
 
-  auto test_ctx = integration.ctx;
-  auto [e, c] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
+  auto c = integration.public_cluster();
 
   auto manager = c.bucket(integration.ctx.bucket).scope("_default").search_indexes();
   auto index_name = test::utils::uniq_id("index");
@@ -682,10 +670,7 @@ TEST_CASE("integration: scope search returns feature not available", "[integrati
   if (integration.cluster_version().supports_scope_search()) {
     SKIP("cluster supports scope search");
   }
-  auto test_ctx = integration.ctx;
-  auto [e, c] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
+  auto c = integration.public_cluster();
 
   auto manager = c.bucket(integration.ctx.bucket).scope("_default").search_indexes();
   auto index_name = test::utils::uniq_id("index");
@@ -706,10 +691,7 @@ TEST_CASE("integration: upsert vector index feature not available", "[integratio
     SKIP("cluster supports vector search");
   }
 
-  auto test_ctx = integration.ctx;
-  auto [e, c] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
+  auto c = integration.public_cluster();
 
   auto manager = c.search_indexes();
   {

--- a/test/test_integration_query.cxx
+++ b/test/test_integration_query.cxx
@@ -595,10 +595,7 @@ TEST_CASE("integration: query with public API", "[integration]")
     test::utils::open_bucket(integration.cluster, integration.ctx.bucket);
   }
 
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto cluster = integration.public_cluster();
 
   {
     auto [ctx, resp] = cluster.query("SELECT 42 AS the_answer", {}).get();
@@ -642,10 +639,7 @@ TEST_CASE("integration: query from scope with public API", "[integration]")
     test::utils::open_bucket(integration.cluster, integration.ctx.bucket);
   }
 
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto cluster = integration.public_cluster();
 
   auto scope_name = test::utils::uniq_id("scope");
   auto collection_name = test::utils::uniq_id("coll");

--- a/test/test_integration_range_scan.cxx
+++ b/test/test_integration_range_scan.cxx
@@ -157,10 +157,7 @@ TEST_CASE("integration: range scan large values", "[integration]")
     SKIP("cluster does not support range_scan");
   }
 
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto cluster = integration.public_cluster();
 
   auto collection = cluster.bucket(integration.ctx.bucket)
                       .scope(couchbase::scope::default_name)
@@ -219,10 +216,7 @@ TEST_CASE("integration: range scan small values", "[integration]")
     SKIP("cluster does not support range_scan");
   }
 
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto cluster = integration.public_cluster();
 
   auto collection = cluster.bucket(integration.ctx.bucket)
                       .scope(couchbase::scope::default_name)
@@ -288,10 +282,7 @@ TEST_CASE("integration: range scan collection retry", "[integration]")
 
   const test::utils::collection_guard new_collection(integration);
 
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto cluster = integration.public_cluster();
 
   auto collection = cluster.bucket(integration.ctx.bucket)
                       .scope(couchbase::scope::default_name)
@@ -359,10 +350,7 @@ TEST_CASE("integration: range scan only keys", "[integration]")
     SKIP("cluster does not support range_scan");
   }
 
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto cluster = integration.public_cluster();
 
   auto collection = cluster.bucket(integration.ctx.bucket)
                       .scope(couchbase::scope::default_name)
@@ -424,10 +412,7 @@ TEST_CASE("integration: range scan cancellation before continue", "[integration]
     SKIP("cluster does not support range_scan");
   }
 
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto cluster = integration.public_cluster();
 
   auto collection = cluster.bucket(integration.ctx.bucket)
                       .scope(couchbase::scope::default_name)
@@ -539,10 +524,7 @@ TEST_CASE("integration: range scan cancel during streaming using protocol cancel
     SKIP("cluster does not support range_scan");
   }
 
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto cluster = integration.public_cluster();
 
   auto collection = cluster.bucket(integration.ctx.bucket)
                       .scope(couchbase::scope::default_name)
@@ -662,10 +644,7 @@ TEST_CASE("integration: range scan cancel during streaming using pending_operati
     SKIP("cluster does not support range_scan");
   }
 
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto cluster = integration.public_cluster();
 
   auto collection = cluster.bucket(integration.ctx.bucket)
                       .scope(couchbase::scope::default_name)
@@ -779,10 +758,7 @@ TEST_CASE("integration: sampling scan keys only", "[integration]")
     SKIP("cluster does not support range_scan");
   }
 
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto cluster = integration.public_cluster();
 
   auto collection = cluster.bucket(integration.ctx.bucket)
                       .scope(couchbase::scope::default_name)
@@ -856,10 +832,7 @@ TEST_CASE("integration: orchestrator scan range without content", "[integration]
     SKIP("cluster does not support range_scan");
   }
 
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto cluster = integration.public_cluster();
 
   auto collection = cluster.bucket(integration.ctx.bucket)
                       .scope(couchbase::scope::default_name)
@@ -923,10 +896,7 @@ TEST_CASE("integration: orchestrator scan range with content", "[integration]")
     SKIP("cluster does not support range_scan");
   }
 
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto cluster = integration.public_cluster();
 
   auto collection = cluster.bucket(integration.ctx.bucket)
                       .scope(couchbase::scope::default_name)
@@ -992,10 +962,7 @@ TEST_CASE("integration: orchestrator sampling scan with custom collection", "[in
 
   const test::utils::collection_guard new_collection(integration);
 
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto cluster = integration.public_cluster();
 
   auto collection = cluster.bucket(integration.ctx.bucket)
                       .scope(couchbase::scope::default_name)
@@ -1062,10 +1029,7 @@ TEST_CASE("integration: orchestrator sampling scan with seed & custom collection
 
   const test::utils::collection_guard new_collection(integration);
 
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto cluster = integration.public_cluster();
 
   auto collection = cluster.bucket(integration.ctx.bucket)
                       .scope(couchbase::scope::default_name)
@@ -1157,10 +1121,7 @@ TEST_CASE("integration: orchestrator prefix scan without content", "[integration
     SKIP("cluster does not support range_scan");
   }
 
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto cluster = integration.public_cluster();
 
   auto collection = cluster.bucket(integration.ctx.bucket)
                       .scope(couchbase::scope::default_name)
@@ -1225,10 +1186,7 @@ TEST_CASE(
 
   const test::utils::collection_guard new_collection(integration);
 
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto cluster = integration.public_cluster();
 
   auto collection = cluster.bucket(integration.ctx.bucket)
                       .scope(couchbase::scope::default_name)
@@ -1299,10 +1257,7 @@ TEST_CASE("integration: orchestrator sampling scan with custom collection and up
 
   const test::utils::collection_guard new_collection(integration);
 
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto cluster = integration.public_cluster();
 
   auto collection = cluster.bucket(integration.ctx.bucket)
                       .scope(couchbase::scope::default_name)
@@ -1370,10 +1325,7 @@ TEST_CASE("integration: orchestrator prefix scan without content and up to 5 con
     SKIP("cluster does not support range_scan");
   }
 
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto cluster = integration.public_cluster();
 
   auto collection = cluster.bucket(integration.ctx.bucket)
                       .scope(couchbase::scope::default_name)
@@ -1435,10 +1387,7 @@ TEST_CASE("integration: orchestrator prefix scan, get 10 items and cancel", "[in
     SKIP("cluster does not support range_scan");
   }
 
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto cluster = integration.public_cluster();
 
   auto collection = cluster.bucket(integration.ctx.bucket)
                       .scope(couchbase::scope::default_name)
@@ -1508,10 +1457,7 @@ TEST_CASE("integration: orchestrator prefix scan with concurrency 0 (invalid arg
     SKIP("cluster does not support range_scan");
   }
 
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto cluster = integration.public_cluster();
 
   auto collection = cluster.bucket(integration.ctx.bucket)
                       .scope(couchbase::scope::default_name)
@@ -1556,10 +1502,7 @@ TEST_CASE("integration: range scan public API feature not available", "[integrat
     SKIP("cluster supports range scan");
   }
 
-  auto test_ctx = integration.ctx;
-  auto [e, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
+  auto cluster = integration.public_cluster();
 
   auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
 
@@ -1637,10 +1580,7 @@ TEST_CASE("integration: range scan public API", "[integration]")
     SKIP("cluster does not support range scan");
   }
 
-  auto test_ctx = integration.ctx;
-  auto [e, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
+  auto cluster = integration.public_cluster();
 
   auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
 

--- a/test/test_integration_read_replica.cxx
+++ b/test/test_integration_read_replica.cxx
@@ -116,10 +116,7 @@ TEST_CASE("integration: get any replica", "[integration]")
   }
 
   {
-    auto test_ctx = integration.ctx;
-    auto [e, cluster] =
-      couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-    REQUIRE_SUCCESS(e.ec());
+    auto cluster = integration.public_cluster();
 
     auto collection =
       cluster.bucket(integration.ctx.bucket).scope(scope_name).collection(collection_name);
@@ -165,10 +162,7 @@ TEST_CASE("integration: get all replicas", "[integration]")
   }
 
   {
-    auto test_ctx = integration.ctx;
-    auto [e, cluster] =
-      couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-    REQUIRE_SUCCESS(e.ec());
+    auto cluster = integration.public_cluster();
 
     auto collection =
       cluster.bucket(integration.ctx.bucket).scope(scope_name).collection(collection_name);
@@ -198,10 +192,7 @@ TEST_CASE("integration: get all replicas with missing key", "[integration]")
   test::utils::open_bucket(integration.cluster, integration.ctx.bucket);
 
   {
-    auto test_ctx = integration.ctx;
-    auto [e, cluster] =
-      couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-    REQUIRE_SUCCESS(e.ec());
+    auto cluster = integration.public_cluster();
 
     const std::string scope_name{ "_default" };
     const std::string collection_name{ "_default" };
@@ -232,10 +223,7 @@ TEST_CASE("integration: get any replica with missing key", "[integration]")
   std::string key = test::utils::uniq_id("get_any_replica_missing_key");
 
   {
-    auto test_ctx = integration.ctx;
-    auto [e, cluster] =
-      couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-    REQUIRE_SUCCESS(e.ec());
+    auto cluster = integration.public_cluster();
 
     auto collection =
       cluster.bucket(integration.ctx.bucket).scope(scope_name).collection(collection_name);
@@ -688,6 +676,9 @@ TEST_CASE("integration: zone-aware read replicas on balanced cluster", "[integra
                            : couchbase::cluster_options(couchbase::certificate_authenticator(
                                integration.ctx.certificate_path, integration.ctx.certificate_path));
   cluster_options.network().preferred_server_group(server_groups.front());
+  if (integration.ctx.use_wan_development_profile) {
+    cluster_options.apply_profile("wan_development");
+  }
   auto [e, c] =
     couchbase::cluster::connect(integration.ctx.connection_string, cluster_options).get();
   REQUIRE_SUCCESS(e.ec());
@@ -829,6 +820,9 @@ TEST_CASE("integration: zone-aware read replicas on unbalanced cluster", "[integ
   //! [select-preferred_server_group]
   cluster_options.network().preferred_server_group(selected_server_group);
   //! [select-preferred_server_group]
+  if (integration.ctx.use_wan_development_profile) {
+    cluster_options.apply_profile("wan_development");
+  }
   auto [e, cluster] =
     couchbase::cluster::connect(integration.ctx.connection_string, cluster_options).get();
   REQUIRE_SUCCESS(e.ec());

--- a/test/test_integration_search.cxx
+++ b/test/test_integration_search.cxx
@@ -661,10 +661,7 @@ TEST_CASE("integration: scope search returns feature not available", "[integrati
     SKIP("cluster supports scope search");
   }
 
-  auto test_ctx = integration.ctx;
-  auto [err, c] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
+  auto c = integration.public_cluster();
 
   auto search_request = couchbase::search_request(couchbase::match_none_query{});
   auto [error, result] =

--- a/test/test_integration_subdoc.cxx
+++ b/test/test_integration_subdoc.cxx
@@ -1478,10 +1478,7 @@ TEST_CASE("integration: subdoc all replica reads", "[integration]")
 
   SECTION("public API")
   {
-    auto test_ctx = integration.ctx;
-    auto [e, cluster] =
-      couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-    REQUIRE_SUCCESS(e.ec());
+    auto cluster = integration.public_cluster();
 
     auto collection =
       cluster.bucket(integration.ctx.bucket).scope("_default").collection("_default");
@@ -1761,10 +1758,7 @@ TEST_CASE("integration: subdoc any replica reads", "[integration]")
 
   SECTION("public API")
   {
-    auto test_ctx = integration.ctx;
-    auto [e, cluster] =
-      couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-    REQUIRE_SUCCESS(e.ec());
+    auto cluster = integration.public_cluster();
 
     auto collection =
       cluster.bucket(integration.ctx.bucket).scope("_default").collection("_default");
@@ -1851,12 +1845,9 @@ TEST_CASE("integration: subdoc invalid_argument if empty specs", "[integration]"
 
   SECTION("public API")
   {
-    auto test_ctx = integration.ctx;
-    auto [e, cluster] =
-      couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-    REQUIRE_SUCCESS(e.ec());
+    auto cluster = integration.public_cluster();
 
-    auto collection = cluster.bucket(test_ctx.bucket).scope("_default").collection("_default");
+    auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
 
     auto key = test::utils::uniq_id("empty_specs");
     auto [lookupin_err, lookupin_resp] = collection.lookup_in(key, {}).get();
@@ -1882,10 +1873,7 @@ TEST_CASE("integration: public API lookup in per-spec errors", "[integration]")
 {
   test::utils::integration_test_guard integration;
 
-  auto test_ctx = integration.ctx;
-  auto [e, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
+  auto cluster = integration.public_cluster();
 
   auto collection = cluster.bucket(integration.ctx.bucket).scope("_default").collection("_default");
 

--- a/test/test_integration_transcoders.cxx
+++ b/test/test_integration_transcoders.cxx
@@ -39,14 +39,9 @@ TEST_CASE("integration: upsert/get with json transcoder", "[integration]")
 {
   test::utils::integration_test_guard integration;
 
-  auto test_ctx = integration.ctx;
-  auto [e, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
 
-  auto collection = cluster.bucket(integration.ctx.bucket)
-                      .scope(couchbase::scope::default_name)
-                      .collection(couchbase::collection::default_name);
   auto id = test::utils::uniq_id("foo");
   profile albert{ "this_guy_again", "Albert Einstein", 1879 };
 
@@ -69,14 +64,9 @@ TEST_CASE("integration: insert/get with json transcoder", "[integration]")
 {
   test::utils::integration_test_guard integration;
 
-  auto test_ctx = integration.ctx;
-  auto [e, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
 
-  auto collection = cluster.bucket(integration.ctx.bucket)
-                      .scope(couchbase::scope::default_name)
-                      .collection(couchbase::collection::default_name);
   auto id = test::utils::uniq_id("foo");
   profile albert{ "this_guy_again", "Albert Einstein", 1879 };
 
@@ -99,14 +89,9 @@ TEST_CASE("integration: insert/replace with json transcoder", "[integration]")
 {
   test::utils::integration_test_guard integration;
 
-  auto test_ctx = integration.ctx;
-  auto [e, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
 
-  auto collection = cluster.bucket(integration.ctx.bucket)
-                      .scope(couchbase::scope::default_name)
-                      .collection(couchbase::collection::default_name);
   auto id = test::utils::uniq_id("foo");
   profile albert{ "this_guy_again", "Albert Einstein", 1879 };
 
@@ -158,14 +143,9 @@ TEST_CASE("integration: upsert/remove with json transcoder", "[integration]")
 {
   test::utils::integration_test_guard integration;
 
-  auto test_ctx = integration.ctx;
-  auto [e, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
 
-  auto collection = cluster.bucket(integration.ctx.bucket)
-                      .scope(couchbase::scope::default_name)
-                      .collection(couchbase::collection::default_name);
   auto id = test::utils::uniq_id("foo");
   profile albert{ "this_guy_again", "Albert Einstein", 1879 };
 
@@ -196,14 +176,9 @@ TEST_CASE("integration: upsert/append/prepend with raw binary transcoder", "[int
 {
   test::utils::integration_test_guard integration;
 
-  auto test_ctx = integration.ctx;
-  auto [e, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
 
-  auto collection = cluster.bucket(integration.ctx.bucket)
-                      .scope(couchbase::scope::default_name)
-                      .collection(couchbase::collection::default_name);
   auto id = test::utils::uniq_id("foo");
   std::vector data{ std::byte{ 20 }, std::byte{ 21 } };
 
@@ -265,14 +240,9 @@ TEST_CASE("integration: get with expiry and json transcoder", "[integration]")
 {
   test::utils::integration_test_guard integration;
 
-  auto test_ctx = integration.ctx;
-  auto [e, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
 
-  auto collection = cluster.bucket(integration.ctx.bucket)
-                      .scope(couchbase::scope::default_name)
-                      .collection(couchbase::collection::default_name);
   auto id = test::utils::uniq_id("foo");
   profile albert{ "this_guy_again", "Albert Einstein", 1879 };
   auto skynet_birthday =
@@ -300,14 +270,9 @@ TEST_CASE("integration: get with projections and json transcoder", "[integration
 {
   test::utils::integration_test_guard integration;
 
-  auto test_ctx = integration.ctx;
-  auto [e, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
 
-  auto collection = cluster.bucket(integration.ctx.bucket)
-                      .scope(couchbase::scope::default_name)
-                      .collection(couchbase::collection::default_name);
   auto id = test::utils::uniq_id("foo");
   profile albert{ "this_guy_again", "Albert Einstein", 1879 };
 
@@ -354,14 +319,8 @@ TEST_CASE("integration: get_and_touch and json transcoder", "[integration]")
 {
   test::utils::integration_test_guard integration;
 
-  auto test_ctx = integration.ctx;
-  auto [e, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
-
-  auto collection = cluster.bucket(integration.ctx.bucket)
-                      .scope(couchbase::scope::default_name)
-                      .collection(couchbase::collection::default_name);
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
 
   const auto skynet_birthday =
     std::chrono::system_clock::time_point{ std::chrono::seconds{ 1807056000 } };
@@ -420,14 +379,8 @@ TEST_CASE("integration: touch with public API", "[integration]")
 {
   test::utils::integration_test_guard integration;
 
-  auto test_ctx = integration.ctx;
-  auto [e, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
-
-  auto collection = cluster.bucket(integration.ctx.bucket)
-                      .scope(couchbase::scope::default_name)
-                      .collection(couchbase::collection::default_name);
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
 
   const auto skynet_birthday =
     std::chrono::system_clock::time_point{ std::chrono::seconds{ 1807056000 } };
@@ -488,14 +441,8 @@ TEST_CASE("integration: subdoc with public API", "[integration]")
          "https://github.com/couchbaselabs/gocaves/issues/107");
   }
 
-  auto test_ctx = integration.ctx;
-  auto [e, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
-
-  auto collection = cluster.bucket(integration.ctx.bucket)
-                      .scope(couchbase::scope::default_name)
-                      .collection(couchbase::collection::default_name);
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
 
   auto id = test::utils::uniq_id("liu_cixin");
   profile cixin{ "liu_cixin", "刘慈欣", 1963 };
@@ -666,14 +613,9 @@ TEST_CASE("integration: upsert with raw json transcoder, get with json and raw j
 {
   test::utils::integration_test_guard integration;
 
-  auto test_ctx = integration.ctx;
-  auto [e, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
 
-  auto collection = cluster.bucket(integration.ctx.bucket)
-                      .scope(couchbase::scope::default_name)
-                      .collection(couchbase::collection::default_name);
   auto id = test::utils::uniq_id("foo");
   profile albert{ "this_guy_again", "Albert Einstein", 1879 };
   auto data = couchbase::codec::tao_json_serializer::serialize(albert);
@@ -708,14 +650,9 @@ TEST_CASE("integration: upsert and get string with raw json transcoder", "[integ
 {
   test::utils::integration_test_guard integration;
 
-  auto test_ctx = integration.ctx;
-  auto [e, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
 
-  auto collection = cluster.bucket(integration.ctx.bucket)
-                      .scope(couchbase::scope::default_name)
-                      .collection(couchbase::collection::default_name);
   auto id = test::utils::uniq_id("foo");
   std::string data{ R"({"foo": "bar"})" };
 
@@ -752,14 +689,9 @@ TEST_CASE(
 {
   test::utils::integration_test_guard integration;
 
-  auto test_ctx = integration.ctx;
-  auto [e, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(e.ec());
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
 
-  auto collection = cluster.bucket(integration.ctx.bucket)
-                      .scope(couchbase::scope::default_name)
-                      .collection(couchbase::collection::default_name);
   auto id = test::utils::uniq_id("foo");
   std::string document{ "lorem ipsum dolor sit amet" };
 

--- a/test/test_transaction_public_blocking_api.cxx
+++ b/test/test_transaction_public_blocking_api.cxx
@@ -48,24 +48,6 @@ with_new_guard(std::function<void(test::utils::integration_test_guard&)> fn)
     // noop
   }
 }
-void
-with_new_cluster(test::utils::integration_test_guard& integration,
-                 std::function<void(couchbase::cluster&)> fn)
-{
-  // make new virginal public cluster
-  auto test_ctx = integration.ctx;
-  auto [err, cluster] =
-    couchbase::cluster::connect(test_ctx.connection_string, test_ctx.build_options()).get();
-  REQUIRE_SUCCESS(err.ec());
-
-  try {
-    if (!err) {
-      fn(cluster);
-    }
-  } catch (...) {
-    // noop, just eat it.
-  }
-}
 
 void
 upsert_scope_and_collection(const couchbase::core::cluster& cluster,

--- a/test/utils/integration_test_guard.cxx
+++ b/test/utils/integration_test_guard.cxx
@@ -316,7 +316,7 @@ auto
 integration_test_guard::public_cluster() const -> couchbase::cluster
 {
   auto options = ctx.build_options();
-  options.transactions().timeout(std::chrono::seconds(2));
+
   auto [err, c] = couchbase::cluster::connect(ctx.connection_string, options).get();
   if (err.ec()) {
     CB_LOG_CRITICAL("unable to connect to cluster (public API): {}", err.message());

--- a/test/utils/test_context.cxx
+++ b/test/utils/test_context.cxx
@@ -146,7 +146,7 @@ test_context::build_options() const -> couchbase::cluster_options
     };
   }() };
 
-  if (deployment == deployment_type::capella || deployment == deployment_type::elixir) {
+  if (use_wan_development_profile) {
     options.apply_profile("wan_development");
   }
   options.dns().nameserver(


### PR DESCRIPTION
With this change our GHA workflows will use cbdinocluster to create Couchbase clusters, allowing to test against multi-node clusters, for which we currently rely on Jenkins.

In the future we can configure the workflows to test against pre-release versions, but for that we need to configure an access token in the repository's secrets.