### PR TITLE
CXXCBC-717: GHA - separate unit & integration test jobs

### DIFF
--- a/.github/actions/create-cluster/action.yml
+++ b/.github/actions/create-cluster/action.yml
@@ -72,6 +72,6 @@ runs:
         cbdinocluster buckets add $CBDC_ID secBucket --ram-quota-mb 100
     - name: Load travel-sample bucket
       shell: bash
-      if: ${{ inputs.suite == 'unit' }}
+      if: ${{ inputs.suite == 'integration' }}
       run: |
         cbdinocluster buckets load-sample $CBDC_ID travel-sample

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -16,21 +16,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  sanitize:
+  build:
     strategy:
       fail-fast: false
       matrix:
-        server:
-          - 7.6.7
         sanitizer:
           - asan
           - lsan
           - tsan
           - ubsan
           - valgrind
-        tls:
-          - tls
-          - plain
     runs-on: ubuntu-24.04
     steps:
       - name: Install dependencies
@@ -40,12 +35,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Create Couchbase cluster with cbdinocluster
-        id: cbdino
-        uses: ./.github/actions/create-cluster
-        with:
-          version: ${{ matrix.server }}
-          suite: unit
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
@@ -56,7 +45,90 @@ jobs:
           # SA: see CXXCBC-571, Valgrind reports memory leak, because ASIO does
           # not deallocate thread-local state of OpenSSL properly
           CB_BORINGSSL: OFF
+          CB_NUMBER_OF_JOBS: 8
         run: ./bin/build-tests
+      - name: Upload build artifacts
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-${{ matrix.sanitizer }}
+          path: ./cmake-build-tests-${{ matrix.sanitizer }}
+  unit:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer:
+          - asan
+          - lsan
+          - tsan
+          - ubsan
+          - valgrind
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libssl-dev cmake curl wget gnupg2 gdb clang clang-tools valgrind
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-${{ matrix.sanitizer }}
+          path: ./cmake-build-tests-${{ matrix.sanitizer }}
+      - name: Run tests
+        timeout-minutes: 60
+        env:
+          CB_SANITIZER: ${{ matrix.sanitizer }}
+          TEST_LOG_LEVEL: trace
+        run: |
+          chmod -R +x ./cmake-build-tests-${{ matrix.sanitizer }}
+          ./bin/run-unit-tests
+      - name: Upload report
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: report-unit-${{ matrix.sanitizer }}
+          path: |
+            cmake-build-tests-${{ matrix.sanitizer }}/Testing/Temporary/*.log
+  integration:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer:
+          - asan
+          - lsan
+          - tsan
+          - ubsan
+          - valgrind
+        server:
+          - 7.6.7
+        tls:
+          - plain
+          - tls
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libssl-dev cmake curl wget gnupg2 gdb clang clang-tools valgrind
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-${{ matrix.sanitizer }}
+          path: ./cmake-build-tests-${{ matrix.sanitizer }}
+      - name: Create Couchbase cluster with cbdinocluster
+        id: cbdino
+        uses: ./.github/actions/create-cluster
+        with:
+          version: ${{ matrix.server }}
+          suite: integration
       - name: Check couchbase
         env:
           HOST: ${{ steps.cbdino.outputs.ip }}
@@ -68,7 +140,9 @@ jobs:
           TEST_SERVER_VERSION: ${{ matrix.server }}
           TEST_CONNECTION_STRING: ${{ matrix.tls == 'tls' && format('{0}?trust_certificate=cluster.crt', steps.cbdino.outputs.tls-connstr) || steps.cbdino.outputs.connstr }}
           TEST_LOG_LEVEL: trace
-        run: ./bin/run-unit-tests
+        run: |
+          chmod -R +x ./cmake-build-tests-${{ matrix.sanitizer }}
+          ./bin/run-integration-tests
       - name: Remove Couchbase cluster
         uses: ./.github/actions/remove-cluster
         with:
@@ -77,6 +151,6 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: report-${{ matrix.sanitizer }}-${{ matrix.tls }}-${{ matrix.server }}
+          name: report-integration-${{ matrix.sanitizer }}-${{ matrix.tls }}-${{ matrix.server }}
           path: |
             cmake-build-tests-${{ matrix.sanitizer }}/Testing/Temporary/*.log

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,62 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  build:
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libssl-dev cmake gcc g++ curl gdb
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Validate test labels
+        run: ./bin/validate-test-labels
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.job }}
+      - name: Build tests
+        timeout-minutes: 40
+        run: ./bin/build-tests
+        env:
+          CB_NUMBER_OF_JOBS: 8
+      - name: Upload build artifacts
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: ./cmake-build-tests
+  unit:
+    needs: build
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libssl-dev cmake gcc g++ curl gdb
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+          path: ./cmake-build-tests
+      - name: Run tests
+        timeout-minutes: 40
+        env:
+          TEST_LOG_LEVEL: trace
+        run: |
+          chmod -R +x ./cmake-build-tests
+          ./bin/run-unit-tests
+  integration:
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -26,38 +81,31 @@ jobs:
           - 7.1.6
           - 7.0.5
         suite:
-          - unit
+          - integration
           - transaction
         include:
           - server: 6.6.6
-            suite: unit
-
+            suite: integration
     runs-on: ubuntu-24.04
     steps:
-      - name: Install build environment
+      - name: Install dependencies
         run: |
           sudo apt-get update -y
           sudo apt-get install -y libssl-dev cmake gcc g++ curl gdb
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Validate test labels
-        run: ./bin/validate-test-labels
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+          path: ./cmake-build-tests
       - name: Create Couchbase cluster with cbdinocluster
         id: cbdino
         uses: ./.github/actions/create-cluster
         with:
           version: ${{ matrix.server }}
           suite: ${{ matrix.suite }}
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
-        with:
-          key: ${{ github.job }}
-      - name: Build tests
-        timeout-minutes: 40
-        env:
-          CB_TEST_SUITE: ${{ matrix.suite }}
-        run: ./bin/build-tests
       - name: Check couchbase
         env:
           HOST: ${{ steps.cbdino.outputs.ip }}
@@ -68,7 +116,9 @@ jobs:
           TEST_SERVER_VERSION: ${{ matrix.server }}
           TEST_CONNECTION_STRING: ${{ steps.cbdino.outputs.connstr }}
           TEST_LOG_LEVEL: trace
-        run: ./bin/run-${{ matrix.suite }}-tests
+        run: |
+          chmod -R +x ./cmake-build-tests
+          ./bin/run-${{ matrix.suite }}-tests
       - name: Remove Couchbase cluster
         uses: ./.github/actions/remove-cluster
         with:

--- a/bin/build-tests
+++ b/bin/build-tests
@@ -99,10 +99,6 @@ cd "${BUILD_DIR}"
 CB_CMAKE_BUILD_EXTRAS=
 if [ "x${CB_TEST_SUITE}" != "x" ] ; then
     CB_CMAKE_BUILD_EXTRAS="--target build_${CB_TEST_SUITE}_tests"
-    if [ "x${CB_TEST_SUITE}" = "xunit" ]; then
-        # always run integration tests if "unit" target selected
-        CB_CMAKE_BUILD_EXTRAS="${CB_CMAKE_BUILD_EXTRAS} --target build_integration_tests"
-    fi
 fi
 
 ${CB_CMAKE}  \

--- a/bin/run-integration-tests
+++ b/bin/run-integration-tests
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+
+#  Copyright 2025 Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+PROJECT_ROOT="$( cd "$(dirname "$0")/.." >/dev/null 2>&1 ; pwd -P )"
+
+echo "HOSTNAME=${HOSTNAME}"
+echo "NODE_NAME=${NODE_NAME}"
+echo "CONTAINER_TAG=${CONTAINER_TAG}"
+echo "JENKINS_SLAVE_LABELS=${JENKINS_SLAVE_LABELS}"
+echo "NODE_LABELS=${NODE_LABELS}"
+echo "TEST_DEPLOYMENT_TYPE=${TEST_DEPLOYMENT_TYPE}"
+
+CB_CTEST=${CB_CTEST:-$(which ctest)}
+CB_CTEST_EXTRAS=${CB_CTEST_EXTRAS:-""}
+CB_SANITIZER=${CB_SANITIZER:-""}
+
+echo "CB_CTEST=${CB_CTEST}"
+
+set -xu
+
+BUILD_DIR="${PROJECT_ROOT}/cmake-build-tests"
+if [ "x${CB_SANITIZER}" != "x" ]; then
+    BUILD_DIR="${BUILD_DIR}-${CB_SANITIZER}"
+fi
+if [ "x${CB_SANITIZER}" = "xvalgrind" ]; then
+    CB_CTEST_EXTRAS="--test-action memcheck"
+    export TEST_USE_WAN_DEVELOPMENT_PROFILE=yes
+fi
+
+cd "${BUILD_DIR}"
+
+CB_USE_GOCAVES=${CB_USE_GOCAVES:-""}
+GOCAVES_PID=
+GOCAVES_CONNECTION_STRING=
+if [ "$CB_USE_GOCAVES" = "yes" -o "$CB_USE_GOCAVES" = "1" ]
+then
+    GOCAVES=
+    case "$(uname -sm)" in
+        "Darwin x86_64")
+            GOCAVES="gocaves-macos"
+            ;;
+
+        "Darwin arm64")
+            GOCAVES="gocaves-macos-arm64"
+            ;;
+
+        "Linux x86_64")
+            GOCAVES="gocaves-linux-amd64"
+            ;;
+
+        "Linux aarch64")
+            GOCAVES="gocaves-linux-arm64"
+            ;;
+    esac
+    echo "GOCAVES=${GOCAVES}"
+    if [ "${GOCAVES}x" != "x" ]
+    then
+        GOCAVES_VERSION="v0.0.1-78"
+        echo "GOCAVES_VERSION=${GOCAVES_VERSION}"
+        GOCAVES_PATH="${BUILD_DIR}/${GOCAVES}-${GOCAVES_VERSION}"
+        if [ ! -e "${GOCAVES_PATH}" ]
+        then
+            curl -L -o "${GOCAVES_PATH}" https://github.com/couchbaselabs/gocaves/releases/download/${GOCAVES_VERSION}/${GOCAVES}
+            chmod u+x "${GOCAVES_PATH}"
+        fi
+        ${GOCAVES_PATH} -mock-only > gocaves.txt 2>&1 &
+        sleep 1
+        GOCAVES_PID=$!
+        GOCAVES_CONNECTION_STRING=$(grep -o 'couchbase://[^"]\+' gocaves.txt)
+        echo "GOCAVES_CONNECTION_STRING=${GOCAVES_CONNECTION_STRING}"
+        if [ ! -z "${GOCAVES_CONNECTION_STRING}" ]
+        then
+            export TEST_CONNECTION_STRING="${GOCAVES_CONNECTION_STRING}"
+            export TEST_USE_GOCAVES=1
+            trap "kill -9 ${GOCAVES_PID}" SIGINT SIGTERM
+        fi
+    fi
+fi
+
+[ -f /proc/sys/kernel/core_pattern ] && cat /proc/sys/kernel/core_pattern
+if [ -e /usr/bin/apport-unpack ]
+then
+    mkdir -p $HOME/.config/apport
+    cat <<EOF >$HOME/.config/apport/settings
+[main]
+unpackaged=true
+EOF
+fi
+
+ulimit -c unlimited
+
+export TEST_CONNECTION_STRING="${TEST_CONNECTION_STRING//cluster.crt/${PROJECT_ROOT}/cluster.crt}"
+${CB_CTEST} ${CB_CTEST_EXTRAS} --output-on-failure --label-regex 'integration' --output-junit results.xml
+STATUS=$?
+
+if [ ! -z "${GOCAVES_PID}" ]
+then
+    kill -9 ${GOCAVES_PID}
+fi
+
+if [ "x${STATUS}" != "x0" ]
+then
+    if [ -e /usr/bin/coredumpctl ]
+    then
+        /usr/bin/coredumpctl list --no-pager --json=pretty
+        executable="$(coredumpctl --json=pretty list | jq -r .[-1].exe)"
+        if [ -f "${executable}" ]
+        then
+            file "${executable}"
+            ldd "${executable}"
+        fi
+        /usr/bin/coredumpctl -1 info
+    elif [ -e /usr/bin/apport-unpack ]
+    then
+        for crash in /var/crash/*
+        do
+           if [ -f $crash ]
+           then
+             echo $crash
+             /usr/bin/apport-unpack $crash /tmp/the_crash/
+             executable=$(cat /tmp/the_crash/ExecutablePath)
+             if [ -f "${executable}" ]
+             then
+                 file "${executable}"
+                 ldd "${executable}"
+             fi
+             gdb $executable /tmp/the_crash/CoreDump --batch -ex "thread apply all bt"
+             rm -rf $crash /tmp/the_crash
+           fi
+        done
+    fi
+    for core in /tmp/core.* "${PWD}/{vg,}core*"
+    do
+        if [ -f $core ]
+        then
+            echo $core
+            executable=$(file $core | ruby -e "print ARGF.read[/execfn: '([^']+)'/, 1]")
+            echo $executable
+             if [ -f "${executable}" ]
+             then
+                 file "${executable}"
+                 ldd "${executable}"
+             fi
+            gdb $executable $core --batch -ex "thread apply all bt"
+            rm -f $core
+        fi
+    done
+fi
+
+exit $STATUS

--- a/bin/run-unit-tests
+++ b/bin/run-unit-tests
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-#  Copyright 2020-2021 Couchbase, Inc.
+#  Copyright 2025 Couchbase, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -14,14 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-PROJECT_ROOT="$( cd "$(dirname "$0")/.." >/dev/null 2>&1 ; pwd -P )"
-
-echo "HOSTNAME=${HOSTNAME}"
-echo "NODE_NAME=${NODE_NAME}"
-echo "CONTAINER_TAG=${CONTAINER_TAG}"
-echo "JENKINS_SLAVE_LABELS=${JENKINS_SLAVE_LABELS}"
-echo "NODE_LABELS=${NODE_LABELS}"
-echo "TEST_DEPLOYMENT_TYPE=${TEST_DEPLOYMENT_TYPE}"
+PROJECT_ROOT="$( cd "$(dirname "$0"/..)" >/dev/null 2>&1 ; pwd -P )"
 
 CB_CTEST=${CB_CTEST:-$(which ctest)}
 CB_CTEST_EXTRAS=${CB_CTEST_EXTRAS:-""}
@@ -37,127 +30,8 @@ if [ "x${CB_SANITIZER}" != "x" ]; then
 fi
 if [ "x${CB_SANITIZER}" = "xvalgrind" ]; then
     CB_CTEST_EXTRAS="--test-action memcheck"
-    export TEST_USE_WAN_DEVELOPMENT_PROFILE=yes
 fi
 
 cd "${BUILD_DIR}"
 
-CB_USE_GOCAVES=${CB_USE_GOCAVES:-""}
-GOCAVES_PID=
-GOCAVES_CONNECTION_STRING=
-if [ "$CB_USE_GOCAVES" = "yes" -o "$CB_USE_GOCAVES" = "1" ]
-then
-    GOCAVES=
-    case "$(uname -sm)" in
-        "Darwin x86_64")
-            GOCAVES="gocaves-macos"
-            ;;
-
-        "Darwin arm64")
-            GOCAVES="gocaves-macos-arm64"
-            ;;
-
-        "Linux x86_64")
-            GOCAVES="gocaves-linux-amd64"
-            ;;
-
-        "Linux aarch64")
-            GOCAVES="gocaves-linux-arm64"
-            ;;
-    esac
-    echo "GOCAVES=${GOCAVES}"
-    if [ "${GOCAVES}x" != "x" ]
-    then
-        GOCAVES_VERSION="v0.0.1-78"
-        echo "GOCAVES_VERSION=${GOCAVES_VERSION}"
-        GOCAVES_PATH="${BUILD_DIR}/${GOCAVES}-${GOCAVES_VERSION}"
-        if [ ! -e "${GOCAVES_PATH}" ]
-        then
-            curl -L -o "${GOCAVES_PATH}" https://github.com/couchbaselabs/gocaves/releases/download/${GOCAVES_VERSION}/${GOCAVES}
-            chmod u+x "${GOCAVES_PATH}"
-        fi
-        ${GOCAVES_PATH} -mock-only > gocaves.txt 2>&1 &
-        sleep 1
-        GOCAVES_PID=$!
-        GOCAVES_CONNECTION_STRING=$(grep -o 'couchbase://[^"]\+' gocaves.txt)
-        echo "GOCAVES_CONNECTION_STRING=${GOCAVES_CONNECTION_STRING}"
-        if [ ! -z "${GOCAVES_CONNECTION_STRING}" ]
-        then
-            export TEST_CONNECTION_STRING="${GOCAVES_CONNECTION_STRING}"
-            export TEST_USE_GOCAVES=1
-            trap "kill -9 ${GOCAVES_PID}" SIGINT SIGTERM
-        fi
-    fi
-fi
-
-[ -f /proc/sys/kernel/core_pattern ] && cat /proc/sys/kernel/core_pattern
-if [ -e /usr/bin/apport-unpack ]
-then
-    mkdir -p $HOME/.config/apport
-    cat <<EOF >$HOME/.config/apport/settings
-[main]
-unpackaged=true
-EOF
-fi
-
-ulimit -c unlimited
-
-export TEST_CONNECTION_STRING="${TEST_CONNECTION_STRING//cluster.crt/${PROJECT_ROOT}/cluster.crt}"
-${CB_CTEST} ${CB_CTEST_EXTRAS} --output-on-failure --label-regex 'integration|unit' --output-junit results.xml
-STATUS=$?
-
-if [ ! -z "${GOCAVES_PID}" ]
-then
-    kill -9 ${GOCAVES_PID}
-fi
-
-if [ "x${STATUS}" != "x0" ]
-then
-    if [ -e /usr/bin/coredumpctl ]
-    then
-        /usr/bin/coredumpctl list --no-pager --json=pretty
-        executable="$(coredumpctl --json=pretty list | jq -r .[-1].exe)"
-        if [ -f "${executable}" ]
-        then
-            file "${executable}"
-            ldd "${executable}"
-        fi
-        /usr/bin/coredumpctl -1 info
-    elif [ -e /usr/bin/apport-unpack ]
-    then
-        for crash in /var/crash/*
-        do
-           if [ -f $crash ]
-           then
-             echo $crash
-             /usr/bin/apport-unpack $crash /tmp/the_crash/
-             executable=$(cat /tmp/the_crash/ExecutablePath)
-             if [ -f "${executable}" ]
-             then
-                 file "${executable}"
-                 ldd "${executable}"
-             fi
-             gdb $executable /tmp/the_crash/CoreDump --batch -ex "thread apply all bt"
-             rm -rf $crash /tmp/the_crash
-           fi
-        done
-    fi
-    for core in /tmp/core.* "${PWD}/{vg,}core*"
-    do
-        if [ -f $core ]
-        then
-            echo $core
-            executable=$(file $core | ruby -e "print ARGF.read[/execfn: '([^']+)'/, 1]")
-            echo $executable
-             if [ -f "${executable}" ]
-             then
-                 file "${executable}"
-                 ldd "${executable}"
-             fi
-            gdb $executable $core --batch -ex "thread apply all bt"
-            rm -f $core
-        fi
-    done
-fi
-
-exit $STATUS
+${CB_CTEST} --output-on-failure --label-regex 'unit' --output-junit results.xml


### PR DESCRIPTION
## Changes

* Add separate jobs for unit & integration tests. Unit tests don't need a cluster to be set up
* Add a build job in the tests & sanitizers workflows, all test runs use the build artifacts from that job, avoiding having to build the library repeatedly 