### PR TITLE
[Backport] CXXCBC-828: Use std::string::find() when building errors based on server response text

### DIFF
--- a/core/operations/management/collection_create.cxx
+++ b/core/operations/management/collection_create.cxx
@@ -24,13 +24,11 @@
 #include <spdlog/fmt/bundled/core.h>
 #include <tao/json/value.hpp>
 
-#include <regex>
-
 namespace couchbase::core::operations::management
 {
 auto
-collection_create_request::encode_to(encoded_request_type& encoded,
-                                     http_context& /*context*/) const -> std::error_code
+collection_create_request::encode_to(encoded_request_type& encoded, http_context& /*context*/) const
+  -> std::error_code
 {
   encoded.method = "POST";
   encoded.path = fmt::format("/pools/default/buckets/{}/scopes/{}/collections",
@@ -58,18 +56,20 @@ collection_create_request::make_response(error_context::http&& ctx,
 {
   collection_create_response response{ std::move(ctx) };
   if (!response.ctx.ec) {
-    switch (encoded.status_code) {
+    switch (const auto& body = encoded.body.data(); encoded.status_code) {
       case 400: {
-        const std::regex collection_exists("Collection with name .+ already exists");
-        if (std::regex_search(encoded.body.data(), collection_exists)) {
+        const auto prefix_pos = body.find("Collection with name ");
+        if (prefix_pos != std::string_view::npos &&
+            body.find(" already exists", prefix_pos) != std::string_view::npos) {
           response.ctx.ec = errc::management::collection_exists;
         } else {
           response.ctx.ec = errc::common::invalid_argument;
         }
       } break;
       case 404: {
-        const std::regex scope_not_found("Scope with name .+ is not found");
-        if (std::regex_search(encoded.body.data(), scope_not_found)) {
+        const auto prefix_pos = body.find("Scope with name ");
+        if (prefix_pos != std::string_view::npos &&
+            body.find(" is not found", prefix_pos) != std::string_view::npos) {
           response.ctx.ec = errc::common::scope_not_found;
         } else {
           response.ctx.ec = errc::common::bucket_not_found;
@@ -78,7 +78,7 @@ collection_create_request::make_response(error_context::http&& ctx,
       case 200: {
         tao::json::value payload{};
         try {
-          payload = utils::json::parse(encoded.body.data());
+          payload = utils::json::parse(body);
         } catch (const tao::pegtl::parse_error&) {
           response.ctx.ec = errc::common::parsing_failure;
           return response;
@@ -86,7 +86,7 @@ collection_create_request::make_response(error_context::http&& ctx,
         response.uid = std::stoull(payload.at("uid").get_string(), nullptr, 16);
       } break;
       default:
-        response.ctx.ec = extract_common_error_code(encoded.status_code, encoded.body.data());
+        response.ctx.ec = extract_common_error_code(encoded.status_code, body);
         break;
     }
   }

--- a/core/operations/management/collection_drop.cxx
+++ b/core/operations/management/collection_drop.cxx
@@ -24,13 +24,11 @@
 #include <spdlog/fmt/bundled/core.h>
 #include <tao/json/value.hpp>
 
-#include <regex>
-
 namespace couchbase::core::operations::management
 {
 auto
-collection_drop_request::encode_to(encoded_request_type& encoded,
-                                   http_context& /* context */) const -> std::error_code
+collection_drop_request::encode_to(encoded_request_type& encoded, http_context& /* context */) const
+  -> std::error_code
 {
   encoded.method = "DELETE";
   encoded.path = fmt::format("/pools/default/buckets/{}/scopes/{}/collections/{}",
@@ -47,16 +45,18 @@ collection_drop_request::make_response(error_context::http&& ctx,
 {
   collection_drop_response response{ std::move(ctx) };
   if (!response.ctx.ec) {
-    switch (encoded.status_code) {
+    switch (const auto& body = encoded.body.data(); encoded.status_code) {
       case 400:
         response.ctx.ec = errc::common::unsupported_operation;
         break;
       case 404: {
-        const std::regex scope_not_found("Scope with name .+ is not found");
-        const std::regex collection_not_found("Collection with name .+ is not found");
-        if (std::regex_search(encoded.body.data(), collection_not_found)) {
+        const auto collection_prefix_pos = body.find("Collection with name ");
+        const auto scope_prefix_pos = body.find("Scope with name ");
+        if (collection_prefix_pos != std::string_view::npos &&
+            body.find(" is not found", collection_prefix_pos) != std::string_view::npos) {
           response.ctx.ec = errc::common::collection_not_found;
-        } else if (std::regex_search(encoded.body.data(), scope_not_found)) {
+        } else if (scope_prefix_pos != std::string_view::npos &&
+                   body.find(" is not found", scope_prefix_pos) != std::string_view::npos) {
           response.ctx.ec = errc::common::scope_not_found;
         } else {
           response.ctx.ec = errc::common::bucket_not_found;
@@ -65,7 +65,7 @@ collection_drop_request::make_response(error_context::http&& ctx,
       case 200: {
         tao::json::value payload{};
         try {
-          payload = utils::json::parse(encoded.body.data());
+          payload = utils::json::parse(body);
         } catch (const tao::pegtl::parse_error&) {
           response.ctx.ec = errc::common::parsing_failure;
           return response;
@@ -73,7 +73,7 @@ collection_drop_request::make_response(error_context::http&& ctx,
         response.uid = std::stoull(payload.at("uid").get_string(), nullptr, 16);
       } break;
       default:
-        response.ctx.ec = extract_common_error_code(encoded.status_code, encoded.body.data());
+        response.ctx.ec = extract_common_error_code(encoded.status_code, body);
         break;
     }
   }

--- a/core/operations/management/collection_update.cxx
+++ b/core/operations/management/collection_update.cxx
@@ -24,13 +24,11 @@
 #include <spdlog/fmt/bundled/core.h>
 #include <tao/json/value.hpp>
 
-#include <regex>
-
 namespace couchbase::core::operations::management
 {
 auto
-collection_update_request::encode_to(encoded_request_type& encoded,
-                                     http_context& /*context*/) const -> std::error_code
+collection_update_request::encode_to(encoded_request_type& encoded, http_context& /*context*/) const
+  -> std::error_code
 {
   encoded.method = "PATCH";
   encoded.path = fmt::format("/pools/default/buckets/{}/scopes/{}/collections/{}",
@@ -60,16 +58,18 @@ collection_update_request::make_response(error_context::http&& ctx,
 {
   collection_update_response response{ std::move(ctx) };
   if (!response.ctx.ec) {
-    switch (encoded.status_code) {
+    switch (const auto& body = encoded.body.data(); encoded.status_code) {
       case 400: {
         response.ctx.ec = errc::common::invalid_argument;
       } break;
       case 404: {
-        const std::regex scope_not_found("Scope with name .+ is not found");
-        const std::regex collection_not_found("Collection with name .+ is not found");
-        if (std::regex_search(encoded.body.data(), collection_not_found)) {
+        const auto collection_prefix_pos = body.find("Collection with name ");
+        const auto scope_prefix_pos = body.find("Scope with name ");
+        if (collection_prefix_pos != std::string_view::npos &&
+            body.find(" is not found", collection_prefix_pos) != std::string_view::npos) {
           response.ctx.ec = errc::common::collection_not_found;
-        } else if (std::regex_search(encoded.body.data(), scope_not_found)) {
+        } else if (scope_prefix_pos != std::string_view::npos &&
+                   body.find(" is not found", scope_prefix_pos) != std::string_view::npos) {
           response.ctx.ec = errc::common::scope_not_found;
         } else {
           response.ctx.ec = errc::common::bucket_not_found;
@@ -78,7 +78,7 @@ collection_update_request::make_response(error_context::http&& ctx,
       case 200: {
         tao::json::value payload{};
         try {
-          payload = utils::json::parse(encoded.body.data());
+          payload = utils::json::parse(body);
         } catch (const tao::pegtl::parse_error&) {
           response.ctx.ec = errc::common::parsing_failure;
           return response;
@@ -86,7 +86,7 @@ collection_update_request::make_response(error_context::http&& ctx,
         response.uid = std::stoull(payload.at("uid").get_string(), nullptr, 16);
       } break;
       default:
-        response.ctx.ec = extract_common_error_code(encoded.status_code, encoded.body.data());
+        response.ctx.ec = extract_common_error_code(encoded.status_code, body);
         break;
     }
   }

--- a/core/operations/management/error_utils.cxx
+++ b/core/operations/management/error_utils.cxx
@@ -143,15 +143,20 @@ translate_query_error_code(std::uint64_t error, const std::string& message, std:
 {
   switch (error) {
     case 5000: /* IKey: "Internal Error" */
-      if (std::regex_search(message, std::regex{ ".*[iI]ndex .*already exist.*" })) {
+    {
+      static const std::regex index_already_exists_re{ ".*[iI]ndex .*already exist.*" };
+      static const std::regex index_not_found_re{ ".*[iI]ndex .*[nN]ot [fF]ound.*" };
+      if (std::regex_search(message, index_already_exists_re)) {
         return errc::common::index_exists;
-      } else if (message.find("Index does not exist") != std::string::npos ||
-                 std::regex_search(message, std::regex{ ".*[iI]ndex .*[nN]ot [fF]ound.*" })) {
+      }
+      if (message.find("Index does not exist") != std::string::npos ||
+          std::regex_search(message, index_not_found_re)) {
         return errc::common::index_not_found;
-      } else if (message.find("Bucket Not Found") != std::string::npos) {
+      }
+      if (message.find("Bucket Not Found") != std::string::npos) {
         return errc::common::bucket_not_found;
       }
-      break;
+    } break;
 
     case 12003: /* IKey: "datastore.couchbase.keyspace_not_found" */
       return errc::common::bucket_not_found;

--- a/core/operations/management/query_index_create.cxx
+++ b/core/operations/management/query_index_create.cxx
@@ -118,13 +118,15 @@ query_index_create_request::make_response(error_context::http&& ctx,
         error.message = entry.at("msg").get_string();
         switch (error.code) {
           case 5000: /* IKey: "Internal Error" */
-            if (std::regex_search(error.message, std::regex{ ".*[iI]ndex .*already exist.*" })) {
+          {
+            static const std::regex index_already_exists_re{ ".*[iI]ndex .*already exist.*" };
+            if (std::regex_search(error.message, index_already_exists_re)) {
               index_already_exists = true;
             }
             if (error.message.find("Bucket Not Found") != std::string::npos) {
               bucket_not_found = true;
             }
-            break;
+          } break;
 
           case 12003: /* IKey: "datastore.couchbase.keyspace_not_found" */
             if (error.message.find("missing_collection") != std::string::npos) {

--- a/core/operations/management/query_index_drop.cxx
+++ b/core/operations/management/query_index_drop.cxx
@@ -29,8 +29,8 @@
 namespace couchbase::core::operations::management
 {
 auto
-query_index_drop_request::encode_to(encoded_request_type& encoded,
-                                    http_context& /*context*/) const -> std::error_code
+query_index_drop_request::encode_to(encoded_request_type& encoded, http_context& /*context*/) const
+  -> std::error_code
 {
   if (!utils::check_query_management_request(*this)) {
     return errc::common::invalid_argument;
@@ -87,10 +87,12 @@ query_index_drop_request::make_response(error_context::http&& ctx,
         error.message = entry.at("msg").get_string();
         switch (error.code) {
           case 5000: /* IKey: "Internal Error" */
-            if (std::regex_search(error.message, std::regex{ ".*[iI]ndex .*[nN]ot [fF]ound.*" })) {
+          {
+            static const std::regex index_not_found_re{ ".*[iI]ndex .*[nN]ot [fF]ound.*" };
+            if (std::regex_search(error.message, index_not_found_re)) {
               index_not_found = true;
             }
-            break;
+          } break;
 
           case 12003: /* IKey: "datastore.couchbase.keyspace_not_found" */
             if (error.message.find("missing_collection") != std::string::npos) {

--- a/core/operations/management/scope_create.cxx
+++ b/core/operations/management/scope_create.cxx
@@ -24,13 +24,11 @@
 #include <spdlog/fmt/bundled/core.h>
 #include <tao/json/value.hpp>
 
-#include <regex>
-
 namespace couchbase::core::operations::management
 {
 auto
-scope_create_request::encode_to(encoded_request_type& encoded,
-                                http_context& /* context */) const -> std::error_code
+scope_create_request::encode_to(encoded_request_type& encoded, http_context& /* context */) const
+  -> std::error_code
 {
   encoded.method = "POST";
   encoded.path = fmt::format("/pools/default/buckets/{}/scopes",
@@ -41,18 +39,19 @@ scope_create_request::encode_to(encoded_request_type& encoded,
 }
 
 auto
-scope_create_request::make_response(error_context::http&& ctx, const encoded_response_type& encoded)
-  const -> scope_create_response
+scope_create_request::make_response(error_context::http&& ctx,
+                                    const encoded_response_type& encoded) const
+  -> scope_create_response
 {
   scope_create_response response{ std::move(ctx) };
   if (!response.ctx.ec) {
-    switch (encoded.status_code) {
+    switch (const auto& body = encoded.body.data(); encoded.status_code) {
       case 400: {
-        const std::regex scope_exists("Scope with name .+ already exists");
-        if (std::regex_search(encoded.body.data(), scope_exists)) {
+        const auto prefix_pos = body.find("Scope with name ");
+        if (prefix_pos != std::string_view::npos &&
+            body.find(" already exists", prefix_pos) != std::string_view::npos) {
           response.ctx.ec = errc::management::scope_exists;
-        } else if (encoded.body.data().find("Not allowed on this version of cluster") !=
-                   std::string::npos) {
+        } else if (body.find("Not allowed on this version of cluster") != std::string::npos) {
           response.ctx.ec = errc::common::feature_not_available;
         } else {
           response.ctx.ec = errc::common::invalid_argument;
@@ -64,7 +63,7 @@ scope_create_request::make_response(error_context::http&& ctx, const encoded_res
       case 200: {
         tao::json::value payload{};
         try {
-          payload = utils::json::parse(encoded.body.data());
+          payload = utils::json::parse(body);
         } catch (const tao::pegtl::parse_error&) {
           response.ctx.ec = errc::common::parsing_failure;
           return response;
@@ -72,7 +71,7 @@ scope_create_request::make_response(error_context::http&& ctx, const encoded_res
         response.uid = std::stoull(payload.at("uid").get_string(), nullptr, 16);
       } break;
       default:
-        response.ctx.ec = extract_common_error_code(encoded.status_code, encoded.body.data());
+        response.ctx.ec = extract_common_error_code(encoded.status_code, body);
         break;
     }
   }

--- a/core/operations/management/scope_drop.cxx
+++ b/core/operations/management/scope_drop.cxx
@@ -24,13 +24,11 @@
 #include <spdlog/fmt/bundled/core.h>
 #include <tao/json/value.hpp>
 
-#include <regex>
-
 namespace couchbase::core::operations::management
 {
 auto
-scope_drop_request::encode_to(encoded_request_type& encoded,
-                              http_context& /* context */) const -> std::error_code
+scope_drop_request::encode_to(encoded_request_type& encoded, http_context& /* context */) const
+  -> std::error_code
 {
   encoded.method = "DELETE";
   encoded.path = fmt::format("/pools/default/buckets/{}/scopes/{}",
@@ -45,13 +43,14 @@ scope_drop_request::make_response(error_context::http&& ctx,
 {
   scope_drop_response response{ std::move(ctx) };
   if (!response.ctx.ec) {
-    switch (encoded.status_code) {
+    switch (const auto& body = encoded.body.data(); encoded.status_code) {
       case 400:
         response.ctx.ec = errc::common::unsupported_operation;
         break;
       case 404: {
-        const std::regex scope_not_found("Scope with name .+ is not found");
-        if (std::regex_search(encoded.body.data(), scope_not_found)) {
+        const auto prefix_pos = body.find("Scope with name ");
+        if (prefix_pos != std::string_view::npos &&
+            body.find(" is not found", prefix_pos) != std::string_view::npos) {
           response.ctx.ec = errc::common::scope_not_found;
         } else {
           response.ctx.ec = errc::common::bucket_not_found;
@@ -60,7 +59,7 @@ scope_drop_request::make_response(error_context::http&& ctx,
       case 200: {
         tao::json::value payload{};
         try {
-          payload = utils::json::parse(encoded.body.data());
+          payload = utils::json::parse(body);
         } catch (const tao::pegtl::parse_error&) {
           response.ctx.ec = errc::common::parsing_failure;
           return response;
@@ -68,7 +67,7 @@ scope_drop_request::make_response(error_context::http&& ctx,
         response.uid = std::stoull(payload.at("uid").get_string(), nullptr, 16);
       } break;
       default:
-        response.ctx.ec = extract_common_error_code(encoded.status_code, encoded.body.data());
+        response.ctx.ec = extract_common_error_code(encoded.status_code, body);
         break;
     }
   }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,6 +42,7 @@ unit_test(logger)
 unit_test(crypto)
 unit_test(orphan_reporter)
 unit_test(node_id)
+unit_test(management_collection)
 target_link_libraries(test_unit_jsonsl PRIVATE jsonsl)
 
 integration_benchmark(get)

--- a/test/test_unit_management_collection.cxx
+++ b/test/test_unit_management_collection.cxx
@@ -1,0 +1,135 @@
+#include "test_helper.hxx"
+
+#include "core/error_context/http.hxx"
+#include "core/io/http_message.hxx"
+#include "core/operations/management/collection_create.hxx"
+#include "core/operations/management/collection_drop.hxx"
+#include "core/operations/management/collection_update.hxx"
+#include "core/operations/management/scope_create.hxx"
+#include "core/operations/management/scope_drop.hxx"
+
+#include <couchbase/error_codes.hxx>
+
+namespace
+{
+auto
+make_encoded(std::uint32_t status, std::string body) -> couchbase::core::io::http_response
+{
+  couchbase::core::io::http_response encoded{};
+  encoded.status_code = status;
+  encoded.body.append(body);
+  return encoded;
+}
+} // namespace
+
+TEST_CASE("unit: collection_create::make_response error mapping", "[unit]")
+{
+  using couchbase::core::operations::management::collection_create_request;
+  collection_create_request req{ "default", "_default", "c1" };
+
+  SECTION("404 'Scope with name X is not found' -> scope_not_found")
+  {
+    auto encoded = make_encoded(404, "Scope with name `myscope` is not found in bucket `default`");
+    CHECK(req.make_response({}, encoded).ctx.ec == couchbase::errc::common::scope_not_found);
+  }
+  SECTION("404 'Bucket ... is not found' -> bucket_not_found (NOT scope_not_found)")
+  {
+    auto encoded = make_encoded(404, "Bucket with name `nope` is not found");
+    CHECK(req.make_response({}, encoded).ctx.ec == couchbase::errc::common::bucket_not_found);
+  }
+  SECTION("400 'Collection with name X already exists' -> collection_exists")
+  {
+    auto encoded =
+      make_encoded(400, "Collection with name `c1` already exists in scope `_default`");
+    CHECK(req.make_response({}, encoded).ctx.ec == couchbase::errc::management::collection_exists);
+  }
+  SECTION("400 unrelated body -> invalid_argument")
+  {
+    auto encoded = make_encoded(400, "name - max length (251) exceeded");
+    CHECK(req.make_response({}, encoded).ctx.ec == couchbase::errc::common::invalid_argument);
+  }
+}
+
+TEST_CASE("unit: scope_drop::make_response error mapping", "[unit]")
+{
+  using couchbase::core::operations::management::scope_drop_request;
+  scope_drop_request req{ "default", "myscope" };
+
+  SECTION("404 'Scope with name X is not found' -> scope_not_found")
+  {
+    auto encoded = make_encoded(404, "Scope with name `myscope` is not found in bucket `default`");
+    CHECK(req.make_response({}, encoded).ctx.ec == couchbase::errc::common::scope_not_found);
+  }
+  SECTION("404 'Bucket ... is not found' -> bucket_not_found (NOT scope_not_found)")
+  {
+    auto encoded = make_encoded(404, "Bucket with name `nope` is not found");
+    CHECK(req.make_response({}, encoded).ctx.ec == couchbase::errc::common::bucket_not_found);
+  }
+}
+
+TEST_CASE("unit: scope_create::make_response error mapping", "[unit]")
+{
+  using couchbase::core::operations::management::scope_create_request;
+  scope_create_request req{ "default", "myscope" };
+
+  SECTION("400 'Scope with name X already exists' -> scope_exists")
+  {
+    auto encoded =
+      make_encoded(400, "Scope with name `myscope` already exists in bucket `default`");
+    CHECK(req.make_response({}, encoded).ctx.ec == couchbase::errc::management::scope_exists);
+  }
+  SECTION("400 'Not allowed on this version of cluster' -> feature_not_available")
+  {
+    auto encoded = make_encoded(400, "Not allowed on this version of cluster");
+    CHECK(req.make_response({}, encoded).ctx.ec == couchbase::errc::common::feature_not_available);
+  }
+  SECTION("400 unrelated body -> invalid_argument")
+  {
+    auto encoded = make_encoded(400, "name - max length (251) exceeded");
+    CHECK(req.make_response({}, encoded).ctx.ec == couchbase::errc::common::invalid_argument);
+  }
+}
+
+TEST_CASE("unit: collection_drop::make_response error mapping", "[unit]")
+{
+  using couchbase::core::operations::management::collection_drop_request;
+  collection_drop_request req{ "default", "_default", "c1" };
+
+  SECTION("404 'Collection with name' -> collection_not_found")
+  {
+    auto encoded = make_encoded(404, "Collection with name `c1` is not found in scope `_default`");
+    CHECK(req.make_response({}, encoded).ctx.ec == couchbase::errc::common::collection_not_found);
+  }
+  SECTION("404 'Scope with name' -> scope_not_found")
+  {
+    auto encoded = make_encoded(404, "Scope with name `nope` is not found in bucket `default`");
+    CHECK(req.make_response({}, encoded).ctx.ec == couchbase::errc::common::scope_not_found);
+  }
+  SECTION("404 'Bucket ...' -> bucket_not_found")
+  {
+    auto encoded = make_encoded(404, "Bucket with name `default` is not found");
+    CHECK(req.make_response({}, encoded).ctx.ec == couchbase::errc::common::bucket_not_found);
+  }
+}
+
+TEST_CASE("unit: collection_update::make_response error mapping", "[unit]")
+{
+  using couchbase::core::operations::management::collection_update_request;
+  collection_update_request req{ "default", "_default", "c1" };
+
+  SECTION("404 'Collection with name' -> collection_not_found")
+  {
+    auto encoded = make_encoded(404, "Collection with name `c1` is not found in scope `_default`");
+    CHECK(req.make_response({}, encoded).ctx.ec == couchbase::errc::common::collection_not_found);
+  }
+  SECTION("404 'Scope with name' -> scope_not_found")
+  {
+    auto encoded = make_encoded(404, "Scope with name `nope` is not found in bucket `default`");
+    CHECK(req.make_response({}, encoded).ctx.ec == couchbase::errc::common::scope_not_found);
+  }
+  SECTION("404 'Bucket ...' -> bucket_not_found")
+  {
+    auto encoded = make_encoded(404, "Bucket with name `default` is not found");
+    CHECK(req.make_response({}, encoded).ctx.ec == couchbase::errc::common::bucket_not_found);
+  }
+}


### PR DESCRIPTION
Changes
--------
* Replace inline `std::regex` construction w/ `std::string::find()` in collection/scope mgmt operations where possible
* Make `std::regex` objects `static const` in query_index_create/drop and error_utils where case-insensitive matching is required