### PR TITLE
CXXCBC-826: Add collection::node_ids() to enumerate KV-serving cluster nodes

### DIFF
--- a/core/impl/collection.cxx
+++ b/core/impl/collection.cxx
@@ -1311,6 +1311,63 @@ public:
       });
   }
 
+  void node_ids(const node_ids_options::built& options, node_ids_handler&& handler) const
+  {
+    auto [origin_ec, origin] = core_.origin();
+    if (origin_ec) {
+      return handler(error{ origin_ec }, {});
+    }
+    const bool is_tls = origin.options().enable_tls;
+    const auto timeout = options.timeout.value_or(origin.options().key_value_timeout);
+
+    // Same shape as node_id_for: with_bucket_configuration() is not
+    // cancellable, so a steady_timer guarded by an atomic done-flag is
+    // the only way to bound the wait when no config arrives.
+    struct state {
+      std::atomic<bool> done{ false };
+      asio::steady_timer timer;
+      node_ids_handler handler;
+
+      state(asio::io_context& ioc, node_ids_handler&& h)
+        : timer{ ioc }
+        , handler{ std::move(h) }
+      {
+      }
+    };
+    auto shared = std::make_shared<state>(core_.io_context(), std::move(handler));
+
+    shared->timer.expires_after(timeout);
+    shared->timer.async_wait([shared](std::error_code timer_ec) -> void {
+      if (timer_ec == asio::error::operation_aborted) {
+        return;
+      }
+      if (shared->done.exchange(true)) {
+        return;
+      }
+      shared->handler(error{ errc::common::unambiguous_timeout }, {});
+    });
+
+    core_.with_bucket_configuration(
+      bucket_name_,
+      [shared, is_tls](std::error_code ec,
+                       const std::shared_ptr<core::topology::configuration>& config) -> void {
+        if (shared->done.exchange(true)) {
+          return;
+        }
+        shared->timer.cancel();
+        if (ec) {
+          return shared->handler(error{ ec }, {});
+        }
+        if (!config) {
+          // No config arrived but no error either — this should not
+          // happen in practice, but surface it the same way node_id_for
+          // does so callers can distinguish from request_canceled.
+          return shared->handler(error{ errc::network::configuration_not_available }, {});
+        }
+        return shared->handler({}, config->effective_node_ids(is_tls));
+      });
+  }
+
 private:
   static auto get_encoded_value(
     std::variant<codec::encoded_value, std::function<codec::encoded_value()>> value,
@@ -1417,6 +1474,24 @@ collection::node_id_for(std::string document_id, const node_id_for_options& opti
   auto future = barrier->get_future();
   node_id_for(std::move(document_id), options, [barrier](auto err, auto nid) {
     barrier->set_value({ std::move(err), std::move(nid) });
+  });
+  return future;
+}
+
+void
+collection::node_ids(const node_ids_options& options, node_ids_handler&& handler) const
+{
+  return impl_->node_ids(options.build(), std::move(handler));
+}
+
+auto
+collection::node_ids(const node_ids_options& options) const
+  -> std::future<std::pair<error, std::vector<node_id>>>
+{
+  auto barrier = std::make_shared<std::promise<std::pair<error, std::vector<node_id>>>>();
+  auto future = barrier->get_future();
+  node_ids(options, [barrier](auto err, auto nids) {
+    barrier->set_value({ std::move(err), std::move(nids) });
   });
   return future;
 }

--- a/core/topology/configuration.cxx
+++ b/core/topology/configuration.cxx
@@ -179,6 +179,20 @@ configuration::node::effective_node_id(bool is_tls) const -> couchbase::node_id
 }
 
 auto
+configuration::effective_node_ids(bool is_tls) const -> std::vector<couchbase::node_id>
+{
+  std::vector<couchbase::node_id> result;
+  result.reserve(nodes.size());
+  for (const auto& n : nodes) {
+    if (n.port_or(service_type::key_value, is_tls, 0) == 0) {
+      continue;
+    }
+    result.push_back(n.effective_node_id(is_tls));
+  }
+  return result;
+}
+
+auto
 configuration::has_node(const std::string& network,
                         service_type type,
                         bool is_tls,

--- a/core/topology/configuration.hxx
+++ b/core/topology/configuration.hxx
@@ -101,6 +101,20 @@ struct configuration {
 
   [[nodiscard]] auto select_network(const std::string& bootstrap_hostname) const -> std::string;
 
+  /**
+   * Returns one node_id per cluster node that currently serves the
+   * key-value service over the requested transport. Nodes that do not
+   * expose a KV port for @p is_tls are filtered out — without a KV port
+   * the fallback hash would be derived from a meaningless port=0 and
+   * could collide with a sibling node that is also missing its KV port.
+   *
+   * The returned vector preserves topology order; callers that want a
+   * set semantic should hash the entries themselves (couchbase::node_id
+   * is hashable). Topology nodes are unique by construction, so no
+   * dedup is performed here.
+   */
+  [[nodiscard]] auto effective_node_ids(bool is_tls) const -> std::vector<couchbase::node_id>;
+
   using vbucket_map = typename std::vector<std::vector<std::int16_t>>;
 
   std::optional<std::int64_t> epoch{};

--- a/couchbase/collection.hxx
+++ b/couchbase/collection.hxx
@@ -36,6 +36,7 @@
 #include <couchbase/mutate_in_options.hxx>
 #include <couchbase/mutate_in_specs.hxx>
 #include <couchbase/node_id_for_options.hxx>
+#include <couchbase/node_ids_options.hxx>
 #include <couchbase/query_options.hxx>
 #include <couchbase/remove_options.hxx>
 #include <couchbase/replace_options.hxx>
@@ -1120,6 +1121,47 @@ public:
   [[nodiscard]] auto node_id_for(std::string document_id,
                                  const node_id_for_options& options = {}) const
     -> std::future<std::pair<error, node_id>>;
+
+  /**
+   * Returns the set of cluster nodes that currently serve key-value
+   * traffic for this collection's bucket, drawn from the client-side
+   * topology snapshot (no network round-trip).
+   *
+   * Each entry corresponds to one cluster node and is the same node_id
+   * the SDK reports on KV results and errors that touched that node, so
+   * the returned set is directly comparable to the keys of any
+   * application-side state that is keyed by node_id (e.g. a per-node
+   * circuit breaker registry). A periodic sweep that diffs the
+   * registry's keys against this set is the canonical way to retire
+   * tracker state for a node that has been removed from the cluster
+   * topology.
+   *
+   * Nodes that do not expose a key-value port for the configured
+   * transport (TLS or plain) are excluded from the returned set, since
+   * they do not serve KV operations and therefore have no meaningful
+   * identity from the SDK's point of view.
+   *
+   * @param options options to customize the request
+   * @param handler the handler that receives the result
+   *
+   * @since 1.3.2
+   * @uncommitted
+   */
+  void node_ids(const node_ids_options& options, node_ids_handler&& handler) const;
+
+  /**
+   * Returns the set of cluster nodes that currently serve key-value
+   * traffic for this collection's bucket, drawn from the client-side
+   * topology snapshot (no network round-trip).
+   *
+   * @param options options to customize the request
+   * @return future carrying the error (if any) and the set of node_ids
+   *
+   * @since 1.3.2
+   * @uncommitted
+   */
+  [[nodiscard]] auto node_ids(const node_ids_options& options = {}) const
+    -> std::future<std::pair<error, std::vector<node_id>>>;
 
   [[nodiscard]] auto query_indexes() const -> collection_query_index_manager;
 

--- a/couchbase/node_ids_options.hxx
+++ b/couchbase/node_ids_options.hxx
@@ -1,0 +1,62 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2024-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/common_options.hxx>
+#include <couchbase/error.hxx>
+#include <couchbase/node_id.hxx>
+
+#include <functional>
+#include <vector>
+
+namespace couchbase
+{
+
+/**
+ * Options for @ref collection#node_ids().
+ *
+ * @since 1.3.2
+ * @uncommitted
+ */
+struct node_ids_options : public common_options<node_ids_options> {
+  /**
+   * Immutable value object representing consistent options.
+   *
+   * @since 1.3.2
+   * @internal
+   */
+  struct built : public common_options<node_ids_options>::built {
+  };
+
+  /**
+   * Validates options and returns them as an immutable value.
+   *
+   * @return consistent options as an immutable value
+   *
+   * @since 1.3.2
+   * @internal
+   */
+  [[nodiscard]] auto build() const -> built
+  {
+    return { build_common_options() };
+  }
+};
+
+using node_ids_handler = std::function<void(error, std::vector<node_id>)>;
+
+} // namespace couchbase

--- a/test/test_integration_node_id.cxx
+++ b/test/test_integration_node_id.cxx
@@ -25,7 +25,9 @@
 #include <couchbase/node_id.hxx>
 
 #include <algorithm>
+#include <chrono>
 #include <cstddef>
+#include <unordered_set>
 
 static const tao::json::value basic_doc = {
   { "a", 1.0 },
@@ -159,6 +161,100 @@ TEST_CASE("integration: node_id_for fails cleanly on missing bucket", "[integrat
       .get();
   REQUIRE(err.ec());
   REQUIRE_FALSE(static_cast<bool>(nid));
+}
+
+TEST_CASE("integration: node_ids returns the bucket's KV-serving nodes", "[integration]")
+{
+  test::utils::integration_test_guard integration;
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
+
+  auto [err, nids] = collection.node_ids().get();
+  REQUIRE_FALSE(err.ec());
+  REQUIRE_FALSE(nids.empty());
+  // Cannot exceed the bucket's node count; nodes lacking a KV port for the
+  // selected transport are filtered out, so equality is not guaranteed.
+  REQUIRE(nids.size() <= integration.number_of_nodes());
+
+  // Every entry must be a fully-formed node_id: truthy, with a non-empty
+  // id() and hostname(). Mirrors the per-node assertions used elsewhere
+  // in this file for result.node_id() and error.node_id().
+  for (const auto& nid : nids) {
+    REQUIRE(static_cast<bool>(nid));
+    REQUIRE_FALSE(nid.id().empty());
+    REQUIRE_FALSE(nid.hostname().empty());
+  }
+}
+
+TEST_CASE("integration: node_ids contains the result of node_id_for", "[integration]")
+{
+  test::utils::integration_test_guard integration;
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
+
+  auto id = test::utils::uniq_id("node_ids_contains_for");
+
+  auto [for_err, target] = collection.node_id_for(id).get();
+  REQUIRE_FALSE(for_err.ec());
+
+  auto [ids_err, nids] = collection.node_ids().get();
+  REQUIRE_FALSE(ids_err.ec());
+
+  std::unordered_set<couchbase::node_id> live{ nids.begin(), nids.end() };
+  REQUIRE(live.find(target) != live.end());
+}
+
+TEST_CASE("integration: node_ids contains the result.node_id of a successful KV op",
+          "[integration]")
+{
+  // The end-to-end consistency check: the node_id surfaced on a real KV
+  // result must be one of the entries node_ids() reports as live. This is
+  // what makes a registry keyed on result.node_id() directly diffable
+  // against node_ids() in a sweep.
+  test::utils::integration_test_guard integration;
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
+
+  auto id = test::utils::uniq_id("node_ids_contains_result");
+
+  auto [up_err, up_resp] = collection.upsert(id, basic_doc, {}).get();
+  REQUIRE_SUCCESS(up_err.ec());
+  REQUIRE(static_cast<bool>(up_resp.node_id()));
+
+  auto [ids_err, nids] = collection.node_ids().get();
+  REQUIRE_FALSE(ids_err.ec());
+
+  std::unordered_set<couchbase::node_id> live{ nids.begin(), nids.end() };
+  REQUIRE(live.find(up_resp.node_id()) != live.end());
+}
+
+TEST_CASE("integration: node_ids is deterministic across calls", "[integration]")
+{
+  test::utils::integration_test_guard integration;
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
+
+  auto [err1, nids1] = collection.node_ids().get();
+  REQUIRE_FALSE(err1.ec());
+
+  auto [err2, nids2] = collection.node_ids().get();
+  REQUIRE_FALSE(err2.ec());
+
+  // Topology order is deterministic on a stable cluster, so the vectors
+  // must compare element-wise — not merely have the same set of entries.
+  REQUIRE(nids1 == nids2);
+}
+
+TEST_CASE("integration: node_ids fails cleanly on missing bucket", "[integration]")
+{
+  test::utils::integration_test_guard integration;
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket("bucket-that-does-not-exist").default_collection();
+
+  auto [err, nids] =
+    collection.node_ids(couchbase::node_ids_options{}.timeout(std::chrono::seconds{ 5 })).get();
+  REQUIRE(err.ec());
+  REQUIRE(nids.empty());
 }
 
 TEST_CASE("integration: lookup_in result carries node_id on success", "[integration]")

--- a/test/test_unit_node_id.cxx
+++ b/test/test_unit_node_id.cxx
@@ -301,6 +301,213 @@ TEST_CASE("unit: node_id ignores alternate addresses with node_uuid", "[unit]")
   REQUIRE(tls.port() == 11207);
 }
 
+TEST_CASE("unit: configuration::effective_node_ids on empty topology", "[unit]")
+{
+  // A configuration with no nodes maps to an empty list — not an error.
+  // The node_ids() public API returns this verbatim; only a missing
+  // configuration (which never reaches this helper) is surfaced as
+  // configuration_not_available at the impl layer.
+  couchbase::core::topology::configuration config;
+  REQUIRE(config.effective_node_ids(false).empty());
+  REQUIRE(config.effective_node_ids(true).empty());
+}
+
+TEST_CASE("unit: configuration::effective_node_ids preserves order", "[unit]")
+{
+  couchbase::core::topology::configuration config;
+  config.nodes.resize(3);
+  config.nodes[0].node_uuid = "uuid-a";
+  config.nodes[0].hostname = "h0";
+  config.nodes[0].services_plain.key_value = 11210;
+  config.nodes[1].node_uuid = "uuid-b";
+  config.nodes[1].hostname = "h1";
+  config.nodes[1].services_plain.key_value = 11210;
+  config.nodes[2].node_uuid = "uuid-c";
+  config.nodes[2].hostname = "h2";
+  config.nodes[2].services_plain.key_value = 11210;
+
+  auto ids = config.effective_node_ids(false);
+  REQUIRE(ids.size() == 3);
+  REQUIRE(ids[0].id() == "uuid-a");
+  REQUIRE(ids[1].id() == "uuid-b");
+  REQUIRE(ids[2].id() == "uuid-c");
+}
+
+TEST_CASE("unit: configuration::effective_node_ids filters non-KV nodes", "[unit]")
+{
+  // Mirrors a heterogeneous deployment where the query and search nodes
+  // do not host the KV service for this bucket. A circuit breaker keyed
+  // on node_id only cares about KV-serving nodes, so dropping them keeps
+  // the registry's keys directly comparable to the SDK's KV result/error
+  // node_ids on every code path.
+  couchbase::core::topology::configuration config;
+  config.nodes.resize(4);
+  config.nodes[0].node_uuid = "kv-1";
+  config.nodes[0].hostname = "h0";
+  config.nodes[0].services_plain.key_value = 11210;
+  // node 1 is a query-only node — no KV port at all
+  config.nodes[1].node_uuid = "query-only";
+  config.nodes[1].hostname = "h1";
+  config.nodes[1].services_plain.query = 8093;
+  // node 2 has KV but only on TLS — must drop on plain transport
+  config.nodes[2].node_uuid = "tls-only-kv";
+  config.nodes[2].hostname = "h2";
+  config.nodes[2].services_tls.key_value = 11207;
+  config.nodes[3].node_uuid = "kv-2";
+  config.nodes[3].hostname = "h3";
+  config.nodes[3].services_plain.key_value = 11210;
+  config.nodes[3].services_tls.key_value = 11207;
+
+  auto plain = config.effective_node_ids(false);
+  REQUIRE(plain.size() == 2);
+  REQUIRE(plain[0].id() == "kv-1");
+  REQUIRE(plain[1].id() == "kv-2");
+
+  auto tls = config.effective_node_ids(true);
+  REQUIRE(tls.size() == 2);
+  REQUIRE(tls[0].id() == "tls-only-kv");
+  REQUIRE(tls[1].id() == "kv-2");
+}
+
+TEST_CASE("unit: configuration::effective_node_ids matches per-node effective_node_id", "[unit]")
+{
+  // For every node that survives the filter, the result must be byte-for-byte
+  // identical to what node::effective_node_id(is_tls) produces on its own —
+  // node_ids() is documented as the same identity the SDK reports on KV
+  // results/errors, and that identity comes through node::effective_node_id.
+  couchbase::core::topology::configuration config;
+  config.nodes.resize(2);
+  config.nodes[0].hostname = "172.18.0.2";
+  config.nodes[0].services_plain.key_value = 11210;
+  config.nodes[0].services_tls.key_value = 11207;
+  config.nodes[1].node_uuid = "node-uuid-7";
+  config.nodes[1].hostname = "172.18.0.3";
+  config.nodes[1].services_plain.key_value = 11210;
+  config.nodes[1].services_tls.key_value = 11207;
+
+  for (bool is_tls : { false, true }) {
+    auto ids = config.effective_node_ids(is_tls);
+    REQUIRE(ids.size() == 2);
+    REQUIRE(ids[0] == config.nodes[0].effective_node_id(is_tls));
+    REQUIRE(ids[1] == config.nodes[1].effective_node_id(is_tls));
+  }
+}
+
+TEST_CASE("unit: configuration::effective_node_ids differs between TLS and plain on pre-8.0 nodes",
+          "[unit]")
+{
+  // Without UUIDs the fallback hash incorporates the actual KV port the
+  // client connects to, so the same node yields a different node_id over
+  // TLS vs plain. node_ids() must reflect that — otherwise a registry
+  // populated from TLS-side results could fail to match keys derived from
+  // plain-side topology data.
+  couchbase::core::topology::configuration config;
+  config.nodes.resize(1);
+  config.nodes[0].hostname = "172.18.0.2";
+  config.nodes[0].services_plain.key_value = 11210;
+  config.nodes[0].services_tls.key_value = 11207;
+
+  auto plain = config.effective_node_ids(false);
+  auto tls = config.effective_node_ids(true);
+  REQUIRE(plain.size() == 1);
+  REQUIRE(tls.size() == 1);
+  REQUIRE(plain[0] != tls[0]);
+}
+
+TEST_CASE("unit: configuration::effective_node_ids agrees on TLS and plain when uuids are present",
+          "[unit]")
+{
+  // The reverse of the previous test: with UUIDs the identity is transport-
+  // independent, so the same node has the same node_id on both transports.
+  // This is the property that makes a circuit breaker registry portable
+  // across a TLS upgrade on a Server 8.0.1+ cluster.
+  couchbase::core::topology::configuration config;
+  config.nodes.resize(2);
+  config.nodes[0].node_uuid = "uuid-a";
+  config.nodes[0].hostname = "172.18.0.2";
+  config.nodes[0].services_plain.key_value = 11210;
+  config.nodes[0].services_tls.key_value = 11207;
+  config.nodes[1].node_uuid = "uuid-b";
+  config.nodes[1].hostname = "172.18.0.3";
+  config.nodes[1].services_plain.key_value = 11210;
+  config.nodes[1].services_tls.key_value = 11207;
+
+  auto plain = config.effective_node_ids(false);
+  auto tls = config.effective_node_ids(true);
+  REQUIRE(plain.size() == 2);
+  REQUIRE(tls.size() == 2);
+  for (std::size_t i = 0; i < plain.size(); ++i) {
+    REQUIRE(plain[i] == tls[i]);
+  }
+}
+
+TEST_CASE("unit: configuration::effective_node_ids ignores alternate addresses", "[unit]")
+{
+  // A consumer using the default-network identity (which the SDK exposes
+  // via node_ids()) must not see entries from the external/alt alias —
+  // otherwise the same physical node could appear twice in the breaker
+  // registry under two different keys.
+  couchbase::core::topology::configuration config;
+  config.nodes.resize(1);
+  config.nodes[0].hostname = "172.18.0.2";
+  config.nodes[0].services_plain.key_value = 11210;
+  config.nodes[0].services_tls.key_value = 11207;
+
+  couchbase::core::topology::configuration::alternate_address ext;
+  ext.name = "external";
+  ext.hostname = "172-18-0-2.my.cloud.com";
+  ext.services_plain.key_value = 31100;
+  ext.services_tls.key_value = 31207;
+  config.nodes[0].alt["external"] = ext;
+
+  for (bool is_tls : { false, true }) {
+    auto ids = config.effective_node_ids(is_tls);
+    REQUIRE(ids.size() == 1);
+    REQUIRE(ids[0].hostname() == "172.18.0.2");
+    REQUIRE(ids[0].hostname() != ext.hostname);
+  }
+}
+
+TEST_CASE("unit: configuration::effective_node_ids feeds into hash-based containers", "[unit]")
+{
+  // The point of node_ids() is to be diffable against application-side
+  // unordered_map<node_id, ...> registries. Lock in that the result type
+  // works as both a key (via std::hash specialization) and as a member of
+  // an unordered_set so callers can express "which keys do I track that
+  // the cluster no longer has?" with a single set_difference-equivalent.
+  couchbase::core::topology::configuration config;
+  config.nodes.resize(3);
+  config.nodes[0].node_uuid = "uuid-a";
+  config.nodes[0].hostname = "h0";
+  config.nodes[0].services_plain.key_value = 11210;
+  config.nodes[1].node_uuid = "uuid-b";
+  config.nodes[1].hostname = "h1";
+  config.nodes[1].services_plain.key_value = 11210;
+  config.nodes[2].node_uuid = "uuid-c";
+  config.nodes[2].hostname = "h2";
+  config.nodes[2].services_plain.key_value = 11210;
+
+  auto ids = config.effective_node_ids(false);
+  std::unordered_set<couchbase::node_id> live{ ids.begin(), ids.end() };
+  REQUIRE(live.size() == 3);
+
+  // Tracker registry that has one stale key (the cluster has dropped uuid-c
+  // and added a node with no entry yet for "stale-x").
+  std::unordered_map<couchbase::node_id, int> tracked;
+  tracked[couchbase::internal_node_id::build("uuid-a", "h0", 11210)] = 1;
+  tracked[couchbase::internal_node_id::build("uuid-b", "h1", 11210)] = 1;
+  tracked[couchbase::internal_node_id::build("stale-x", "h-gone", 11210)] = 1;
+
+  std::vector<couchbase::node_id> retired;
+  for (const auto& [k, _] : tracked) {
+    if (live.find(k) == live.end()) {
+      retired.push_back(k);
+    }
+  }
+  REQUIRE(retired.size() == 1);
+  REQUIRE(retired[0].id() == "stale-x");
+}
+
 TEST_CASE("unit: vbucket map resolves to correct node_id", "[unit]")
 {
   couchbase::core::topology::configuration config;


### PR DESCRIPTION
Expose the set of cluster nodes that currently serve key-value traffic for a collection's bucket as a public API drawn from the client-side topology snapshot, with no network round-trip. This closes the third corner of the node_id surface introduced by CXXCBC-820 (the value type) and CXXCBC-821 (node_id_for and result/error attribution): it is the piece application-side state machines keyed on couchbase::node_id need in order to retire tracking entries when a node is removed from the cluster topology.

Public API:

- couchbase::collection gains node_ids(options, handler) and a std::future-returning overload, both marked `@since 1.3.2` and `@uncommitted` to mirror node_id_for.
- couchbase::node_ids_options carries the standard common_options (timeout, parent_span, retry_strategy) and builds an immutable node_ids_options::built for the impl layer.
- Each entry in the returned vector is the same node_id the SDK reports on KV results and errors that touched that node, so the result is directly comparable to the keys of any unordered_map<node_id, ...> the application keeps (e.g. an external circuit breaker registry).

Semantics:

- Nodes that do not expose a key-value port for the configured transport (TLS or plain) are filtered out — keeping them in the result would mean the fallback hash for pre-8.0 servers would be derived from a meaningless port=0 and could collide across KV-less nodes.
- Order is topology order; topology nodes are unique by construction, so no dedup is performed. Callers that want a set semantic can hash the entries themselves (std::hash<couchbase::node_id> is specialized).
- Errors mirror node_id_for: errc::network::configuration_not_available when the bucket configuration is absent, errc::common::unambiguous_timeout when it does not arrive within the request timeout, and any error returned from core::cluster::origin().

Internal layering:

- core::topology::configuration::effective_node_ids(is_tls) is the pure helper — node iteration, KV-port filter, per-node call to effective_node_id(is_tls). Lives next to node::effective_node_id for symmetry; unit-testable without an io_context or a cluster.
- collection_impl::node_ids is the async wrapper — same shape as collection_impl::node_id_for: an atomic<bool> done guard plus a steady_timer plus a single with_bucket_configuration call, exactly one of {timer, config callback} fires the user handler.
- collection::node_ids forwards to the impl; the future form wraps the handler form in the standard promise pattern used elsewhere in collection.