### PR TITLE
CXXCBC-623: Add parent span to all Core API operations

### DIFF
--- a/core/impl/analytics_index_manager.cxx
+++ b/core/impl/analytics_index_manager.cxx
@@ -158,6 +158,7 @@ public:
         options.ignore_if_exists,
         {},
         options.timeout,
+        options.parent_span,
       },
       [dataverse_name, handler = std::move(handler)](const auto& resp) {
         CB_LOG_DEBUG(
@@ -176,6 +177,7 @@ public:
         options.ignore_if_not_exists,
         {},
         options.timeout,
+        options.parent_span,
       },
       [handler = std::move(handler)](const auto& resp) {
         handler(core::impl::make_error(resp.ctx));
@@ -196,6 +198,7 @@ public:
         {},
         options.timeout,
         options.ignore_if_exists,
+        options.parent_span,
       },
       [handler = std::move(handler)](const auto& resp) {
         handler(core::impl::make_error(resp.ctx));
@@ -213,6 +216,7 @@ public:
         options.ignore_if_not_exists,
         {},
         options.timeout,
+        options.parent_span,
       },
       [handler = std::move(handler)](const auto& resp) {
         handler(core::impl::make_error(resp.ctx));
@@ -226,6 +230,7 @@ public:
       core::operations::management::analytics_dataset_get_all_request{
         {},
         options.timeout,
+        options.parent_span,
       },
       [handler = std::move(handler)](
         const core::operations::management::analytics_dataset_get_all_response& resp) {
@@ -261,6 +266,7 @@ public:
         options.ignore_if_exists,
         {},
         options.timeout,
+        options.parent_span,
       },
       [handler = std::move(handler)](const auto& resp) {
         handler(core::impl::make_error(resp.ctx));
@@ -280,6 +286,7 @@ public:
         options.ignore_if_not_exists,
         {},
         options.timeout,
+        options.parent_span,
       },
       [handler = std::move(handler)](const auto& resp) {
         handler(core::impl::make_error(resp.ctx));
@@ -293,6 +300,7 @@ public:
       core::operations::management::analytics_index_get_all_request{
         {},
         options.timeout,
+        options.parent_span,
       },
       [handler = std::move(handler)](
         const core::operations::management::analytics_index_get_all_response& resp) {
@@ -323,6 +331,7 @@ public:
         options.force,
         {},
         options.timeout,
+        options.parent_span,
       },
       [handler = std::move(handler)](const auto& resp) {
         handler(core::impl::make_error(resp.ctx));
@@ -338,6 +347,7 @@ public:
         options.link_name.value_or(DEFAULT_LINK_NAME),
         {},
         options.timeout,
+        options.parent_span,
       },
       [handler = std::move(handler)](const auto& resp) {
         handler(core::impl::make_error(resp.ctx));
@@ -351,6 +361,7 @@ public:
       core::operations::management::analytics_get_pending_mutations_request{
         {},
         options.timeout,
+        options.parent_span,
       },
       [handler = std::move(handler)](
         const core::operations::management::analytics_get_pending_mutations_response& resp) {
@@ -385,6 +396,7 @@ public:
             to_core_s3_external_link(link),
             {},
             options.timeout,
+            options.parent_span,
           },
           [handler = std::move(handler)](const auto& resp) {
             handler(core::impl::make_error(resp.ctx));
@@ -397,6 +409,7 @@ public:
             to_core_azure_blob_external_link(link),
             {},
             options.timeout,
+            options.parent_span,
           },
           [handler = std::move(handler)](const auto& resp) {
             handler(core::impl::make_error(resp.ctx));
@@ -409,6 +422,7 @@ public:
             to_core_couchbase_remote_link(link),
             {},
             options.timeout,
+            options.parent_span,
           },
           [handler = std::move(handler)](const auto& resp) {
             handler(core::impl::make_error(resp.ctx));
@@ -428,6 +442,7 @@ public:
             to_core_s3_external_link(link),
             {},
             options.timeout,
+            options.parent_span,
           },
           [handler = std::move(handler)](const auto& resp) {
             handler(core::impl::make_error(resp.ctx));
@@ -440,6 +455,7 @@ public:
             to_core_azure_blob_external_link(link),
             {},
             options.timeout,
+            options.parent_span,
           },
           [handler = std::move(handler)](const auto& resp) {
             handler(core::impl::make_error(resp.ctx));
@@ -452,6 +468,7 @@ public:
             to_core_couchbase_remote_link(link),
             {},
             options.timeout,
+            options.parent_span,
           },
           [handler = std::move(handler)](const auto& resp) {
             handler(core::impl::make_error(resp.ctx));
@@ -470,6 +487,7 @@ public:
         dataverse_name,
         {},
         options.timeout,
+        options.parent_span,
       },
       [handler = std::move(handler)](const auto& resp) {
         handler(core::impl::make_error(resp.ctx));
@@ -480,7 +498,7 @@ public:
                  get_links_analytics_handler&& handler) const
   {
     core::operations::management::analytics_link_get_all_request req{
-      {}, {}, {}, {}, options.timeout,
+      {}, {}, {}, {}, options.timeout, options.parent_span,
     };
     if (options.name.has_value()) {
       req.link_name = options.name.value();

--- a/core/impl/bucket_manager.cxx
+++ b/core/impl/bucket_manager.cxx
@@ -270,6 +270,7 @@ public:
         std::move(bucket_name),
         {},
         options.timeout,
+        options.parent_span,
       },
       [handler = std::move(handler)](const auto& resp) mutable {
         return handler(core::impl::make_error(resp.ctx), map_bucket_settings(resp.bucket));
@@ -283,6 +284,7 @@ public:
       core::operations::management::bucket_get_all_request{
         {},
         options.timeout,
+        options.parent_span,
       },
       [handler = std::move(handler)](const auto& resp) mutable {
         return handler(core::impl::make_error(resp.ctx), map_all_bucket_settings(resp.buckets));
@@ -298,6 +300,7 @@ public:
         map_bucket_settings(bucket_settings),
         {},
         options.timeout,
+        options.parent_span,
       },
       [handler = std::move(handler)](const auto& resp) mutable {
         return handler(core::impl::make_error(resp.ctx));
@@ -313,6 +316,7 @@ public:
         map_bucket_settings(bucket_settings),
         {},
         options.timeout,
+        options.parent_span,
       },
       [handler = std::move(handler)](const auto& resp) mutable {
         return handler(core::impl::make_error(resp.ctx));
@@ -328,6 +332,7 @@ public:
         std::move(bucket_name),
         {},
         options.timeout,
+        options.parent_span,
       },
       [handler = std::move(handler)](const auto& resp) mutable {
         return handler(core::impl::make_error(resp.ctx));
@@ -343,6 +348,7 @@ public:
         std::move(bucket_name),
         {},
         options.timeout,
+        options.parent_span,
       },
       [handler = std::move(handler)](const auto& resp) mutable {
         return handler(core::impl::make_error(resp.ctx));

--- a/core/impl/collection_manager.cxx
+++ b/core/impl/collection_manager.cxx
@@ -100,6 +100,7 @@ public:
         std::move(collection_name),
         {},
         options.timeout,
+        options.parent_span,
       },
       [handler = std::move(handler)](const auto& resp) mutable {
         return handler(core::impl::make_error(resp.ctx));
@@ -121,6 +122,7 @@ public:
         settings.history,
         {},
         options.timeout,
+        options.parent_span,
       },
       [handler = std::move(handler)](const auto& resp) mutable {
         return handler(core::impl::make_error(resp.ctx));
@@ -142,6 +144,7 @@ public:
         settings.history,
         {},
         options.timeout,
+        options.parent_span,
       },
       [handler = std::move(handler)](const auto& resp) mutable {
         return handler(core::impl::make_error(resp.ctx));
@@ -156,6 +159,7 @@ public:
         bucket_name_,
         {},
         options.timeout,
+        options.parent_span,
       },
       [handler = std::move(handler)](auto resp) mutable {
         return handler(core::impl::make_error(resp.ctx), map_scope_specs(resp.manifest));
@@ -172,6 +176,7 @@ public:
         std::move(scope_name),
         {},
         options.timeout,
+        options.parent_span,
       },
       [handler = std::move(handler)](const auto& resp) mutable {
         return handler(core::impl::make_error(resp.ctx));
@@ -188,6 +193,7 @@ public:
         std::move(scope_name),
         {},
         options.timeout,
+        options.parent_span,
       },
       [handler = std::move(handler)](const auto& resp) mutable {
         return handler(core::impl::make_error(resp.ctx));

--- a/core/impl/get_replica.hxx
+++ b/core/impl/get_replica.hxx
@@ -23,6 +23,7 @@
 #include "core/io/retry_context.hxx"
 #include "core/protocol/client_request.hxx"
 #include "core/protocol/cmd_get_replica.hxx"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::impl
@@ -48,6 +49,7 @@ struct get_replica_request {
   std::uint16_t partition{};
   std::uint32_t opaque{};
   io::retry_context<true> retries{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] auto encode_to(encoded_request_type& encoded,
                                core::mcbp_context&& context) const -> std::error_code;

--- a/core/impl/observe_seqno.hxx
+++ b/core/impl/observe_seqno.hxx
@@ -23,6 +23,7 @@
 #include "core/io/retry_context.hxx"
 #include "core/protocol/client_request.hxx"
 #include "core/protocol/cmd_observe_seqno.hxx"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::impl
@@ -59,6 +60,7 @@ struct observe_seqno_request {
   std::uint16_t partition{};
   std::uint32_t opaque{};
   io::retry_context<true> retries{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] auto encode_to(encoded_request_type& encoded,
                                core::mcbp_context&& context) const -> std::error_code;

--- a/core/impl/query_index_manager.cxx
+++ b/core/impl/query_index_manager.cxx
@@ -198,6 +198,7 @@ public:
         {},
         {},
         options.timeout,
+        options.parent_span,
       },
       [handler = std::move(handler)](
         const core::operations::management::query_index_get_all_response& resp) {
@@ -231,6 +232,7 @@ public:
         options.num_replicas,
         {},
         options.timeout,
+        options.parent_span,
       },
       [handler = std::move(handler)](const auto& resp) {
         handler(core::impl::make_error(resp.ctx));
@@ -258,6 +260,7 @@ public:
         options.num_replicas,
         {},
         options.timeout,
+        options.parent_span,
       },
       [handler = std::move(handler)](const auto& resp) {
         handler(core::impl::make_error(resp.ctx));
@@ -282,6 +285,7 @@ public:
         options.ignore_if_not_exists,
         {},
         options.timeout,
+        options.parent_span,
       },
       [handler = std::move(handler)](const auto& resp) {
         handler(core::impl::make_error(resp.ctx));
@@ -305,6 +309,7 @@ public:
         options.ignore_if_not_exists,
         {},
         options.timeout,
+        options.parent_span,
       },
       [handler =
          std::move(handler)](const core::operations::management::query_index_drop_response& resp) {
@@ -319,14 +324,23 @@ public:
                               build_deferred_query_indexes_handler&& handler) const
   {
     auto timeout = options.timeout;
+    auto parent_span = options.parent_span;
     return core_.execute(
       core::operations::management::query_index_get_all_deferred_request{
-        bucket_name, scope_name, collection_name, {}, {}, timeout },
+        bucket_name,
+        scope_name,
+        collection_name,
+        {},
+        {},
+        timeout,
+        parent_span,
+      },
       [self = shared_from_this(),
        bucket = bucket_name,
        scope = scope_name,
        collection = collection_name,
        timeout,
+       parent_span,
        handler = std::move(handler)](auto list_resp) mutable {
         if (list_resp.ctx.ec) {
           return handler(core::impl::make_error(list_resp.ctx));
@@ -335,13 +349,16 @@ public:
           return handler(core::impl::make_error(list_resp.ctx));
         }
         self->core_.execute(
-          core::operations::management::query_index_build_request{ std::move(bucket),
-                                                                   scope,
-                                                                   collection,
-                                                                   {},
-                                                                   std::move(list_resp.index_names),
-                                                                   {},
-                                                                   timeout },
+          core::operations::management::query_index_build_request{
+            std::move(bucket),
+            scope,
+            collection,
+            {},
+            std::move(list_resp.index_names),
+            {},
+            timeout,
+            parent_span,
+          },
           [handler = std::move(handler)](const auto& build_resp) {
             return handler(core::impl::make_error(build_resp.ctx));
           });

--- a/core/impl/search_index_manager.cxx
+++ b/core/impl/search_index_manager.cxx
@@ -149,7 +149,13 @@ public:
   {
     core_.execute(
       core::operations::management::search_index_get_request{
-        std::move(index_name), bucket_name_, scope_name_, {}, options.timeout },
+        std::move(index_name),
+        bucket_name_,
+        scope_name_,
+        {},
+        options.timeout,
+        options.parent_span,
+      },
       [handler = std::move(handler)](const auto& resp) mutable {
         return handler(core::impl::make_error(resp.ctx), map_search_index(resp.index));
       });
@@ -160,7 +166,12 @@ public:
   {
     core_.execute(
       core::operations::management::search_index_get_all_request{
-        bucket_name_, scope_name_, {}, options.timeout },
+        bucket_name_,
+        scope_name_,
+        {},
+        options.timeout,
+        options.parent_span,
+      },
       [handler = std::move(handler)](const auto& resp) mutable {
         return handler(core::impl::make_error(resp.ctx), map_all_search_indexes(resp.indexes));
       });
@@ -172,7 +183,13 @@ public:
   {
     core_.execute(
       core::operations::management::search_index_upsert_request{
-        map_search_index(search_index), bucket_name_, scope_name_, {}, options.timeout },
+        map_search_index(search_index),
+        bucket_name_,
+        scope_name_,
+        {},
+        options.timeout,
+        options.parent_span,
+      },
       [handler = std::move(handler)](const auto& resp) mutable {
         return handler(core::impl::make_error(resp.ctx));
       });
@@ -184,7 +201,13 @@ public:
   {
     core_.execute(
       core::operations::management::search_index_drop_request{
-        std::move(index_name), bucket_name_, scope_name_, {}, options.timeout },
+        std::move(index_name),
+        bucket_name_,
+        scope_name_,
+        {},
+        options.timeout,
+        options.parent_span,
+      },
       [handler = std::move(handler)](const auto& resp) mutable {
         return handler(core::impl::make_error(resp.ctx));
       });
@@ -196,7 +219,13 @@ public:
   {
     core_.execute(
       core::operations::management::search_index_get_documents_count_request{
-        std::move(index_name), bucket_name_, scope_name_, {}, options.timeout },
+        std::move(index_name),
+        bucket_name_,
+        scope_name_,
+        {},
+        options.timeout,
+        options.parent_span,
+      },
       [handler = std::move(handler)](const auto& resp) mutable {
         return handler(core::impl::make_error(resp.ctx), resp.count);
       });
@@ -208,7 +237,14 @@ public:
   {
     core_.execute(
       core::operations::management::search_index_control_ingest_request{
-        std::move(index_name), true, bucket_name_, scope_name_, {}, options.timeout },
+        std::move(index_name),
+        true,
+        bucket_name_,
+        scope_name_,
+        {},
+        options.timeout,
+        options.parent_span,
+      },
       [handler = std::move(handler)](const auto& resp) mutable {
         return handler(core::impl::make_error(resp.ctx));
       });
@@ -220,7 +256,14 @@ public:
   {
     core_.execute(
       core::operations::management::search_index_control_ingest_request{
-        std::move(index_name), false, bucket_name_, scope_name_, {}, options.timeout },
+        std::move(index_name),
+        false,
+        bucket_name_,
+        scope_name_,
+        {},
+        options.timeout,
+        options.parent_span,
+      },
       [handler = std::move(handler)](const auto& resp) mutable {
         return handler(core::impl::make_error(resp.ctx));
       });
@@ -232,7 +275,14 @@ public:
   {
     core_.execute(
       core::operations::management::search_index_control_query_request{
-        std::move(index_name), true, bucket_name_, scope_name_, {}, options.timeout },
+        std::move(index_name),
+        true,
+        bucket_name_,
+        scope_name_,
+        {},
+        options.timeout,
+        options.parent_span,
+      },
       [handler = std::move(handler)](const auto& resp) mutable {
         return handler(core::impl::make_error(resp.ctx));
       });
@@ -244,7 +294,14 @@ public:
   {
     core_.execute(
       core::operations::management::search_index_control_query_request{
-        std::move(index_name), false, bucket_name_, scope_name_, {}, options.timeout },
+        std::move(index_name),
+        false,
+        bucket_name_,
+        scope_name_,
+        {},
+        options.timeout,
+        options.parent_span,
+      },
       [handler = std::move(handler)](const auto& resp) mutable {
         return handler(core::impl::make_error(resp.ctx));
       });
@@ -256,7 +313,14 @@ public:
   {
     core_.execute(
       core::operations::management::search_index_control_plan_freeze_request{
-        std::move(index_name), true, bucket_name_, scope_name_, {}, options.timeout },
+        std::move(index_name),
+        true,
+        bucket_name_,
+        scope_name_,
+        {},
+        options.timeout,
+        options.parent_span,
+      },
       [handler = std::move(handler)](const auto& resp) mutable {
         return handler(core::impl::make_error(resp.ctx));
       });
@@ -268,7 +332,14 @@ public:
   {
     core_.execute(
       core::operations::management::search_index_control_plan_freeze_request{
-        std::move(index_name), false, bucket_name_, scope_name_, {}, options.timeout },
+        std::move(index_name),
+        false,
+        bucket_name_,
+        scope_name_,
+        {},
+        options.timeout,
+        options.parent_span,
+      },
       [handler = std::move(handler)](const auto& resp) mutable {
         return handler(core::impl::make_error(resp.ctx));
       });
@@ -280,12 +351,15 @@ public:
                         analyze_document_handler&& handler) const
   {
     core_.execute(
-      core::operations::management::search_index_analyze_document_request{ std::move(index_name),
-                                                                           std::move(document),
-                                                                           bucket_name_,
-                                                                           scope_name_,
-                                                                           {},
-                                                                           options.timeout },
+      core::operations::management::search_index_analyze_document_request{
+        std::move(index_name),
+        std::move(document),
+        bucket_name_,
+        scope_name_,
+        {},
+        options.timeout,
+        options.parent_span,
+      },
       [handler = std::move(handler)](const auto& resp) mutable {
         return handler(core::impl::make_error(resp.ctx), convert_analysis(resp.analysis));
       });

--- a/core/io/http_traits.hxx
+++ b/core/io/http_traits.hxx
@@ -29,13 +29,6 @@ template<typename T>
 inline constexpr bool supports_sticky_node_v = supports_sticky_node<T>::value;
 
 template<typename T>
-struct supports_parent_span : public std::false_type {
-};
-
-template<typename T>
-inline constexpr bool supports_parent_span_v = supports_parent_span<T>::value;
-
-template<typename T>
 struct supports_readonly : public std::false_type {
 };
 

--- a/core/io/mcbp_traits.hxx
+++ b/core/io/mcbp_traits.hxx
@@ -27,12 +27,4 @@ struct supports_durability : public std::false_type {
 
 template<typename T>
 inline constexpr bool supports_durability_v = supports_durability<T>::value;
-
-template<typename T>
-struct supports_parent_span : public std::false_type {
-};
-
-template<typename T>
-inline constexpr bool supports_parent_span_v = supports_parent_span<T>::value;
-
 } // namespace couchbase::core::io::mcbp_traits

--- a/core/operations/document_analytics.hxx
+++ b/core/operations/document_analytics.hxx
@@ -115,11 +115,6 @@ struct analytics_request {
 namespace couchbase::core::io::http_traits
 {
 template<>
-struct supports_parent_span<couchbase::core::operations::analytics_request>
-  : public std::true_type {
-};
-
-template<>
 struct supports_readonly<couchbase::core::operations::analytics_request> : public std::true_type {
 };
 } // namespace couchbase::core::io::http_traits

--- a/core/operations/document_append.hxx
+++ b/core/operations/document_append.hxx
@@ -76,8 +76,4 @@ namespace couchbase::core::io::mcbp_traits
 template<>
 struct supports_durability<couchbase::core::operations::append_request> : public std::true_type {
 };
-
-template<>
-struct supports_parent_span<couchbase::core::operations::append_request> : public std::true_type {
-};
 } // namespace couchbase::core::io::mcbp_traits

--- a/core/operations/document_decrement.hxx
+++ b/core/operations/document_decrement.hxx
@@ -79,9 +79,4 @@ namespace couchbase::core::io::mcbp_traits
 template<>
 struct supports_durability<couchbase::core::operations::decrement_request> : public std::true_type {
 };
-
-template<>
-struct supports_parent_span<couchbase::core::operations::decrement_request>
-  : public std::true_type {
-};
 } // namespace couchbase::core::io::mcbp_traits

--- a/core/operations/document_exists.hxx
+++ b/core/operations/document_exists.hxx
@@ -67,10 +67,3 @@ struct exists_request {
 };
 
 } // namespace couchbase::core::operations
-
-namespace couchbase::core::io::mcbp_traits
-{
-template<>
-struct supports_parent_span<couchbase::core::operations::exists_request> : public std::true_type {
-};
-} // namespace couchbase::core::io::mcbp_traits

--- a/core/operations/document_get.hxx
+++ b/core/operations/document_get.hxx
@@ -57,10 +57,3 @@ struct get_request {
                                    const encoded_response_type& encoded) const -> get_response;
 };
 } // namespace couchbase::core::operations
-
-namespace couchbase::core::io::mcbp_traits
-{
-template<>
-struct supports_parent_span<couchbase::core::operations::get_request> : public std::true_type {
-};
-} // namespace couchbase::core::io::mcbp_traits

--- a/core/operations/document_get_all_replicas.hxx
+++ b/core/operations/document_get_all_replicas.hxx
@@ -17,14 +17,16 @@
 
 #pragma once
 
+#include <couchbase/error_codes.hxx>
+
 #include "core/error_context/key_value.hxx"
 #include "core/impl/get_replica.hxx"
 #include "core/impl/replica_utils.hxx"
 #include "core/logger/logger.hxx"
 #include "core/operations/document_get.hxx"
 #include "core/operations/operation_traits.hxx"
+#include "core/public_fwd.hxx"
 #include "core/utils/movable_function.hxx"
-#include "couchbase/error_codes.hxx"
 
 #include <memory>
 #include <mutex>
@@ -54,6 +56,7 @@ struct get_all_replicas_request {
   core::document_id id;
   std::optional<std::chrono::milliseconds> timeout{};
   couchbase::read_preference read_preference{ couchbase::read_preference::no_preference };
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   template<typename Core, typename Handler>
   void execute(Core core, Handler handler)

--- a/core/operations/document_get_and_lock.hxx
+++ b/core/operations/document_get_and_lock.hxx
@@ -58,13 +58,4 @@ struct get_and_lock_request {
                                    const encoded_response_type& encoded) const
     -> get_and_lock_response;
 };
-
 } // namespace couchbase::core::operations
-
-namespace couchbase::core::io::mcbp_traits
-{
-template<>
-struct supports_parent_span<couchbase::core::operations::get_and_lock_request>
-  : public std::true_type {
-};
-} // namespace couchbase::core::io::mcbp_traits

--- a/core/operations/document_get_and_touch.hxx
+++ b/core/operations/document_get_and_touch.hxx
@@ -59,13 +59,4 @@ struct get_and_touch_request {
                                    const encoded_response_type& encoded) const
     -> get_and_touch_response;
 };
-
 } // namespace couchbase::core::operations
-
-namespace couchbase::core::io::mcbp_traits
-{
-template<>
-struct supports_parent_span<couchbase::core::operations::get_and_touch_request>
-  : public std::true_type {
-};
-} // namespace couchbase::core::io::mcbp_traits

--- a/core/operations/document_get_projected.hxx
+++ b/core/operations/document_get_projected.hxx
@@ -62,13 +62,4 @@ struct get_projected_request {
                                    const encoded_response_type& encoded) const
     -> get_projected_response;
 };
-
 } // namespace couchbase::core::operations
-
-namespace couchbase::core::io::mcbp_traits
-{
-template<>
-struct supports_parent_span<couchbase::core::operations::get_projected_request>
-  : public std::true_type {
-};
-} // namespace couchbase::core::io::mcbp_traits

--- a/core/operations/document_increment.hxx
+++ b/core/operations/document_increment.hxx
@@ -79,9 +79,4 @@ namespace couchbase::core::io::mcbp_traits
 template<>
 struct supports_durability<couchbase::core::operations::increment_request> : public std::true_type {
 };
-
-template<>
-struct supports_parent_span<couchbase::core::operations::increment_request>
-  : public std::true_type {
-};
 } // namespace couchbase::core::io::mcbp_traits

--- a/core/operations/document_insert.hxx
+++ b/core/operations/document_insert.hxx
@@ -77,8 +77,4 @@ namespace couchbase::core::io::mcbp_traits
 template<>
 struct supports_durability<couchbase::core::operations::insert_request> : public std::true_type {
 };
-
-template<>
-struct supports_parent_span<couchbase::core::operations::insert_request> : public std::true_type {
-};
 } // namespace couchbase::core::io::mcbp_traits

--- a/core/operations/document_lookup_in.hxx
+++ b/core/operations/document_lookup_in.hxx
@@ -72,13 +72,4 @@ struct lookup_in_request {
                                    const encoded_response_type& encoded) const
     -> lookup_in_response;
 };
-
 } // namespace couchbase::core::operations
-namespace couchbase::core::io::mcbp_traits
-{
-
-template<>
-struct supports_parent_span<couchbase::core::operations::lookup_in_request>
-  : public std::true_type {
-};
-} // namespace couchbase::core::io::mcbp_traits

--- a/core/operations/document_mutate_in.hxx
+++ b/core/operations/document_mutate_in.hxx
@@ -95,9 +95,4 @@ namespace couchbase::core::io::mcbp_traits
 template<>
 struct supports_durability<couchbase::core::operations::mutate_in_request> : public std::true_type {
 };
-
-template<>
-struct supports_parent_span<couchbase::core::operations::mutate_in_request>
-  : public std::true_type {
-};
 } // namespace couchbase::core::io::mcbp_traits

--- a/core/operations/document_prepend.hxx
+++ b/core/operations/document_prepend.hxx
@@ -76,8 +76,4 @@ namespace couchbase::core::io::mcbp_traits
 template<>
 struct supports_durability<couchbase::core::operations::prepend_request> : public std::true_type {
 };
-
-template<>
-struct supports_parent_span<couchbase::core::operations::prepend_request> : public std::true_type {
-};
 } // namespace couchbase::core::io::mcbp_traits

--- a/core/operations/document_query.hxx
+++ b/core/operations/document_query.hxx
@@ -131,10 +131,6 @@ struct supports_sticky_node<couchbase::core::operations::query_request> : public
 };
 
 template<>
-struct supports_parent_span<couchbase::core::operations::query_request> : public std::true_type {
-};
-
-template<>
 struct supports_readonly<couchbase::core::operations::query_request> : public std::true_type {
 };
 } // namespace couchbase::core::io::http_traits

--- a/core/operations/document_remove.hxx
+++ b/core/operations/document_remove.hxx
@@ -75,8 +75,4 @@ namespace couchbase::core::io::mcbp_traits
 template<>
 struct supports_durability<couchbase::core::operations::remove_request> : public std::true_type {
 };
-
-template<>
-struct supports_parent_span<couchbase::core::operations::remove_request> : public std::true_type {
-};
 } // namespace couchbase::core::io::mcbp_traits

--- a/core/operations/document_replace.hxx
+++ b/core/operations/document_replace.hxx
@@ -79,8 +79,4 @@ namespace couchbase::core::io::mcbp_traits
 template<>
 struct supports_durability<couchbase::core::operations::replace_request> : public std::true_type {
 };
-
-template<>
-struct supports_parent_span<couchbase::core::operations::replace_request> : public std::true_type {
-};
 } // namespace couchbase::core::io::mcbp_traits

--- a/core/operations/document_search.hxx
+++ b/core/operations/document_search.hxx
@@ -174,11 +174,4 @@ struct search_request {
 
   std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 };
-
 } // namespace couchbase::core::operations
-namespace couchbase::core::io::http_traits
-{
-template<>
-struct supports_parent_span<couchbase::core::operations::search_request> : public std::true_type {
-};
-} // namespace couchbase::core::io::http_traits

--- a/core/operations/document_touch.hxx
+++ b/core/operations/document_touch.hxx
@@ -55,11 +55,4 @@ struct touch_request {
   [[nodiscard]] auto make_response(key_value_error_context&& ctx,
                                    const encoded_response_type& encoded) const -> touch_response;
 };
-
 } // namespace couchbase::core::operations
-namespace couchbase::core::io::mcbp_traits
-{
-template<>
-struct supports_parent_span<couchbase::core::operations::touch_request> : public std::true_type {
-};
-} // namespace couchbase::core::io::mcbp_traits

--- a/core/operations/document_unlock.hxx
+++ b/core/operations/document_unlock.hxx
@@ -57,9 +57,3 @@ struct unlock_request {
 };
 
 } // namespace couchbase::core::operations
-namespace couchbase::core::io::mcbp_traits
-{
-template<>
-struct supports_parent_span<couchbase::core::operations::unlock_request> : public std::true_type {
-};
-} // namespace couchbase::core::io::mcbp_traits

--- a/core/operations/document_upsert.hxx
+++ b/core/operations/document_upsert.hxx
@@ -78,8 +78,4 @@ namespace couchbase::core::io::mcbp_traits
 template<>
 struct supports_durability<couchbase::core::operations::upsert_request> : public std::true_type {
 };
-
-template<>
-struct supports_parent_span<couchbase::core::operations::upsert_request> : public std::true_type {
-};
 } // namespace couchbase::core::io::mcbp_traits

--- a/core/operations/document_view.hxx
+++ b/core/operations/document_view.hxx
@@ -105,11 +105,3 @@ struct document_view_request {
 };
 
 } // namespace couchbase::core::operations
-
-namespace couchbase::core::io::http_traits
-{
-template<>
-struct supports_parent_span<couchbase::core::operations::document_view_request>
-  : public std::true_type {
-};
-} // namespace couchbase::core::io::http_traits

--- a/core/operations/http_noop.hxx
+++ b/core/operations/http_noop.hxx
@@ -21,6 +21,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations
@@ -41,6 +42,7 @@ struct http_noop_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] auto encode_to(encoded_request_type& encoded,
                                http_context& context) -> std::error_code;

--- a/core/operations/management/analytics_dataset_create.hxx
+++ b/core/operations/management/analytics_dataset_create.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -50,6 +51,7 @@ struct analytics_dataset_create_request {
   std::optional<std::chrono::milliseconds> timeout{};
 
   bool ignore_if_exists{ false };
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/analytics_dataset_drop.hxx
+++ b/core/operations/management/analytics_dataset_drop.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -47,6 +48,7 @@ struct analytics_dataset_drop_request {
   bool ignore_if_does_not_exist{ false };
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/analytics_dataset_get_all.hxx
+++ b/core/operations/management/analytics_dataset_get_all.hxx
@@ -23,6 +23,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/analytics_dataset.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -45,6 +46,7 @@ struct analytics_dataset_get_all_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/analytics_dataverse_create.hxx
+++ b/core/operations/management/analytics_dataverse_create.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -46,6 +47,7 @@ struct analytics_dataverse_create_request {
   bool ignore_if_exists{ false };
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/analytics_dataverse_drop.hxx
+++ b/core/operations/management/analytics_dataverse_drop.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -46,6 +47,7 @@ struct analytics_dataverse_drop_request {
   bool ignore_if_does_not_exist{ false };
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/analytics_get_pending_mutations.hxx
+++ b/core/operations/management/analytics_get_pending_mutations.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -45,6 +46,7 @@ struct analytics_get_pending_mutations_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/analytics_index_create.hxx
+++ b/core/operations/management/analytics_index_create.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -49,6 +50,7 @@ struct analytics_index_create_request {
   bool ignore_if_exists{ false };
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/analytics_index_drop.hxx
+++ b/core/operations/management/analytics_index_drop.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -48,6 +49,7 @@ struct analytics_index_drop_request {
   bool ignore_if_does_not_exist{ false };
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/analytics_index_get_all.hxx
+++ b/core/operations/management/analytics_index_get_all.hxx
@@ -23,6 +23,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/analytics_index.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -45,6 +46,7 @@ struct analytics_index_get_all_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/analytics_link_connect.hxx
+++ b/core/operations/management/analytics_link_connect.hxx
@@ -21,6 +21,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -50,6 +51,7 @@ struct analytics_link_connect_request {
   bool force{ false };
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/analytics_link_create.hxx
+++ b/core/operations/management/analytics_link_create.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -56,6 +57,7 @@ struct analytics_link_create_request {
   analytics_link_type link{};
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& /* context */) const

--- a/core/operations/management/analytics_link_disconnect.hxx
+++ b/core/operations/management/analytics_link_disconnect.hxx
@@ -21,6 +21,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -49,6 +50,7 @@ struct analytics_link_disconnect_request {
   std::string link_name{ "Local" };
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/analytics_link_drop.hxx
+++ b/core/operations/management/analytics_link_drop.hxx
@@ -21,6 +21,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -49,6 +50,7 @@ struct analytics_link_drop_request {
   std::string dataverse_name{};
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/analytics_link_get_all.hxx
+++ b/core/operations/management/analytics_link_get_all.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/analytics_link.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -56,6 +57,7 @@ struct analytics_link_get_all_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/analytics_link_replace.hxx
+++ b/core/operations/management/analytics_link_replace.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -57,6 +58,7 @@ struct analytics_link_replace_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& /* context */) const

--- a/core/operations/management/bucket_create.hxx
+++ b/core/operations/management/bucket_create.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/bucket_settings.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -44,6 +45,7 @@ struct bucket_create_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/bucket_describe.hxx
+++ b/core/operations/management/bucket_describe.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/bucket_settings.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -80,6 +81,7 @@ struct bucket_describe_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/bucket_drop.hxx
+++ b/core/operations/management/bucket_drop.hxx
@@ -21,6 +21,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -42,6 +43,7 @@ struct bucket_drop_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/bucket_flush.hxx
+++ b/core/operations/management/bucket_flush.hxx
@@ -21,6 +21,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -42,6 +43,7 @@ struct bucket_flush_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/bucket_get.hxx
+++ b/core/operations/management/bucket_get.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/bucket_settings.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -44,6 +45,7 @@ struct bucket_get_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/bucket_get_all.hxx
+++ b/core/operations/management/bucket_get_all.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/bucket_settings.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -42,6 +43,7 @@ struct bucket_get_all_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/bucket_update.hxx
+++ b/core/operations/management/bucket_update.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/bucket_settings.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -45,6 +46,7 @@ struct bucket_update_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/change_password.hxx
+++ b/core/operations/management/change_password.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/rbac.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -43,6 +44,7 @@ struct change_password_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/cluster_describe.hxx
+++ b/core/operations/management/cluster_describe.hxx
@@ -21,6 +21,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/service_type.hxx"
 #include "core/timeout_defaults.hxx"
 
@@ -65,6 +66,7 @@ struct cluster_describe_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/cluster_developer_preview_enable.hxx
+++ b/core/operations/management/cluster_developer_preview_enable.hxx
@@ -21,6 +21,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -40,6 +41,7 @@ struct cluster_developer_preview_enable_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/collection_create.hxx
+++ b/core/operations/management/collection_create.hxx
@@ -21,6 +21,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -48,6 +49,7 @@ struct collection_create_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/collection_drop.hxx
+++ b/core/operations/management/collection_drop.hxx
@@ -21,6 +21,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -45,6 +46,7 @@ struct collection_drop_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/collection_update.hxx
+++ b/core/operations/management/collection_update.hxx
@@ -21,6 +21,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -48,6 +49,7 @@ struct collection_update_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/collections_manifest_get.hxx
+++ b/core/operations/management/collections_manifest_get.hxx
@@ -23,6 +23,7 @@
 #include "core/io/retry_context.hxx"
 #include "core/protocol/client_request.hxx"
 #include "core/protocol/cmd_get_collections_manifest.hxx"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 #include "core/topology/collections_manifest.hxx"
 
@@ -48,6 +49,7 @@ struct collections_manifest_get_request {
 
   std::optional<std::chrono::milliseconds> timeout{};
   io::retry_context<true> retries{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           mcbp_context&& /* context */) const;

--- a/core/operations/management/eventing_deploy_function.hxx
+++ b/core/operations/management/eventing_deploy_function.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/eventing_function.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 #include "eventing_problem.hxx"
 
@@ -48,6 +49,7 @@ struct eventing_deploy_function_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/eventing_drop_function.hxx
+++ b/core/operations/management/eventing_drop_function.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/eventing_function.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 #include "eventing_problem.hxx"
 
@@ -48,6 +49,7 @@ struct eventing_drop_function_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/eventing_get_all_functions.hxx
+++ b/core/operations/management/eventing_get_all_functions.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/eventing_function.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 #include "eventing_problem.hxx"
 
@@ -47,6 +48,7 @@ struct eventing_get_all_functions_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/eventing_get_function.hxx
+++ b/core/operations/management/eventing_get_function.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/eventing_function.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 #include "eventing_problem.hxx"
 
@@ -48,6 +49,7 @@ struct eventing_get_function_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/eventing_get_status.hxx
+++ b/core/operations/management/eventing_get_status.hxx
@@ -23,6 +23,7 @@
 #include "core/management/eventing_function.hxx"
 #include "core/management/eventing_status.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 #include "eventing_problem.hxx"
 
@@ -49,6 +50,7 @@ struct eventing_get_status_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/eventing_pause_function.hxx
+++ b/core/operations/management/eventing_pause_function.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/eventing_function.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 #include "eventing_problem.hxx"
 
@@ -48,6 +49,7 @@ struct eventing_pause_function_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/eventing_resume_function.hxx
+++ b/core/operations/management/eventing_resume_function.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/eventing_function.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 #include "eventing_problem.hxx"
 
@@ -48,6 +49,7 @@ struct eventing_resume_function_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/eventing_undeploy_function.hxx
+++ b/core/operations/management/eventing_undeploy_function.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/eventing_function.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 #include "eventing_problem.hxx"
 
@@ -48,6 +49,7 @@ struct eventing_undeploy_function_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/eventing_upsert_function.hxx
+++ b/core/operations/management/eventing_upsert_function.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/eventing_function.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 #include "eventing_problem.hxx"
 
@@ -48,6 +49,7 @@ struct eventing_upsert_function_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/freeform.hxx
+++ b/core/operations/management/freeform.hxx
@@ -21,6 +21,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/service_type.hxx"
 #include "core/timeout_defaults.hxx"
 
@@ -49,6 +50,7 @@ struct freeform_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/group_drop.hxx
+++ b/core/operations/management/group_drop.hxx
@@ -21,6 +21,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -42,6 +43,7 @@ struct group_drop_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/group_get.hxx
+++ b/core/operations/management/group_get.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/rbac.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -44,6 +45,7 @@ struct group_get_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/group_get_all.hxx
+++ b/core/operations/management/group_get_all.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/rbac.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -42,6 +43,7 @@ struct group_get_all_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/group_upsert.hxx
+++ b/core/operations/management/group_upsert.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/rbac.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -44,6 +45,7 @@ struct group_upsert_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/query_index_build.hxx
+++ b/core/operations/management/query_index_build.hxx
@@ -21,6 +21,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/query_context.hxx"
 #include "core/timeout_defaults.hxx"
 
@@ -55,6 +56,7 @@ struct query_index_build_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] auto encode_to(encoded_request_type& encoded, http_context& context) const
     -> std::error_code;

--- a/core/operations/management/query_index_build_deferred.hxx
+++ b/core/operations/management/query_index_build_deferred.hxx
@@ -21,6 +21,7 @@
 #include "core/operations/management/query_index_build.hxx"
 #include "core/operations/management/query_index_get_all_deferred.hxx"
 #include "core/operations/operation_traits.hxx"
+#include "core/public_fwd.hxx"
 #include "core/query_context.hxx"
 #include "couchbase/management/query_index.hxx"
 
@@ -56,6 +57,7 @@ struct query_index_build_deferred_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] response_type make_response(error_context::http&& ctx,
                                             const encoded_response_type& /* encoded */) const

--- a/core/operations/management/query_index_create.hxx
+++ b/core/operations/management/query_index_create.hxx
@@ -21,6 +21,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/query_context.hxx"
 #include "core/timeout_defaults.hxx"
 
@@ -60,6 +61,7 @@ struct query_index_create_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/query_index_drop.hxx
+++ b/core/operations/management/query_index_drop.hxx
@@ -21,6 +21,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/query_context.hxx"
 #include "core/timeout_defaults.hxx"
 
@@ -56,6 +57,7 @@ struct query_index_drop_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/query_index_get_all.hxx
+++ b/core/operations/management/query_index_get_all.hxx
@@ -17,13 +17,13 @@
 
 #pragma once
 
+#include <couchbase/management/query_index.hxx>
+
 #include "core/error_context/http.hxx"
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
-#include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/query_context.hxx"
-#include "core/timeout_defaults.hxx"
-#include "couchbase/management/query_index.hxx"
 
 namespace couchbase::core::operations::management
 {
@@ -50,6 +50,7 @@ struct query_index_get_all_request {
   query_context query_ctx;
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/query_index_get_all_deferred.hxx
+++ b/core/operations/management/query_index_get_all_deferred.hxx
@@ -21,9 +21,9 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/query_context.hxx"
 #include "core/timeout_defaults.hxx"
-#include "couchbase/management/query_index.hxx"
 
 namespace couchbase::core::operations::management
 {
@@ -51,6 +51,7 @@ struct query_index_get_all_deferred_request {
   query_context query_ctx;
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/role_get_all.hxx
+++ b/core/operations/management/role_get_all.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/rbac.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -42,6 +43,7 @@ struct role_get_all_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/scope_create.hxx
+++ b/core/operations/management/scope_create.hxx
@@ -21,6 +21,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -44,6 +45,7 @@ struct scope_create_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/scope_drop.hxx
+++ b/core/operations/management/scope_drop.hxx
@@ -21,6 +21,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -44,6 +45,7 @@ struct scope_drop_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/scope_get_all.hxx
+++ b/core/operations/management/scope_get_all.hxx
@@ -21,6 +21,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 #include "core/topology/collections_manifest.hxx"
 
@@ -44,6 +45,7 @@ struct scope_get_all_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/search_get_stats.hxx
+++ b/core/operations/management/search_get_stats.hxx
@@ -21,6 +21,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -41,6 +42,7 @@ struct search_get_stats_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/search_index_analyze_document.hxx
+++ b/core/operations/management/search_index_analyze_document.hxx
@@ -21,6 +21,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -49,6 +50,7 @@ struct search_index_analyze_document_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/search_index_control_ingest.hxx
+++ b/core/operations/management/search_index_control_ingest.hxx
@@ -21,6 +21,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -48,6 +49,7 @@ struct search_index_control_ingest_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/search_index_control_plan_freeze.hxx
+++ b/core/operations/management/search_index_control_plan_freeze.hxx
@@ -21,6 +21,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations
@@ -50,6 +51,7 @@ struct search_index_control_plan_freeze_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/search_index_control_query.hxx
+++ b/core/operations/management/search_index_control_query.hxx
@@ -21,6 +21,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -48,6 +49,7 @@ struct search_index_control_query_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/search_index_drop.hxx
+++ b/core/operations/management/search_index_drop.hxx
@@ -21,6 +21,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -47,6 +48,7 @@ struct search_index_drop_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/search_index_get.hxx
+++ b/core/operations/management/search_index_get.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/search_index.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -48,6 +49,7 @@ struct search_index_get_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/search_index_get_all.hxx
+++ b/core/operations/management/search_index_get_all.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/search_index.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -47,6 +48,7 @@ struct search_index_get_all_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/search_index_get_documents_count.hxx
+++ b/core/operations/management/search_index_get_documents_count.hxx
@@ -21,6 +21,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -49,6 +50,7 @@ struct search_index_get_documents_count_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/search_index_get_stats.hxx
+++ b/core/operations/management/search_index_get_stats.hxx
@@ -21,6 +21,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -45,6 +46,7 @@ struct search_index_get_stats_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/search_index_upsert.hxx
+++ b/core/operations/management/search_index_upsert.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/search_index.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -50,6 +51,7 @@ struct search_index_upsert_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/user_drop.hxx
+++ b/core/operations/management/user_drop.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/rbac.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -46,6 +47,7 @@ struct user_drop_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/user_get.hxx
+++ b/core/operations/management/user_get.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/rbac.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -47,6 +48,7 @@ struct user_get_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/user_get_all.hxx
+++ b/core/operations/management/user_get_all.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/rbac.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -46,6 +47,7 @@ struct user_get_all_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/user_upsert.hxx
+++ b/core/operations/management/user_upsert.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/rbac.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -47,6 +48,7 @@ struct user_upsert_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/view_index_drop.hxx
+++ b/core/operations/management/view_index_drop.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_context.hxx"
 #include "core/io/http_message.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -45,6 +46,7 @@ struct view_index_drop_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/view_index_get.hxx
+++ b/core/operations/management/view_index_get.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/design_document.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -46,6 +47,7 @@ struct view_index_get_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/view_index_get_all.hxx
+++ b/core/operations/management/view_index_get_all.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/design_document.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -46,6 +47,7 @@ struct view_index_get_all_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;

--- a/core/operations/management/view_index_upsert.hxx
+++ b/core/operations/management/view_index_upsert.hxx
@@ -22,6 +22,7 @@
 #include "core/io/http_message.hxx"
 #include "core/management/design_document.hxx"
 #include "core/platform/uuid.h"
+#include "core/public_fwd.hxx"
 #include "core/timeout_defaults.hxx"
 
 namespace couchbase::core::operations::management
@@ -44,6 +45,7 @@ struct view_index_upsert_request {
 
   std::optional<std::string> client_context_id{};
   std::optional<std::chrono::milliseconds> timeout{};
+  std::shared_ptr<couchbase::tracing::request_span> parent_span{ nullptr };
 
   [[nodiscard]] std::error_code encode_to(encoded_request_type& encoded,
                                           http_context& context) const;


### PR DESCRIPTION
## Motivation

Wrappers and the Public API must be able to specify a parent span for all Core API operations

## Changes

* Add a `parent_span` field to all core API operations that were missing it (mostly management operations) and pass on the parent span set in the Public API options to the core.
* Remove the `supports_parent_span` trait