### PR TITLE
CXXCBC-820: Add couchbase::node_id public type for cluster node identification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ set(couchbase_cxx_client_FILES
     core/impl/doc_id_query.cxx
     core/impl/error.cxx
     core/impl/error_context.cxx
+    core/impl/node_id.cxx
     core/impl/expiry.cxx
     core/impl/fail_fast_retry_strategy.cxx
     core/impl/field_level_encryption_error_category.cxx

--- a/core/impl/node_id.cxx
+++ b/core/impl/node_id.cxx
@@ -1,0 +1,110 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "node_id.hxx"
+
+#include "core/utils/crc32.hxx"
+
+#include <spdlog/fmt/bundled/core.h>
+
+#include <cstdint>
+#include <string>
+
+namespace couchbase
+{
+
+namespace
+{
+/**
+ * Produces a stable, opaque hex string from hostname + KV port.
+ *
+ * Uses CRC32 (already in-tree for vBucket mapping) rather than a
+ * cryptographic hash — collision resistance across a handful of cluster
+ * nodes is more than sufficient, and this avoids pulling in OpenSSL headers.
+ */
+auto
+derive_fallback_id(const std::string& hostname, std::uint16_t port) -> std::string
+{
+  auto input = fmt::format("{}:{}", hostname, port);
+  auto crc = core::utils::hash_crc32(input.data(), input.size());
+  return fmt::format("{:08x}", crc);
+}
+} // namespace
+
+node_id::node_id(std::string node_uuid, std::string hostname, std::uint16_t port)
+  : node_uuid_{ std::move(node_uuid) }
+  , hostname_{ std::move(hostname) }
+  , port_{ port }
+  , id_{ node_uuid_.empty() ? derive_fallback_id(hostname_, port_) : node_uuid_ }
+{
+}
+
+auto
+node_id::id() const -> const std::string&
+{
+  return id_;
+}
+
+auto
+node_id::node_uuid() const -> const std::string&
+{
+  return node_uuid_;
+}
+
+auto
+node_id::hostname() const -> const std::string&
+{
+  return hostname_;
+}
+
+auto
+node_id::port() const -> std::uint16_t
+{
+  return port_;
+}
+
+node_id::
+operator bool() const
+{
+  return !id_.empty();
+}
+
+auto
+node_id::operator==(const node_id& other) const -> bool
+{
+  return id_ == other.id_;
+}
+
+auto
+node_id::operator!=(const node_id& other) const -> bool
+{
+  return !(*this == other);
+}
+
+auto
+node_id::operator<(const node_id& other) const -> bool
+{
+  return id_ < other.id_;
+}
+
+auto
+internal_node_id::build(std::string node_uuid, std::string hostname, std::uint16_t port) -> node_id
+{
+  return { std::move(node_uuid), std::move(hostname), port };
+}
+
+} // namespace couchbase

--- a/core/impl/node_id.hxx
+++ b/core/impl/node_id.hxx
@@ -1,0 +1,40 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/node_id.hxx>
+
+#include <cstdint>
+#include <string>
+
+namespace couchbase
+{
+
+/**
+ * Internal factory for constructing node_id instances from core-level data.
+ *
+ * This class is a friend of node_id and provides the only way to construct
+ * a non-default node_id outside the couchbase namespace.
+ */
+class internal_node_id
+{
+public:
+  static auto build(std::string node_uuid, std::string hostname, std::uint16_t port) -> node_id;
+};
+
+} // namespace couchbase

--- a/couchbase/node_id.hxx
+++ b/couchbase/node_id.hxx
@@ -1,0 +1,123 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <string>
+
+namespace couchbase
+{
+
+/**
+ * Uniquely identifies a cluster node.
+ *
+ * On Couchbase Server 8.0.1+ the identifier is the server-assigned node UUID.
+ * On older releases, a stable opaque token is derived from the node's hostname
+ * and management port.
+ *
+ * The type is equality-comparable, ordered, and hashable.
+ *
+ * @since 1.3.2
+ * @uncommitted
+ */
+class node_id
+{
+public:
+  /**
+   * Creates an empty (invalid) node_id.
+   *
+   * @since 1.3.2
+   * @uncommitted
+   */
+  node_id() = default;
+
+  /**
+   * User-facing identifier string.
+   *
+   * Returns node_uuid when the server provides one, otherwise a stable
+   * hex-encoded hash derived from hostname and management port.
+   *
+   * @return opaque identifier string (empty for default-constructed instances)
+   *
+   * @since 1.3.2
+   * @uncommitted
+   */
+  [[nodiscard]] auto id() const -> const std::string&;
+
+  /**
+   * The server-assigned node UUID (empty on servers before 8.0.1).
+   *
+   * @since 1.3.2
+   * @uncommitted
+   */
+  [[nodiscard]] auto node_uuid() const -> const std::string&;
+
+  /**
+   * The hostname of the node.
+   *
+   * @since 1.3.2
+   * @uncommitted
+   */
+  [[nodiscard]] auto hostname() const -> const std::string&;
+
+  /**
+   * The port of the node's key-value service.
+   *
+   * This reflects the port actually used by the client: the TLS port when the
+   * cluster connection is TLS-enabled, otherwise the plain port.
+   *
+   * @since 1.3.2
+   * @uncommitted
+   */
+  [[nodiscard]] auto port() const -> std::uint16_t;
+
+  /**
+   * Returns true when the node_id was properly initialized (not default-constructed).
+   *
+   * @since 1.3.2
+   * @uncommitted
+   */
+  explicit operator bool() const;
+
+  auto operator==(const node_id& other) const -> bool;
+  auto operator!=(const node_id& other) const -> bool;
+  auto operator<(const node_id& other) const -> bool;
+
+private:
+  friend class internal_node_id;
+
+  node_id(std::string node_uuid, std::string hostname, std::uint16_t port);
+
+  std::string node_uuid_{};
+  std::string hostname_{};
+  std::uint16_t port_{ 0 };
+  // Computed once at construction: node_uuid_ if non-empty, otherwise a
+  // deterministic hex-encoded CRC32 hash of "hostname:port".
+  std::string id_{};
+};
+
+} // namespace couchbase
+
+template<>
+struct std::hash<couchbase::node_id> {
+  auto operator()(const couchbase::node_id& nid) const noexcept -> std::size_t
+  {
+    return std::hash<std::string>{}(nid.id());
+  }
+};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,6 +40,7 @@ unit_test(range_scan)
 unit_test(logger)
 unit_test(crypto)
 unit_test(orphan_reporter)
+unit_test(node_id)
 target_link_libraries(test_unit_jsonsl PRIVATE jsonsl)
 
 integration_benchmark(get)

--- a/test/test_unit_node_id.cxx
+++ b/test/test_unit_node_id.cxx
@@ -1,0 +1,111 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "test_helper.hxx"
+
+#include "core/impl/node_id.hxx"
+
+#include <couchbase/node_id.hxx>
+
+#include <map>
+#include <set>
+#include <unordered_map>
+#include <unordered_set>
+
+TEST_CASE("unit: default node_id is falsy", "[unit]")
+{
+  couchbase::node_id nid;
+  REQUIRE_FALSE(static_cast<bool>(nid));
+  REQUIRE(nid.id().empty());
+  REQUIRE(nid.node_uuid().empty());
+  REQUIRE(nid.hostname().empty());
+  REQUIRE(nid.port() == 0);
+}
+
+TEST_CASE("unit: node_id with node_uuid uses uuid as id", "[unit]")
+{
+  auto nid = couchbase::internal_node_id::build("abc-123", "172.18.0.2", 11210);
+  REQUIRE(static_cast<bool>(nid));
+  REQUIRE(nid.id() == "abc-123");
+  REQUIRE(nid.node_uuid() == "abc-123");
+  REQUIRE(nid.hostname() == "172.18.0.2");
+  REQUIRE(nid.port() == 11210);
+}
+
+TEST_CASE("unit: node_id without node_uuid falls back to hash", "[unit]")
+{
+  auto nid = couchbase::internal_node_id::build("", "172.18.0.2", 11210);
+  REQUIRE(static_cast<bool>(nid));
+  // The fallback id should be non-empty and NOT the raw "host:port"
+  REQUIRE_FALSE(nid.id().empty());
+  REQUIRE(nid.id() != "172.18.0.2:11210");
+  REQUIRE(nid.node_uuid().empty());
+}
+
+TEST_CASE("unit: node_id fallback hash is deterministic", "[unit]")
+{
+  auto nid1 = couchbase::internal_node_id::build("", "172.18.0.2", 11210);
+  auto nid2 = couchbase::internal_node_id::build("", "172.18.0.2", 11210);
+  REQUIRE(nid1.id() == nid2.id());
+  REQUIRE(nid1 == nid2);
+}
+
+TEST_CASE("unit: node_id different host/port produce different fallback ids", "[unit]")
+{
+  auto nid1 = couchbase::internal_node_id::build("", "172.18.0.2", 11210);
+  auto nid2 = couchbase::internal_node_id::build("", "172.18.0.3", 11210);
+  auto nid3 = couchbase::internal_node_id::build("", "172.18.0.2", 11207);
+  REQUIRE(nid1 != nid2);
+  REQUIRE(nid1 != nid3);
+  REQUIRE(nid2 != nid3);
+}
+
+TEST_CASE("unit: node_id equality compares by id", "[unit]")
+{
+  auto nid1 = couchbase::internal_node_id::build("same-uuid", "host-a", 11210);
+  auto nid2 = couchbase::internal_node_id::build("same-uuid", "host-b", 11207);
+  // Same uuid => same id() => equal, even though host/port differ
+  REQUIRE(nid1 == nid2);
+}
+
+TEST_CASE("unit: node_id works in ordered containers", "[unit]")
+{
+  auto nid1 = couchbase::internal_node_id::build("aaa", "h", 1);
+  auto nid2 = couchbase::internal_node_id::build("bbb", "h", 1);
+  std::set<couchbase::node_id> s;
+  s.insert(nid1);
+  s.insert(nid2);
+  REQUIRE(s.size() == 2);
+  std::map<couchbase::node_id, int> m;
+  m[nid1] = 1;
+  m[nid2] = 2;
+  REQUIRE(m.size() == 2);
+}
+
+TEST_CASE("unit: node_id works in unordered containers", "[unit]")
+{
+  auto nid1 = couchbase::internal_node_id::build("uuid-1", "h", 1);
+  auto nid2 = couchbase::internal_node_id::build("uuid-2", "h", 1);
+  std::unordered_set<couchbase::node_id> s;
+  s.insert(nid1);
+  s.insert(nid2);
+  REQUIRE(s.size() == 2);
+  std::unordered_map<couchbase::node_id, int> m;
+  m[nid1] = 1;
+  m[nid2] = 2;
+  REQUIRE(m.size() == 2);
+}


### PR DESCRIPTION
Introduce node_id as a value type that uniquely identifies a cluster node. On Server 8.0.1+ the identifier is the server-assigned nodeUUID; on older releases a stable CRC32-based hash is derived from the node's hostname and management port. The type is equality-comparable, ordered, and hashable (std::hash specialization provided).

An internal_node_id factory provides the only construction path from core-level data, keeping the public constructor private.