### PR TITLE
Improve stability of update collection max expiry tests

### DIFF
--- a/test/test_integration_management.cxx
+++ b/test/test_integration_management.cxx
@@ -1633,9 +1633,8 @@ TEST_CASE("integration: collection management update collection with max expiry"
     REQUIRE(test::utils::wait_until([&]() {
       collection =
         get_collection(integration.cluster, integration.ctx.bucket, scope_name, collection_name);
-      return collection.has_value();
+      return collection.has_value() && collection->max_expiry == 0;
     }));
-    REQUIRE(collection->max_expiry == 0);
   }
 
   SECTION("positive max expiry")
@@ -1663,9 +1662,8 @@ TEST_CASE("integration: collection management update collection with max expiry"
     REQUIRE(test::utils::wait_until([&]() {
       collection =
         get_collection(integration.cluster, integration.ctx.bucket, scope_name, collection_name);
-      return collection.has_value();
+      return collection.has_value() && collection->max_expiry == 3600;
     }));
-    REQUIRE(collection->max_expiry == 3600);
   }
 
   SECTION("setting max expiry to no-expiry")
@@ -1694,9 +1692,8 @@ TEST_CASE("integration: collection management update collection with max expiry"
       REQUIRE(test::utils::wait_until([&]() {
         collection =
           get_collection(integration.cluster, integration.ctx.bucket, scope_name, collection_name);
-        return collection.has_value();
+        return collection.has_value() && collection->max_expiry == -1;
       }));
-      REQUIRE(collection->max_expiry == -1);
     } else {
       SECTION("core API")
       {


### PR DESCRIPTION
The max expiry update happens asynchronously, so it's possible to get the pre-update `max_expiry` from the `get_all_scopes` request that follows. Moving it inside the `wait_until` predicate addresses this issue.