### PR TITLE
CXXCBC-736: Add dispatch spans for KV operations

### DIFF
--- a/core/io/http_command.hxx
+++ b/core/io/http_command.hxx
@@ -120,7 +120,7 @@ struct http_command : public std::enable_shared_from_this<http_command<Request>>
     if (span_->uses_tags()) {
       span_->add_tag(tracing::attributes::service,
                      tracing::service_name_for_http_service(request.type));
-      span_->add_tag(tracing::attributes::operation_id, client_context_id_);
+      span_->add_tag(tracing::attributes::dispatch::operation_id, client_context_id_);
     }
 
     handler_ = std::move(handler);
@@ -209,7 +209,7 @@ struct http_command : public std::enable_shared_from_this<http_command<Request>>
       return;
     }
     if (span_->uses_tags()) {
-      span_->add_tag(tracing::attributes::local_id, session_->id());
+      span_->add_tag(tracing::attributes::dispatch::local_id, session_->id());
     }
     send();
   }

--- a/core/io/mcbp_session.hxx
+++ b/core/io/mcbp_session.hxx
@@ -119,6 +119,8 @@ public:
   [[nodiscard]] auto id() const -> const std::string&;
   [[nodiscard]] auto node_uuid() const -> const std::string&;
   [[nodiscard]] auto remote_address() const -> std::string;
+  [[nodiscard]] auto remote_hostname() const -> std::string;
+  [[nodiscard]] auto remote_port() const -> std::uint16_t;
   [[nodiscard]] auto local_address() const -> std::string;
   [[nodiscard]] auto bootstrap_address() const -> const std::string&;
   [[nodiscard]] auto bootstrap_hostname() const -> const std::string&;
@@ -126,6 +128,8 @@ public:
   [[nodiscard]] auto bootstrap_port_number() const -> std::uint16_t;
   [[nodiscard]] auto last_bootstrap_error() && -> std::optional<impl::bootstrap_error>;
   [[nodiscard]] auto last_bootstrap_error() const& -> const std::optional<impl::bootstrap_error>&;
+  [[nodiscard]] auto canonical_hostname() const -> const std::string&;
+  [[nodiscard]] auto canonical_port_number() const -> std::uint16_t;
   void write_and_flush(std::vector<std::byte>&& buffer);
   void write_and_subscribe(const std::shared_ptr<mcbp::queue_request>&,
                            const std::shared_ptr<response_handler>& handler);

--- a/core/tracing/constants.hxx
+++ b/core/tracing/constants.hxx
@@ -27,8 +27,9 @@ namespace couchbase::core::tracing
 {
 namespace operation
 {
-constexpr auto step_dispatch = "cb.dispatch_to_server";
-constexpr auto step_request_encoding = "cb.request_encoding";
+constexpr auto step_dispatch = "dispatch_to_server";
+constexpr auto step_request_encoding = "request_encoding";
+
 constexpr auto http_query = "cb.query";
 constexpr auto http_analytics = "cb.analytics";
 constexpr auto http_search = "cb.search";
@@ -77,7 +78,7 @@ constexpr auto mcbp_internal = "cb.internal";
 
 namespace attributes
 {
-constexpr auto system = "db.system";
+constexpr auto system = "db.system.name";
 constexpr auto cluster_name = "db.couchbase.cluster_name";
 constexpr auto cluster_uuid = "db.couchbase.cluster_uuid";
 
@@ -86,12 +87,20 @@ constexpr auto component = "db.couchbase.component";
 constexpr auto instance = "db.instance";
 
 constexpr auto service = "cb.service";
-constexpr auto operation_id = "cb.operation_id";
-
-constexpr auto server_duration = "cb.server_duration";
-constexpr auto local_id = "cb.local_id";
 constexpr auto local_socket = "cb.local_socket";
 constexpr auto remote_socket = "cb.remote_socket";
+
+namespace dispatch
+{
+constexpr auto server_duration = "db.couchbase.server_duration";
+constexpr auto local_id = "db.couchbase.local_id";
+constexpr auto server_address = "server.address";
+constexpr auto server_port = "server.port";
+constexpr auto peer_address = "network.peer.address";
+constexpr auto peer_port = "network.peer.port";
+constexpr auto network_transport = "network.transport";
+constexpr auto operation_id = "db.couchbase.operation_id";
+} // namespace dispatch
 } // namespace attributes
 
 namespace service

--- a/couchbase/tracing/request_span.hxx
+++ b/couchbase/tracing/request_span.hxx
@@ -56,7 +56,7 @@ public:
     return parent_;
   }
 
-  virtual auto uses_tags() const -> bool
+  [[nodiscard]] virtual auto uses_tags() const -> bool
   {
     return true;
   }


### PR DESCRIPTION
## Motivation

The Observability RFC expects having separate `dispatch_to_server` spans. Currently, we are recording all dispatch-level attributes on the top-level operation span.

## Changes

* Add dispatch spans for KV operations, one span per server round-trip. Update the dispatch-level attribute names so they conform to the latest semantic conventions
* Update the threshold logging tracer so it can handle both the legacy top level spans that have dispatch-level attributes (temporarily, for compatibility with HTTP operations) and the new dispatch spans.
* Add "canonical" address & port fields to memd sessions, these are the default (non-external) hostname & port as they appear in the config, which are now being reported in the new `server.endpoint` and `server.port` dispatch span attributes.