### PR TITLE
CXXCBC-727: Columnar - fix how client handles connect_then_send_pending_op callback

### DIFF
--- a/core/columnar/query_component.cxx
+++ b/core/columnar/query_component.cxx
@@ -170,8 +170,9 @@ public:
       if (ec == asio::error::operation_aborted) {
         return;
       }
-      CB_LOG_DEBUG(R"(Columnar Query request timed out: retry_attempts={})",
-                   self->retry_info_.retry_attempts);
+      CB_LOG_DEBUG(R"(Columnar Query request timed out: retry_attempts={}, client_context_id={})",
+                   self->retry_info_.retry_attempts,
+                   self->client_context_id_);
       self->trigger_timeout();
     });
 
@@ -334,8 +335,8 @@ private:
     }
   }
 
-  auto parse_error(const std::uint32_t& http_status_code,
-                   const tao::json::value& metadata_header) -> error_parse_result
+  auto parse_error(const std::uint32_t& http_status_code, const tao::json::value& metadata_header)
+    -> error_parse_result
   {
     const auto* errors_json = metadata_header.find("errors");
     if (errors_json == nullptr) {


### PR DESCRIPTION

Changes
=======
* Use std::move() to pass the callback provided to `connect_then_send_pending_op` when the session fails to connect and retries the call (using a new session)
* Do not invoke the callback if a deadline has been reached or the session was stopped.  The pending_http_operation already has hooks in play to handle these scenarios and attempting to invoke the callback from the session's connection callback and lead to UB.
* When a query times out, log the client_context_id as well.  This helps to pair the log message to when the query request was made.