### PR TITLE
CXXCBC-824: Separate transactions::run Core and Public API implementations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,7 @@ set(couchbase_cxx_client_FILES
     core/impl/wildcard_query.cxx
     core/impl/crypto.cxx
     core/impl/observability_recorder.cxx
+    core/impl/transactions.cxx
     core/io/config_tracker.cxx
     core/io/dns_client.cxx
     core/io/dns_config.cxx

--- a/core/impl/public_cluster.cxx
+++ b/core/impl/public_cluster.cxx
@@ -445,9 +445,9 @@ public:
     return core_;
   }
 
-  [[nodiscard]] auto transactions() const -> std::shared_ptr<core::transactions::transactions>
+  [[nodiscard]] auto transactions() const -> std::shared_ptr<transactions::transactions>
   {
-    return transactions_;
+    return std::make_shared<transactions::transactions>(transactions_);
   }
 
 private:
@@ -487,7 +487,7 @@ private:
   cluster_options::built options_;
   asio::io_context io_{ ASIO_CONCURRENCY_HINT_SAFE };
   core::cluster core_{ io_ };
-  std::shared_ptr<core::transactions::transactions> transactions_{ nullptr };
+  std::shared_ptr<couchbase::core::transactions::transactions> transactions_{ nullptr };
   std::thread io_thread_{ [&io = io_] {
     io.run();
   } };

--- a/core/impl/transactions.cxx
+++ b/core/impl/transactions.cxx
@@ -1,0 +1,130 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include <couchbase/cluster.hxx>
+#include <couchbase/transactions.hxx>
+
+#include "core/impl/error.hxx"
+#include "core/transactions.hxx"
+#include "core/transactions/attempt_context_impl.hxx"
+#include "core/transactions/exceptions.hxx"
+
+#include <spdlog/fmt/bundled/format.h>
+
+#include <couchbase/fmt/error.hxx>
+
+namespace couchbase::transactions
+{
+void
+maybe_throw(error err)
+{
+  if (err && err.ec() != errc::transaction_op::transaction_op_failed) {
+    // We intentionally don't handle transaction_op_failed here, as we must have cached the
+    // transaction error internally already, which has the full context with the right error class
+    // etc.
+    if (err.ec().category() == core::impl::transaction_op_category()) {
+      throw core::transactions::op_exception(std::move(err));
+    }
+    throw std::system_error(err.ec(), fmt::format("{}", err));
+  }
+}
+
+class transactions_impl
+{
+public:
+  explicit transactions_impl(std::shared_ptr<core::transactions::transactions> core_txns)
+    : core_txns_{ std::move(core_txns) }
+  {
+  }
+
+  auto run(txn_logic&& logic, const transaction_options& options) const
+    -> std::pair<error, transaction_result>
+  {
+    try {
+      auto res = core_txns_->run(options, [logic = std::move(logic)](auto ctx) mutable {
+        const auto err =
+          logic(std::static_pointer_cast<core::transactions::attempt_context_impl>(ctx));
+        maybe_throw(std::move(err));
+      });
+      return { {}, res };
+    } catch (const core::transactions::transaction_exception& e) {
+      auto [err_ctx, res_from_exc] = e.get_transaction_result();
+      return std::make_pair(core::impl::make_error(err_ctx), std::move(res_from_exc));
+    }
+  }
+
+  void run(async_txn_logic&& logic,
+           async_txn_complete_logic&& callback,
+           const transaction_options& options) const
+  {
+    core_txns_->run(
+      options,
+      [logic = std::move(logic)](auto ctx) mutable {
+        auto err = logic(std::static_pointer_cast<core::transactions::attempt_context_impl>(ctx));
+        maybe_throw(std::move(err));
+      },
+      [callback = std::move(callback)](auto exc, auto res) mutable {
+        if (exc.has_value()) {
+          auto [err_ctx, res_from_exc] = exc.value().get_transaction_result();
+          return callback(core::impl::make_error(err_ctx), std::move(res_from_exc));
+        }
+        return callback({}, std::move(res.value()));
+      });
+  }
+
+  [[nodiscard]] auto core() const -> std::shared_ptr<core::transactions::transactions>
+  {
+    return core_txns_;
+  }
+
+private:
+  std::shared_ptr<core::transactions::transactions> core_txns_;
+};
+
+transactions::transactions(std::shared_ptr<core::transactions::transactions> core_txns)
+  : impl_{ std::make_shared<transactions_impl>(std::move(core_txns)) }
+{
+}
+
+auto
+transactions::run(txn_logic&& logic, const transaction_options& cfg)
+  -> std::pair<error, transaction_result>
+{
+  return impl_->run(std::move(logic), cfg);
+}
+
+void
+transactions::run(async_txn_logic&& logic,
+                  async_txn_complete_logic&& complete_callback,
+                  const transaction_options& cfg)
+{
+  return impl_->run(std::move(logic), std::move(complete_callback), cfg);
+}
+} // namespace couchbase::transactions
+
+namespace couchbase::core::transactions
+{
+auto
+get_core_transactions(const std::shared_ptr<couchbase::transactions::transactions>& transactions)
+  -> std::shared_ptr<core::transactions::transactions>
+{
+  return reinterpret_cast<const std::shared_ptr<couchbase::transactions::transactions_impl>*>(
+           transactions.get())
+    ->get()
+    ->core();
+}
+} // namespace couchbase::core::transactions

--- a/core/meta/features.hxx
+++ b/core/meta/features.hxx
@@ -268,3 +268,10 @@
  * Support for the stable OpenTelemetry conventions (Observability RFC revisions 26 & 27)
  */
 #define COUCHBASE_CXX_CLIENT_STABLE_OTEL_CONVENTIONS 1
+
+/**
+ * The implementations for couchbase::transactions::transactions and
+ * couchbase::core::transactions::transactions are separate, i.e.,
+ * couchbase::core::transactions::transactions does not implement the Public API.
+ */
+#define COUCHBASE_CXX_CLIENT_TRANSACTIONS_PUBLIC_CORE_IMPL_SEPARATION 1

--- a/core/transactions.hxx
+++ b/core/transactions.hxx
@@ -127,7 +127,7 @@ using txn_complete_callback =
 /** @brief Main class for creating a transaction
  *
  */
-class transactions : public couchbase::transactions::transactions
+class transactions
 {
 public:
   /**
@@ -182,10 +182,6 @@ public:
   auto run(const couchbase::transactions::transaction_options& config,
            logic&& code) -> couchbase::transactions::transaction_result;
 
-  auto run(::couchbase::transactions::txn_logic&& code,
-           const couchbase::transactions::transaction_options& config)
-    -> std::pair<couchbase::error, couchbase::transactions::transaction_result> override;
-
   /**
    * @brief Run a transaction
    *
@@ -204,9 +200,6 @@ public:
            async_logic&& code,
            txn_complete_callback&& cb);
 
-  void run(couchbase::transactions::async_txn_logic&& code,
-           couchbase::transactions::async_txn_complete_logic&& complete_cb,
-           const couchbase::transactions::transaction_options& config) override;
   /**
    * @internal
    * called internally - will likely move
@@ -279,7 +272,7 @@ public:
   transactions(core::cluster cluster, couchbase::transactions::transactions_config::built config);
   transactions(core::cluster cluster, const couchbase::transactions::transactions_config& config);
 
-  ~transactions() override;
+  ~transactions();
 
 private:
   core::cluster cluster_;
@@ -288,5 +281,12 @@ private:
   const std::size_t max_attempts_{ 1000 };
   const std::chrono::milliseconds min_retry_delay_{ 1 };
 };
+
+// TODO(DC): Can we replace this with something better?
+// This is needed as the performer needs to access the Core API to set hooks, access cleanup-related
+// metrics, which are not exposed in the Public API.
+auto
+get_core_transactions(const std::shared_ptr<couchbase::transactions::transactions>& transactions)
+  -> std::shared_ptr<couchbase::core::transactions::transactions>;
 } // namespace transactions
 } // namespace couchbase::core

--- a/core/transactions/transactions.cxx
+++ b/core/transactions/transactions.cxx
@@ -166,34 +166,6 @@ wrap_run(transactions& txns,
   return overall->get_transaction_result();
 }
 
-template<typename Handler>
-auto
-wrap_public_api_run(transactions& txns,
-                    const couchbase::transactions::transaction_options& config,
-                    std::size_t max_attempts,
-                    Handler&& fn) -> ::couchbase::transactions::transaction_result
-{
-  return wrap_run(txns, config, max_attempts, [fn = std::forward<Handler>(fn)](const auto& ctx) {
-    const couchbase::error err = fn(ctx);
-    if (err && err.ec() != errc::transaction_op::transaction_op_failed) {
-      // We intentionally don't handle transaction_op_failed here, as we must have cached the
-      // transaction error internally already, which has the full context with the right error class
-      // etc.
-      if (err.ec().category() == core::impl::transaction_op_category()) {
-        throw op_exception(err);
-      }
-      throw std::system_error(err.ec(), fmt::format("{}", err));
-    }
-  });
-}
-
-auto
-transactions::run(logic&& code) -> ::couchbase::transactions::transaction_result
-{
-  const couchbase::transactions::transaction_options config;
-  return wrap_run(*this, config, max_attempts_, std::move(code));
-}
-
 auto
 transactions::run(const couchbase::transactions::transaction_options& config, logic&& code)
   -> ::couchbase::transactions::transaction_result
@@ -202,17 +174,9 @@ transactions::run(const couchbase::transactions::transaction_options& config, lo
 }
 
 auto
-transactions::run(couchbase::transactions::txn_logic&& code,
-                  const couchbase::transactions::transaction_options& config)
-  -> std::pair<couchbase::error, couchbase::transactions::transaction_result>
+transactions::run(logic&& code) -> ::couchbase::transactions::transaction_result
 {
-  try {
-    return { {}, wrap_public_api_run(*this, config, max_attempts_, std::move(code)) };
-  } catch (const transaction_exception& e) {
-    // get error from e and return it in the transaction_result
-    auto [err_ctx, result] = e.get_transaction_result();
-    return std::make_pair(core::impl::make_error(err_ctx), result);
-  }
+  return run({}, std::move(code));
 }
 
 void
@@ -229,27 +193,11 @@ transactions::run(const couchbase::transactions::transaction_options& config,
     }
   }).detach();
 }
-void
-transactions::run(couchbase::transactions::async_txn_logic&& code,
-                  couchbase::transactions::async_txn_complete_logic&& cb,
-                  const couchbase::transactions::transaction_options& config)
-{
-  std::thread([this, config, code = std::move(code), cb = std::move(cb)]() {
-    try {
-      auto result = wrap_public_api_run(*this, config, max_attempts_, code);
-      return cb({}, result);
-    } catch (const transaction_exception& e) {
-      auto [ctx, res] = e.get_transaction_result();
-      return cb(core::impl::make_error(ctx), res);
-    }
-  }).detach();
-}
 
 void
 transactions::run(async_logic&& code, txn_complete_callback&& cb)
 {
-  const couchbase::transactions::transaction_options config;
-  return run(config, std::move(code), std::move(cb));
+  return run({}, std::move(code), std::move(cb));
 }
 
 void

--- a/couchbase/transactions.hxx
+++ b/couchbase/transactions.hxx
@@ -24,6 +24,21 @@
 
 #include <functional>
 
+#ifndef COUCHBASE_CXX_CLIENT_DOXYGEN
+namespace couchbase
+{
+namespace transactions
+{
+class transactions_impl;
+} // namespace transactions
+
+namespace core::transactions
+{
+class transactions;
+} // namespace core::transactions
+} // namespace couchbase
+#endif
+
 namespace couchbase::transactions
 {
 using txn_logic = std::function<error(std::shared_ptr<attempt_context>)>;
@@ -32,14 +47,10 @@ using async_txn_complete_logic = std::function<void(error, transaction_result)>;
 
 /**
  * The transactions object is used to initiate a transaction.
- *
- *
  */
 class transactions
 {
 public:
-  virtual ~transactions() = default;
-
   /**
    * Run a blocking transaction.
    *
@@ -56,13 +67,8 @@ public:
    * @return an {@link error}, and a {@link transaction_result} representing the results of the
    * transaction.
    */
-  virtual auto run(txn_logic&& logic,
-                   const transaction_options& cfg) -> std::pair<error, transaction_result> = 0;
-
-  auto run(txn_logic&& logic) -> std::pair<error, transaction_result>
-  {
-    return run(std::move(logic), {});
-  }
+  auto run(txn_logic&& logic, const transaction_options& cfg = {})
+    -> std::pair<error, transaction_result>;
 
   /**
    * Run an asynchronous transaction.
@@ -83,13 +89,16 @@ public:
    * @param cfg if passed in, these options override the defaults, or those set in the {@link
    * cluster_options}.
    */
-  virtual void run(async_txn_logic&& logic,
-                   async_txn_complete_logic&& complete_callback,
-                   const transaction_options& cfg) = 0;
+  void run(async_txn_logic&& logic,
+           async_txn_complete_logic&& complete_callback,
+           const transaction_options& cfg = {});
 
-  void run(async_txn_logic&& logic, async_txn_complete_logic&& complete_callback)
-  {
-    return run(std::move(logic), std::move(complete_callback), {});
-  }
+  /**
+   * @internal
+   */
+  explicit transactions(std::shared_ptr<core::transactions::transactions> core_txns);
+
+private:
+  std::shared_ptr<transactions_impl> impl_;
 };
 } // namespace couchbase::transactions

--- a/test/test_transaction_simple.cxx
+++ b/test/test_transaction_simple.cxx
@@ -1215,3 +1215,22 @@ TEST_CASE("transactions: sergey example", "[transactions]")
       CHECK_FALSE(remove_res.has_value());
     }));
 }
+
+TEST_CASE("transactions: extract core transactions from public API transactions", "[transactions]")
+{
+  test::utils::integration_test_guard integration;
+  auto cluster = integration.public_cluster();
+  const auto core_txns =
+    couchbase::core::transactions::get_core_transactions(cluster.transactions());
+
+  REQUIRE(core_txns != nullptr);
+
+  const auto doc_id = couchbase::core::document_id{
+    integration.ctx.bucket, "_default", "_default", test::utils::uniq_id("txn")
+  };
+
+  core_txns->run([doc_id](std::shared_ptr<couchbase::core::transactions::attempt_context> ctx) {
+    const auto res = ctx->get_optional(doc_id);
+    REQUIRE_FALSE(res.has_value());
+  });
+}


### PR DESCRIPTION
## Motivation

Currently, the core transactions class implements the `run` method for both the core and public APIs. We should have a clearer separation between the two APIs, and make the Public API utilize the corresponding core methods, instead of duplicating the implementation.

## Changes

* The core transactions class no longer implements the Public API's transactions class's virtual methods. The methods are now non-virtual and are implemented by an internal `transactions_impl` class.
* The Public API run methods now call the corresponding core methods, instead of being almost a duplicate of the core implementation.
* Add a (temporary?) `get_core_transactions` helper. This is needed as the FIT performer needs to access the Core API to report cleanup metrics, modify hooks, trigger a cleanup, etc. Previously this was achieved by casting the Public API transactions object to the core transactions object, which is no longer possible.
* There are no behavioral changes as part of this PR.

FIT performer patch: https://review.couchbase.org/c/transactions-fit-performer/+/244168