### PR TITLE
CXXCBC-832: Document deferred-destruction idiom in http_session_manager

### DIFF
--- a/core/io/http_session_manager.hxx
+++ b/core/io/http_session_manager.hxx
@@ -402,6 +402,8 @@ public:
       return;
     }
     if (!session->is_connected()) {
+      // Declared outside the lock so the destructor runs after sessions_mutex_ is released.
+      // cppcheck-suppress variableScope
       std::shared_ptr<http_session> dropped;
       {
         std::scoped_lock lock(sessions_mutex_);
@@ -761,6 +763,8 @@ private:
     }
 
     session->on_stop([type, id = session->id(), self = this->shared_from_this()]() {
+      // Declared outside the lock so destructors run after sessions_mutex_ is released.
+      // cppcheck-suppress variableScope
       std::vector<std::shared_ptr<http_session>> dropped;
       {
         const std::scoped_lock inner_lock(self->sessions_mutex_);


### PR DESCRIPTION
cppcheck flags the `dropped` declarations in `check_in()` and the session `on_stop()` callback with a `variableScope` warning, suggesting the variables be moved into the inner `scoped_lock` block. Doing so would silently change semantics: the whole point of declaring them outside the lock is to defer the `shared_ptr<http_session>` destructors until *after* `sessions_mutex_` is released, avoiding holding the manager mutex across session teardown (which can re-enter the manager or take other locks).

Add a brief comment explaining the intent and a `cppcheck-suppress variableScope` directive at each site so the linter doesn't keep prompting future readers to "fix" the deliberate scope.