### PR TITLE
CXXCBC-822: Add external circuit breaker example using node_id API

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,9 @@
-macro(define_example name)
-  add_executable(${name} ${name}.cxx)
+function(define_example name)
+  set(_example_sources "${ARGN}")
+  if(NOT _example_sources)
+    set(_example_sources "${name}.cxx")
+  endif()
+  add_executable(${name} ${_example_sources})
   set_project_warnings(${name})
   set_project_options(${name})
   target_include_directories(${name} PUBLIC ${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/private)
@@ -9,11 +13,11 @@ macro(define_example name)
   propagate_public_compile_definitions(${name} spdlog::spdlog asio)
   target_link_libraries(${name} PRIVATE ${CMAKE_THREAD_LIBS_INIT} taocpp::json ${couchbase_cxx_client_DEFAULT_LIBRARY})
   if(COUCHBASE_CXX_CLIENT_STATIC_BORINGSSL AND WIN32)
-    # Ignore the `LNK4099: PDB ['crypto.pdb'|'ssl.pdb'] was not found` warnings, as we don't (atm) keep track fo the
+    # Ignore the `LNK4099: PDB ['crypto.pdb'|'ssl.pdb'] was not found` warnings, as we don't (atm) keep track of the
     # *.PDB from the BoringSSL build
     set_target_properties(${name} PROPERTIES LINK_FLAGS "/ignore:4099")
   endif()
-endmacro()
+endfunction()
 
 define_example(minimal)
 define_example(bulk_base_api)
@@ -23,6 +27,26 @@ define_example(game_server)
 define_example(async_game_server)
 define_example(distributed_mutex)
 
+if(WIN32)
+  set(_external_circuit_breaker_platform_ui external_circuit_breaker/ui_windows.cxx)
+else()
+  set(_external_circuit_breaker_platform_ui external_circuit_breaker/ui_unix.cxx)
+endif()
+define_example(
+  external_circuit_breaker
+  external_circuit_breaker/main.cxx
+  external_circuit_breaker/circuit_breaker.cxx
+  external_circuit_breaker/ui.cxx
+  ${_external_circuit_breaker_platform_ui}
+  external_circuit_breaker/demo_common.cxx
+  external_circuit_breaker/demo_healthy_traffic.cxx
+  external_circuit_breaker/demo_state_transitions.cxx
+  external_circuit_breaker/demo_failed_probe.cxx
+  external_circuit_breaker/demo_admin.cxx
+  external_circuit_breaker/demo_slow_calls.cxx
+  external_circuit_breaker/demo_per_node_isolation.cxx
+  external_circuit_breaker/demo_topology_sweep.cxx)
+
 macro(define_asio_example name)
   add_executable(${name} ${name}.cxx)
   set_project_warnings(${name})
@@ -30,7 +54,7 @@ macro(define_asio_example name)
   target_include_directories(${name} PUBLIC ${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/private)
   target_link_libraries(${name} PRIVATE ${CMAKE_THREAD_LIBS_INIT} asio taocpp::json)
   if(COUCHBASE_CXX_CLIENT_STATIC_BORINGSSL AND WIN32)
-    # Ignore the `LNK4099: PDB ['crypto.pdb'|'ssl.pdb'] was not found` warnings, as we don't (atm) keep track fo the
+    # Ignore the `LNK4099: PDB ['crypto.pdb'|'ssl.pdb'] was not found` warnings, as we don't (atm) keep track of the
     # *.PDB from the BoringSSL build
     set_target_properties(${name} PROPERTIES LINK_FLAGS "/ignore:4099")
   endif()

--- a/examples/external_circuit_breaker/circuit_breaker.cxx
+++ b/examples/external_circuit_breaker/circuit_breaker.cxx
@@ -1,0 +1,627 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "circuit_breaker.hxx"
+
+#include <limits>
+#include <sstream>
+#include <thread>
+#include <utility>
+
+namespace example::cb
+{
+
+auto
+to_string(circuit_state s) -> const char*
+{
+  switch (s) {
+    case circuit_state::closed:
+      return "CLOSED";
+    case circuit_state::open:
+      return "OPEN";
+    case circuit_state::half_open:
+      return "HALF_OPEN";
+    case circuit_state::forced_open:
+      return "FORCED_OPEN";
+    case circuit_state::disabled:
+      return "DISABLED";
+  }
+  return "UNKNOWN";
+}
+
+auto
+breaker_category() -> const std::error_category&
+{
+  struct category : std::error_category {
+    auto name() const noexcept -> const char* override
+    {
+      return "example::cb::circuit_breaker";
+    }
+    auto message(int ev) const -> std::string override
+    {
+      switch (static_cast<breaker_errc>(ev)) {
+        case breaker_errc::user_canceled:
+          return "circuit breaker rejected call (user-side cancellation)";
+      }
+      return "unknown circuit breaker error";
+    }
+  };
+  static const category instance;
+  return instance;
+}
+
+// ---------------------------------------------------------------------------
+// sliding_window_counters
+// ---------------------------------------------------------------------------
+
+namespace
+{
+auto
+clamp_bucket_count(std::chrono::milliseconds window, std::uint32_t buckets) -> std::uint32_t
+{
+  // Each bucket needs at least 1ms of window to itself; otherwise integer
+  // division below would produce bucket_size_ms == 0 and we'd have to clamp
+  // it up to 1, silently inflating the effective window length beyond what
+  // the caller configured.  Reduce the bucket count instead so the sampled
+  // window still matches the configured one.
+  auto window_ms = std::max<std::int64_t>(1, window.count());
+  // Saturate rather than narrow: window_ms above UINT32_MAX (~49.7 days) would
+  // wrap modulo 2^32 and could clamp the bucket count to a small/garbage value.
+  constexpr auto kU32Max = std::numeric_limits<std::uint32_t>::max();
+  auto max_buckets = window_ms > static_cast<std::int64_t>(kU32Max)
+                       ? kU32Max
+                       : static_cast<std::uint32_t>(window_ms);
+  return std::max<std::uint32_t>(1, std::min(buckets, max_buckets));
+}
+} // namespace
+
+sliding_window_counters::sliding_window_counters(std::chrono::milliseconds window,
+                                                 std::uint32_t buckets)
+  : bucket_count_{ clamp_bucket_count(window, buckets) }
+  , bucket_size_ms_{ std::max<std::int64_t>(1, window.count()) / bucket_count_ }
+{
+  buckets_.reserve(bucket_count_);
+  for (std::uint32_t i = 0; i < bucket_count_; ++i) {
+    buckets_.emplace_back(std::make_unique<bucket>());
+  }
+}
+
+auto
+sliding_window_counters::record(call_outcome o, bool slow) -> void
+{
+  auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                  std::chrono::steady_clock::now().time_since_epoch())
+                  .count();
+  auto epoch = now_ms / bucket_size_ms_;
+  auto& b = *buckets_[bucket_index_for(epoch)];
+  auto stored = b.epoch.load(std::memory_order_acquire);
+  while (stored != epoch) {
+    if (stored == kRotatingEpoch) {
+      // Another thread is mid-rotation; back off and re-read.
+      std::this_thread::yield();
+      stored = b.epoch.load(std::memory_order_acquire);
+      continue;
+    }
+    if (b.epoch.compare_exchange_weak(
+          stored, kRotatingEpoch, std::memory_order_acq_rel, std::memory_order_acquire)) {
+      // We own the rotation: zero the counters before publishing the new
+      // epoch so concurrent recorders never see a partially-reset bucket.
+      b.successes.store(0, std::memory_order_relaxed);
+      b.failures.store(0, std::memory_order_relaxed);
+      b.slow.store(0, std::memory_order_relaxed);
+      b.epoch.store(epoch, std::memory_order_release);
+      break;
+    }
+  }
+  if (o == call_outcome::success) {
+    b.successes.fetch_add(1, std::memory_order_relaxed);
+  } else {
+    b.failures.fetch_add(1, std::memory_order_relaxed);
+  }
+  if (slow) {
+    b.slow.fetch_add(1, std::memory_order_relaxed);
+  }
+}
+
+auto
+sliding_window_counters::sample() const -> snapshot
+{
+  auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                  std::chrono::steady_clock::now().time_since_epoch())
+                  .count();
+  auto current_epoch = now_ms / bucket_size_ms_;
+  auto min_epoch = current_epoch - static_cast<std::int64_t>(bucket_count_) + 1;
+  snapshot s{};
+  for (std::uint32_t i = 0; i < bucket_count_; ++i) {
+    const auto& b = *buckets_[i];
+    // Explicit sentinel exclusion: when steady_clock is small (early after
+    // process boot) min_epoch can go negative, in which case the sentinels
+    // (kUninitializedEpoch = -1, kRotatingEpoch = -2) would otherwise pass
+    // the in-range check below.
+    auto ep = b.epoch.load(std::memory_order_acquire);
+    if (ep == kRotatingEpoch || ep == kUninitializedEpoch) {
+      continue;
+    }
+    if (ep < min_epoch || ep > current_epoch) {
+      continue;
+    }
+    auto succ = b.successes.load(std::memory_order_relaxed);
+    auto fail = b.failures.load(std::memory_order_relaxed);
+    auto slow = b.slow.load(std::memory_order_relaxed);
+    // Re-check the epoch: if the bucket rotated between the epoch load and
+    // the counter loads we may have read freshly-zeroed counters that
+    // belong to the new epoch, not the one we admitted.  Skip the bucket
+    // rather than mix epochs in the snapshot.
+    if (b.epoch.load(std::memory_order_acquire) != ep) {
+      continue;
+    }
+    s.successes += succ;
+    s.failures += fail;
+    s.slow += slow;
+  }
+  s.total = s.successes + s.failures;
+  return s;
+}
+
+auto
+sliding_window_counters::reset() -> void
+{
+  for (std::uint32_t i = 0; i < bucket_count_; ++i) {
+    buckets_[i]->epoch.store(kUninitializedEpoch, std::memory_order_relaxed);
+    buckets_[i]->successes.store(0, std::memory_order_relaxed);
+    buckets_[i]->failures.store(0, std::memory_order_relaxed);
+    buckets_[i]->slow.store(0, std::memory_order_relaxed);
+  }
+}
+
+auto
+sliding_window_counters::bucket_index_for(std::int64_t epoch) const -> std::size_t
+{
+  return static_cast<std::size_t>(((epoch % bucket_count_) + bucket_count_) % bucket_count_);
+}
+
+// ---------------------------------------------------------------------------
+// node_breaker
+// ---------------------------------------------------------------------------
+
+node_breaker::node_breaker(circuit_breaker_config config, transition_callback on_transition)
+  : config_{ std::move(config) }
+  , on_transition_{ std::move(on_transition) }
+  , window_{ config_.sliding_window(), config_.number_of_buckets() }
+  , state_{ circuit_state::closed }
+  , half_open_permits_{ 0 }
+  , half_open_successes_{ 0 }
+  , half_open_failures_{ 0 }
+  , rejected_{ 0 }
+  , opened_at_ms_{ kNotOpenedYet }
+{
+}
+
+auto
+node_breaker::try_acquire() -> bool
+{
+  switch (state_.load(std::memory_order_acquire)) {
+    case circuit_state::disabled:
+      return true;
+    case circuit_state::forced_open:
+      rejected_.fetch_add(1, std::memory_order_relaxed);
+      return false;
+    case circuit_state::closed:
+      return true;
+    case circuit_state::open:
+      if (cool_off_elapsed()) {
+        try_transition_to_half_open("cool-off elapsed");
+        if (try_acquire_half_open_permit()) {
+          return true;
+        }
+      }
+      rejected_.fetch_add(1, std::memory_order_relaxed);
+      return false;
+    case circuit_state::half_open:
+      if (try_acquire_half_open_permit()) {
+        return true;
+      }
+      rejected_.fetch_add(1, std::memory_order_relaxed);
+      return false;
+  }
+  return true;
+}
+
+auto
+node_breaker::record(call_outcome o, std::chrono::milliseconds duration) -> void
+{
+  auto s = state_.load(std::memory_order_acquire);
+  if (s == circuit_state::disabled || s == circuit_state::forced_open) {
+    return;
+  }
+  auto slow = duration >= config_.slow_call_duration_threshold();
+  window_.record(o, slow);
+
+  if (s == circuit_state::half_open) {
+    if (o == call_outcome::success) {
+      auto succ = half_open_successes_.fetch_add(1, std::memory_order_acq_rel) + 1;
+      if (succ >= config_.permitted_calls_in_half_open_state()) {
+        try_transition_to_closed("half-open probes succeeded");
+      }
+    } else {
+      half_open_failures_.fetch_add(1, std::memory_order_acq_rel);
+      try_transition_to_open("half-open probe failed");
+    }
+    return;
+  }
+
+  if (s == circuit_state::closed) {
+    evaluate_and_maybe_open();
+  }
+}
+
+auto
+node_breaker::force_open() -> void
+{
+  transition("administrative force_open", circuit_state::forced_open);
+}
+
+auto
+node_breaker::disable() -> void
+{
+  transition("administrative disable", circuit_state::disabled);
+}
+
+auto
+node_breaker::reset() -> void
+{
+  std::lock_guard guard{ state_mutex_ };
+  // Mirror transition()'s aux-fields-before-state_ ordering (see the
+  // comment there).  Otherwise a reader could observe stale state_=open
+  // and the freshly-zeroed opened_at_ms_=kNotOpenedYet, which makes
+  // cool_off_elapsed() return false and produces a spurious rejected_++
+  // for a breaker that has just been reset to CLOSED.
+  auto prev = state_.load(std::memory_order_acquire);
+  window_.reset();
+  half_open_permits_.store(0, std::memory_order_relaxed);
+  half_open_successes_.store(0, std::memory_order_relaxed);
+  half_open_failures_.store(0, std::memory_order_relaxed);
+  rejected_.store(0, std::memory_order_relaxed);
+  opened_at_ms_.store(kNotOpenedYet, std::memory_order_relaxed);
+  state_.store(circuit_state::closed, std::memory_order_release);
+  if (prev != circuit_state::closed && on_transition_) {
+    on_transition_(prev, circuit_state::closed, "reset");
+  }
+}
+
+auto
+node_breaker::snapshot_metrics() const -> circuit_breaker_metrics
+{
+  auto snap = window_.sample();
+  circuit_breaker_metrics m{};
+  m.state = state_.load(std::memory_order_acquire);
+  m.successful_calls = snap.successes;
+  m.failed_calls = snap.failures;
+  m.slow_calls = snap.slow;
+  m.total_calls = snap.total;
+  m.failure_rate_percent =
+    snap.total == 0 ? 0 : static_cast<std::uint32_t>((snap.failures * 100) / snap.total);
+  m.slow_call_rate_percent =
+    snap.total == 0 ? 0 : static_cast<std::uint32_t>((snap.slow * 100) / snap.total);
+  m.rejected_calls = rejected_.load(std::memory_order_relaxed);
+  return m;
+}
+
+auto
+node_breaker::cool_off_elapsed() const -> bool
+{
+  // transition() always stores a real opened_at_ms_ before publishing
+  // state_=open, and the caller only reaches this method after observing
+  // state_=open via an acquire-load of state_, so by C++17 [intro.races]
+  // we are guaranteed to see a real timestamp here.  The kNotOpenedYet
+  // branch is a defensive guard: if the invariant is ever broken, fail
+  // safe by refusing to elapse rather than spuriously promoting the
+  // breaker to HALF_OPEN.
+  auto opened_ms = opened_at_ms_.load(std::memory_order_acquire);
+  if (opened_ms == kNotOpenedYet) {
+    return false;
+  }
+  auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                  std::chrono::steady_clock::now().time_since_epoch())
+                  .count();
+  return (now_ms - opened_ms) >= config_.wait_duration_in_open_state().count();
+}
+
+auto
+node_breaker::try_acquire_half_open_permit() -> bool
+{
+  auto current = half_open_permits_.load(std::memory_order_acquire);
+  while (current > 0) {
+    if (half_open_permits_.compare_exchange_weak(
+          current, current - 1, std::memory_order_acq_rel, std::memory_order_acquire)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+auto
+node_breaker::evaluate_and_maybe_open() -> void
+{
+  auto snap = window_.sample();
+  if (snap.total < config_.minimum_number_of_calls()) {
+    return;
+  }
+  auto fail_pct = static_cast<std::uint32_t>((snap.failures * 100) / snap.total);
+  auto slow_pct = static_cast<std::uint32_t>((snap.slow * 100) / snap.total);
+  if (fail_pct >= config_.failure_rate_threshold_percent()) {
+    std::ostringstream why;
+    why << "failure rate " << fail_pct << "% >= threshold "
+        << config_.failure_rate_threshold_percent() << "% over " << snap.total << " calls";
+    try_transition_to_open(why.str());
+  } else if (slow_pct >= config_.slow_call_rate_threshold_percent()) {
+    std::ostringstream why;
+    why << "slow-call rate " << slow_pct << "% >= threshold "
+        << config_.slow_call_rate_threshold_percent() << "% over " << snap.total << " calls";
+    try_transition_to_open(why.str());
+  }
+}
+
+auto
+node_breaker::try_transition_to_open(const std::string& why) -> void
+{
+  transition(why, circuit_state::open);
+}
+
+auto
+node_breaker::try_transition_to_half_open(const std::string& why) -> void
+{
+  transition(why, circuit_state::half_open);
+}
+
+auto
+node_breaker::try_transition_to_closed(const std::string& why) -> void
+{
+  transition(why, circuit_state::closed);
+}
+
+auto
+node_breaker::transition(const std::string& why, circuit_state target) -> void
+{
+  circuit_state prev;
+  {
+    std::lock_guard guard{ state_mutex_ };
+    prev = state_.load(std::memory_order_acquire);
+    if (prev == target) {
+      return;
+    }
+    // An administrative override (forced_open / disabled) must not be undone
+    // by a concurrent automatic transition.  force_open() / disable() can
+    // still swap one admin state for another; reset() bypasses transition()
+    // entirely and is the only path back to closed.
+    auto is_admin_state = [](circuit_state s) -> bool {
+      return s == circuit_state::forced_open || s == circuit_state::disabled;
+    };
+    if (is_admin_state(prev) && !is_admin_state(target)) {
+      return;
+    }
+    // Publish the auxiliary fields (opened_at_ms_, half-open counters, etc.)
+    // *before* the state_ store below.  state_ is the single synchronization
+    // point on the read path: a reader doing state_.load(acquire) that
+    // observes a value written by the state_.store(release) below is also
+    // guaranteed to see every store sequenced-before that release in this
+    // thread (C++17 [intro.races] synchronizes-with).  That covers all of
+    // the auxiliary fields here, so the read path can use plain atomic
+    // loads on each field without an additional fence.
+    if (target == circuit_state::open) {
+      auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                      std::chrono::steady_clock::now().time_since_epoch())
+                      .count();
+      opened_at_ms_.store(now_ms, std::memory_order_release);
+      half_open_permits_.store(0, std::memory_order_release);
+      half_open_successes_.store(0, std::memory_order_release);
+      half_open_failures_.store(0, std::memory_order_release);
+    } else if (target == circuit_state::half_open) {
+      half_open_permits_.store(config_.permitted_calls_in_half_open_state(),
+                               std::memory_order_release);
+      half_open_successes_.store(0, std::memory_order_release);
+      half_open_failures_.store(0, std::memory_order_release);
+    } else if (target == circuit_state::closed) {
+      window_.reset();
+      half_open_permits_.store(0, std::memory_order_release);
+      half_open_successes_.store(0, std::memory_order_release);
+      half_open_failures_.store(0, std::memory_order_release);
+      opened_at_ms_.store(kNotOpenedYet, std::memory_order_release);
+    }
+    state_.store(target, std::memory_order_release);
+  }
+  if (on_transition_) {
+    on_transition_(prev, target, why);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// circuit_breaker
+// ---------------------------------------------------------------------------
+
+circuit_breaker::circuit_breaker(circuit_breaker_config config)
+  : config_{ std::move(config) }
+{
+}
+
+auto
+circuit_breaker::set_transition_callback(transition_callback cb) -> void
+{
+  std::unique_lock guard{ mutex_ };
+  on_transition_ = std::move(cb);
+}
+
+auto
+circuit_breaker::dispatch_transition(const std::string& node_id_str,
+                                     circuit_state from,
+                                     circuit_state to,
+                                     const std::string& why) const -> void
+{
+  transition_callback cb;
+  {
+    std::shared_lock guard{ mutex_ };
+    cb = on_transition_;
+  }
+  if (cb) {
+    cb(from, to, "[node " + node_id_str + "] " + why);
+  }
+}
+
+auto
+circuit_breaker::allow(const couchbase::node_id& nid) -> bool
+{
+  if (!nid) {
+    return true;
+  }
+  auto b = get_or_create(nid);
+  return b->try_acquire();
+}
+
+auto
+circuit_breaker::record_success(const couchbase::node_id& nid, std::chrono::milliseconds duration)
+  -> void
+{
+  if (!nid) {
+    return;
+  }
+  get_or_create(nid)->record(call_outcome::success, duration);
+}
+
+auto
+circuit_breaker::record_failure(const couchbase::node_id& nid, std::chrono::milliseconds duration)
+  -> void
+{
+  if (!nid) {
+    return;
+  }
+  get_or_create(nid)->record(call_outcome::failure, duration);
+}
+
+auto
+circuit_breaker::state_of(const couchbase::node_id& nid) const -> circuit_state
+{
+  if (auto b = find(nid)) {
+    return b->state();
+  }
+  return circuit_state::closed;
+}
+
+auto
+circuit_breaker::metrics_of(const couchbase::node_id& nid) const
+  -> std::optional<circuit_breaker_metrics>
+{
+  if (auto b = find(nid)) {
+    return b->snapshot_metrics();
+  }
+  return std::nullopt;
+}
+
+auto
+circuit_breaker::all_metrics() const
+  -> std::vector<std::pair<couchbase::node_id, circuit_breaker_metrics>>
+{
+  // Copy the (id, breaker) pairs out from under the registry lock first, so
+  // sampling each node — which involves steady_clock and a handful of
+  // atomic loads per bucket — does not stall concurrent get_or_create() or
+  // set_transition_callback() callers.  shared_ptr keeps each node_breaker
+  // alive while we sample.
+  std::vector<std::pair<couchbase::node_id, std::shared_ptr<node_breaker>>> snapshot;
+  {
+    std::shared_lock guard{ mutex_ };
+    snapshot.reserve(nodes_.size());
+    for (const auto& [k, v] : nodes_) {
+      snapshot.emplace_back(k, v);
+    }
+  }
+  std::vector<std::pair<couchbase::node_id, circuit_breaker_metrics>> out;
+  out.reserve(snapshot.size());
+  for (const auto& [k, v] : snapshot) {
+    out.emplace_back(k, v->snapshot_metrics());
+  }
+  return out;
+}
+
+auto
+circuit_breaker::force_open(const couchbase::node_id& nid) -> void
+{
+  if (nid) {
+    get_or_create(nid)->force_open();
+  }
+}
+
+auto
+circuit_breaker::disable(const couchbase::node_id& nid) -> void
+{
+  if (nid) {
+    get_or_create(nid)->disable();
+  }
+}
+
+auto
+circuit_breaker::reset(const couchbase::node_id& nid) -> void
+{
+  if (auto b = find(nid)) {
+    b->reset();
+  }
+}
+
+auto
+circuit_breaker::forget(const couchbase::node_id& nid) -> bool
+{
+  if (!nid) {
+    return false;
+  }
+  std::unique_lock guard{ mutex_ };
+  return nodes_.erase(nid) != 0;
+}
+
+auto
+circuit_breaker::find(const couchbase::node_id& nid) const -> std::shared_ptr<node_breaker>
+{
+  if (!nid) {
+    return nullptr;
+  }
+  std::shared_lock guard{ mutex_ };
+  if (auto it = nodes_.find(nid); it != nodes_.end()) {
+    return it->second;
+  }
+  return nullptr;
+}
+
+auto
+circuit_breaker::get_or_create(const couchbase::node_id& nid) -> std::shared_ptr<node_breaker>
+{
+  {
+    std::shared_lock guard{ mutex_ };
+    if (auto it = nodes_.find(nid); it != nodes_.end()) {
+      return it->second;
+    }
+  }
+  std::unique_lock guard{ mutex_ };
+  if (auto it = nodes_.find(nid); it != nodes_.end()) {
+    return it->second;
+  }
+  auto wrapped = [self = this, id = nid.id()](
+                   circuit_state from, circuit_state to, const std::string& why) -> void {
+    self->dispatch_transition(id, from, to, why);
+  };
+  auto breaker = std::make_shared<node_breaker>(config_, std::move(wrapped));
+  nodes_.emplace(nid, breaker);
+  return breaker;
+}
+
+} // namespace example::cb

--- a/examples/external_circuit_breaker/circuit_breaker.hxx
+++ b/examples/external_circuit_breaker/circuit_breaker.hxx
@@ -1,0 +1,859 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+/**
+ * @file
+ *
+ * Standalone, production-quality circuit breaker layered on top of the
+ * Couchbase C++ SDK's node_id API.  The implementation lives in the
+ * ::example::cb namespace so applications can copy this pair of files
+ * (circuit_breaker.hxx / circuit_breaker.cxx) verbatim, rename the
+ * namespace, and drop them into their codebase.
+ *
+ * Design references: Netflix Hystrix, Resilience4j.
+ *
+ * Features:
+ *   * Per-node isolation — a degraded node does not poison the others.
+ *   * Time-based sliding window with fixed bucket ring (lock-free hot path).
+ *   * Failure-rate and slow-call-rate thresholds.
+ *   * Minimum-calls gate so a cold cache does not flap the breaker.
+ *   * Five states: closed, open, half_open, disabled, forced_open.
+ *   * Bounded probe concurrency in half_open (permits).
+ *   * State-transition listener for logging and telemetry hooks.
+ *   * Administrative disable / force-open overrides.
+ *   * No dependencies beyond the C++17 standard library and the SDK.
+ *
+ * The breaker sits outside the SDK — it decides whether to attempt an
+ * operation, and records the outcome.  It does not modify SDK retry
+ * behavior.  Integration with a call site is illustrated by
+ * circuit_breaker::execute().
+ */
+
+#pragma once
+
+#include <couchbase/error.hxx>
+#include <couchbase/error_codes.hxx>
+#include <couchbase/node_id.hxx>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <shared_mutex>
+#include <string>
+#include <system_error>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace example::cb
+{
+
+/**
+ * Lifecycle states of a per-node breaker.
+ *
+ *   closed       — requests flow through; outcomes update the sliding window.
+ *   open         — requests are short-circuited until the sleep window elapses.
+ *   half_open    — a bounded number of probe requests are allowed; their
+ *                  outcome decides whether to close or re-open.
+ *   forced_open  — administrative: always rejects, never auto-transitions.
+ *   disabled     — administrative: always allows, does not record metrics.
+ */
+enum class circuit_state : std::uint8_t {
+  closed,
+  open,
+  half_open,
+  forced_open,
+  disabled,
+};
+
+[[nodiscard]] auto
+to_string(circuit_state s) -> const char*;
+
+/**
+ * Classification of a single call outcome, supplied by the caller.
+ *
+ * The breaker does not try to be clever about which std::error_code values
+ * indicate a server-side problem versus a client-side user error — the
+ * caller decides, because only the caller knows the business context.
+ */
+enum class call_outcome : std::uint8_t {
+  success,
+  failure,
+};
+
+/**
+ * Error codes synthesized by the breaker itself (never by the SDK).
+ *
+ * When circuit_breaker::execute() short-circuits a call it returns a
+ * couchbase::error whose error_code lives in this dedicated category, so a
+ * caller can tell a breaker rejection apart from a real SDK error and choose
+ * not to feed it back into the breaker's failure rate.  The SDK's own
+ * couchbase::errc::common::request_canceled is reserved for actual
+ * SDK-emitted cancellations (e.g. socket close mid-flight) and is therefore
+ * still a legitimate breaker-trippable signal.
+ */
+enum class breaker_errc {
+  user_canceled = 1,
+};
+
+[[nodiscard]] auto
+breaker_category() -> const std::error_category&;
+
+[[nodiscard]] inline auto
+make_error_code(breaker_errc e) -> std::error_code
+{
+  return { static_cast<int>(e), breaker_category() };
+}
+
+/**
+ * Tunables for the breaker.  The defaults are conservative and match the
+ * common recommendation (50% error rate over a 10-second window with at
+ * least 20 calls, 5-second cool-off).  Every setter validates and clamps
+ * its argument and returns *this so calls can be chained:
+ *
+ * @code
+ * auto cfg = example::cb::circuit_breaker_config{}
+ *              .with_failure_rate_threshold_percent(60)
+ *              .with_sliding_window(std::chrono::seconds{ 30 })
+ *              .with_minimum_number_of_calls(50);
+ * @endcode
+ */
+class circuit_breaker_config
+{
+public:
+  /**
+   * Failure rate (in percent, 1..100) that opens the breaker.  Evaluated
+   * over the sliding window once at least minimum_number_of_calls() calls
+   * have accumulated.
+   *
+   * @par Example
+   * With the default of 50, the breaker trips when 50% or more of the
+   * recent calls failed.
+   *
+   * @par Tuning
+   * Lower values (e.g. 25) make the breaker more aggressive and trip
+   * sooner; higher values tolerate more transient failure but delay
+   * isolating a misbehaving node.
+   *
+   * @return the configured failure-rate threshold, in percent.
+   */
+  [[nodiscard]] auto failure_rate_threshold_percent() const -> std::uint32_t
+  {
+    return failure_rate_threshold_percent_;
+  }
+
+  /**
+   * Set the failure-rate trip threshold.  See
+   * failure_rate_threshold_percent() for semantics.
+   *
+   * @param value percent of failed calls that opens the breaker; clamped
+   * to the range [1, 100].
+   * @return *this, for chaining.
+   */
+  auto with_failure_rate_threshold_percent(std::uint32_t value) -> circuit_breaker_config&
+  {
+    failure_rate_threshold_percent_ = std::clamp<std::uint32_t>(value, 1, 100);
+    return *this;
+  }
+
+  /**
+   * Slow-call rate (in percent, 1..100) that opens the breaker.  A call is
+   * "slow" when its measured duration is at least
+   * slow_call_duration_threshold().  This is independent of the failure
+   * rate: a node that answers every request but answers them slowly will
+   * still be tripped by this rule.
+   *
+   * @par Example
+   * With the default of 100, the breaker only trips on slow-rate when
+   * *every* call in the window exceeded the duration threshold — a very
+   * conservative setting that effectively disables the slow-call rule
+   * unless every observed call is degraded.
+   *
+   * @par Tuning
+   * Set this lower (e.g. 50) if you want a node that answers slowly for
+   * half its traffic to be considered unhealthy.
+   *
+   * @return the configured slow-call-rate threshold, in percent.
+   */
+  [[nodiscard]] auto slow_call_rate_threshold_percent() const -> std::uint32_t
+  {
+    return slow_call_rate_threshold_percent_;
+  }
+
+  /**
+   * Set the slow-call-rate trip threshold.  See
+   * slow_call_rate_threshold_percent() for semantics.
+   *
+   * @param value percent of slow calls that opens the breaker; clamped to
+   * the range [1, 100].
+   * @return *this, for chaining.
+   */
+  auto with_slow_call_rate_threshold_percent(std::uint32_t value) -> circuit_breaker_config&
+  {
+    slow_call_rate_threshold_percent_ = std::clamp<std::uint32_t>(value, 1, 100);
+    return *this;
+  }
+
+  /**
+   * Duration above which a successful call is still classified as "slow"
+   * for the slow-call-rate calculation.  This is the latency above which
+   * you stop considering a response useful even if it eventually arrived.
+   *
+   * @par Example
+   * With the default of 2000ms, every call that takes 2s or more counts
+   * as slow regardless of whether it ultimately succeeded.
+   *
+   * @par Tuning
+   * Should be set comfortably above the p99 of healthy latency for your
+   * workload but well under any user-facing timeout.
+   *
+   * @return the slow-call duration cut-off.
+   */
+  [[nodiscard]] auto slow_call_duration_threshold() const -> std::chrono::milliseconds
+  {
+    return slow_call_duration_threshold_;
+  }
+
+  /**
+   * Set the slow-call duration cut-off.  See
+   * slow_call_duration_threshold() for semantics.
+   *
+   * @param value the latency above which a call is treated as slow;
+   * clamped to be non-negative (a negative threshold would classify
+   * every call as slow and continually trip the breaker).
+   * @return *this, for chaining.
+   */
+  auto with_slow_call_duration_threshold(std::chrono::milliseconds value) -> circuit_breaker_config&
+  {
+    slow_call_duration_threshold_ = std::max(value, std::chrono::milliseconds{ 0 });
+    return *this;
+  }
+
+  /**
+   * Minimum number of recorded calls in the sliding window before the
+   * breaker is allowed to trip.  This is the cold-start gate — without it
+   * a single failed call (one failure out of one) would register as 100%
+   * failure rate and trip the breaker on the first hiccup.
+   *
+   * @par Example
+   * With the default of 20, the breaker waits until at least 20 calls
+   * have occurred in the current window before checking the failure-rate
+   * or slow-call-rate thresholds.
+   *
+   * @par Tuning
+   * Raise this for high-throughput services where a couple of bad calls
+   * are statistical noise; lower it for low-traffic paths where waiting
+   * for 20 samples would mean tolerating a long stretch of failures.
+   *
+   * @return the minimum call volume gate.
+   */
+  [[nodiscard]] auto minimum_number_of_calls() const -> std::uint32_t
+  {
+    return minimum_number_of_calls_;
+  }
+
+  /**
+   * Set the minimum-call gate.  See minimum_number_of_calls() for
+   * semantics.
+   *
+   * @param value the cold-start gate; clamped to be at least 1.
+   * @return *this, for chaining.
+   */
+  auto with_minimum_number_of_calls(std::uint32_t value) -> circuit_breaker_config&
+  {
+    minimum_number_of_calls_ = std::max<std::uint32_t>(1, value);
+    return *this;
+  }
+
+  /**
+   * Length of the time-based sliding window over which call outcomes are
+   * aggregated.  Every threshold (failure rate, slow-call rate, minimum
+   * calls) is evaluated against the calls that fall inside this rolling
+   * window.
+   *
+   * @par Example
+   * With the default of 10s, the breaker reasons about "the last ten
+   * seconds of traffic" — a brief outage is detected quickly and a
+   * recovered node is forgiven quickly.
+   *
+   * @par Tuning
+   * A longer window smooths over transient blips but reacts more slowly
+   * to a real outage; a shorter window is twitchier.  The window is
+   * divided into number_of_buckets() equal slices.
+   *
+   * @return the sliding window length.
+   */
+  [[nodiscard]] auto sliding_window() const -> std::chrono::milliseconds
+  {
+    return sliding_window_;
+  }
+
+  /**
+   * Set the sliding window length.  See sliding_window() for semantics.
+   * If the requested window is shorter than the configured bucket count
+   * (in ms), the bucket count will be reduced at construction time so
+   * each bucket still covers at least 1ms.
+   *
+   * @param value the rolling window length; clamped to be at least 1ms
+   * so the stored value matches what the breaker actually applies.
+   * @return *this, for chaining.
+   */
+  auto with_sliding_window(std::chrono::milliseconds value) -> circuit_breaker_config&
+  {
+    sliding_window_ = std::max(value, std::chrono::milliseconds{ 1 });
+    return *this;
+  }
+
+  /**
+   * Number of equal-size buckets the sliding window is divided into.
+   * Buckets are the granularity at which old data ages out: as time
+   * advances, the oldest bucket falls out of the window and a fresh one
+   * is rotated in.  More buckets give finer time resolution at the cost
+   * of memory and a small bit of work per record() call.
+   *
+   * @par Example
+   * With the default of 10 buckets and a 10s window, each bucket covers
+   * 1s of traffic.
+   *
+   * @par Tuning
+   * 10 is a sensible default.  Going much higher rarely changes the
+   * decisions the breaker makes; going much lower (e.g. 2) makes the
+   * window jerk forward in coarse steps.
+   *
+   * @return the bucket count.
+   */
+  [[nodiscard]] auto number_of_buckets() const -> std::uint32_t
+  {
+    return number_of_buckets_;
+  }
+
+  /**
+   * Set the bucket count.  See number_of_buckets() for semantics.  The
+   * value is clamped to be at least 1 and is further capped at
+   * construction time if it would force a sub-millisecond bucket size.
+   *
+   * @param value the number of buckets in the sliding window.
+   * @return *this, for chaining.
+   */
+  auto with_number_of_buckets(std::uint32_t value) -> circuit_breaker_config&
+  {
+    number_of_buckets_ = std::max<std::uint32_t>(1, value);
+    return *this;
+  }
+
+  /**
+   * Cool-off duration the breaker stays in the OPEN state before allowing
+   * probe traffic.  While OPEN the breaker short-circuits every request
+   * to spare the failing node and the calling threads; after this
+   * duration elapses the next call promotes the breaker to HALF_OPEN and
+   * a small number of probes are admitted.
+   *
+   * @par Example
+   * With the default of 5s, a tripped node is given five seconds to
+   * settle before any client traffic is sent its way again.
+   *
+   * @par Tuning
+   * Too short and you stampede a node that hasn't recovered; too long
+   * and you keep rejecting traffic after the node is healthy again.  Set
+   * roughly to the time you'd expect a transient incident (failover,
+   * GC pause, restart) to clear.
+   *
+   * @return the cool-off duration.
+   */
+  [[nodiscard]] auto wait_duration_in_open_state() const -> std::chrono::milliseconds
+  {
+    return wait_duration_in_open_state_;
+  }
+
+  /**
+   * Set the OPEN-state cool-off.  See wait_duration_in_open_state() for
+   * semantics.
+   *
+   * @param value the time the breaker stays OPEN before probing;
+   * clamped to be at least 1ms.  A zero or negative cool-off would let
+   * the breaker flap directly back to HALF_OPEN on the very next call,
+   * which defeats the purpose.
+   * @return *this, for chaining.
+   */
+  auto with_wait_duration_in_open_state(std::chrono::milliseconds value) -> circuit_breaker_config&
+  {
+    wait_duration_in_open_state_ = std::max(value, std::chrono::milliseconds{ 1 });
+    return *this;
+  }
+
+  /**
+   * Number of probe slots issued when the breaker enters HALF_OPEN.
+   * This value plays two roles:
+   *
+   *  -# It is the total number of probe attempts admitted while
+   *     HALF_OPEN.  Each call to allow() consumes one slot; slots are
+   *     **not** returned when a probe completes, so once N probes have
+   *     been admitted, further calls are rejected even if some of the
+   *     in-flight probes have already finished.
+   *  -# It is also the success threshold that closes the breaker: when
+   *     the count of successful probes reaches N the breaker closes.
+   *     A single failed probe immediately re-opens the breaker without
+   *     waiting for the others.
+   *
+   * @par Example
+   * With the default of 3, when a tripped breaker enters HALF_OPEN it
+   * admits up to three probes; if all three succeed the breaker closes
+   * and full traffic resumes, but if any one fails the breaker reverts
+   * to OPEN for another cool-off period.
+   *
+   * @par Tuning
+   * Higher values demand more evidence of recovery before closing,
+   * which is safer but takes longer; lower values close the breaker
+   * sooner but risk closing on a flaky node.
+   *
+   * @return the number of probe attempts admitted in HALF_OPEN.
+   */
+  [[nodiscard]] auto permitted_calls_in_half_open_state() const -> std::uint32_t
+  {
+    return permitted_calls_in_half_open_state_;
+  }
+
+  /**
+   * Set the HALF_OPEN probe count.  See
+   * permitted_calls_in_half_open_state() for semantics.
+   *
+   * @param value the probe count; clamped to be at least 1.
+   * @return *this, for chaining.
+   */
+  auto with_permitted_calls_in_half_open_state(std::uint32_t value) -> circuit_breaker_config&
+  {
+    permitted_calls_in_half_open_state_ = std::max<std::uint32_t>(1, value);
+    return *this;
+  }
+
+private:
+  std::uint32_t failure_rate_threshold_percent_{ 50 };
+  std::uint32_t slow_call_rate_threshold_percent_{ 100 };
+  std::chrono::milliseconds slow_call_duration_threshold_{ 2000 };
+  std::uint32_t minimum_number_of_calls_{ 20 };
+  std::chrono::milliseconds sliding_window_{ 10000 };
+  std::uint32_t number_of_buckets_{ 10 };
+  std::chrono::milliseconds wait_duration_in_open_state_{ 5000 };
+  std::uint32_t permitted_calls_in_half_open_state_{ 3 };
+};
+
+/**
+ * Observable state of a single per-node breaker, as viewed at the time of
+ * sampling.  successful_calls, failed_calls, slow_calls, total_calls, and
+ * the two rate fields refer to the current sliding window.  rejected_calls
+ * is a lifetime counter — it tracks every call short-circuited since the
+ * breaker was constructed and is only cleared by reset().
+ */
+struct circuit_breaker_metrics {
+  circuit_state state{ circuit_state::closed };
+  std::uint64_t successful_calls{ 0 };
+  std::uint64_t failed_calls{ 0 };
+  std::uint64_t slow_calls{ 0 };
+  std::uint64_t total_calls{ 0 };
+  std::uint32_t failure_rate_percent{ 0 };
+  std::uint32_t slow_call_rate_percent{ 0 };
+  std::uint64_t rejected_calls{ 0 };
+};
+
+// ---------------------------------------------------------------------------
+// Time-based sliding window of fixed bucket ring.
+//
+// Each bucket covers sliding_window / number_of_buckets milliseconds.  A
+// bucket holds atomic counters and an atomic "epoch" that identifies which
+// time slice the bucket currently represents.  Recording is lock-free; a
+// recording thread lazily resets a bucket whose epoch has advanced.
+// ---------------------------------------------------------------------------
+
+class sliding_window_counters
+{
+public:
+  struct snapshot {
+    std::uint64_t successes{ 0 };
+    std::uint64_t failures{ 0 };
+    std::uint64_t slow{ 0 };
+    std::uint64_t total{ 0 };
+  };
+
+  sliding_window_counters(std::chrono::milliseconds window, std::uint32_t buckets);
+
+  auto record(call_outcome o, bool slow) -> void;
+  [[nodiscard]] auto sample() const -> snapshot;
+  auto reset() -> void;
+
+private:
+  static constexpr std::int64_t kUninitializedEpoch = -1;
+  // Sentinel published while a thread is mid-rotation: zero counters, then
+  // publish the real epoch.  Other threads observing the sentinel spin until
+  // the rotation completes; samplers treat it as a momentarily skipped
+  // bucket.
+  static constexpr std::int64_t kRotatingEpoch = -2;
+
+  struct bucket {
+    std::atomic<std::int64_t> epoch{ kUninitializedEpoch };
+    std::atomic<std::uint64_t> successes{ 0 };
+    std::atomic<std::uint64_t> failures{ 0 };
+    std::atomic<std::uint64_t> slow{ 0 };
+  };
+
+  [[nodiscard]] auto bucket_index_for(std::int64_t epoch) const -> std::size_t;
+
+  std::uint32_t bucket_count_;
+  std::int64_t bucket_size_ms_;
+  std::vector<std::unique_ptr<bucket>> buckets_;
+};
+
+// ---------------------------------------------------------------------------
+// Per-node breaker — owns the state machine and the sliding window for one
+// cluster node.  Thread-safe.  state_mutex_ is held only to serialize state
+// transitions; the hot path (allow / record) is atomic.
+// ---------------------------------------------------------------------------
+
+class node_breaker
+{
+public:
+  using transition_callback =
+    std::function<void(circuit_state /*from*/, circuit_state /*to*/, const std::string& /*why*/)>;
+
+  node_breaker(circuit_breaker_config config, transition_callback on_transition);
+
+  [[nodiscard]] auto state() const -> circuit_state
+  {
+    return state_.load(std::memory_order_acquire);
+  }
+
+  /**
+   * Admission decision.  Side-effects limited to the open -> half_open
+   * transition triggered by the first caller observed after the cool-off
+   * elapses.  Rejections increment a counter that is reported in metrics.
+   */
+  [[nodiscard]] auto try_acquire() -> bool;
+
+  auto record(call_outcome o, std::chrono::milliseconds duration) -> void;
+
+  auto force_open() -> void;
+  auto disable() -> void;
+  auto reset() -> void;
+
+  [[nodiscard]] auto snapshot_metrics() const -> circuit_breaker_metrics;
+
+private:
+  // Sentinel for opened_at_ms_ meaning "no open timestamp recorded".  We use
+  // a negative value so it cannot collide with a legitimate steady_clock
+  // count (which is always non-negative; the standard does allow the count
+  // to be 0 on a freshly-booted system).
+  static constexpr std::int64_t kNotOpenedYet = -1;
+
+  [[nodiscard]] auto cool_off_elapsed() const -> bool;
+  auto try_acquire_half_open_permit() -> bool;
+  auto evaluate_and_maybe_open() -> void;
+
+  auto try_transition_to_open(const std::string& why) -> void;
+  auto try_transition_to_half_open(const std::string& why) -> void;
+  auto try_transition_to_closed(const std::string& why) -> void;
+  auto transition(const std::string& why, circuit_state target) -> void;
+
+  circuit_breaker_config config_;
+  transition_callback on_transition_;
+  sliding_window_counters window_;
+  std::mutex state_mutex_;
+  std::atomic<circuit_state> state_;
+  std::atomic<std::uint32_t> half_open_permits_;
+  std::atomic<std::uint32_t> half_open_successes_;
+  std::atomic<std::uint32_t> half_open_failures_;
+  std::atomic<std::uint64_t> rejected_;
+  std::atomic<std::int64_t> opened_at_ms_;
+};
+
+// ---------------------------------------------------------------------------
+// Registry of per-node breakers, keyed by couchbase::node_id.  The registry
+// is the object applications interact with directly.
+// ---------------------------------------------------------------------------
+
+class circuit_breaker
+{
+public:
+  /**
+   * Type of the user-supplied state-transition listener.  Receives the
+   * previous state, the new state, and a human-readable reason; the reason
+   * is prefixed with "[node <id>] " by the breaker so a single shared
+   * callback can identify which node tripped without extra plumbing.
+   */
+  using transition_callback = node_breaker::transition_callback;
+
+  /**
+   * Construct a breaker with default tunables.  See circuit_breaker_config
+   * for the defaults; pass a configured instance to the other constructor
+   * to override them.
+   */
+  circuit_breaker() = default;
+
+  /**
+   * Construct a breaker with explicit tunables.  The configuration is
+   * captured by value and applied to every per-node breaker created
+   * afterwards.
+   *
+   * @param config the tunables this breaker (and all of its per-node
+   * children) will use.
+   */
+  explicit circuit_breaker(circuit_breaker_config config);
+
+  /**
+   * Read-only access to the configuration this breaker was constructed
+   * with.  Useful for callers that need to coordinate timing with the
+   * breaker (e.g. a probe loop that sleeps for the configured cool-off).
+   */
+  [[nodiscard]] auto config() const -> const circuit_breaker_config&
+  {
+    return config_;
+  }
+
+  /**
+   * Install or replace the listener invoked on every state transition of
+   * any per-node breaker owned by this registry.  Updates take effect
+   * immediately, including for breakers that were created before this
+   * call.  Pass an empty std::function to disable notifications.
+   *
+   * @param cb the listener; safe to capture references to long-lived
+   * objects but not to anything that may outlive this circuit_breaker.
+   */
+  auto set_transition_callback(transition_callback cb) -> void;
+
+  /**
+   * Admission decision: ask the breaker whether a call to @p nid should
+   * be attempted right now.  Cheap and lock-free on the hot path.  An
+   * empty node_id is treated as "always allowed" (the breaker has no
+   * opinion when it can't identify the target node).
+   *
+   * Side-effects: the very first call observed after the OPEN cool-off
+   * elapses promotes the per-node breaker to HALF_OPEN.  Rejected calls
+   * increment the per-node rejected counter.
+   *
+   * @param nid the node the call would target.
+   * @return true if the call may proceed; false if the breaker
+   * short-circuited it.
+   */
+  [[nodiscard]] auto allow(const couchbase::node_id& nid) -> bool;
+
+  /**
+   * Record a successful call against @p nid.  Should be paired with a
+   * preceding allow() that returned true.  An empty node_id is silently
+   * ignored.
+   *
+   * @param nid the node the call hit.
+   * @param duration how long the call took, end-to-end; used to feed the
+   * slow-call rate.
+   */
+  auto record_success(const couchbase::node_id& nid, std::chrono::milliseconds duration) -> void;
+
+  /**
+   * Record a failed call against @p nid.  "Failure" here means an error
+   * the caller has decided counts toward the breaker (e.g. timeouts,
+   * service unavailable) — *not* user errors like document_not_found.
+   * Pairs with a preceding allow() that returned true.  An empty
+   * node_id is silently ignored.
+   *
+   * @param nid the node the call hit.
+   * @param duration how long the call took before failing.
+   */
+  auto record_failure(const couchbase::node_id& nid, std::chrono::milliseconds duration) -> void;
+
+  /**
+   * Read the current circuit state for @p nid.  If no per-node breaker
+   * exists yet for the given id (no traffic has touched it), CLOSED is
+   * returned — that is the default for any unobserved node.
+   */
+  [[nodiscard]] auto state_of(const couchbase::node_id& nid) const -> circuit_state;
+
+  /**
+   * Snapshot the current metrics for @p nid.  Returns std::nullopt if
+   * the breaker has never seen this node; otherwise returns a copy of
+   * the counters and the current state at the moment of sampling.
+   */
+  [[nodiscard]] auto metrics_of(const couchbase::node_id& nid) const
+    -> std::optional<circuit_breaker_metrics>;
+
+  /**
+   * Snapshot metrics for every node the breaker is currently tracking.
+   * Useful for periodic dashboards and logging — pair each entry with
+   * its node id to render a per-node view.
+   *
+   * @return one (node_id, metrics) pair per known node.
+   */
+  [[nodiscard]] auto all_metrics() const
+    -> std::vector<std::pair<couchbase::node_id, circuit_breaker_metrics>>;
+
+  /**
+   * Operator override: force the breaker for @p nid into FORCED_OPEN.
+   * All future calls to that node short-circuit and the breaker will not
+   * auto-recover until reset().  Use during incident response or
+   * planned maintenance.
+   */
+  auto force_open(const couchbase::node_id& nid) -> void;
+
+  /**
+   * Operator override: disable the breaker for @p nid.  All future calls
+   * are admitted and outcomes are *not* recorded — effectively turning
+   * the breaker off for that node.  Reverse with reset().
+   */
+  auto disable(const couchbase::node_id& nid) -> void;
+
+  /**
+   * Clear all state for @p nid: counters, half-open bookkeeping, and the
+   * rejected-call lifetime counter all return to zero, and the state
+   * machine returns to CLOSED.  This is also the only path back to
+   * CLOSED from FORCED_OPEN or DISABLED.  No-op if @p nid is unknown.
+   */
+  auto reset(const couchbase::node_id& nid) -> void;
+
+  /**
+   * Erase the per-node breaker for @p nid from the registry entirely.
+   * Unlike reset(), this is the right call when the underlying cluster
+   * node has *gone away* — its tracking entry is no longer reachable
+   * from the topology and should not consume memory waiting for traffic
+   * that will never arrive.  No-op if @p nid is unknown.
+   *
+   * Pair with couchbase::collection::node_ids() in a periodic sweep:
+   *
+   * @code
+   * auto [err, live] = collection.node_ids().get();
+   * if (!err) {
+   *   std::unordered_set<couchbase::node_id> live_set{ live.begin(), live.end() };
+   *   for (const auto& [tracked, _] : breaker.all_metrics()) {
+   *     if (live_set.find(tracked) == live_set.end()) {
+   *       breaker.forget(tracked);
+   *     }
+   *   }
+   * }
+   * @endcode
+   *
+   * @return true if an entry was removed, false if the node was unknown.
+   */
+  auto forget(const couchbase::node_id& nid) -> bool;
+
+  /**
+   * Synchronous execute helper that wraps an SDK call with breaker
+   * admission control, latency timing, and outcome reporting.  Use this
+   * when you want a one-liner that does the right thing; if you need
+   * finer control over the flow (e.g. retries, fan-out, custom timing)
+   * call allow() / record_success() / record_failure() directly.
+   *
+   * Behaviour:
+   *  -# Asks the breaker whether @p target may be called via allow().
+   *  -# If admission is denied, returns immediately with
+   *     example::cb::breaker_errc::user_canceled and a value-initialized
+   *     placeholder for the response — the SDK is never invoked.  The
+   *     dedicated category lets callers distinguish a breaker rejection
+   *     from a real SDK couchbase::errc::common::request_canceled, which
+   *     remains a valid breaker-trippable failure signal.
+   *  -# Otherwise invokes @p op, blocks on the returned future, measures
+   *     wall-clock duration, and records success or failure.
+   *  -# The recorded outcome is attributed to the node_id reported by
+   *     the SDK (err.node_id() or resp.node_id()).  This may differ from
+   *     @p target if the SDK retried internally and ultimately landed on
+   *     a different node; if the SDK reported no node, @p target is used
+   *     as a fallback.
+   *
+   * @tparam Operation a nullary callable returning a future-like object
+   * whose `get()` yields `std::pair<couchbase::error, R>`.  Typically a
+   * lambda that initiates an SDK request, e.g.
+   * `[&]{ return collection.upsert(key, doc, {}); }`.
+   * @tparam Classifier a callable invocable as `bool(const
+   * couchbase::error&)` that decides whether an error counts as a
+   * breaker-trippable failure.  A typical implementation maps
+   * timeouts, temporary_failure, and service_not_available to true and
+   * everything else (especially application errors like
+   * document_not_found) to false — the demo provides
+   * example::demo::is_breaker_failure as a starting point.
+   *
+   * @param target the node the operation is meant for; used both as the
+   * admission key and as the fallback attribution when the SDK does not
+   * report a node id on the response/error.
+   * @param op the SDK operation to invoke; called at most once per
+   * execute() invocation, only after admission is granted.
+   * @param is_breaker_failure the error classifier described above.
+   *
+   * @return the SDK's `(error, response)` pair on a real call, or a
+   * synthesized `(breaker_errc::user_canceled, R{})` pair if the breaker
+   * short-circuited the call.
+   *
+   * @note R must be default-constructible; this is enforced by a
+   * static_assert.  Most SDK response types satisfy this; if yours
+   * doesn't, perform admission and recording yourself or have your
+   * Operation wrap the response in std::optional.
+   */
+  template<typename Operation, typename Classifier>
+  auto execute(const couchbase::node_id& target, Operation op, Classifier is_breaker_failure)
+    -> std::pair<couchbase::error, std::decay_t<decltype(op().get().second)>>
+  {
+    using result_type = std::decay_t<decltype(op().get().second)>;
+    static_assert(std::is_default_constructible_v<result_type>,
+                  "circuit_breaker::execute() requires a default-constructible result type so it "
+                  "can synthesize a placeholder when the breaker rejects the call");
+    if (!allow(target)) {
+      auto state = state_of(target);
+      auto message = std::string{ "circuit breaker rejected call to node " } + target.id() +
+                     " (state=" + to_string(state) + ")";
+      return { couchbase::error{ make_error_code(breaker_errc::user_canceled),
+                                 std::move(message),
+                                 couchbase::error_context{},
+                                 target },
+               result_type{} };
+    }
+    auto start = std::chrono::steady_clock::now();
+    auto [err, resp] = op().get();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - start);
+    auto effective_nid = err ? err.node_id() : resp.node_id();
+    if (!effective_nid) {
+      effective_nid = target;
+    }
+    if (err && is_breaker_failure(err)) {
+      record_failure(effective_nid, duration);
+    } else {
+      record_success(effective_nid, duration);
+    }
+    return { std::move(err), std::move(resp) };
+  }
+
+private:
+  [[nodiscard]] auto find(const couchbase::node_id& nid) const -> std::shared_ptr<node_breaker>;
+  [[nodiscard]] auto get_or_create(const couchbase::node_id& nid) -> std::shared_ptr<node_breaker>;
+  auto dispatch_transition(const std::string& node_id_str,
+                           circuit_state from,
+                           circuit_state to,
+                           const std::string& why) const -> void;
+
+  mutable std::shared_mutex mutex_;
+  circuit_breaker_config config_{};
+  std::unordered_map<couchbase::node_id, std::shared_ptr<node_breaker>> nodes_{};
+  transition_callback on_transition_{};
+};
+
+} // namespace example::cb
+
+namespace std
+{
+template<>
+struct is_error_code_enum<example::cb::breaker_errc> : true_type {
+};
+} // namespace std

--- a/examples/external_circuit_breaker/demo_admin.cxx
+++ b/examples/external_circuit_breaker/demo_admin.cxx
@@ -1,0 +1,56 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "demo_admin.hxx"
+
+#include "ui.hxx"
+
+#include <string>
+
+namespace example::demo
+{
+
+auto
+demo_admin(example::cb::circuit_breaker& breaker, const couchbase::node_id& victim) -> void
+{
+  example::ui::print_demo_header("Demo 4",
+                                 "Operator overrides",
+                                 "An on-call engineer can force the breaker into a specific state "
+                                 "for maintenance or incident response.");
+  if (!victim) {
+    example::ui::print_warning("no victim node available, skipping");
+    return;
+  }
+  breaker.reset(victim);
+
+  example::ui::print_step(
+    "force_open() — every call to this node is rejected until disable() or reset().");
+  breaker.force_open(victim);
+  example::ui::print_note(std::string{ "allow() = " } +
+                          (breaker.allow(victim) ? "ALLOWED" : "REJECTED"));
+
+  example::ui::print_step("disable() — the breaker steps aside and every call is "
+                          "passed through, even if the node is unhealthy.");
+  breaker.disable(victim);
+  example::ui::print_note(std::string{ "allow() = " } +
+                          (breaker.allow(victim) ? "ALLOWED" : "REJECTED"));
+
+  example::ui::print_step("reset()  — back to a clean slate.");
+  breaker.reset(victim);
+}
+
+} // namespace example::demo

--- a/examples/external_circuit_breaker/demo_admin.hxx
+++ b/examples/external_circuit_breaker/demo_admin.hxx
@@ -1,0 +1,35 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include "circuit_breaker.hxx"
+
+#include <couchbase/node_id.hxx>
+
+namespace example::demo
+{
+
+/**
+ * Administrative overrides: force_open, disable, reset.  On-call engineers
+ * can drive the breaker into a known state for maintenance or incident
+ * response.
+ */
+auto
+demo_admin(example::cb::circuit_breaker& breaker, const couchbase::node_id& victim) -> void;
+
+} // namespace example::demo

--- a/examples/external_circuit_breaker/demo_common.cxx
+++ b/examples/external_circuit_breaker/demo_common.cxx
@@ -1,0 +1,40 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "demo_common.hxx"
+
+#include <couchbase/error_codes.hxx>
+
+namespace example::demo
+{
+
+auto
+is_breaker_failure(const couchbase::error& err) -> bool
+{
+  using couchbase::errc::common;
+  if (!err) {
+    return false;
+  }
+  if (err.ec() == common::ambiguous_timeout || err.ec() == common::unambiguous_timeout ||
+      err.ec() == common::temporary_failure || err.ec() == common::service_not_available ||
+      err.ec() == common::internal_server_failure || err.ec() == common::request_canceled) {
+    return true;
+  }
+  return false;
+}
+
+} // namespace example::demo

--- a/examples/external_circuit_breaker/demo_common.hxx
+++ b/examples/external_circuit_breaker/demo_common.hxx
@@ -1,0 +1,33 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/error.hxx>
+
+namespace example::demo
+{
+
+/**
+ * Classifier shared by every example flow.  The breaker should open for
+ * signs of remote-side trouble (timeouts, temp failures, unavailable
+ * services), not for user errors the app could legitimately produce.
+ */
+[[nodiscard]] auto
+is_breaker_failure(const couchbase::error& err) -> bool;
+
+} // namespace example::demo

--- a/examples/external_circuit_breaker/demo_failed_probe.cxx
+++ b/examples/external_circuit_breaker/demo_failed_probe.cxx
@@ -1,0 +1,60 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "demo_failed_probe.hxx"
+
+#include "ui.hxx"
+
+#include <string>
+#include <thread>
+
+namespace example::demo
+{
+
+auto
+demo_failed_probe(example::cb::circuit_breaker& breaker, const couchbase::node_id& victim) -> void
+{
+  using namespace std::chrono_literals;
+  example::ui::print_demo_header("Demo 3",
+                                 "A failing probe re-opens the circuit",
+                                 "If the half-open probe shows the node is still unhealthy, the "
+                                 "breaker immediately re-opens — no thundering herd.");
+  if (!victim) {
+    example::ui::print_warning("no victim node available, skipping");
+    return;
+  }
+  breaker.reset(victim);
+  example::ui::print_step("Tripping the breaker with 25 synthetic failures...");
+  for (int i = 0; i < 25; ++i) {
+    breaker.record_failure(victim, 50ms);
+  }
+  auto cool_off = breaker.config().wait_duration_in_open_state() + 100ms;
+  example::ui::print_step("Waiting for the cool-off window (" + std::to_string(cool_off.count()) +
+                          "ms)...");
+  std::this_thread::sleep_for(cool_off);
+  example::ui::print_step("Cool-off elapsed; sending a probe that simulates a still-bad node...");
+  if (!breaker.allow(victim)) {
+    example::ui::print_warning(
+      "probe was not admitted; the breaker did not transition to HALF_OPEN");
+    return;
+  }
+  breaker.record_failure(victim, 50ms);
+  example::ui::print_success("One failed probe is enough: the circuit jumped straight back to OPEN "
+                             "without needing to see all 25 failures again.");
+}
+
+} // namespace example::demo

--- a/examples/external_circuit_breaker/demo_failed_probe.hxx
+++ b/examples/external_circuit_breaker/demo_failed_probe.hxx
@@ -1,0 +1,34 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include "circuit_breaker.hxx"
+
+#include <couchbase/node_id.hxx>
+
+namespace example::demo
+{
+
+/**
+ * Show that a failed probe in HALF_OPEN re-opens the circuit — one bad
+ * probe is enough, no need to see 25 failures again.
+ */
+auto
+demo_failed_probe(example::cb::circuit_breaker& breaker, const couchbase::node_id& victim) -> void;
+
+} // namespace example::demo

--- a/examples/external_circuit_breaker/demo_healthy_traffic.cxx
+++ b/examples/external_circuit_breaker/demo_healthy_traffic.cxx
@@ -1,0 +1,83 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "demo_healthy_traffic.hxx"
+
+#include "demo_common.hxx"
+#include "ui.hxx"
+
+#include <couchbase/codec/tao_json_serializer.hxx>
+#include <couchbase/mutation_result.hxx>
+
+#include <cstdint>
+#include <future>
+#include <string>
+#include <utility>
+
+namespace example::demo
+{
+
+auto
+demo_healthy_traffic(couchbase::collection& collection, example::cb::circuit_breaker& breaker)
+  -> void
+{
+  example::ui::print_demo_header("Demo 1",
+                                 "Healthy traffic",
+                                 "While every node is responsive, the breaker stays out of the way "
+                                 "— every node remains CLOSED.");
+  const tao::json::value doc{ { "type", "cb-demo" }, { "value", 42 } };
+  constexpr int total_ops = 30;
+  example::ui::print_step("Sending " + std::to_string(total_ops) +
+                          " upsert operations through the breaker...");
+  std::uint32_t ok = 0;
+  std::uint32_t failed = 0;
+  std::uint32_t unresolved = 0;
+  for (int i = 0; i < total_ops; ++i) {
+    auto key = "cb-demo-" + std::to_string(i);
+    auto [nid_err, target] = collection.node_id_for(key).get();
+    if (nid_err) {
+      example::ui::print_error("node_id_for(\"" + key + "\") failed: " + nid_err.ec().message());
+      ++unresolved;
+      continue;
+    }
+    auto [err, resp] = breaker.execute(
+      target,
+      [&]() -> std::future<std::pair<couchbase::error, couchbase::mutation_result>> {
+        return collection.upsert(key, doc, {});
+      },
+      is_breaker_failure);
+    if (err) {
+      ++failed;
+    } else {
+      ++ok;
+    }
+  }
+  if (failed == 0 && unresolved == 0) {
+    example::ui::print_success("All " + std::to_string(total_ops) +
+                               " operations completed successfully — nothing to trip the breaker.");
+  } else {
+    auto msg = std::to_string(ok) + " succeeded, " + std::to_string(failed) + " failed";
+    if (unresolved != 0) {
+      msg += ", " + std::to_string(unresolved) + " skipped (node_id_for failed)";
+    }
+    msg += " — but still below the trip threshold.";
+    example::ui::print_warning(msg);
+  }
+  example::ui::print_metrics_table(breaker);
+}
+
+} // namespace example::demo

--- a/examples/external_circuit_breaker/demo_healthy_traffic.hxx
+++ b/examples/external_circuit_breaker/demo_healthy_traffic.hxx
@@ -1,0 +1,35 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include "circuit_breaker.hxx"
+
+#include <couchbase/collection.hxx>
+
+namespace example::demo
+{
+
+/**
+ * Drive 30 real KV upserts through the breaker.  Nothing fails, so every
+ * node ends up with a healthy sliding window and remains CLOSED.
+ */
+auto
+demo_healthy_traffic(couchbase::collection& collection, example::cb::circuit_breaker& breaker)
+  -> void;
+
+} // namespace example::demo

--- a/examples/external_circuit_breaker/demo_per_node_isolation.cxx
+++ b/examples/external_circuit_breaker/demo_per_node_isolation.cxx
@@ -1,0 +1,82 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "demo_per_node_isolation.hxx"
+
+#include "ui.hxx"
+
+#include <cstdint>
+#include <string>
+
+namespace example::demo
+{
+
+auto
+demo_per_node_isolation(couchbase::collection& collection, example::cb::circuit_breaker& breaker)
+  -> void
+{
+  using namespace std::chrono_literals;
+  example::ui::print_demo_header("Demo 6",
+                                 "One sick node doesn't poison the rest",
+                                 "Per-node isolation: only keys routed to the bad node are "
+                                 "short-circuited — traffic to healthy nodes keeps "
+                                 "flowing.");
+
+  auto [nid_err, victim] = collection.node_id_for("cb-demo-0").get();
+  if (nid_err || !victim) {
+    example::ui::print_warning("could not resolve a victim node, skipping");
+    return;
+  }
+  breaker.reset(victim);
+  example::ui::print_step("Poisoning one node with 25 synthetic failures...");
+  for (int i = 0; i < 25; ++i) {
+    breaker.record_failure(victim, 50ms);
+  }
+
+  std::uint32_t short_circuited = 0;
+  std::uint32_t passed = 0;
+  std::uint32_t unresolved = 0;
+  constexpr int total_keys = 30;
+  for (int i = 0; i < total_keys; ++i) {
+    auto key = "cb-demo-iso-" + std::to_string(i);
+    auto [e, target] = collection.node_id_for(key).get();
+    if (e) {
+      ++unresolved;
+      continue;
+    }
+    if (!breaker.allow(target)) {
+      ++short_circuited;
+    } else {
+      ++passed;
+    }
+  }
+  auto summary = "Routed " + std::to_string(passed + short_circuited) + " of " +
+                 std::to_string(total_keys) +
+                 " keys across the cluster: " + std::to_string(passed) + " allowed to proceed, " +
+                 std::to_string(short_circuited) +
+                 " short-circuited because they happen to map to the poisoned node.";
+  if (unresolved != 0) {
+    summary += " " + std::to_string(unresolved) +
+               " key(s) could not be resolved to a node and were skipped.";
+  }
+  example::ui::print_success(summary);
+  example::ui::print_metrics_table(breaker);
+
+  breaker.reset(victim);
+}
+
+} // namespace example::demo

--- a/examples/external_circuit_breaker/demo_per_node_isolation.hxx
+++ b/examples/external_circuit_breaker/demo_per_node_isolation.hxx
@@ -1,0 +1,36 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include "circuit_breaker.hxx"
+
+#include <couchbase/collection.hxx>
+
+namespace example::demo
+{
+
+/**
+ * Per-node isolation: one bad node does not take the others down with it.
+ * Route 30 keys across the cluster and show that only those routed to the
+ * poisoned node are short-circuited.
+ */
+auto
+demo_per_node_isolation(couchbase::collection& collection, example::cb::circuit_breaker& breaker)
+  -> void;
+
+} // namespace example::demo

--- a/examples/external_circuit_breaker/demo_slow_calls.cxx
+++ b/examples/external_circuit_breaker/demo_slow_calls.cxx
@@ -1,0 +1,52 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "demo_slow_calls.hxx"
+
+#include "ui.hxx"
+
+#include <string>
+
+namespace example::demo
+{
+
+auto
+demo_slow_calls(example::cb::circuit_breaker& breaker, const couchbase::node_id& victim) -> void
+{
+  using namespace std::chrono_literals;
+  example::ui::print_demo_header(
+    "Demo 5",
+    "Slow is the new broken",
+    "A node that answers every request but takes too long is just as bad as one that fails "
+    "outright — the breaker trips on slow-call rate too.");
+  if (!victim) {
+    example::ui::print_warning("no victim node available, skipping");
+    return;
+  }
+  breaker.reset(victim);
+  example::ui::print_step(
+    "Recording 25 successful calls, but each one is above the slow-call threshold (2.0s)...");
+  for (int i = 0; i < 25; ++i) {
+    breaker.record_success(victim, 3000ms);
+  }
+  auto m = breaker.metrics_of(victim).value();
+  example::ui::print_success(
+    "slow-call rate " + std::to_string(m.slow_call_rate_percent) +
+    "% crossed the configured threshold and tripped the breaker, even though zero calls failed.");
+}
+
+} // namespace example::demo

--- a/examples/external_circuit_breaker/demo_slow_calls.hxx
+++ b/examples/external_circuit_breaker/demo_slow_calls.hxx
@@ -1,0 +1,34 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include "circuit_breaker.hxx"
+
+#include <couchbase/node_id.hxx>
+
+namespace example::demo
+{
+
+/**
+ * Slow-call rate threshold trips the breaker even when nothing fails —
+ * a node that just answers slowly is still bad news for the caller.
+ */
+auto
+demo_slow_calls(example::cb::circuit_breaker& breaker, const couchbase::node_id& victim) -> void;
+
+} // namespace example::demo

--- a/examples/external_circuit_breaker/demo_state_transitions.cxx
+++ b/examples/external_circuit_breaker/demo_state_transitions.cxx
@@ -1,0 +1,86 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "demo_state_transitions.hxx"
+
+#include "ui.hxx"
+
+#include <string>
+#include <thread>
+
+namespace example::demo
+{
+
+auto
+demo_state_transitions(example::cb::circuit_breaker& breaker, const couchbase::node_id& victim)
+  -> void
+{
+  using namespace std::chrono_literals;
+  example::ui::print_demo_header("Demo 2",
+                                 "A node turns bad, recovers, and rejoins",
+                                 "Closed → Open → Half-Open → Closed, walked step by step.");
+  if (!victim) {
+    example::ui::print_warning("no victim node available, skipping");
+    return;
+  }
+
+  breaker.reset(victim);
+  example::ui::print_step("Victim node: " + std::string{ victim.id() });
+  example::ui::print_step("Injecting 25 synthetic failures to simulate an unhealthy node...");
+  for (int i = 0; i < 25; ++i) {
+    breaker.record_failure(victim, 50ms);
+  }
+  example::ui::print_note("The circuit has tripped: further calls to this node are now "
+                          "short-circuited, protecting client threads from piling up on a bad "
+                          "endpoint.");
+
+  bool allowed_during_open = breaker.allow(victim);
+  if (allowed_during_open) {
+    example::ui::print_warning("unexpected: breaker allowed a call while OPEN");
+  } else {
+    example::ui::print_success("Attempted call during OPEN was rejected instantly (no round-trip "
+                               "to the node).");
+  }
+
+  // Sleep just past the configured cool-off so the next allow() promotes
+  // the breaker to HALF_OPEN.  Reading the duration from the breaker's
+  // config keeps the demo correct if the timing in main.cxx is tweaked.
+  auto cool_off = breaker.config().wait_duration_in_open_state() + 100ms;
+  example::ui::print_step("Sleeping " + std::to_string(cool_off.count()) +
+                          "ms to let the cool-off window elapse...");
+  std::this_thread::sleep_for(cool_off);
+
+  example::ui::print_step("The first call after cool-off promotes the circuit to HALF_OPEN "
+                          "— a small number of probe requests are now allowed through.");
+  for (int i = 1; i <= 3; ++i) {
+    if (!breaker.allow(victim)) {
+      example::ui::print_warning("probe " + std::to_string(i) + " was not admitted");
+      continue;
+    }
+    // Print before record_success() so the "Probe #N succeeded" note shows
+    // up *before* any transition log fired by recording — otherwise the
+    // closing transition triggered by the third probe is rendered between
+    // probes 2 and 3, which reads as if the close happened first.
+    example::ui::print_note("Probe #" + std::to_string(i) + " succeeded.");
+    breaker.record_success(victim, 30ms);
+  }
+  example::ui::print_success(
+    "Enough probes succeeded — the breaker closed and normal traffic resumes.");
+  example::ui::print_metrics_table(breaker);
+}
+
+} // namespace example::demo

--- a/examples/external_circuit_breaker/demo_state_transitions.hxx
+++ b/examples/external_circuit_breaker/demo_state_transitions.hxx
@@ -1,0 +1,37 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include "circuit_breaker.hxx"
+
+#include <couchbase/node_id.hxx>
+
+namespace example::demo
+{
+
+/**
+ * Drive a real node_id through the full state machine using synthetic
+ * failure/success records.  We do not depend on the cluster actually
+ * being sick — the breaker is a passive observer of whatever the caller
+ * reports.
+ */
+auto
+demo_state_transitions(example::cb::circuit_breaker& breaker, const couchbase::node_id& victim)
+  -> void;
+
+} // namespace example::demo

--- a/examples/external_circuit_breaker/demo_topology_sweep.cxx
+++ b/examples/external_circuit_breaker/demo_topology_sweep.cxx
@@ -1,0 +1,171 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "demo_topology_sweep.hxx"
+
+#include "ui.hxx"
+
+#include <couchbase/node_id.hxx>
+
+#include <chrono>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace example::demo
+{
+
+namespace
+{
+
+// The canonical sweep, factored out so both the steady-state pass and the
+// "shrink simulation" pass below use the same code path.  This is the
+// loop a production process would run on a timer (e.g. once per minute):
+// fetch the current set of KV-serving nodes, diff against what the
+// breaker is tracking, and forget the difference.
+auto
+sweep_against(example::cb::circuit_breaker& breaker,
+              const std::unordered_set<couchbase::node_id>& live) -> std::vector<couchbase::node_id>
+{
+  // Snapshot the registry's keys before mutating: forget() under the hood
+  // mutates nodes_, which is the same map all_metrics() iterated to build
+  // its return value.  We copy the candidate keys out and only then call
+  // forget() to keep that mutation safely outside the iteration.
+  std::vector<couchbase::node_id> retired;
+  for (const auto& [tracked, _] : breaker.all_metrics()) {
+    if (live.find(tracked) == live.end()) {
+      retired.push_back(tracked);
+    }
+  }
+  for (const auto& nid : retired) {
+    breaker.forget(nid);
+  }
+  return retired;
+}
+
+} // namespace
+
+auto
+demo_topology_sweep(couchbase::collection& collection, example::cb::circuit_breaker& breaker)
+  -> void
+{
+  using namespace std::chrono_literals;
+  example::ui::print_demo_header(
+    "Demo 7",
+    "Topology sweep — retire breakers for nodes that left the cluster",
+    "A long-running process accumulates per-node breaker state forever unless something prunes "
+    "entries for nodes the cluster no longer has.  Diff breaker.all_metrics() against "
+    "collection.node_ids() and forget the difference.");
+
+  // Step 1: ground truth from the SDK. node_ids() is the canonical source
+  // for "which cluster nodes serve KV traffic right now" — exactly the
+  // identities the SDK reports back on every result and error, so the
+  // returned set is directly comparable to anything the breaker is keying
+  // on.  No network round-trip — this comes off the client-side topology.
+  example::ui::print_step("Calling collection::node_ids() to learn the current cluster shape...");
+  auto [ids_err, live] = collection.node_ids().get();
+  if (ids_err) {
+    example::ui::print_warning("node_ids() failed: " + std::string{ ids_err.ec().message() } +
+                               " — skipping demo.");
+    return;
+  }
+  if (live.empty()) {
+    example::ui::print_warning("node_ids() returned an empty set — skipping demo.");
+    return;
+  }
+  example::ui::print_note("Cluster currently exposes " + std::to_string(live.size()) +
+                          " KV-serving node(s).");
+
+  // Step 2: populate the registry by exercising every live node. We use
+  // node_id_for() per key + record_success() to materialize one breaker
+  // per node without depending on the keys actually mapping uniformly —
+  // a real workload will populate the registry via execute() on its hot
+  // path; both flows produce identical registry state.
+  example::ui::print_step(
+    "Populating the registry with one entry per live node via node_id_for() + record_success()...");
+  std::unordered_set<couchbase::node_id> populated;
+  for (int i = 0; i < 64 && populated.size() < live.size(); ++i) {
+    auto key = "cb-demo-sweep-" + std::to_string(i);
+    auto [err, target] = collection.node_id_for(key).get();
+    if (err || !target) {
+      continue;
+    }
+    if (populated.insert(target).second) {
+      breaker.record_success(target, 0ms);
+    }
+  }
+  example::ui::print_note("Registry now tracks " + std::to_string(breaker.all_metrics().size()) +
+                          " entry/entries (one per live node we routed to).");
+
+  // Step 3: steady-state sweep. With the registry populated from the live
+  // cluster, the diff is empty — exactly what every sweep iteration looks
+  // like when the topology has not changed since the last pass.  This is
+  // the no-op baseline the production loop must handle cheaply.
+  example::ui::print_step("Steady-state sweep against the current node_ids() set...");
+  std::unordered_set<couchbase::node_id> live_set{ live.begin(), live.end() };
+  auto retired_steady = sweep_against(breaker, live_set);
+  example::ui::print_note("Retired " + std::to_string(retired_steady.size()) +
+                          " entry/entries (expected: 0 in steady state).");
+
+  // Step 4: simulate a topology shrink.  We cannot decommission a real
+  // cluster node from a demo against a live deployment, so instead we
+  // construct a smaller "live" set that omits one of the entries the
+  // registry currently holds.  This is exactly the shape collection.
+  // node_ids() would return on the first sweep after a node has been
+  // removed from the cluster, so the sweep code path it exercises is
+  // the same one production would execute against the real shrunk set.
+  if (populated.size() < 2) {
+    example::ui::print_warning(
+      "Single-node cluster — cannot simulate a topology shrink.  The mechanism is the same "
+      "regardless of cluster size: anything in breaker.all_metrics() that is not in "
+      "collection.node_ids() is retired.");
+    return;
+  }
+  auto shrunk = live_set;
+  auto victim = *shrunk.begin();
+  shrunk.erase(shrunk.begin());
+  example::ui::print_step("Simulating a topology shrink: pretending node " +
+                          example::ui::short_node(victim.id()) +
+                          " has been decommissioned (omitted from the next node_ids() snapshot).");
+
+  auto retired_shrunk = sweep_against(breaker, shrunk);
+  example::ui::print_note("Retired " + std::to_string(retired_shrunk.size()) +
+                          " stale entry/entries against the simulated smaller set.");
+  for (const auto& nid : retired_shrunk) {
+    example::ui::print_note(std::string{ "  forget(" } + example::ui::short_node(nid.id()) + ")");
+  }
+
+  example::ui::print_step("Post-sweep registry:");
+  example::ui::print_metrics_table(breaker);
+
+  // Final message: spell out the production shape so the reader knows
+  // exactly how to wire this into their own scheduler.  Cadence is a
+  // tradeoff between memory reclaim latency and the (tiny) cost of one
+  // node_ids() call plus the all_metrics()/forget() loop.
+  example::ui::print_success(
+    "In production, replace the simulated 'shrunk' set with the actual collection.node_ids() "
+    "result and run sweep_against() on a timer (once per minute is plenty); a decommissioned "
+    "node's tracker is then reclaimed within one sweep interval, regardless of whether any "
+    "traffic ever arrives for it again.");
+
+  // Re-populate the entry we dropped so we leave the registry in the
+  // same shape we found it — purely a courtesy to anything that runs
+  // after this demo.
+  breaker.record_success(victim, 0ms);
+}
+
+} // namespace example::demo

--- a/examples/external_circuit_breaker/demo_topology_sweep.hxx
+++ b/examples/external_circuit_breaker/demo_topology_sweep.hxx
@@ -1,0 +1,40 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include "circuit_breaker.hxx"
+
+#include <couchbase/collection.hxx>
+
+namespace example::demo
+{
+
+/**
+ * Topology sweep: a long-running process accumulates per-node breaker
+ * entries forever unless someone retires the entries for nodes that have
+ * left the cluster.  This demo shows the canonical sweep — diff the
+ * registry's keys against couchbase::collection::node_ids() and forget
+ * the difference — using a synthesized stale entry to stand in for a
+ * node that has been removed from the topology since the breaker first
+ * saw it.
+ */
+auto
+demo_topology_sweep(couchbase::collection& collection, example::cb::circuit_breaker& breaker)
+  -> void;
+
+} // namespace example::demo

--- a/examples/external_circuit_breaker/main.cxx
+++ b/examples/external_circuit_breaker/main.cxx
@@ -1,0 +1,148 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "circuit_breaker.hxx"
+#include "demo_admin.hxx"
+#include "demo_failed_probe.hxx"
+#include "demo_healthy_traffic.hxx"
+#include "demo_per_node_isolation.hxx"
+#include "demo_slow_calls.hxx"
+#include "demo_state_transitions.hxx"
+#include "demo_topology_sweep.hxx"
+#include "ui.hxx"
+
+#include <couchbase/cluster.hxx>
+#include <couchbase/logger.hxx>
+
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <string>
+
+namespace
+{
+
+constexpr auto default_connection_string{ "couchbase://127.0.0.1" };
+constexpr auto default_username{ "Administrator" };
+constexpr auto default_password{ "password" };
+constexpr auto default_bucket_name{ "default" };
+
+auto
+safe_getenv(const std::string& name) noexcept -> std::optional<std::string>
+{
+  if (name.empty()) {
+    return std::nullopt;
+  }
+#if defined(_WIN32)
+  char* buf = nullptr;
+  size_t len = 0;
+  if (_dupenv_s(&buf, &len, name.c_str()) == 0 && buf != nullptr) {
+    std::string value(buf);
+    free(buf);
+    if (!value.empty()) {
+      return value;
+    }
+  }
+  return std::nullopt;
+#else
+  if (const char* val = std::getenv(name.c_str())) { // NOLINT(concurrency-mt-unsafe)
+    if (val[0] != '\0') {
+      return std::string(val);
+    }
+  }
+  return std::nullopt;
+#endif
+}
+
+auto
+env_or(const char* var, const char* fallback) -> std::string
+{
+  return safe_getenv(var).value_or(fallback);
+}
+
+} // namespace
+
+auto
+main() -> int
+{
+  example::ui::style::initialize();
+
+  auto conn_str = env_or("CB_CONNECTION_STRING", default_connection_string);
+  auto username = env_or("CB_USERNAME", default_username);
+  auto password = env_or("CB_PASSWORD", default_password);
+  auto bucket = env_or("CB_BUCKET", default_bucket_name);
+
+  couchbase::logger::initialize_console_logger();
+  couchbase::logger::set_level(couchbase::logger::log_level::warn);
+
+  auto options = couchbase::cluster_options(username, password);
+  options.apply_profile("wan_development");
+
+  auto [connect_err, cluster] = couchbase::cluster::connect(conn_str, options).get();
+  if (connect_err) {
+    std::cerr << "connect failed: " << connect_err.ec().message() << "\n";
+    return 1;
+  }
+  auto collection = cluster.bucket(bucket).default_collection();
+
+  example::cb::circuit_breaker_config config;
+  config.with_failure_rate_threshold_percent(50)
+    .with_slow_call_rate_threshold_percent(80)
+    .with_slow_call_duration_threshold(std::chrono::milliseconds{ 2000 })
+    .with_minimum_number_of_calls(20)
+    .with_sliding_window(std::chrono::seconds{ 10 })
+    .with_number_of_buckets(10)
+    .with_wait_duration_in_open_state(std::chrono::seconds{ 5 })
+    .with_permitted_calls_in_half_open_state(3);
+
+  example::cb::circuit_breaker breaker(config);
+  breaker.set_transition_callback([](example::cb::circuit_state from,
+                                     example::cb::circuit_state to,
+                                     const std::string& why) -> void {
+    example::ui::print_transition(from, to, why);
+  });
+
+  example::ui::print_intro(
+    "External Circuit Breaker — Couchbase C++ SDK",
+    "Seven demos: healthy traffic, state transitions, failed probe, operator overrides, "
+    "slow-call tripping, per-node isolation, topology sweep.");
+  example::ui::print_legend();
+
+  example::demo::demo_healthy_traffic(collection, breaker);
+
+  // Discover a real node_id from the cluster to use as the victim in the
+  // failure-injection demos.
+  auto [nid_err, victim] = collection.node_id_for("cb-demo-0").get();
+  if (nid_err) {
+    example::ui::print_error("failed to resolve a victim node: " +
+                             std::string{ nid_err.ec().message() });
+  }
+
+  example::demo::demo_state_transitions(breaker, victim);
+  example::demo::demo_failed_probe(breaker, victim);
+  example::demo::demo_admin(breaker, victim);
+  example::demo::demo_slow_calls(breaker, victim);
+  example::demo::demo_per_node_isolation(collection, breaker);
+  example::demo::demo_topology_sweep(collection, breaker);
+
+  std::cout << "\n"
+            << example::ui::paint("All demos complete.", example::ui::style::bold) << "\n\n";
+
+  cluster.close().get();
+  return 0;
+}

--- a/examples/external_circuit_breaker/ui.cxx
+++ b/examples/external_circuit_breaker/ui.cxx
@@ -1,0 +1,406 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "ui.hxx"
+
+#include <algorithm>
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace example::ui
+{
+
+auto
+c(const char* code) -> const char*
+{
+  return style::enabled() ? code : "";
+}
+
+auto
+paint(std::string_view text, const char* code) -> std::string
+{
+  if (!style::enabled()) {
+    return std::string{ text };
+  }
+  std::string out;
+  out.reserve(text.size() + 16);
+  out.append(code).append(text).append(style::reset);
+  return out;
+}
+
+namespace
+{
+
+[[nodiscard]] auto
+repeat(std::string_view s, std::size_t n) -> std::string
+{
+  std::string out;
+  out.reserve(s.size() * n);
+  for (std::size_t i = 0; i < n; ++i) {
+    out.append(s);
+  }
+  return out;
+}
+
+[[nodiscard]] auto
+pad_right(std::string_view text, std::size_t width) -> std::string
+{
+  std::string out{ text };
+  if (out.size() < width) {
+    out.append(width - out.size(), ' ');
+  }
+  return out;
+}
+
+[[nodiscard]] auto
+pad_left(std::string_view text, std::size_t width) -> std::string
+{
+  std::string out;
+  if (text.size() < width) {
+    out.append(width - text.size(), ' ');
+  }
+  out.append(text);
+  return out;
+}
+
+/**
+ * Approximate monospace display width of a UTF-8 string.  Counts code
+ * points (every byte whose top two bits are not 10) and assumes each code
+ * point occupies one cell — good enough for the box-drawing chars,
+ * em-dashes and arrows used in this demo.
+ */
+[[nodiscard]] auto
+visible_width(std::string_view s) -> std::size_t
+{
+  std::size_t w = 0;
+  for (char ch : s) {
+    if ((static_cast<unsigned char>(ch) & 0xC0U) != 0x80U) {
+      ++w;
+    }
+  }
+  return w;
+}
+
+[[nodiscard]] auto
+pad_right_visible(std::string_view text, std::size_t width) -> std::string
+{
+  std::string out{ text };
+  auto vw = visible_width(text);
+  if (vw < width) {
+    out.append(width - vw, ' ');
+  }
+  return out;
+}
+
+/**
+ * Word-wrap @p text into lines no wider than @p max_width visible cells,
+ * breaking on whitespace where possible.  A single token longer than
+ * max_width is emitted on its own line and left to overflow rather than
+ * truncated — better to mangle alignment than to silently drop content.
+ */
+[[nodiscard]] auto
+wrap_visible(std::string_view text, std::size_t max_width) -> std::vector<std::string>
+{
+  std::vector<std::string> lines;
+  if (max_width == 0) {
+    lines.emplace_back(text);
+    return lines;
+  }
+  std::string current;
+  std::size_t current_w = 0;
+  std::size_t i = 0;
+  while (i < text.size()) {
+    while (i < text.size() && text[i] == ' ') {
+      ++i;
+    }
+    if (i >= text.size()) {
+      break;
+    }
+    auto word_start = i;
+    while (i < text.size() && text[i] != ' ') {
+      ++i;
+    }
+    auto word = text.substr(word_start, i - word_start);
+    auto word_w = visible_width(word);
+    auto needed = current.empty() ? word_w : current_w + 1 + word_w;
+    if (!current.empty() && needed > max_width) {
+      lines.push_back(std::move(current));
+      current.clear();
+      current_w = 0;
+    }
+    if (current.empty()) {
+      current.assign(word);
+      current_w = word_w;
+    } else {
+      current.push_back(' ');
+      current.append(word);
+      current_w += 1 + word_w;
+    }
+  }
+  if (!current.empty()) {
+    lines.push_back(std::move(current));
+  }
+  if (lines.empty()) {
+    lines.emplace_back();
+  }
+  return lines;
+}
+
+} // namespace
+
+auto
+color_for(example::cb::circuit_state s) -> const char*
+{
+  switch (s) {
+    case example::cb::circuit_state::closed:
+      return style::green;
+    case example::cb::circuit_state::open:
+      return style::red;
+    case example::cb::circuit_state::half_open:
+      return style::yellow;
+    case example::cb::circuit_state::forced_open:
+      return style::magenta;
+    case example::cb::circuit_state::disabled:
+      return style::gray;
+  }
+  return style::gray;
+}
+
+auto
+icon_for(example::cb::circuit_state s) -> const char*
+{
+  switch (s) {
+    case example::cb::circuit_state::closed:
+      return "\xE2\x9C\x93"; // ✓
+    case example::cb::circuit_state::open:
+      return "\xE2\x9C\x97"; // ✗
+    case example::cb::circuit_state::half_open:
+      return "\xE2\x97\x90"; // ◐
+    case example::cb::circuit_state::forced_open:
+      return "\xE2\x96\xA0"; // ■
+    case example::cb::circuit_state::disabled:
+      return "\xE2\x97\x8B"; // ○
+  }
+  return "?";
+}
+
+auto
+state_badge(example::cb::circuit_state s) -> std::string
+{
+  std::string label;
+  label.append(icon_for(s)).append(" ").append(example::cb::to_string(s));
+  return paint(label, color_for(s));
+}
+
+auto
+state_badge_visible_width(example::cb::circuit_state s) -> std::size_t
+{
+  return 2 + std::string_view{ example::cb::to_string(s) }.size();
+}
+
+auto
+short_node(std::string_view id) -> std::string
+{
+  if (id.size() <= 12) {
+    return std::string{ id };
+  }
+  std::string out;
+  out.reserve(12);
+  out.append(id.substr(0, 8)).append("\xE2\x80\xA6"); // …
+  out.append(id.substr(id.size() - 4));
+  return out;
+}
+
+auto
+print_intro(std::string_view title, std::string_view subtitle) -> void
+{
+  constexpr std::size_t inner = 78;
+  // Leave one column of padding on each side of the box interior, so the
+  // wrappable region is two columns shy of `inner`.
+  constexpr std::size_t text_width = inner - 2;
+  const auto horiz = repeat("\xE2\x94\x80", inner); // ─
+  auto print_line = [&](std::string_view body, const char* style_code) -> void {
+    std::cout << c(style::cyan) << "\xE2\x94\x82" << c(style::reset) << c(style_code) << " "
+              << pad_right_visible(body, inner - 1) << c(style::reset) << c(style::cyan)
+              << "\xE2\x94\x82" << c(style::reset) << "\n";
+  };
+  std::cout << "\n"
+            << c(style::bold) << c(style::cyan) << "\xE2\x95\xAD" << horiz << "\xE2\x95\xAE"
+            << c(style::reset) << "\n";
+  for (const auto& line : wrap_visible(title, text_width)) {
+    print_line(line, style::bold);
+  }
+  if (!subtitle.empty()) {
+    for (const auto& line : wrap_visible(subtitle, text_width)) {
+      print_line(line, style::dim);
+    }
+  }
+  std::cout << c(style::bold) << c(style::cyan) << "\xE2\x95\xB0" << horiz << "\xE2\x95\xAF"
+            << c(style::reset) << "\n";
+}
+
+auto
+print_demo_header(std::string_view tag, std::string_view title, std::string_view sub) -> void
+{
+  std::cout << "\n"
+            << c(style::bold) << c(style::blue) << tag << c(style::reset) << "  " << c(style::bold)
+            << title << c(style::reset) << "\n";
+  if (!sub.empty()) {
+    std::cout << "  " << c(style::dim) << sub << c(style::reset) << "\n";
+  }
+  std::cout << c(style::dim) << repeat("\xE2\x94\x80", 80) // ─
+            << c(style::reset) << "\n";
+}
+
+auto
+print_step(std::string_view msg) -> void
+{
+  std::cout << "  " << c(style::cyan) << "\xE2\x96\xB8" << c(style::reset) << " " << msg << "\n";
+}
+
+auto
+print_note(std::string_view msg) -> void
+{
+  std::cout << "    " << c(style::dim) << msg << c(style::reset) << "\n";
+}
+
+auto
+print_success(std::string_view msg) -> void
+{
+  std::cout << "  " << paint("\xE2\x9C\x93", style::green) << " " << msg << "\n";
+}
+
+auto
+print_warning(std::string_view msg) -> void
+{
+  std::cout << "  " << paint("\xE2\x9A\xA0", style::yellow) << " " << msg << "\n";
+}
+
+auto
+print_error(std::string_view msg) -> void
+{
+  std::cout << "  " << paint("\xE2\x9C\x97", style::red) << " " << msg << "\n";
+}
+
+auto
+print_transition(example::cb::circuit_state from,
+                 example::cb::circuit_state to,
+                 std::string_view why) -> void
+{
+  std::string_view node{};
+  std::string_view reason = why;
+  if (reason.size() > 6 && reason.substr(0, 6) == "[node ") {
+    if (auto end = reason.find("] ", 6); end != std::string_view::npos) {
+      node = reason.substr(6, end - 6);
+      reason = reason.substr(end + 2);
+    }
+  }
+  std::cout << "    " << paint("\xE2\x9A\xA1", style::yellow) // ⚡
+            << "  " << state_badge(from) << " " << c(style::bold) << "\xE2\x86\x92"
+            << c(style::reset) // →
+            << " " << state_badge(to);
+  if (!node.empty()) {
+    std::cout << "  " << c(style::dim) << "node " << c(style::reset) << c(style::gray)
+              << short_node(node) << c(style::reset);
+  }
+  std::cout << "  " << c(style::dim) << reason << c(style::reset) << "\n";
+}
+
+auto
+print_metrics_table(example::cb::circuit_breaker& breaker) -> void
+{
+  auto rows = breaker.all_metrics();
+  std::sort(rows.begin(), rows.end(), [](const auto& a, const auto& b) -> bool {
+    return a.first.id() < b.first.id();
+  });
+  if (rows.empty()) {
+    print_note("no per-node breakers have been exercised yet");
+    return;
+  }
+
+  // Node IDs are fixed-size for any given cluster but vary across cluster
+  // versions: legacy servers synthesize an 8-char CRC32, newer ones return
+  // a 36-char UUID.  Size the column to the widest id actually present so
+  // the table stays compact on legacy clusters and stays aligned on new
+  // ones, with a floor of "Node" header width.
+  std::size_t w_node = std::string_view{ "Node" }.size();
+  for (const auto& [nid, m] : rows) {
+    w_node = std::max(w_node, visible_width(nid.id()));
+  }
+  constexpr std::size_t w_state = 13;
+  constexpr std::size_t w_total = 6;
+  constexpr std::size_t w_ok = 4;
+  constexpr std::size_t w_fail = 5;
+  constexpr std::size_t w_slow = 5;
+  constexpr std::size_t w_pct = 6;
+  constexpr std::size_t w_rej = 4;
+
+  auto hline = [&](std::string_view left, std::string_view mid, std::string_view right) -> void {
+    std::cout << "  " << c(style::dim) << left << repeat("\xE2\x94\x80", w_node + 2) << mid
+              << repeat("\xE2\x94\x80", w_state + 2) << mid << repeat("\xE2\x94\x80", w_total + 2)
+              << mid << repeat("\xE2\x94\x80", w_ok + 2) << mid
+              << repeat("\xE2\x94\x80", w_fail + 2) << mid << repeat("\xE2\x94\x80", w_slow + 2)
+              << mid << repeat("\xE2\x94\x80", w_pct + 2) << mid
+              << repeat("\xE2\x94\x80", w_rej + 2) << right << c(style::reset) << "\n";
+  };
+  auto cell_v = [&]() -> std::string {
+    return std::string{ c(style::dim) } + "\xE2\x94\x82" + c(style::reset);
+  };
+
+  std::cout << "\n";
+  hline("\xE2\x94\x8C", "\xE2\x94\xAC", "\xE2\x94\x90"); // ┌ ┬ ┐
+  std::cout << "  " << cell_v() << c(style::bold) << " " << pad_right("Node", w_node) << " "
+            << c(style::reset) << cell_v() << c(style::bold) << " " << pad_right("State", w_state)
+            << " " << c(style::reset) << cell_v() << c(style::bold) << " "
+            << pad_left("Total", w_total) << " " << c(style::reset) << cell_v() << c(style::bold)
+            << " " << pad_left("OK", w_ok) << " " << c(style::reset) << cell_v() << c(style::bold)
+            << " " << pad_left("Fail", w_fail) << " " << c(style::reset) << cell_v()
+            << c(style::bold) << " " << pad_left("Slow", w_slow) << " " << c(style::reset)
+            << cell_v() << c(style::bold) << " " << pad_left("Fail%", w_pct) << " "
+            << c(style::reset) << cell_v() << c(style::bold) << " " << pad_left("Rej", w_rej) << " "
+            << c(style::reset) << cell_v() << "\n";
+  hline("\xE2\x94\x9C", "\xE2\x94\xBC", "\xE2\x94\xA4"); // ├ ┼ ┤
+
+  for (const auto& [nid, m] : rows) {
+    auto state_cell_padding = w_state - state_badge_visible_width(m.state);
+    std::cout << "  " << cell_v() << " " << pad_right(nid.id(), w_node) << " " << cell_v() << " "
+              << state_badge(m.state) << std::string(state_cell_padding, ' ') << " " << cell_v()
+              << " " << pad_left(std::to_string(m.total_calls), w_total) << " " << cell_v() << " "
+              << pad_left(std::to_string(m.successful_calls), w_ok) << " " << cell_v() << " "
+              << pad_left(std::to_string(m.failed_calls), w_fail) << " " << cell_v() << " "
+              << pad_left(std::to_string(m.slow_calls), w_slow) << " " << cell_v() << " "
+              << pad_left(std::to_string(m.failure_rate_percent) + "%", w_pct) << " " << cell_v()
+              << " " << pad_left(std::to_string(m.rejected_calls), w_rej) << " " << cell_v()
+              << "\n";
+  }
+  hline("\xE2\x94\x94", "\xE2\x94\xB4", "\xE2\x94\x98"); // └ ┴ ┘
+}
+
+auto
+print_legend() -> void
+{
+  std::cout << "\n  " << c(style::bold) << "Legend" << c(style::reset) << "   ";
+  std::cout << paint("\xE2\x9C\x93 CLOSED", style::green) << "  "
+            << paint("\xE2\x9C\x97 OPEN", style::red) << "  "
+            << paint("\xE2\x97\x90 HALF_OPEN", style::yellow) << "  "
+            << paint("\xE2\x96\xA0 FORCED_OPEN", style::magenta) << "  "
+            << paint("\xE2\x97\x8B DISABLED", style::gray) << "\n";
+}
+
+} // namespace example::ui

--- a/examples/external_circuit_breaker/ui.hxx
+++ b/examples/external_circuit_breaker/ui.hxx
@@ -1,0 +1,123 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+/**
+ * @file
+ *
+ * Presentation layer for the external_circuit_breaker demo.  Everything
+ * here is purely cosmetic — it turns the breaker's events into something
+ * a human (or the human's manager) can read over the shoulder.  The
+ * example::cb breaker has no dependency on this namespace; copy the
+ * circuit_breaker.hxx / circuit_breaker.cxx pair without any of the ui
+ * helpers and it will work just the same.
+ */
+
+#pragma once
+
+#include "circuit_breaker.hxx"
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+
+namespace example::ui
+{
+
+namespace style
+{
+/**
+ * Prepare the platform's standard output for the demo UI.  On Windows this
+ * sets the console output code page to UTF-8 so the box-drawing characters,
+ * arrows, and glyph icons render correctly.  ANSI virtual-terminal
+ * processing is enabled lazily on the first call to style::enabled(), where
+ * it is gated on isatty() and the NO_COLOR environment variable.  On Unix
+ * it is a no-op — terminals handle both natively.
+ *
+ * Safe to call more than once.  Should be called once, early in main(),
+ * before any ui::print_* function.
+ */
+auto
+initialize() -> void;
+
+[[nodiscard]] auto
+enabled() -> bool;
+
+constexpr const char* reset = "\033[0m";
+constexpr const char* bold = "\033[1m";
+constexpr const char* dim = "\033[2m";
+constexpr const char* red = "\033[31m";
+constexpr const char* green = "\033[32m";
+constexpr const char* yellow = "\033[33m";
+constexpr const char* blue = "\033[34m";
+constexpr const char* magenta = "\033[35m";
+constexpr const char* cyan = "\033[36m";
+constexpr const char* gray = "\033[90m";
+} // namespace style
+
+[[nodiscard]] auto
+c(const char* code) -> const char*;
+[[nodiscard]] auto
+paint(std::string_view text, const char* code) -> std::string;
+
+[[nodiscard]] auto
+color_for(example::cb::circuit_state s) -> const char*;
+[[nodiscard]] auto
+icon_for(example::cb::circuit_state s) -> const char*;
+
+/**
+ * Colored, icon-prefixed state label.  The visible width (icon + space +
+ * name) is deterministic, so the caller can pad around it.
+ */
+[[nodiscard]] auto
+state_badge(example::cb::circuit_state s) -> std::string;
+[[nodiscard]] auto
+state_badge_visible_width(example::cb::circuit_state s) -> std::size_t;
+
+[[nodiscard]] auto
+short_node(std::string_view id) -> std::string;
+
+auto
+print_intro(std::string_view title, std::string_view subtitle) -> void;
+auto
+print_demo_header(std::string_view tag, std::string_view title, std::string_view sub) -> void;
+auto
+print_step(std::string_view msg) -> void;
+auto
+print_note(std::string_view msg) -> void;
+auto
+print_success(std::string_view msg) -> void;
+auto
+print_warning(std::string_view msg) -> void;
+auto
+print_error(std::string_view msg) -> void;
+
+/**
+ * Pretty-print a breaker transition.  Strips the "[node XXX] " prefix that
+ * example::cb::circuit_breaker embeds in the reason string and rerenders
+ * the node id in its own visually distinct slot.
+ */
+auto
+print_transition(example::cb::circuit_state from,
+                 example::cb::circuit_state to,
+                 std::string_view why) -> void;
+
+auto
+print_metrics_table(example::cb::circuit_breaker& breaker) -> void;
+auto
+print_legend() -> void;
+
+} // namespace example::ui

--- a/examples/external_circuit_breaker/ui_unix.cxx
+++ b/examples/external_circuit_breaker/ui_unix.cxx
@@ -1,0 +1,51 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#if !defined(_WIN32)
+
+#include "ui.hxx"
+
+#include <cstdio>
+#include <cstdlib>
+
+#include <unistd.h>
+
+namespace example::ui::style
+{
+
+auto
+initialize() -> void
+{
+  // POSIX terminals handle ANSI escapes and UTF-8 natively — nothing to do.
+}
+
+auto
+enabled() -> bool
+{
+  static const bool on = []() -> bool {
+    const char* no_color = std::getenv("NO_COLOR"); // NOLINT(concurrency-mt-unsafe)
+    if (no_color != nullptr && no_color[0] != '\0') {
+      return false;
+    }
+    return ::isatty(::fileno(stdout)) != 0;
+  }();
+  return on;
+}
+
+} // namespace example::ui::style
+
+#endif // !defined(_WIN32)

--- a/examples/external_circuit_breaker/ui_windows.cxx
+++ b/examples/external_circuit_breaker/ui_windows.cxx
@@ -1,0 +1,108 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#if defined(_WIN32)
+
+#include "ui.hxx"
+
+#include <cstdio>
+#include <cstdlib>
+
+#include <io.h>
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+
+namespace example::ui::style
+{
+
+namespace
+{
+
+/**
+ * Try to put the stdout console into ANSI/virtual-terminal mode.  Returns
+ * true on Windows 10 1511+ (which is where VT support landed) and on any
+ * modern Windows Terminal host.  Returns false on legacy consoles, when
+ * stdout is redirected to a file or pipe, or when another host has captured
+ * the handle in a way that does not support VT.
+ */
+auto
+try_enable_virtual_terminal() -> bool
+{
+  HANDLE h = ::GetStdHandle(STD_OUTPUT_HANDLE);
+  if (h == nullptr || h == INVALID_HANDLE_VALUE) {
+    return false;
+  }
+  DWORD mode = 0;
+  if (::GetConsoleMode(h, &mode) == 0) {
+    return false; // stdout is not a console (redirected to pipe/file).
+  }
+  const DWORD with_vt = mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+  if (::SetConsoleMode(h, with_vt) != 0) {
+    return true;
+  }
+  return false;
+}
+
+auto
+no_color_env_set() -> bool
+{
+  char* value = nullptr;
+  std::size_t value_len = 0;
+  if (_dupenv_s(&value, &value_len, "NO_COLOR") == 0 && value != nullptr) {
+    const bool disabled = value[0] != '\0';
+    std::free(value);
+    return disabled;
+  }
+  return false;
+}
+
+} // namespace
+
+auto
+initialize() -> void
+{
+  // Tell the console to interpret our output as UTF-8 so the box-drawing
+  // characters, arrows, and glyph icons render correctly.  This is
+  // independent of ANSI color support and is worth doing even when the
+  // terminal does not support VT escape sequences.
+  ::SetConsoleOutputCP(CP_UTF8);
+}
+
+auto
+enabled() -> bool
+{
+  static const bool on = []() -> bool {
+    if (no_color_env_set()) {
+      return false;
+    }
+    if (_isatty(_fileno(stdout)) == 0) {
+      return false;
+    }
+    return try_enable_virtual_terminal();
+  }();
+  return on;
+}
+
+} // namespace example::ui::style
+
+#endif // defined(_WIN32)


### PR DESCRIPTION
Provides a production-quality circuit breaker built on top of the node_id API, intended for customers to copy into their own codebase. The implementation lives in the example::cb namespace and follows the Netflix Hystrix / Resilience4j model.

State machine: closed, open, half_open, forced_open, disabled. Auto-transitions (closed -> open -> half_open -> closed) are driven by a time-based sliding window with a fixed bucket ring and lock-free recording on the hot path. The breaker opens on either the failure-rate or the slow-call-rate threshold, gated by a minimum-call volume to prevent cold-start flapping. In half_open, a bounded number of probe requests are permitted; a configurable number of successes closes the circuit, any failure re-opens it.

Per-node isolation is provided by a registry keyed on couchbase::node_id, so a single degraded node does not poison the rest of the cluster. Administrative force_open, disable, and reset overrides are included, along with a state-transition listener hook for logging and telemetry. An execute() template helper wraps an SDK call, consults the breaker, measures duration, and records the outcome against the node id carried by the response or error.

main() drives six demos against a live cluster: healthy traffic, the full CLOSED -> OPEN -> HALF_OPEN -> CLOSED cycle, a failed half-open probe re-opening the circuit, administrative overrides, slow-call-rate tripping without any hard failures, and per-node isolation showing that poisoning one node leaves the others unaffected. Connection parameters are read from environment variables for test-cluster compatibility.

<img width="1098" height="2169" alt="image" src="https://github.com/user-attachments/assets/b19eeb53-9ac6-408f-b85f-e4f49fa644fe" />