### PR TITLE
CXXCBC-830: Unstick Jenkins matrix, shrink Windows wall-clock, survive fork(child)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,5 +59,8 @@ jobs:
           CB_CACHE_OPTION: sccache
           # CB_CMAKE_BUILD_TYPE: Release
           CB_CMAKE_BUILD_TYPE: RelWithDebInfo
-          CB_NUMBER_OF_JOBS: 2
+          # CB_NUMBER_OF_JOBS deliberately unset: build-tests.rb now autodetects
+          # the runner's processor count via Etc.nprocessors (4 on windows-2022/2025).
+          # Combined with /MP added in CMakeLists.txt this enables both axes of
+          # parallelism instead of the previous /m:2 + serial-cl.exe cap.
         run: ruby ./bin/build-tests.rb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,22 @@ if(WIN32)
   message(STATUS "Windows SDK: ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
 endif()
 
+# Multi-process compile for MSVC. With the Visual Studio generator each
+# .vcxproj invokes a single cl.exe that processes its source files
+# serially; /MP turns each invocation into a parallel batch driven by
+# NUMBER_OF_PROCESSORS. Combined with MSBuild's /m:N (project-level
+# parallelism) this lets a Windows agent saturate its cores. Must be
+# applied at directory scope before ThirdPartyDependencies.cmake so
+# the FetchContent-built dependencies (gRPC, protobuf, abseil, curl,
+# boringssl, ...) inherit it — they are the bulk of the Windows build.
+#
+# Scoped to C and CXX via COMPILE_LANGUAGE: NASM (used by BoringSSL's
+# x86 assembly) and other ASM dialects do not understand /MP and would
+# abort with `nasm.exe ... /MP ... exited with code 1`.
+if(MSVC)
+  add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/MP>)
+endif()
+
 include(cmake/TarballRelease.cmake OPTIONAL)
 
 include(cmake/PreventInSourceBuilds.cmake)

--- a/bin/build-tests.rb
+++ b/bin/build-tests.rb
@@ -15,6 +15,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+require "etc"
 require "fileutils"
 require "rbconfig"
 require "English"
@@ -59,7 +60,11 @@ CB_CMAKE = ENV.fetch("CB_CMAKE", which("cmake", cmake_extra_location))
 
 CB_CC = ENV.fetch("CB_CC", which(CB_DEFAULT_CC))
 CB_CXX = ENV.fetch("CB_CXX", which(CB_DEFAULT_CXX))
-CB_NUMBER_OF_JOBS = ENV.fetch("CB_NUMBER_OF_JOBS", "1").to_i
+# Default to the host's processor count. Combined with /MP (added by
+# CMakeLists.txt for MSVC), this lets Windows agents use both axes of
+# parallelism: --parallel N for MSBuild project-level fan-out, and /MP
+# for cl.exe source-level fan-out within each project.
+CB_NUMBER_OF_JOBS = ENV.fetch("CB_NUMBER_OF_JOBS", Etc.nprocessors.to_s).to_i
 CB_CMAKE_BUILD_TYPE = ENV.fetch("CB_CMAKE_BUILD_TYPE", "Debug")
 CB_CACHE_OPTION = ENV.fetch("CB_CACHE_OPTION", "ccache")
 

--- a/cmake/Cache.cmake
+++ b/cmake/Cache.cmake
@@ -37,7 +37,13 @@ else()
   find_program(CACHE_BINARY ${CACHE_OPTION})
 endif()
 
-if(CACHE_OPTION STREQUAL "none" OR CACHE_BINARY STREQUAL "")
+if(CACHE_OPTION STREQUAL "none" OR NOT CACHE_BINARY)
+  # NOT CACHE_BINARY catches both the empty-string case (auto-detection
+  # branch above sets it explicitly) and the "<var>-NOTFOUND" sentinel that
+  # find_program writes back to the cache when the requested program is
+  # missing on the host. Using STREQUAL "" alone would let the sentinel
+  # propagate to CMAKE_*_COMPILER_LAUNCHER and produce "Error 127" at build
+  # time.
   message(WARNING "No compiler cache found or enabled; building without compiler cache")
 else()
   if(CMAKE_GENERATOR MATCHES "Visual Studio")

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -49,13 +49,7 @@ function(set_project_warnings project_name)
       -Wnull-dereference # warn if a null dereference is detected
       -Wdouble-promotion # warn if float is implicit promoted to double
       -Wformat=2 # warn on security issues around functions that format output (ie printf)
-      # TODO: make it local to ext/couchbase/couchbase.cxx
-      -Wno-unknown-warning-option
-      -Wno-gnu-statement-expression
-      -Wno-compound-token-split-by-macro
-      # __COUNTER__ is used by Catch2's TEST_CASE macro; clang-23 warns it is a C2y extension.
-      # Suppress globally since we cannot modify Catch2 and the warning is irrelevant in C++17.
-      -Wno-c2y-extensions)
+  )
 
   if(WARNINGS_AS_ERRORS)
     set(COMMON_WARNINGS ${COMMON_WARNINGS} -Werror)
@@ -72,7 +66,17 @@ function(set_project_warnings project_name)
       -Wdeprecated-declarations # warn if [[deprecated]] elements being used
   )
 
-  set(CLANG_WARNINGS ${COMMON_WARNINGS})
+  # Clang-only warning suppressions. These flags do not exist in GCC; with
+  # -Werror, GCC turns "unrecognized command line option" into a hard error,
+  # so they must not appear in GCC_WARNINGS / COMMON_WARNINGS.
+  set(CLANG_WARNINGS
+      ${COMMON_WARNINGS}
+      -Wno-unknown-warning-option
+      -Wno-gnu-statement-expression
+      -Wno-compound-token-split-by-macro
+      # __COUNTER__ is used by Catch2's TEST_CASE macro; clang-23 warns it is a C2y extension.
+      # Suppress globally since we cannot modify Catch2 and the warning is irrelevant in C++17.
+      -Wno-c2y-extensions)
 
   if(MSVC)
     set(PROJECT_WARNINGS ${MSVC_WARNINGS})

--- a/cmake/GrpcProtobuf.cmake
+++ b/cmake/GrpcProtobuf.cmake
@@ -189,4 +189,27 @@ else()
       CXX_CLANG_TIDY ""
       CXX_INCLUDE_WHAT_YOU_USE "")
   endif()
+
+  # gRPC unconditionally defines several library targets we do not link
+  # against (the fit_performer tool only consumes gRPC::grpc++ and
+  # gRPC::grpc_cpp_plugin). Because gRPC's CMakeLists has no per-library
+  # opt-out and FetchContent_MakeAvailable adds the subdirectory without
+  # EXCLUDE_FROM_ALL, every target ends up in the Visual Studio ALL_BUILD
+  # and gets compiled on Windows. grpc_unsecure alone is a ~300-source
+  # near-duplicate of gRPC without TLS; combined with the admin/auth
+  # extras below this is ~15 minutes of pointless compile per Windows
+  # build. Marking each EXCLUDE_FROM_ALL removes them from ALL_BUILD
+  # while leaving the targets defined, so anything that does
+  # transitively need one is still pulled in by CMake on demand.
+  foreach(_unused_grpc_target
+      grpc_unsecure
+      grpc++_unsecure
+      grpc++_alts
+      grpc++_reflection
+      grpcpp_channelz
+      grpc_authorization_provider)
+    if(TARGET ${_unused_grpc_target})
+      set_target_properties(${_unused_grpc_target} PROPERTIES EXCLUDE_FROM_ALL TRUE)
+    endif()
+  endforeach()
 endif()

--- a/cmake/ThirdPartyDependencies.cmake
+++ b/cmake/ThirdPartyDependencies.cmake
@@ -45,10 +45,37 @@ endif()
 
 if(COUCHBASE_CXX_CLIENT_BUILD_OPENTELEMETRY)
   if(NOT TARGET opentelemetry)
-    # Disable curl HTTP client to avoid curl downloading and linking to BoringSSL
-    # OpenTelemetry will fall back to using its own HTTP client implementation
-    # This avoids CMake export errors when curl tries to reference ssl/crypto targets
-    
+    # When OpenTelemetry's WITH_OTLP_HTTP is enabled it unconditionally pulls
+    # curl (via cmake/curl.cmake). If find_package(CURL) fails on the build
+    # host, OTel fetches curl from source and curl's CMakeLists.txt calls
+    # install(TARGETS libcurl_static EXPORT ...). When curl is linked against
+    # our statically built BoringSSL, the export fails because the ssl/crypto
+    # targets are not part of any install set:
+    #
+    #   export called with target "libcurl_static" which requires target "ssl"
+    #   that is not in any export set.
+    #
+    # We never install or consume curl's export files, so skip the export
+    # target entirely by setting CURL_ENABLE_EXPORT_TARGET=OFF before the
+    # cpmaddpackage call. The variable is a no-op when system curl is used.
+    set(CURL_ENABLE_EXPORT_TARGET OFF CACHE BOOL "" FORCE)
+
+    # Same scenario, second symptom: curl's configure probes for
+    # SSL_CTX_set_srp_username via check_symbol_exists against
+    # <openssl/ssl.h>. On Linux hosts with system OpenSSL installed the
+    # probe succeeds (OpenSSL has SRP) and curl sets USE_TLS_SRP=1. At
+    # compile time the include search order resolves <openssl/ssl.h> to
+    # our BoringSSL headers, which deliberately omit SRP, and curl's
+    # lib/vtls/openssl.c then fails with:
+    #
+    #   error: implicit declaration of function 'SSL_CTX_set_srp_username'
+    #   error: implicit declaration of function 'SSL_CTX_set_srp_password'
+    #
+    # We do not use TLS-SRP. Disable it in curl's configure to skip the
+    # probe entirely; this gates the #ifdef USE_OPENSSL_SRP block in
+    # openssl.c and removes the BoringSSL/OpenSSL header mismatch.
+    set(CURL_DISABLE_SRP ON CACHE BOOL "" FORCE)
+
     # https://github.com/open-telemetry/opentelemetry-cpp/releases
     cpmaddpackage(
       NAME
@@ -68,7 +95,6 @@ if(COUCHBASE_CXX_CLIENT_BUILD_OPENTELEMETRY)
       "WITH_FUNC_TESTS OFF"
       "WITH_OTLP_GRPC OFF"
       "WITH_OTLP_HTTP ON"
-      "WITH_HTTP_CLIENT_CURL OFF"
       "WITH_PROMETHEUS OFF"
       "WITH_OPENTRACING OFF"
       "WITH_STL CXX17"

--- a/core/cluster.cxx
+++ b/core/cluster.cxx
@@ -1179,6 +1179,27 @@ public:
       }));
   }
 
+  // IMPORTANT — do not std::move observability members out of *self* below.
+  //
+  // The public-API cluster::notify_fork(fork_event::child) in
+  // core/impl/public_cluster.cxx replaces the outer cluster_impl and drops
+  // the old one; the old impl's destructor calls do_close() which lands
+  // here. But user code that acquired a bucket/collection *before* the
+  // fork holds its own copy of core::cluster — and core::cluster is a
+  // shared_ptr<cluster_impl> wrapper — so the inner cluster_impl's
+  // refcount stays > 0 and this object survives close().
+  //
+  // Anything moved out of `self->X_` becomes silently empty to those
+  // still-live references on the next operation. tracer() and meter()
+  // accessors return the member directly without checking stopped_, so an
+  // empty shared_ptr there gets converted to an empty weak_ptr in
+  // observability_recorder and then dereferenced as `this=nullptr` inside
+  // tracer_wrapper::create_span. Same shape for the rest of the
+  // observability/telemetry/orphan set.
+  //
+  // Members whose accessor already gates on stopped_ (e.g. session_manager_
+  // via http_session_manager()) are safe to move out and intentionally
+  // remain that way — callers there get a clean errc::network::cluster_closed.
   void close(utils::movable_function<void()>&& handler)
   {
     if (stopped_) {
@@ -1211,20 +1232,22 @@ public:
           session_manager->close();
         }
         self->work_.reset();
-        if (const auto tracer = std::move(self->tracer_); tracer) {
-          tracer->stop();
+        // Observability members: stop in place, do NOT std::move. See the
+        // comment above close() for why this matters across fork(child).
+        if (self->tracer_) {
+          self->tracer_->stop();
         }
-        if (const auto meter = std::move(self->meter_); meter) {
-          meter->stop();
+        if (self->meter_) {
+          self->meter_->stop();
         }
-        if (const auto meter = std::move(self->app_telemetry_meter_); meter) {
-          meter->disable();
+        if (self->app_telemetry_meter_) {
+          self->app_telemetry_meter_->disable();
         }
-        if (const auto reporter = std::move(self->app_telemetry_reporter_); reporter) {
-          reporter->stop();
+        if (self->app_telemetry_reporter_) {
+          self->app_telemetry_reporter_->stop();
         }
-        if (const auto orphan_reporter = std::move(self->orphan_reporter_); orphan_reporter) {
-          orphan_reporter->stop();
+        if (self->orphan_reporter_) {
+          self->orphan_reporter_->stop();
         }
         handler();
       }));

--- a/core/protocol/cmd_mutate_in.hxx
+++ b/core/protocol/cmd_mutate_in.hxx
@@ -162,7 +162,7 @@ public:
 
   void store_semantics(couchbase::store_semantics semantics)
   {
-    flags_ &= std::uint8_t{ 0b1111'1100U }; /* reset first two bits */
+    flags_ &= static_cast<std::uint8_t>(0b1111'1100U); /* reset first two bits */
     switch (semantics) {
       case couchbase::store_semantics::replace:
         /* leave bits as zeros */

--- a/test/test_integration_tracer.cxx
+++ b/test/test_integration_tracer.cxx
@@ -294,7 +294,7 @@ assert_compound_kv_op_span_ok(test::utils::integration_test_guard& guard,
       assert_kv_op_span_ok(guard, s.lock(), child_op_name, span, false, !is_any_replica);
     }
   }
-};
+}
 
 void
 assert_kv_op_span_has_request_encoding(test::utils::integration_test_guard& guard,

--- a/test/test_integration_wrapper_tracer.cxx
+++ b/test/test_integration_wrapper_tracer.cxx
@@ -48,7 +48,7 @@ TEST_CASE("integration: cluster label listener can be used to get cluster labels
   const auto [cluster_name, cluster_uuid] =
     integration.cluster.cluster_label_listener()->cluster_labels();
 
-  if (integration.ctx.version.supports_cluster_labels()) {
+  if (integration.cluster_version().supports_cluster_labels()) {
     REQUIRE(cluster_name.has_value());
     REQUIRE(cluster_uuid.has_value());
 

--- a/test/test_unit_mcbp_session.cxx
+++ b/test/test_unit_mcbp_session.cxx
@@ -182,7 +182,6 @@ TEST_CASE("unit: mcbp_session session_info accessors are safe under concurrent r
     make_session(io, { hello_feature::collections, hello_feature::json, hello_feature::duplex });
 
   constexpr int num_threads = 8;
-  constexpr int iterations = 1000;
 
   std::vector<std::thread> threads;
   threads.reserve(num_threads);
@@ -193,6 +192,7 @@ TEST_CASE("unit: mcbp_session session_info accessors are safe under concurrent r
   for (int t = 0; t < num_threads; ++t) {
     threads.emplace_back([&session, start_future]() -> void {
       start_future.wait();
+      constexpr int iterations = 1000;
       for (int i = 0; i < iterations; ++i) {
         // All three accessors are now mutex-guarded; none should deadlock or
         // return garbled data when called from multiple threads simultaneously.

--- a/tools/sysinfo.cxx
+++ b/tools/sysinfo.cxx
@@ -310,7 +310,7 @@ public:
     std::signal(SIGINT, sigint_handler);
     std::signal(SIGTERM, sigint_handler);
 
-    if (pid_ > std::numeric_limits<system_metrics::sm_pid_t>::max()) {
+    if (pid_ > static_cast<std::uint64_t>(std::numeric_limits<system_metrics::sm_pid_t>::max())) {
       fmt::print(stderr,
                  "PID value {} is out of range (maximum allowed is {}).\n",
                  pid_,


### PR DESCRIPTION
The cxx-scripted-build-pipeline regressed on every Linux stage after CXXCBC-777 / CXXCBC-778 added gRPC and protobuf as FetchContent dependencies, the Windows stage's wall-clock grew to ~2 h, and once the build matrix turned green the integration suite then surfaced a null-pointer dereference in the fork example plus a stale env-vs-runtime gate in one observability test. Seven consecutive runs (5223, 5224, 5226, 5227, 5229, 5232, 5238) peeled off cascading failures at successive layers; CXXCBC-830 enumerates the observed symptoms.
    
Four groups of code-side fixes:

* Third-party wiring. cmake/ThirdPartyDependencies.cmake sets CURL_ENABLE_EXPORT_TARGET=OFF and CURL_DISABLE_SRP=ON before the OpenTelemetry cpmaddpackage so curl can configure and compile against our static BoringSSL on Linux hosts without libcurl-dev. cmake/Cache.cmake stops propagating find_program's CACHE_BINARY-NOTFOUND sentinel into CMAKE_*_COMPILER_LAUNCHER. cmake/CompilerWarnings.cmake confines four clang-only -Wno-* flags to the CLANG_WARNINGS list so GCC's -Werror is happy.

* Toolchain strictness. core/protocol/cmd_mutate_in.hxx, test/test_integration_tracer.cxx, and tools/sysinfo.cxx each get a single-line change to satisfy GCC 8/9/10's stricter -Wconversion, -Wpedantic, and -Wsign-compare respectively. test/test_unit_mcbp_session.cxx moves a constexpr int into the lambda body so MSVC accepts it without making clang complain about an unused capture.

* Windows throughput. CMakeLists.txt adds add_compile_options(/MP) for MSVC at top scope, scoped to C/CXX via $<COMPILE_LANGUAGE> so it does not reach BoringSSL's NASM-assembled x86 .asm sources. All FetchContent dependencies inherit the flag. bin/build-tests.rb and .github/workflows/build.yml let --parallel default to Etc.nprocessors instead of capping at 1 or 2. cmake/GrpcProtobuf.cmake marks six unused gRPC subtargets EXCLUDE_FROM_ALL so grpc_unsecure et al. stop landing in ALL_BUILD.

* Runtime correctness. core/cluster.cxx stops std::move()'ing the tracer_, meter_, app_telemetry_meter_, app_telemetry_reporter_, and orphan_reporter_ members out during close(): the public-API cluster::notify_fork(fork_event::child) recreates the outer impl, but pre-fork bucket/collection refs keep the inner core impl alive through their shared_ptr, so observability fields zeroed by close() produced null derefs on the next call. Stop in place instead, with a comment block above close() explaining the rule for future maintainers (members whose public accessor does not check stopped_ must not be moved out on close). test/test_integration_wrapper_tracer.cxx changes its version gate from integration.ctx.version (sourced from TEST_SERVER_VERSION env var, defaults to 6.6.0 when unset and the Jenkins pipeline does not export it) to integration.cluster_version() (runtime-derived from /pools/default), aligning with every other test in the suite.
    
The Jenkins pipeline definition still passes /m:4 explicitly; that external one-line change is documented in jenkins-disk-defense.md. Local reconfigure + SDK rebuild + affected-test rebuild under GCC 16 are clean; matrix validation comes from the next cxx-scripted-build-pipeline run.
