### PR TITLE
[Backport] CXXCBC-829: Replace std::regex_search with utils::contains_string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -437,6 +437,7 @@ set(couchbase_cxx_client_FILES
     core/transactions/utils.cxx
     core/utils/binary.cxx
     core/utils/connection_string.cxx
+    core/utils/contains_string.cxx
     core/utils/duration_parser.cxx
     core/utils/json.cxx
     core/utils/json_streaming_lexer.cxx

--- a/core/operations/document_query.cxx
+++ b/core/operations/document_query.cxx
@@ -20,6 +20,7 @@
 #include "core/cluster_options.hxx"
 #include "core/logger/logger.hxx"
 #include "core/operations/management/error_utils.hxx"
+#include "core/utils/contains_string.hxx"
 #include "core/utils/duration_parser.hxx"
 #include "core/utils/json.hxx"
 
@@ -28,13 +29,11 @@
 #include <gsl/assert>
 #include <tao/json/value.hpp>
 
-#include <regex>
-
 namespace couchbase::core::operations
 {
 auto
-query_request::encode_to(query_request::encoded_request_type& encoded,
-                         http_context& context) -> std::error_code
+query_request::encode_to(query_request::encoded_request_type& encoded, http_context& context)
+  -> std::error_code
 {
   ctx_.emplace(context);
   tao::json::value body{
@@ -209,8 +208,8 @@ query_request::encode_to(query_request::encoded_request_type& encoded,
 }
 
 auto
-query_request::make_response(error_context::query&& ctx,
-                             const encoded_response_type& encoded) -> query_response
+query_request::make_response(error_context::query&& ctx, const encoded_response_type& encoded)
+  -> query_response
 {
   query_response response{ std::move(ctx) };
   response.ctx.statement = statement;
@@ -374,13 +373,14 @@ query_request::make_response(error_context::query&& ctx,
             response.ctx.ec = errc::common::index_exists;
             break;
           case 5000: /* IKey: "Internal Error" */
-            if (std::regex_search(response.ctx.first_error_message,
-                                  std::regex{ ".*[iI]ndex .*already exist.*" })) {
+            if (utils::contains_string(response.ctx.first_error_message, "index", true) &&
+                utils::contains_string(response.ctx.first_error_message, "already exist", true)) {
               response.ctx.ec = errc::common::index_exists;
-            } else if (response.ctx.first_error_message.find("Index does not exist") !=
-                         std::string::npos ||
-                       std::regex_search(response.ctx.first_error_message,
-                                         std::regex{ ".*[iI]ndex .*[nN]ot [fF]ound.*" })) {
+            } else if (utils::contains_string(response.ctx.first_error_message,
+                                              "Index does not exist") ||
+                       (utils::contains_string(response.ctx.first_error_message, "index", true) &&
+                        utils::contains_string(
+                          response.ctx.first_error_message, "not found", true))) {
               response.ctx.ec = errc::common::index_not_found;
             } else if (response.ctx.first_error_message.find("Bucket Not Found") !=
                        std::string::npos) {

--- a/core/operations/management/error_utils.cxx
+++ b/core/operations/management/error_utils.cxx
@@ -16,11 +16,10 @@
  */
 
 #include "error_utils.hxx"
+#include "core/utils/contains_string.hxx"
 #include "core/utils/json.hxx"
 
 #include <tao/json/value.hpp>
-
-#include <regex>
 
 namespace couchbase::core::operations::management
 {
@@ -143,20 +142,19 @@ translate_query_error_code(std::uint64_t error, const std::string& message, std:
 {
   switch (error) {
     case 5000: /* IKey: "Internal Error" */
-    {
-      static const std::regex index_already_exists_re{ ".*[iI]ndex .*already exist.*" };
-      static const std::regex index_not_found_re{ ".*[iI]ndex .*[nN]ot [fF]ound.*" };
-      if (std::regex_search(message, index_already_exists_re)) {
+      if (utils::contains_string(message, "index", true) &&
+          utils::contains_string(message, "already exist", true)) {
         return errc::common::index_exists;
       }
-      if (message.find("Index does not exist") != std::string::npos ||
-          std::regex_search(message, index_not_found_re)) {
+      if (utils::contains_string(message, "Index does not exist") ||
+          (utils::contains_string(message, "index", true) &&
+           utils::contains_string(message, "not found", true))) {
         return errc::common::index_not_found;
       }
       if (message.find("Bucket Not Found") != std::string::npos) {
         return errc::common::bucket_not_found;
       }
-    } break;
+      break;
 
     case 12003: /* IKey: "datastore.couchbase.keyspace_not_found" */
       return errc::common::bucket_not_found;

--- a/core/operations/management/query_index_create.cxx
+++ b/core/operations/management/query_index_create.cxx
@@ -17,14 +17,13 @@
 
 #include "query_index_create.hxx"
 
+#include "core/utils/contains_string.hxx"
 #include "core/utils/json.hxx"
 #include "core/utils/keyspace.hxx"
 #include "error_utils.hxx"
 
 #include <spdlog/fmt/bundled/core.h>
 #include <tao/json/value.hpp>
-
-#include <regex>
 
 namespace couchbase::core::operations::management
 {
@@ -119,8 +118,8 @@ query_index_create_request::make_response(error_context::http&& ctx,
         switch (error.code) {
           case 5000: /* IKey: "Internal Error" */
           {
-            static const std::regex index_already_exists_re{ ".*[iI]ndex .*already exist.*" };
-            if (std::regex_search(error.message, index_already_exists_re)) {
+            if (utils::contains_string(error.message, "index", true) &&
+                utils::contains_string(error.message, "already exist", true)) {
               index_already_exists = true;
             }
             if (error.message.find("Bucket Not Found") != std::string::npos) {

--- a/core/operations/management/query_index_drop.cxx
+++ b/core/operations/management/query_index_drop.cxx
@@ -17,14 +17,13 @@
 
 #include "query_index_drop.hxx"
 
+#include "core/utils/contains_string.hxx"
 #include "core/utils/json.hxx"
 #include "core/utils/keyspace.hxx"
 #include "error_utils.hxx"
 
 #include <spdlog/fmt/bundled/core.h>
 #include <tao/json/value.hpp>
-
-#include <regex>
 
 namespace couchbase::core::operations::management
 {
@@ -88,8 +87,8 @@ query_index_drop_request::make_response(error_context::http&& ctx,
         switch (error.code) {
           case 5000: /* IKey: "Internal Error" */
           {
-            static const std::regex index_not_found_re{ ".*[iI]ndex .*[nN]ot [fF]ound.*" };
-            if (std::regex_search(error.message, index_not_found_re)) {
+            if (utils::contains_string(error.message, "index", true) &&
+                utils::contains_string(error.message, "not found", true)) {
               index_not_found = true;
             }
           } break;

--- a/core/utils/contains_string.cxx
+++ b/core/utils/contains_string.cxx
@@ -1,0 +1,61 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2021-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "contains_string.hxx"
+
+namespace couchbase::core::utils
+{
+
+namespace
+{
+constexpr auto ascii_lower = [](unsigned char c) -> unsigned char {
+  return (c >= 'A' && c <= 'Z') ? static_cast<unsigned char>(c + ('a' - 'A')) : c;
+};
+} // namespace
+
+auto
+contains_string(std::string_view input, std::string_view substr, bool ignore_case) -> bool
+{
+  if (substr.empty()) {
+    return true;
+  }
+
+  if (input.empty() || substr.size() > input.size()) {
+    return false;
+  }
+
+  if (!ignore_case) {
+    return input.find(substr) != std::string_view::npos;
+  }
+
+  const auto end = input.size() - substr.size() + 1;
+  for (std::size_t i = 0; i < end; i++) {
+    bool match = true;
+    for (std::size_t j = 0; j < substr.size(); j++) {
+      if (ascii_lower(static_cast<unsigned char>(input[i + j])) !=
+          ascii_lower(static_cast<unsigned char>(substr[j]))) {
+        match = false;
+        break;
+      }
+    }
+    if (match) {
+      return true;
+    }
+  }
+  return false;
+}
+} // namespace couchbase::core::utils

--- a/core/utils/contains_string.hxx
+++ b/core/utils/contains_string.hxx
@@ -1,0 +1,26 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2021-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <string_view>
+
+namespace couchbase::core::utils
+{
+auto
+contains_string(std::string_view input, std::string_view substr, bool ignore_case = false) -> bool;
+} // namespace couchbase::core::utils

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,7 @@ integration_test(http_session_manager)
 integration_test(node_id)
 
 unit_test(connection_string)
+unit_test(contains_string)
 unit_test(utils)
 unit_test(binary_transcoder)
 unit_test(json_transcoder)

--- a/test/test_unit_contains_string.cxx
+++ b/test/test_unit_contains_string.cxx
@@ -1,0 +1,141 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2021-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "test_helper.hxx"
+
+#include "core/utils/contains_string.hxx"
+
+TEST_CASE("unit: contains_string empty inputs", "[unit]")
+{
+  using couchbase::core::utils::contains_string;
+
+  SECTION("empty substring always matches")
+  {
+    CHECK(contains_string("", ""));
+    CHECK(contains_string("hello", ""));
+    CHECK(contains_string("", "", true));
+    CHECK(contains_string("hello", "", true));
+  }
+
+  SECTION("empty input cannot contain non-empty substring")
+  {
+    CHECK_FALSE(contains_string("", "x"));
+    CHECK_FALSE(contains_string("", "x", true));
+  }
+
+  SECTION("substring longer than input never matches")
+  {
+    CHECK_FALSE(contains_string("ab", "abc"));
+    CHECK_FALSE(contains_string("ab", "abc", true));
+  }
+}
+
+TEST_CASE("unit: contains_string case-sensitive (default)", "[unit]")
+{
+  using couchbase::core::utils::contains_string;
+
+  SECTION("exact substring is found")
+  {
+    CHECK(contains_string("Index does not exist", "Index"));
+    CHECK(contains_string("Index does not exist", "does not"));
+    CHECK(contains_string("Index does not exist", "exist"));
+  }
+
+  SECTION("differing case does not match")
+  {
+    CHECK_FALSE(contains_string("Index does not exist", "index"));
+    CHECK_FALSE(contains_string("Index does not exist", "INDEX"));
+    CHECK_FALSE(contains_string("Index does not exist", "EXIST"));
+  }
+
+  SECTION("substring equal to input matches")
+  {
+    CHECK(contains_string("Bucket Not Found", "Bucket Not Found"));
+  }
+
+  SECTION("substring at start and end")
+  {
+    CHECK(contains_string("Bucket Not Found", "Bucket"));
+    CHECK(contains_string("Bucket Not Found", "Found"));
+  }
+
+  SECTION("missing substring is not found")
+  {
+    CHECK_FALSE(contains_string("Bucket Not Found", "Scope"));
+  }
+}
+
+TEST_CASE("unit: contains_string case-insensitive", "[unit]")
+{
+  using couchbase::core::utils::contains_string;
+
+  SECTION("matches regardless of case in input or substring")
+  {
+    CHECK(contains_string("Index does not exist", "index", true));
+    CHECK(contains_string("Index does not exist", "INDEX", true));
+    CHECK(contains_string("INDEX DOES NOT EXIST", "index", true));
+    CHECK(contains_string("index does not exist", "INDEX", true));
+    CHECK(contains_string("iNdEx DoEs NoT eXiSt", "InDeX", true));
+  }
+
+  SECTION("non-letter characters are compared exactly")
+  {
+    CHECK(contains_string("Error: 404", "error: 404", true));
+    CHECK_FALSE(contains_string("Error: 404", "error: 500", true));
+  }
+
+  SECTION("only ASCII A-Z / a-z are folded")
+  {
+    // Bytes outside the ASCII letter range are compared byte-for-byte; no
+    // locale machinery is involved.
+    CHECK(contains_string("café", "CAF", true));
+    CHECK(contains_string("café", "café"));
+    CHECK_FALSE(contains_string("café", "CAFE", true));
+  }
+}
+
+TEST_CASE("unit: contains_string query error mapping patterns", "[unit]")
+{
+  // These are the substring checks that replaced the std::regex_search calls
+  // in document_query.cxx for status code 5000 ("Internal Error").
+  using couchbase::core::utils::contains_string;
+
+  SECTION("index already exists pattern")
+  {
+    const std::string msg = "GSI Index idx1 already exists.";
+    CHECK(contains_string(msg, "index", true));
+    CHECK(contains_string(msg, "already exist", true));
+  }
+
+  SECTION("index not found pattern")
+  {
+    const std::string msg = "GSI index idx1 Not Found.";
+    CHECK(contains_string(msg, "index", true));
+    CHECK(contains_string(msg, "not found", true));
+  }
+
+  SECTION("Index does not exist is matched case-sensitively")
+  {
+    CHECK(contains_string("Index does not exist", "Index does not exist"));
+  }
+
+  SECTION("Bucket Not Found is matched case-sensitively")
+  {
+    CHECK(contains_string("Bucket Not Found", "Bucket Not Found"));
+    CHECK_FALSE(contains_string("bucket not found", "Bucket Not Found"));
+  }
+}


### PR DESCRIPTION

Changes
-------
* Add `contains_string(input, substr, ignore_case = false)` substirng match with optional ASCII-only case folding, no `std::locale` dependency
* Replace remaining `std::regex_search` calls with utils::contains_string()
* Add unit tests to confirm `contains_string()` functionality