### PR TITLE
CXXCBC-734: Columnar: Update how client handles streaming timeout and improve log messaging

### DIFF
--- a/core/pending_operation.hxx
+++ b/core/pending_operation.hxx
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include <string>
+
 namespace couchbase::core
 {
 class pending_operation
@@ -22,5 +24,13 @@ class pending_operation
 public:
   virtual ~pending_operation() = default;
   virtual void cancel() = 0;
+
+  virtual auto client_context_id() const -> const std::string&
+  {
+    return default_client_context_id_;
+  }
+
+protected:
+  static inline const std::string default_client_context_id_ = "";
 };
 } // namespace couchbase::core

--- a/core/row_streamer.hxx
+++ b/core/row_streamer.hxx
@@ -19,6 +19,7 @@
 
 #include "utils/movable_function.hxx"
 
+#include <chrono>
 #include <memory>
 #include <optional>
 #include <string>
@@ -31,6 +32,7 @@ class io_context;
 
 namespace couchbase::core
 {
+
 class row_streamer_impl;
 class http_response_body;
 
@@ -39,7 +41,8 @@ class row_streamer
 public:
   row_streamer(asio::io_context& io,
                http_response_body body,
-               const std::string& pointer_expression);
+               const std::string& pointer_expression,
+               const std::string& client_context_id);
 
   /**
    *  Starts the row stream and returns all the metadata preceding the first row. This typically
@@ -61,6 +64,17 @@ public:
    * If all rows have been streamed, returns the metadata encoded as JSON.
    */
   auto metadata() -> std::optional<std::string>;
+
+  /**
+   * Enables the streamer to timeout after the specified duration.
+   */
+  void set_streamer_timeout(std::chrono::milliseconds timeout);
+
+  /**
+   * Enables the streamer execute upstream functionality after streaming completes or the request
+   * times out (if the streamer timeout has been set).
+   */
+  void set_streamer_done_callback(utils::movable_function<void()>&& done_callback);
 
 private:
   std::shared_ptr<row_streamer_impl> impl_;


### PR DESCRIPTION
Changes
=======
* Once streaming has successfully started, allow the row_streamer to trace the remaining time left until the request might timeout
* Add a "done" callback to the row_streamer that can be invoked once streaming is complete
* Add client_context_id to pending_operations
* Add DEBUG logging messages to improve ease of tracing a query through logs