### PR TITLE
CXXCBC-732: Fix bug where concurrent fixed queue doesn't correctly report top N items

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -435,7 +435,9 @@ set(couchbase_cxx_client_FILES
     core/app_telemetry_address.cxx
     core/app_telemetry_meter.cxx
     core/app_telemetry_reporter.cxx
-    core/cluster_credentials.cxx)
+    core/cluster_credentials.cxx
+    core/orphan_reporter.cxx
+)
 
 set(couchbase_cxx_client_LIBRARIES)
 set(couchbase_cxx_client_DEFAULT_LIBRARY)

--- a/core/bucket.cxx
+++ b/core/bucket.cxx
@@ -85,6 +85,7 @@ public:
               couchbase::core::origin origin,
               std::shared_ptr<tracing::tracer_wrapper> tracer,
               std::shared_ptr<metrics::meter_wrapper> meter,
+              std::shared_ptr<orphan_reporter> orphan_reporter,
               std::shared_ptr<core::app_telemetry_meter> app_telemetry,
               std::vector<protocol::hello_feature> known_features,
               std::shared_ptr<impl::bootstrap_state_listener> state_listener,
@@ -96,6 +97,7 @@ public:
     , origin_{ std::move(origin) }
     , tracer_{ std::move(tracer) }
     , meter_{ std::move(meter) }
+    , orphan_reporter_{ std::move(orphan_reporter) }
     , app_telemetry_meter_{ std::move(app_telemetry) }
     , known_features_{ std::move(known_features) }
     , state_listener_{ std::move(state_listener) }
@@ -929,6 +931,11 @@ public:
     return meter_;
   }
 
+  [[nodiscard]] auto orphan_reporter() const -> std::shared_ptr<core::orphan_reporter>
+  {
+    return orphan_reporter_;
+  }
+
   [[nodiscard]] auto app_telemetry_meter() const -> std::shared_ptr<core::app_telemetry_meter>
   {
     return app_telemetry_meter_;
@@ -984,6 +991,7 @@ private:
   const origin origin_;
   const std::shared_ptr<tracing::tracer_wrapper> tracer_;
   const std::shared_ptr<metrics::meter_wrapper> meter_;
+  const std::shared_ptr<core::orphan_reporter> orphan_reporter_;
   const std::shared_ptr<core::app_telemetry_meter> app_telemetry_meter_;
   const std::vector<protocol::hello_feature> known_features_;
   const std::shared_ptr<impl::bootstrap_state_listener> state_listener_;
@@ -1018,6 +1026,7 @@ bucket::bucket(std::string client_id,
                asio::ssl::context& tls,
                std::shared_ptr<tracing::tracer_wrapper> tracer,
                std::shared_ptr<metrics::meter_wrapper> meter,
+               std::shared_ptr<core::orphan_reporter> orphan_reporter,
                std::shared_ptr<core::app_telemetry_meter> app_telemetry_meter,
                std::string name,
                couchbase::core::origin origin,
@@ -1030,6 +1039,7 @@ bucket::bucket(std::string client_id,
                                          std::move(origin),
                                          std::move(tracer),
                                          std::move(meter),
+                                         std::move(orphan_reporter),
                                          std::move(app_telemetry_meter),
                                          std::move(known_features),
                                          std::move(state_listener),
@@ -1096,6 +1106,12 @@ auto
 bucket::meter() const -> std::shared_ptr<metrics::meter_wrapper>
 {
   return impl_->meter();
+}
+
+auto
+bucket::orphan_reporter() const -> std::shared_ptr<core::orphan_reporter>
+{
+  return impl_->orphan_reporter();
 }
 
 auto

--- a/core/bucket.hxx
+++ b/core/bucket.hxx
@@ -70,7 +70,8 @@ public:
          asio::ssl::context& tls,
          std::shared_ptr<tracing::tracer_wrapper> tracer,
          std::shared_ptr<metrics::meter_wrapper> meter,
-         std::shared_ptr<core::app_telemetry_meter> app_telemetry_meter,
+         std::shared_ptr<orphan_reporter> orphan_reporter,
+         std::shared_ptr<app_telemetry_meter> app_telemetry_meter,
          std::string name,
          couchbase::core::origin origin,
          std::vector<protocol::hello_feature> known_features,
@@ -210,6 +211,7 @@ public:
   [[nodiscard]] auto log_prefix() const -> const std::string&;
   [[nodiscard]] auto tracer() const -> std::shared_ptr<tracing::tracer_wrapper>;
   [[nodiscard]] auto meter() const -> std::shared_ptr<metrics::meter_wrapper>;
+  [[nodiscard]] auto orphan_reporter() const -> std::shared_ptr<orphan_reporter>;
   [[nodiscard]] auto app_telemetry_meter() const -> std::shared_ptr<app_telemetry_meter>;
   [[nodiscard]] auto default_retry_strategy() const -> std::shared_ptr<couchbase::retry_strategy>;
   [[nodiscard]] auto is_closed() const -> bool;

--- a/core/cluster_options.hxx
+++ b/core/cluster_options.hxx
@@ -21,6 +21,7 @@
 #include "core/io/dns_config.hxx"
 #include "core/io/ip_protocol.hxx"
 #include "core/metrics/logging_meter_options.hxx"
+#include "core/orphan_reporter.hxx"
 #include "core/tracing/threshold_logging_options.hxx"
 #include "service_type.hxx"
 #include "timeout_defaults.hxx"
@@ -72,9 +73,11 @@ public:
   bool enable_compression{ true };
   bool enable_tracing{ true };
   bool enable_metrics{ true };
+  bool enable_orphan_reporting{ true };
   std::string network{ "auto" };
   tracing::threshold_logging_options tracing_options{};
   metrics::logging_meter_options metrics_options{};
+  orphan_reporter_options orphan_options{};
   tls_verify_mode tls_verify{ tls_verify_mode::peer };
   std::shared_ptr<couchbase::tracing::request_tracer> tracer{ nullptr };
   std::shared_ptr<couchbase::metrics::meter> meter{ nullptr };

--- a/core/impl/public_cluster.cxx
+++ b/core/impl/public_cluster.cxx
@@ -178,8 +178,8 @@ options_to_origin(const std::string& connection_string, cluster_options::built o
   user_options.enable_tracing = opts.tracing.enabled;
   if (opts.tracing.enabled) {
     user_options.tracer = opts.tracing.tracer;
-    user_options.tracing_options.orphaned_emit_interval = opts.tracing.orphaned_emit_interval;
-    user_options.tracing_options.orphaned_sample_size = opts.tracing.orphaned_sample_size;
+    user_options.orphan_options.emit_interval = opts.tracing.orphaned_emit_interval;
+    user_options.orphan_options.sample_size = opts.tracing.orphaned_sample_size;
 
     user_options.tracing_options.threshold_emit_interval = opts.tracing.threshold_emit_interval;
     user_options.tracing_options.threshold_sample_size = opts.tracing.threshold_sample_size;

--- a/core/origin.cxx
+++ b/core/origin.cxx
@@ -100,14 +100,25 @@ struct traits<couchbase::core::io::dns::dns_config> {
 };
 
 template<>
+struct traits<couchbase::core::orphan_reporter_options> {
+  template<template<typename...> class Traits>
+  static void assign(tao::json::basic_value<Traits>& v,
+                     const couchbase::core::orphan_reporter_options& o)
+  {
+    v = {
+      { "emit_interval", o.emit_interval },
+      { "sample_size", o.sample_size },
+    };
+  }
+};
+
+template<>
 struct traits<couchbase::core::tracing::threshold_logging_options> {
   template<template<typename...> class Traits>
   static void assign(tao::json::basic_value<Traits>& v,
                      const couchbase::core::tracing::threshold_logging_options& o)
   {
     v = {
-      { "orphaned_emit_interval", o.orphaned_emit_interval },
-      { "orphaned_sample_size", o.orphaned_sample_size },
       { "threshold_emit_interval", o.threshold_emit_interval },
       { "threshold_sample_size", o.threshold_sample_size },
       { "key_value_threshold", o.key_value_threshold },
@@ -275,12 +286,14 @@ origin::to_json() const -> std::string
         { "enable_compression", options_.enable_compression },
         { "enable_tracing", options_.enable_tracing },
         { "enable_metrics", options_.enable_metrics },
+        { "enable_orphan_reporting", options_.enable_orphan_reporting },
         { "tcp_keep_alive_interval", options_.tcp_keep_alive_interval },
         { "config_idle_redial_timeout", options_.config_idle_redial_timeout },
         { "max_http_connections", options_.max_http_connections },
         { "idle_http_connection_timeout", options_.idle_http_connection_timeout },
         { "metrics_options", options_.metrics_options },
         { "tracing_options", options_.tracing_options },
+        { "orphan_reporter_options", options_.orphan_options },
         { "transactions_options", options_.transactions },
         { "server_group", options_.server_group },
 #endif

--- a/core/orphan_reporter.cxx
+++ b/core/orphan_reporter.cxx
@@ -1,0 +1,158 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2025 Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "orphan_reporter.hxx"
+
+#include <couchbase/build_info.hxx>
+
+#include "logger/logger.hxx"
+#include "utils/concurrent_fixed_queue.hxx"
+#include "utils/json.hxx"
+
+#include <asio/steady_timer.hpp>
+#include <tao/json/value.hpp>
+
+namespace couchbase::core
+{
+auto
+orphan_attributes::operator<(const orphan_attributes& other) const -> bool
+{
+  return total_duration < other.total_duration;
+}
+
+auto
+orphan_attributes::to_json() const -> tao::json::value
+{
+  return tao::json::value{
+    { "total_duration_us", total_duration.count() },
+    { "last_server_duration_us", last_server_duration.count() },
+    { "total_server_duration_us", total_server_duration.count() },
+    { "operation_name", operation_name },
+    { "last_local_id", connection_id },
+    { "operation_id", operation_id },
+    { "last_local_socket", last_local_socket },
+    { "last_remote_socket", last_remote_socket },
+  };
+}
+
+class orphan_reporter_impl
+{
+public:
+  orphan_reporter_impl(asio::io_context& ctx, const orphan_reporter_options& options)
+    : options_{ options }
+    , orphan_queue_{ options.sample_size }
+    , emit_timer_{ ctx }
+  {
+  }
+
+  void add_orphan(orphan_attributes&& orphan)
+  {
+    orphan_queue_.emplace(std::move(orphan));
+  }
+
+  void start()
+  {
+    rearm();
+  }
+
+  void stop()
+  {
+    emit_timer_.cancel();
+  }
+
+  auto flush_and_create_output() -> std::optional<std::string>
+  {
+    if (orphan_queue_.empty()) {
+      return std::nullopt;
+    }
+
+    auto [queue, dropped_count] = orphan_queue_.steal_data();
+
+    auto total_count = queue.size() + dropped_count;
+
+    // We only do orphan reporting for KV at the moment. If we extend this to HTTP services, we must
+    // update this to handle other types of services as well.
+    tao::json::value report{
+#if COUCHBASE_CXX_CLIENT_DEBUG_BUILD
+      { "emit_interval_ms", options_.emit_interval.count() },
+      { "sample_size", options_.sample_size },
+#endif
+      { "kv", tao::json::value{ { "total_count", total_count } } },
+    };
+
+    tao::json::value entries = tao::json::empty_array;
+    while (!queue.empty()) {
+      entries.emplace_back(queue.top().to_json());
+      queue.pop();
+    }
+    report["kv"]["top_requests"] = entries;
+
+    return utils::json::generate(report);
+  }
+
+private:
+  void rearm()
+  {
+    emit_timer_.expires_after(options_.emit_interval);
+    emit_timer_.async_wait([this](std::error_code ec) {
+      if (ec == asio::error::operation_aborted) {
+        return;
+      }
+
+      if (auto report = flush_and_create_output(); report.has_value()) {
+        CB_LOG_WARNING("Orphan responses observed: {}", report.value());
+      }
+
+      rearm();
+    });
+  }
+
+  orphan_reporter_options options_;
+  utils::concurrent_fixed_queue<orphan_attributes> orphan_queue_;
+  asio::steady_timer emit_timer_;
+};
+
+orphan_reporter::orphan_reporter(asio::io_context& ctx, const orphan_reporter_options& options)
+  : impl_{ std::make_shared<orphan_reporter_impl>(ctx, options) }
+{
+}
+
+void
+orphan_reporter::add_orphan(orphan_attributes&& orphan)
+{
+  impl_->add_orphan(std::move(orphan));
+}
+
+void
+orphan_reporter::start()
+{
+  impl_->start();
+}
+
+void
+orphan_reporter::stop()
+{
+  impl_->stop();
+}
+
+auto
+orphan_reporter::flush_and_create_output() -> std::optional<std::string>
+{
+  return impl_->flush_and_create_output();
+}
+
+} // namespace couchbase::core

--- a/core/orphan_reporter.cxx
+++ b/core/orphan_reporter.cxx
@@ -20,7 +20,7 @@
 #include <couchbase/build_info.hxx>
 
 #include "logger/logger.hxx"
-#include "utils/concurrent_fixed_queue.hxx"
+#include "utils/concurrent_fixed_priority_queue.hxx"
 #include "utils/json.hxx"
 
 #include <asio/steady_timer.hpp>
@@ -32,6 +32,12 @@ auto
 orphan_attributes::operator<(const orphan_attributes& other) const -> bool
 {
   return total_duration < other.total_duration;
+}
+
+auto
+orphan_attributes::operator>(const orphan_attributes& other) const -> bool
+{
+  return total_duration > other.total_duration;
 }
 
 auto
@@ -122,7 +128,7 @@ private:
   }
 
   orphan_reporter_options options_;
-  utils::concurrent_fixed_queue<orphan_attributes> orphan_queue_;
+  utils::concurrent_fixed_priority_queue<orphan_attributes> orphan_queue_;
   asio::steady_timer emit_timer_;
 };
 

--- a/core/orphan_reporter.hxx
+++ b/core/orphan_reporter.hxx
@@ -1,0 +1,64 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2025 Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include "core/protocol/client_opcode.hxx"
+
+#include <asio/io_context.hpp>
+#include <tao/json/value.hpp>
+
+#include <chrono>
+#include <memory>
+
+namespace couchbase::core
+{
+struct orphan_reporter_options {
+  std::chrono::milliseconds emit_interval{ std::chrono::seconds{ 10 } };
+  std::size_t sample_size{ 64 };
+};
+
+struct orphan_attributes {
+  std::string connection_id;
+  std::string operation_id;
+  std::string last_remote_socket;
+  std::string last_local_socket;
+  std::chrono::microseconds total_duration;
+  std::chrono::microseconds last_server_duration{ 0 };
+  std::chrono::microseconds total_server_duration{ 0 };
+  std::string operation_name;
+
+  auto operator<(const orphan_attributes& other) const -> bool;
+  auto to_json() const -> tao::json::value;
+};
+
+class orphan_reporter_impl;
+
+class orphan_reporter
+{
+public:
+  orphan_reporter(asio::io_context& ctx, const orphan_reporter_options& options);
+
+  void add_orphan(orphan_attributes&& orphan);
+  void start();
+  void stop();
+  auto flush_and_create_output() -> std::optional<std::string>;
+
+private:
+  std::shared_ptr<orphan_reporter_impl> impl_;
+};
+} // namespace couchbase::core

--- a/core/orphan_reporter.hxx
+++ b/core/orphan_reporter.hxx
@@ -43,6 +43,7 @@ struct orphan_attributes {
   std::string operation_name;
 
   auto operator<(const orphan_attributes& other) const -> bool;
+  auto operator>(const orphan_attributes& other) const -> bool;
   auto to_json() const -> tao::json::value;
 };
 

--- a/core/tracing/constants.hxx
+++ b/core/tracing/constants.hxx
@@ -85,7 +85,6 @@ constexpr auto span_kind = "span.kind";
 constexpr auto component = "db.couchbase.component";
 constexpr auto instance = "db.instance";
 
-constexpr auto orphan = "cb.orphan";
 constexpr auto service = "cb.service";
 constexpr auto operation_id = "cb.operation_id";
 

--- a/core/tracing/threshold_logging_options.hxx
+++ b/core/tracing/threshold_logging_options.hxx
@@ -24,9 +24,6 @@
 namespace couchbase::core::tracing
 {
 struct threshold_logging_options {
-  std::chrono::milliseconds orphaned_emit_interval{ std::chrono::seconds{ 10 } };
-  std::size_t orphaned_sample_size{ 64 };
-
   std::chrono::milliseconds threshold_emit_interval{ std::chrono::seconds{ 10 } };
   std::size_t threshold_sample_size{ 64 };
   std::chrono::milliseconds key_value_threshold{ 500 };

--- a/core/tracing/threshold_logging_tracer.cxx
+++ b/core/tracing/threshold_logging_tracer.cxx
@@ -24,7 +24,7 @@
 #include "core/meta/version.hxx"
 #include "core/platform/uuid.h"
 #include "core/service_type_fmt.hxx"
-#include "core/utils/concurrent_fixed_queue.hxx"
+#include "core/utils/concurrent_fixed_priority_queue.hxx"
 #include "core/utils/json.hxx"
 
 #include <asio/steady_timer.hpp>
@@ -43,6 +43,11 @@ struct reported_span {
   auto operator<(const reported_span& other) const -> bool
   {
     return duration < other.duration;
+  }
+
+  auto operator>(const reported_span& other) const -> bool
+  {
+    return duration > other.duration;
   }
 };
 
@@ -148,7 +153,7 @@ public:
   }
 };
 
-using fixed_span_queue = utils::concurrent_fixed_queue<reported_span>;
+using fixed_span_queue = utils::concurrent_fixed_priority_queue<reported_span>;
 
 auto
 convert(const std::shared_ptr<threshold_logging_span>& span) -> reported_span

--- a/core/tracing/threshold_logging_tracer.cxx
+++ b/core/tracing/threshold_logging_tracer.cxx
@@ -24,13 +24,13 @@
 #include "core/meta/version.hxx"
 #include "core/platform/uuid.h"
 #include "core/service_type_fmt.hxx"
+#include "core/utils/concurrent_fixed_queue.hxx"
 #include "core/utils/json.hxx"
 
 #include <asio/steady_timer.hpp>
 #include <tao/json/value.hpp>
 
 #include <chrono>
-#include <mutex>
 #include <queue>
 #include <utility>
 
@@ -110,11 +110,6 @@ public:
     return total_server_duration_us_;
   }
 
-  [[nodiscard]] auto orphan() const -> bool
-  {
-    return string_tags_.find(tracing::attributes::orphan) != string_tags_.end();
-  }
-
   [[nodiscard]] auto is_key_value() const -> bool
   {
     auto service_tag = string_tags_.find(tracing::attributes::service);
@@ -153,65 +148,7 @@ public:
   }
 };
 
-template<typename T>
-class concurrent_fixed_queue
-{
-private:
-  std::mutex mutex_;
-  std::priority_queue<T> data_;
-  std::size_t capacity_{};
-
-public:
-  using size_type = typename std::priority_queue<T>::size_type;
-
-  explicit concurrent_fixed_queue(std::size_t capacity)
-    : capacity_(capacity)
-  {
-  }
-
-  concurrent_fixed_queue(const concurrent_fixed_queue&) = delete;
-  concurrent_fixed_queue(concurrent_fixed_queue&&) = delete;
-  auto operator=(const concurrent_fixed_queue&) -> concurrent_fixed_queue& = delete;
-  auto operator=(concurrent_fixed_queue&&) -> concurrent_fixed_queue& = delete;
-  ~concurrent_fixed_queue() = default;
-
-  void pop()
-  {
-    std::unique_lock<std::mutex> lock(mutex_);
-    data_.pop();
-  }
-
-  auto size() -> size_type
-  {
-    std::unique_lock<std::mutex> lock(mutex_);
-    return data_.size();
-  }
-
-  auto empty() -> bool
-  {
-    const std::unique_lock<std::mutex> lock(mutex_);
-    return data_.empty();
-  }
-
-  void emplace(const T&& item)
-  {
-    const std::unique_lock<std::mutex> lock(mutex_);
-    data_.emplace(std::forward<const T>(item));
-    if (data_.size() > capacity_) {
-      data_.pop();
-    }
-  }
-
-  auto steal_data() -> std::priority_queue<T>
-  {
-    std::priority_queue<T> data;
-    const std::unique_lock<std::mutex> lock(mutex_);
-    std::swap(data, data_);
-    return data;
-  }
-};
-
-using fixed_span_queue = concurrent_fixed_queue<reported_span>;
+using fixed_span_queue = utils::concurrent_fixed_queue<reported_span>;
 
 auto
 convert(const std::shared_ptr<threshold_logging_span>& span) -> reported_span
@@ -255,9 +192,7 @@ class threshold_logging_tracer_impl
 public:
   threshold_logging_tracer_impl(const threshold_logging_options& options, asio::io_context& ctx)
     : options_(options)
-    , emit_orphan_report_(ctx)
     , emit_threshold_report_(ctx)
-    , orphan_queue_{ options.orphaned_sample_size }
   {
     threshold_queues_.try_emplace(service_type::key_value, options.threshold_sample_size);
     threshold_queues_.try_emplace(service_type::query, options.threshold_sample_size);
@@ -274,28 +209,19 @@ public:
 
   ~threshold_logging_tracer_impl()
   {
-    emit_orphan_report_.cancel();
     emit_threshold_report_.cancel();
 
-    log_orphan_report();
     log_threshold_report();
   }
 
   void start()
   {
-    rearm_orphan_reporter();
     rearm_threshold_reporter();
   }
 
   void stop()
   {
-    emit_orphan_report_.cancel();
     emit_threshold_report_.cancel();
-  }
-
-  void add_orphan(const std::shared_ptr<threshold_logging_span>& span)
-  {
-    orphan_queue_.emplace(convert(span));
   }
 
   void check_threshold(const std::shared_ptr<threshold_logging_span>& span)
@@ -313,18 +239,6 @@ public:
   }
 
 private:
-  void rearm_orphan_reporter()
-  {
-    emit_orphan_report_.expires_after(options_.orphaned_emit_interval);
-    emit_orphan_report_.async_wait([this](std::error_code ec) {
-      if (ec == asio::error::operation_aborted) {
-        return;
-      }
-      log_orphan_report();
-      rearm_orphan_reporter();
-    });
-  }
-
   void rearm_threshold_reporter()
   {
     emit_threshold_report_.expires_after(options_.threshold_emit_interval);
@@ -337,35 +251,13 @@ private:
     });
   }
 
-  void log_orphan_report()
-  {
-    if (orphan_queue_.empty()) {
-      return;
-    }
-    auto queue = orphan_queue_.steal_data();
-    tao::json::value report{
-      { "count", queue.size() },
-#if COUCHBASE_CXX_CLIENT_DEBUG_BUILD
-      { "emit_interval_ms", options_.orphaned_emit_interval.count() },
-      { "sample_size", options_.orphaned_sample_size },
-#endif
-    };
-    tao::json::value entries = tao::json::empty_array;
-    while (!queue.empty()) {
-      entries.emplace_back(queue.top().payload);
-      queue.pop();
-    }
-    report["top"] = entries;
-    CB_LOG_WARNING("Orphan responses observed: {}", utils::json::generate(report));
-  }
-
   void log_threshold_report()
   {
     for (auto& [service, threshold_queue] : threshold_queues_) {
       if (threshold_queue.empty()) {
         continue;
       }
-      auto queue = threshold_queue.steal_data();
+      auto [queue, _] = threshold_queue.steal_data();
       tao::json::value report{
         { "count", queue.size() },
         { "service", fmt::format("{}", service) },
@@ -390,9 +282,7 @@ private:
 
   const threshold_logging_options& options_;
 
-  asio::steady_timer emit_orphan_report_;
   asio::steady_timer emit_threshold_report_;
-  fixed_span_queue orphan_queue_;
   std::map<service_type, fixed_span_queue> threshold_queues_{};
 };
 
@@ -407,11 +297,7 @@ threshold_logging_tracer::start_span(std::string name,
 void
 threshold_logging_tracer::report(const std::shared_ptr<threshold_logging_span>& span)
 {
-  if (span->orphan()) {
-    impl_->add_orphan(span);
-  } else {
-    impl_->check_threshold(span);
-  }
+  impl_->check_threshold(span);
 }
 
 threshold_logging_tracer::threshold_logging_tracer(asio::io_context& ctx,

--- a/core/utils/concurrent_fixed_queue.hxx
+++ b/core/utils/concurrent_fixed_queue.hxx
@@ -1,0 +1,97 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2025 Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <mutex>
+#include <queue>
+
+namespace couchbase::core::utils
+{
+template<typename T>
+class concurrent_fixed_queue
+{
+private:
+  std::mutex mutex_;
+  std::priority_queue<T> data_;
+  std::size_t dropped_count_{ 0 };
+  std::size_t capacity_{};
+
+public:
+  using size_type = typename std::priority_queue<T>::size_type;
+
+  explicit concurrent_fixed_queue(std::size_t capacity)
+    : capacity_(capacity)
+  {
+  }
+
+  concurrent_fixed_queue(const concurrent_fixed_queue&) = delete;
+  concurrent_fixed_queue(concurrent_fixed_queue&&) = delete;
+  auto operator=(const concurrent_fixed_queue&) -> concurrent_fixed_queue& = delete;
+  auto operator=(concurrent_fixed_queue&&) -> concurrent_fixed_queue& = delete;
+  ~concurrent_fixed_queue() = default;
+
+  void pop()
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+    data_.pop();
+  }
+
+  auto size() -> size_type
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return data_.size();
+  }
+
+  auto empty() -> bool
+  {
+    const std::unique_lock<std::mutex> lock(mutex_);
+    return data_.empty();
+  }
+
+  void emplace(const T&& item)
+  {
+    // TODO(CXXCBC-732): We have a bug here where the remaining N items in the queue are the last
+    // N items to be emplaced, irrespective of how they compare to the items currently in the
+    // queue. This means that the oprhan reporter & the threshold logging tracer aren't really
+    // reporting the top requests, but the last ones to be added to this queue.
+    const std::unique_lock<std::mutex> lock(mutex_);
+    data_.emplace(std::forward<const T>(item));
+    if (data_.size() > capacity_) {
+      data_.pop();
+      ++dropped_count_;
+    }
+  }
+
+  /**
+   * Clears the internal queue, and returns the data along with the number of items that have been
+   * dropped.
+   */
+  auto steal_data() -> std::pair<std::priority_queue<T>, std::size_t>
+  {
+    std::priority_queue<T> data;
+    std::size_t dropped_count{};
+
+    const std::unique_lock<std::mutex> lock(mutex_);
+
+    std::swap(data, data_);
+    std::swap(dropped_count, dropped_count_);
+
+    return std::make_pair(std::move(data), dropped_count);
+  }
+};
+} // namespace couchbase::core::utils

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,6 +38,7 @@ unit_test(metrics)
 unit_test(range_scan)
 unit_test(logger)
 unit_test(crypto)
+unit_test(orphan_reporter)
 target_link_libraries(test_unit_jsonsl PRIVATE jsonsl)
 
 integration_benchmark(get)

--- a/test/test_helper.hxx
+++ b/test/test_helper.hxx
@@ -22,6 +22,7 @@
 #include "utils/test_data.hxx"
 
 #include <catch2/catch_test_macros.hpp>
+#include <tao/json/stream.hpp>
 
 #define REQUIRE_SUCCESS(ec)                                                                        \
   INFO((ec).message());                                                                            \

--- a/test/test_unit_orphan_reporter.cxx
+++ b/test/test_unit_orphan_reporter.cxx
@@ -1,0 +1,216 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2025 Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "test_helper.hxx"
+
+#include <couchbase/build_info.hxx>
+
+#include "core/orphan_reporter.hxx"
+
+#include <tao/json/from_string.hpp>
+
+TEST_CASE("unit: orphan reporter output", "[unit]")
+{
+  auto opts = couchbase::core::orphan_reporter_options{};
+  opts.sample_size = 4;
+  asio::io_context io_context;
+  auto reporter = couchbase::core::orphan_reporter{ io_context, opts };
+
+  SECTION("No orphaned responses")
+  {
+    const auto out = reporter.flush_and_create_output();
+    REQUIRE(!out.has_value());
+  }
+
+  // TODO(CXXCBC-732): Add test for the situation where there are more orphans than the sample size
+  // once CXXCBC-732 is resolved.
+
+  SECTION("As many orphaned responses as the sample size")
+  {
+    reporter.add_orphan({ /* .connection_id = */ "conn2",
+                          /* .operation_id = */ "0x24",
+                          /* .last_remote_socket = */ "remote2",
+                          /* .last_local_socket = */ "local2",
+                          /* .total_duration = */ std::chrono::microseconds{ 200 },
+                          /* .last_server_duration = */ std::chrono::microseconds{ 40 },
+                          /* .total_server_duration = */ std::chrono::microseconds{ 80 },
+                          /* .operation_name = */ "upsert" });
+    reporter.add_orphan({ /* .connection_id = */ "conn1",
+                          /* .operation_id = */ "0x23",
+                          /* .last_remote_socket = */ "remote1",
+                          /* .last_local_socket = */ "local1",
+                          /* .total_duration = */ std::chrono::microseconds{ 100 },
+                          /* .last_server_duration = */ std::chrono::microseconds{ 30 },
+                          /* .total_server_duration = */ std::chrono::microseconds{ 60 },
+                          /* .operation_name = */ "get" });
+    reporter.add_orphan({ /* .connection_id = */ "conn4",
+                          /* .operation_id = */ "0x26",
+                          /* .last_remote_socket = */ "remote4",
+                          /* .last_local_socket = */ "local4",
+                          /* .total_duration = */ std::chrono::microseconds{ 400 },
+                          /* .last_server_duration = */ std::chrono::microseconds{ 60 },
+                          /* .total_server_duration = */ std::chrono::microseconds{ 120 },
+                          /* .operation_name = */ "replace" });
+    reporter.add_orphan({ /* .connection_id = */ "conn3",
+                          /* .operation_id = */ "0x25",
+                          /* .last_remote_socket = */ "remote3",
+                          /* .last_local_socket = */ "local3",
+                          /* .total_duration = */ std::chrono::microseconds{ 300 },
+                          /* .last_server_duration = */ std::chrono::microseconds{ 50 },
+                          /* .total_server_duration = */ std::chrono::microseconds{ 100 },
+                          /* .operation_name = */ "remove" });
+
+    const auto out = reporter.flush_and_create_output();
+    REQUIRE(out.has_value());
+
+    tao::json::value expected = tao::json::from_string(R"({
+  "kv": {
+    "total_count": 4,
+    "top_requests": [
+      {
+        "total_duration_us": 400,
+        "last_server_duration_us": 60,
+        "total_server_duration_us": 120,
+        "operation_name": "replace",
+        "last_local_id": "conn4",
+        "operation_id": "0x26",
+        "last_local_socket": "local4",
+        "last_remote_socket": "remote4"
+      },
+      {
+        "total_duration_us": 300,
+        "last_server_duration_us": 50,
+        "total_server_duration_us": 100,
+        "operation_name": "remove",
+        "last_local_id": "conn3",
+        "operation_id": "0x25",
+        "last_local_socket": "local3",
+        "last_remote_socket": "remote3"
+      },
+      {
+        "total_duration_us": 200,
+        "last_server_duration_us": 40,
+        "total_server_duration_us": 80,
+        "operation_name": "upsert",
+        "last_local_id": "conn2",
+        "operation_id": "0x24",
+        "last_local_socket": "local2",
+        "last_remote_socket": "remote2"
+      },
+      {
+        "total_duration_us": 100,
+        "last_server_duration_us": 30,
+        "total_server_duration_us": 60,
+        "operation_name": "get",
+        "last_local_id": "conn1",
+        "operation_id": "0x23",
+        "last_local_socket": "local1",
+        "last_remote_socket": "remote1"
+      }
+    ]
+  }
+})");
+
+#if COUCHBASE_CXX_CLIENT_DEBUG_BUILD
+    expected["emit_interval_ms"] = 10000;
+    expected["sample_size"] = 4;
+#endif
+
+    REQUIRE(expected == tao::json::from_string(out.value()));
+  }
+
+  SECTION("Fewer orphaned responses than sample size")
+  {
+    reporter.add_orphan({ /* .connection_id = */ "conn2",
+                          /* .operation_id = */ "0x24",
+                          /* .last_remote_socket = */ "remote2",
+                          /* .last_local_socket = */ "local2",
+                          /* .total_duration = */ std::chrono::microseconds{ 200 },
+                          /* .last_server_duration = */ std::chrono::microseconds{ 40 },
+                          /* .total_server_duration = */ std::chrono::microseconds{ 80 },
+                          /* .operation_name = */ "upsert" });
+    reporter.add_orphan({ /* .connection_id = */ "conn1",
+                          /* .operation_id = */ "0x23",
+                          /* .last_remote_socket = */ "remote1",
+                          /* .last_local_socket = */ "local1",
+                          /* .total_duration = */ std::chrono::microseconds{ 100 },
+                          /* .last_server_duration = */ std::chrono::microseconds{ 30 },
+                          /* .total_server_duration = */ std::chrono::microseconds{ 60 },
+                          /* .operation_name = */ "get" });
+
+    const auto out = reporter.flush_and_create_output();
+    REQUIRE(out.has_value());
+
+    tao::json::value expected = tao::json::from_string(R"({
+  "kv": {
+    "total_count": 2,
+    "top_requests": [
+      {
+        "total_duration_us": 200,
+        "last_server_duration_us": 40,
+        "total_server_duration_us": 80,
+        "operation_name": "upsert",
+        "last_local_id": "conn2",
+        "operation_id": "0x24",
+        "last_local_socket": "local2",
+        "last_remote_socket": "remote2"
+      },
+      {
+        "total_duration_us": 100,
+        "last_server_duration_us": 30,
+        "total_server_duration_us": 60,
+        "operation_name": "get",
+        "last_local_id": "conn1",
+        "operation_id": "0x23",
+        "last_local_socket": "local1",
+        "last_remote_socket": "remote1"
+      }
+    ]
+  }
+})");
+
+#if COUCHBASE_CXX_CLIENT_DEBUG_BUILD
+    expected["emit_interval_ms"] = 10000;
+    expected["sample_size"] = 4;
+#endif
+
+    REQUIRE(expected == tao::json::from_string(out.value()));
+  }
+
+  SECTION("Flushing & getting the output clears existing orphaned responses")
+  {
+    reporter.add_orphan({ /* .connection_id = */ "conn2",
+                          /* .operation_id = */ "0x24",
+                          /* .last_remote_socket = */ "remote2",
+                          /* .last_local_socket = */ "local2",
+                          /* .total_duration = */ std::chrono::microseconds{ 200 },
+                          /* .last_server_duration = */ std::chrono::microseconds{ 40 },
+                          /* .total_server_duration = */ std::chrono::microseconds{ 80 },
+                          /* .operation_name = */ "upsert" });
+    reporter.add_orphan({ /* .connection_id = */ "conn1",
+                          /* .operation_id = */ "0x23",
+                          /* .last_remote_socket = */ "remote1",
+                          /* .last_local_socket = */ "local1",
+                          /* .total_duration = */ std::chrono::microseconds{ 100 },
+                          /* .last_server_duration = */ std::chrono::microseconds{ 30 },
+                          /* .total_server_duration = */ std::chrono::microseconds{ 60 },
+                          /* .operation_name = */ "get" });
+
+    REQUIRE(reporter.flush_and_create_output().has_value());
+    REQUIRE_FALSE(reporter.flush_and_create_output().has_value());
+  }
+}

--- a/test/test_unit_orphan_reporter.cxx
+++ b/test/test_unit_orphan_reporter.cxx
@@ -36,8 +36,115 @@ TEST_CASE("unit: orphan reporter output", "[unit]")
     REQUIRE(!out.has_value());
   }
 
-  // TODO(CXXCBC-732): Add test for the situation where there are more orphans than the sample size
-  // once CXXCBC-732 is resolved.
+  SECTION("More oprhaned responses than the sample size")
+  {
+    reporter.add_orphan({ /* .connection_id = */ "conn2",
+                          /* .operation_id = */ "0x24",
+                          /* .last_remote_socket = */ "remote2",
+                          /* .last_local_socket = */ "local2",
+                          /* .total_duration = */ std::chrono::microseconds{ 200 },
+                          /* .last_server_duration = */ std::chrono::microseconds{ 40 },
+                          /* .total_server_duration = */ std::chrono::microseconds{ 80 },
+                          /* .operation_name = */ "upsert" });
+    reporter.add_orphan({ /* .connection_id = */ "conn1",
+                          /* .operation_id = */ "0x23",
+                          /* .last_remote_socket = */ "remote1",
+                          /* .last_local_socket = */ "local1",
+                          /* .total_duration = */ std::chrono::microseconds{ 100 },
+                          /* .last_server_duration = */ std::chrono::microseconds{ 30 },
+                          /* .total_server_duration = */ std::chrono::microseconds{ 60 },
+                          /* .operation_name = */ "get" });
+    reporter.add_orphan({ /* .connection_id = */ "conn4",
+                          /* .operation_id = */ "0x26",
+                          /* .last_remote_socket = */ "remote4",
+                          /* .last_local_socket = */ "local4",
+                          /* .total_duration = */ std::chrono::microseconds{ 400 },
+                          /* .last_server_duration = */ std::chrono::microseconds{ 60 },
+                          /* .total_server_duration = */ std::chrono::microseconds{ 120 },
+                          /* .operation_name = */ "replace" });
+    reporter.add_orphan({ /* .connection_id = */ "conn3",
+                          /* .operation_id = */ "0x25",
+                          /* .last_remote_socket = */ "remote3",
+                          /* .last_local_socket = */ "local3",
+                          /* .total_duration = */ std::chrono::microseconds{ 300 },
+                          /* .last_server_duration = */ std::chrono::microseconds{ 50 },
+                          /* .total_server_duration = */ std::chrono::microseconds{ 100 },
+                          /* .operation_name = */ "remove" });
+    reporter.add_orphan({ /* .connection_id = */ "conn6",
+                          /* .operation_id = */ "0x28",
+                          /* .last_remote_socket = */ "remote6",
+                          /* .last_local_socket = */ "local6",
+                          /* .total_duration = */ std::chrono::microseconds{ 600 },
+                          /* .last_server_duration = */ std::chrono::microseconds{ 80 },
+                          /* .total_server_duration = */ std::chrono::microseconds{ 160 },
+                          /* .operation_name = */ "unlock" });
+    reporter.add_orphan({ /* .connection_id = */ "conn5",
+                          /* .operation_id = */ "0x27",
+                          /* .last_remote_socket = */ "remote5",
+                          /* .last_local_socket = */ "local5",
+                          /* .total_duration = */ std::chrono::microseconds{ 500 },
+                          /* .last_server_duration = */ std::chrono::microseconds{ 70 },
+                          /* .total_server_duration = */ std::chrono::microseconds{ 140 },
+                          /* .operation_name = */ "insert" });
+
+    const auto out = reporter.flush_and_create_output();
+    REQUIRE(out.has_value());
+
+    tao::json::value expected = tao::json::from_string(R"({
+  "kv": {
+    "total_count": 6,
+    "top_requests": [
+      {
+        "total_duration_us": 600,
+        "last_server_duration_us": 80,
+        "total_server_duration_us": 160,
+        "operation_name": "unlock",
+        "last_local_id": "conn6",
+        "operation_id": "0x28",
+        "last_local_socket": "local6",
+        "last_remote_socket": "remote6"
+      },
+      {
+        "total_duration_us": 500,
+        "last_server_duration_us": 70,
+        "total_server_duration_us": 140,
+        "operation_name": "insert",
+        "last_local_id": "conn5",
+        "operation_id": "0x27",
+        "last_local_socket": "local5",
+        "last_remote_socket": "remote5"
+      },
+      {
+        "total_duration_us": 400,
+        "last_server_duration_us": 60,
+        "total_server_duration_us": 120,
+        "operation_name": "replace",
+        "last_local_id": "conn4",
+        "operation_id": "0x26",
+        "last_local_socket": "local4",
+        "last_remote_socket": "remote4"
+      },
+      {
+        "total_duration_us": 300,
+        "last_server_duration_us": 50,
+        "total_server_duration_us": 100,
+        "operation_name": "remove",
+        "last_local_id": "conn3",
+        "operation_id": "0x25",
+        "last_local_socket": "local3",
+        "last_remote_socket": "remote3"
+      }
+    ]
+  }
+})");
+
+#if COUCHBASE_CXX_CLIENT_DEBUG_BUILD
+    expected["emit_interval_ms"] = 10000;
+    expected["sample_size"] = 4;
+#endif
+
+    REQUIRE(expected == tao::json::from_string(out.value()));
+  }
 
   SECTION("As many orphaned responses as the sample size")
   {


### PR DESCRIPTION
## Motivation

When the capacity of the concurrent fixed queue is exceeded, and an item is emplaced, currently, it always drops an existing item and replaces it with a new item, irrespective of how the items compare. This results in the queue holding the last N items to be emplaced, rather the top N items.

## Changes

* Turn the priority queue that the concurrent fixed queue uses internally into a min-heap. This allows the concurrent fixed queue to peek the smallest item and check whether it should be replaced with a new item that is being emplaced.
* Remove its `pop` method, as it's not possible to do that anymore with the internal representation being a min-heap. It's no currently used. The only way to access the data is via `steal_data` which transforms the data into a max-heap `std::priority_queue`.
* Rename the `concurrent_fixed_queue` to `concurrent_priority_fixed_queue` to make its purpose clearer.
* Add some unit tests for the concurrent fixed queue & for the orphan reporter for the scenario where the queue's capacity is exceeded.

## Results

All tests pass