### PR TITLE
CXXCBC-838: verify TLS server hostname against the certificate (CWE-297)

### DIFF
--- a/core/app_telemetry_reporter.cxx
+++ b/core/app_telemetry_reporter.cxx
@@ -181,12 +181,13 @@ private:
     } else {
       stream_ = std::make_unique<io::plain_stream_impl>(ctx_);
     }
-    stream_->async_connect(endpoint->endpoint(), [self = shared_from_this()](auto ec) {
-      if (ec) {
-        return self->reconnect_socket(ec, "connection failure");
-      }
-      self->complete_with_success();
-    });
+    stream_->async_connect(
+      endpoint->endpoint(), address_.hostname, [self = shared_from_this()](auto ec) {
+        if (ec) {
+          return self->reconnect_socket(ec, "connection failure");
+        }
+        self->complete_with_success();
+      });
   }
 
   void resolve_address()

--- a/core/capella.hxx
+++ b/core/capella.hxx
@@ -1,0 +1,91 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include "core/tls_verify_mode.hxx"
+
+#include <cstddef>
+#include <string_view>
+
+namespace couchbase::core
+{
+/**
+ * Returns true if @p hostname is the bare "cloud.couchbase.com" or a dot-bounded
+ * subdomain of it (e.g. "cb.<tenant>.cloud.couchbase.com").
+ *
+ * The comparison is:
+ *  - anchored at the END of the string (a trailing match), so
+ *    "cloud.couchbase.com.evil.example" does NOT match;
+ *  - tolerant of a single trailing dot (the FQDN root label), so
+ *    "cloud.couchbase.com." matches -- otherwise a trailing dot would be a way
+ *    to slip a Capella host past the forced peer verification (the connection
+ *    string grammar accepts trailing dots and origin preserves them verbatim);
+ *  - dot-bounded with a non-empty leftmost label, so "mycloud.couchbase.com"
+ *    does NOT match (no '.' immediately before the suffix) and neither does the
+ *    malformed ".cloud.couchbase.com" (empty leftmost label), while the bare
+ *    domain itself does;
+ *  - ASCII case-insensitive, because DNS hostnames are case-insensitive, so
+ *    "Tenant.Cloud.Couchbase.Com" is still recognised as Capella.
+ */
+[[nodiscard]] inline auto
+is_capella_host(std::string_view hostname) -> bool
+{
+  static constexpr std::string_view suffix = "cloud.couchbase.com"; // lowercase ASCII
+  // Ignore a single trailing dot: "host.cloud.couchbase.com." is the same FQDN
+  // as the dotless form and must not be a way to bypass Capella enforcement.
+  if (!hostname.empty() && hostname.back() == '.') {
+    hostname.remove_suffix(1);
+  }
+  if (hostname.size() < suffix.size()) {
+    return false;
+  }
+  const auto offset = hostname.size() - suffix.size();
+  for (std::size_t i = 0; i < suffix.size(); ++i) {
+    auto c = hostname[offset + i];
+    if (c >= 'A' && c <= 'Z') {
+      c = static_cast<char>(c - 'A' + 'a');
+    }
+    if (c != suffix[i]) {
+      return false;
+    }
+  }
+  // Either the bare apex domain, or a dot-bounded subdomain whose '.' before the
+  // suffix is preceded by at least one label character (so the leading-dot form
+  // ".cloud.couchbase.com", with an empty leftmost label, is rejected).
+  return offset == 0 || (offset > 1 && hostname[offset - 1] == '.');
+}
+
+/**
+ * Resolve the TLS peer-verification mode that is actually applied to a
+ * connection, given the user-requested @p requested mode and whether any target
+ * host is Couchbase Capella (@p connecting_to_capella).
+ *
+ * Connections to Capella are ALWAYS peer-verified: a user-supplied
+ * tls_verify=none is ignored for Capella hosts (returning tls_verify_mode::peer)
+ * so that certificate verification cannot be silently disabled against the
+ * managed service. For every other host the requested mode is honoured verbatim.
+ */
+[[nodiscard]] inline auto
+effective_tls_verify_mode(tls_verify_mode requested, bool connecting_to_capella) -> tls_verify_mode
+{
+  if (connecting_to_capella) {
+    return tls_verify_mode::peer;
+  }
+  return requested;
+}
+} // namespace couchbase::core

--- a/core/cluster.cxx
+++ b/core/cluster.cxx
@@ -24,6 +24,7 @@
 #undef COUCHBASE_CXX_CLIENT_IGNORE_CORE_DEPRECATIONS
 
 #include "bucket.hxx"
+#include "capella.hxx"
 #include "capella_ca.hxx"
 #include "core/app_telemetry_meter.hxx"
 #include "core/app_telemetry_reporter.hxx"
@@ -174,6 +175,7 @@
 #include <asio/post.hpp>
 #include <asio/ssl/verify_mode.hpp>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstring>
@@ -334,7 +336,21 @@ public:
       tls_options |= asio::ssl::context::no_tlsv1_2; // published: 2008, still in use
     }
     ctx->set_options(tls_options);
-    switch (origin_.options().tls_verify) {
+    const auto requested_verify = origin_.options().tls_verify;
+    const auto effective_verify = effective_tls_verify_mode(requested_verify, has_capella_host);
+    if (requested_verify == tls_verify_mode::none && effective_verify == tls_verify_mode::peer) {
+      CB_LOG_WARNING(
+        "[{}]: TLS certificate verification cannot be disabled when connecting to Couchbase "
+        "Capella; enforcing peer verification (ignoring tls_verify=none).",
+        id_);
+    } else if (effective_verify == tls_verify_mode::none) {
+      CB_LOG_WARNING(
+        "[{}]: TLS certificate verification is DISABLED (tls_verify=none). The server's "
+        "identity will NOT be checked and the connection is vulnerable to interception. This "
+        "is insecure and must not be used in production.",
+        id_);
+    }
+    switch (effective_verify) {
       case tls_verify_mode::none:
         ctx->set_verify_mode(asio::ssl::verify_none);
         break;
@@ -1375,15 +1391,10 @@ private:
 
   auto has_capella_host() const -> bool
   {
-    bool has_capella_host = false;
-    static const std::string suffix = "cloud.couchbase.com";
-    for (const auto& node : origin_.get_hostnames()) {
-      if (auto pos = node.find(suffix);
-          pos != std::string::npos && pos + suffix.size() == node.size()) {
-        has_capella_host = true;
-      }
-    }
-    return has_capella_host;
+    auto hostnames = origin_.get_hostnames();
+    return std::any_of(hostnames.begin(), hostnames.end(), [](const std::string& host) {
+      return is_capella_host(host);
+    });
   }
 
   std::string id_{ uuid::to_string(uuid::random()) };

--- a/core/io/http_session.cxx
+++ b/core/io/http_session.cxx
@@ -619,8 +619,8 @@ http_session::do_connect(asio::ip::tcp::resolver::results_type::iterator it)
       });
     });
 
-    stream_->async_connect(it->endpoint(), [capture0 = shared_from_this(), it](auto&& PH1) {
-      capture0->on_connect(std::forward<decltype(PH1)>(PH1), it);
+    stream_->async_connect(it->endpoint(), hostname_, [self = shared_from_this(), it](auto&& ec) {
+      self->on_connect(std::forward<decltype(ec)>(ec), it);
     });
   } else {
     CB_LOG_ERROR("{} no more endpoints left to connect, \"{}:{}\" is not reachable",

--- a/core/io/mcbp_session.cxx
+++ b/core/io/mcbp_session.cxx
@@ -2038,9 +2038,10 @@ private:
                        self->bootstrap_port_);
           self->initiate_bootstrap();
         });
-      stream_->async_connect(it->endpoint(), [capture0 = shared_from_this(), it](auto&& PH1) {
-        capture0->on_connect(std::forward<decltype(PH1)>(PH1), it);
-      });
+      stream_->async_connect(
+        it->endpoint(), bootstrap_hostname_, [self = shared_from_this(), it](auto&& ec) {
+          self->on_connect(std::forward<decltype(ec)>(ec), it);
+        });
     } else {
       auto error_msg =
         fmt::format("no more endpoints left to connect to \"{}:{}\", will try another address",

--- a/core/io/streams.cxx
+++ b/core/io/streams.cxx
@@ -22,9 +22,57 @@
 #include <asio.hpp>
 #include <asio/error.hpp>
 #include <asio/ssl.hpp>
+#include <asio/ssl/host_name_verification.hpp>
+// ERR_get_error()/SSL_* come from the OpenSSL or BoringSSL headers pulled in by
+// <asio/ssl.hpp>; do not include <openssl/*.h> directly so the static BoringSSL
+// build (which ships its own headers) keeps working, matching core/io/mcbp_session.cxx.
 
 namespace couchbase::core::io
 {
+auto
+configure_tls_handshake(asio::ssl::stream<asio::ip::tcp::socket>& stream,
+                        const std::string& hostname) -> std::error_code
+{
+  if (hostname.empty()) {
+    // Fail closed: a TLS client connection must have a hostname to verify the
+    // server's identity against. Returning success here would silently fall back
+    // to CA-only validation -- the CWE-297 problem this function exists to prevent.
+    return asio::error::make_error_code(asio::error::invalid_argument);
+  }
+
+  // Send SNI so that name-based / multi-tenant TLS endpoints present the correct
+  // certificate for this hostname.
+  {
+    // SSL_set_tlsext_host_name() is a macro that expands to an internal C-style
+    // cast to void*, which trips -Wold-style-cast; suppress it locally.
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+    ERR_clear_error();
+    const auto sni_result = SSL_set_tlsext_host_name(stream.native_handle(), hostname.c_str());
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    if (sni_result != 1) {
+      // Prefer the underlying SSL reason (if any) so failures are diagnosable,
+      // and fall back to a generic error when the SSL error queue is empty.
+      if (const auto reason = ERR_get_error(); reason != 0) {
+        return { static_cast<int>(reason), asio::error::get_ssl_category() };
+      }
+      return asio::error::make_error_code(asio::error::invalid_argument);
+    }
+  }
+
+  // Verify that the presented certificate actually identifies `hostname`
+  // (SAN/CN). asio::ssl::verify_peer on its own only validates the certificate
+  // chain, not the name. In verify_none mode OpenSSL ignores the callback
+  // result, so this has no effect there.
+  std::error_code ec{};
+  stream.set_verify_callback(asio::ssl::host_name_verification(hostname), ec);
+  return ec;
+}
+
 stream_impl::stream_impl(asio::io_context& ctx, bool is_tls)
   : strand_(asio::make_strand(ctx))
   , tls_(is_tls)
@@ -101,6 +149,7 @@ plain_stream_impl::set_options()
 void
 plain_stream_impl::async_connect(
   const asio::ip::tcp::resolver::results_type::endpoint_type& endpoint,
+  const std::string& /* hostname */,
   utils::movable_function<void(std::error_code)>&& handler)
 {
   if (!stream_) {
@@ -199,6 +248,7 @@ tls_stream_impl::set_options()
 
 void
 tls_stream_impl::async_connect(const asio::ip::tcp::resolver::results_type::endpoint_type& endpoint,
+                               const std::string& hostname,
                                utils::movable_function<void(std::error_code)>&& handler)
 {
   if (!stream_) {
@@ -207,12 +257,22 @@ tls_stream_impl::async_connect(const asio::ip::tcp::resolver::results_type::endp
       asio::ip::tcp::socket(strand_), *tls_.get_ctx());
   }
   return stream_->lowest_layer().async_connect(
-    endpoint, [stream = stream_, handler = std::move(handler)](std::error_code ec_connect) mutable {
+    endpoint,
+    // hostname is copied into the closure (owning std::string) so the async
+    // handler does not depend on the caller's argument lifetime.
+    [stream = stream_, hostname = hostname, handler = std::move(handler)](
+      std::error_code ec_connect) mutable {
       if (ec_connect == asio::error::operation_aborted) {
         return;
       }
       if (ec_connect) {
         return handler(ec_connect);
+      }
+      // Verify the server's identity against `hostname` (SAN/CN) and set SNI
+      // before the handshake. Without this, verify_peer only checks that the
+      // certificate chains to a trusted CA, not that it identifies this host.
+      if (auto ec_identity = configure_tls_handshake(*stream, hostname); ec_identity) {
+        return handler(ec_identity);
       }
       stream->async_handshake(
         asio::ssl::stream_base::client,

--- a/core/io/streams.hxx
+++ b/core/io/streams.hxx
@@ -59,6 +59,27 @@ async_resolve(ip_protocol protocol,
   return resolver.async_resolve(hostname, service, std::forward<Handler>(handler));
 }
 
+/**
+ * Configure server-identity verification on a client TLS stream prior to the
+ * handshake: install a hostname (SAN/CN) verification callback and set the SNI
+ * server name. When the underlying context is in verify_none mode the callback
+ * has no effect, but SNI is still set.
+ *
+ * Without this, asio::ssl::verify_peer only validates that the certificate
+ * chains to a trusted CA -- it does NOT check that the certificate identifies
+ * the host being contacted (CWE-297).
+ *
+ * @param stream the client TLS stream that has connected but not yet handshaken
+ * @param hostname the canonical hostname the caller intended to reach; must not
+ * be empty (an empty hostname is rejected to avoid silently falling back to
+ * CA-only validation)
+ * @return a non-empty error_code if the hostname is empty, SNI could not be set,
+ * or the hostname-verification callback could not be installed; empty on success
+ */
+[[nodiscard]] auto
+configure_tls_handshake(asio::ssl::stream<asio::ip::tcp::socket>& stream,
+                        const std::string& hostname) -> std::error_code;
+
 class stream_impl
 {
 protected:
@@ -88,7 +109,10 @@ public:
 
   virtual void set_options() = 0;
 
+  // `hostname` is the canonical name the caller intends to reach; TLS streams use
+  // it to verify the server certificate's identity (SAN/CN) and to set SNI.
   virtual void async_connect(const asio::ip::tcp::resolver::results_type::endpoint_type& endpoint,
+                             const std::string& hostname,
                              utils::movable_function<void(std::error_code)>&& handler) = 0;
 
   virtual void async_write(
@@ -117,6 +141,7 @@ public:
   void set_options() override;
 
   void async_connect(const asio::ip::tcp::resolver::results_type::endpoint_type& endpoint,
+                     const std::string& hostname,
                      utils::movable_function<void(std::error_code)>&& handler) override;
 
   void async_write(std::vector<asio::const_buffer>& buffers,
@@ -145,6 +170,7 @@ public:
   void set_options() override;
 
   void async_connect(const asio::ip::tcp::resolver::results_type::endpoint_type& endpoint,
+                     const std::string& hostname,
                      utils::movable_function<void(std::error_code)>&& handler) override;
 
   void async_write(std::vector<asio::const_buffer>& buffers,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,8 @@ integration_test(management_search_index)
 integration_test(http_session_manager)
 
 unit_test(connection_string)
+unit_test(capella)
+unit_test(tls_hostname_verification)
 unit_test(protocol_status)
 unit_test(utils)
 unit_test(binary_transcoder)

--- a/test/test_unit_capella.cxx
+++ b/test/test_unit_capella.cxx
@@ -1,0 +1,86 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "test_helper.hxx"
+
+#include "core/capella.hxx"
+#include "core/tls_verify_mode.hxx"
+
+TEST_CASE("unit: is_capella_host recognises Couchbase Capella hostnames", "[unit]")
+{
+  using couchbase::core::is_capella_host;
+
+  SECTION("Capella hosts are recognised")
+  {
+    // A typical Capella connection string host and the bare apex domain.
+    CHECK(is_capella_host("cb.abcdefghij.cloud.couchbase.com"));
+    CHECK(is_capella_host("cloud.couchbase.com"));
+    // Deeper subdomains are still dot-bounded matches.
+    CHECK(is_capella_host("a.b.c.cloud.couchbase.com"));
+    // DNS hostnames are case-insensitive, so any casing is accepted.
+    CHECK(is_capella_host("Tenant.Cloud.Couchbase.Com"));
+    CHECK(is_capella_host("CLOUD.COUCHBASE.COM"));
+    CHECK(is_capella_host("cb.ABCDEF.Cloud.Couchbase.COM"));
+    // The suffix appearing more than once must still be detected at the end.
+    CHECK(is_capella_host("x.cloud.couchbase.com.cloud.couchbase.com"));
+    // A single trailing dot (the FQDN root label) must not be a bypass.
+    CHECK(is_capella_host("cloud.couchbase.com."));
+    CHECK(is_capella_host("cb.abcdefghij.cloud.couchbase.com."));
+  }
+
+  SECTION("look-alike and unrelated hosts are NOT treated as Capella")
+  {
+    // No dot boundary before the suffix: a different registrable name.
+    CHECK_FALSE(is_capella_host("mycloud.couchbase.com"));
+    CHECK_FALSE(is_capella_host("evilcloud.couchbase.com"));
+    CHECK_FALSE(is_capella_host("xcloud.couchbase.com"));
+    // The suffix is present but not at the end (left-anchored attack).
+    CHECK_FALSE(is_capella_host("cloud.couchbase.com.evil.example"));
+    // A trailing dot after a non-suffix is still not Capella.
+    CHECK_FALSE(is_capella_host("cloud.couchbase.com.evil.example."));
+    // Plain Couchbase / unrelated domains.
+    CHECK_FALSE(is_capella_host("couchbase.com"));
+    CHECK_FALSE(is_capella_host("example.com"));
+    CHECK_FALSE(is_capella_host("localhost"));
+    CHECK_FALSE(is_capella_host("127.0.0.1"));
+    // Degenerate inputs must not match or crash.
+    CHECK_FALSE(is_capella_host(""));
+    CHECK_FALSE(is_capella_host("."));
+    CHECK_FALSE(is_capella_host("cloud.couchbase.co"));  // shorter than the suffix
+    CHECK_FALSE(is_capella_host(".cloud.couchbase.co")); // suffix off by one char
+    CHECK_FALSE(is_capella_host(".cloud.couchbase.com"));
+  }
+}
+
+TEST_CASE("unit: effective_tls_verify_mode enforces peer verification for Capella", "[unit]")
+{
+  using couchbase::core::effective_tls_verify_mode;
+  using couchbase::core::tls_verify_mode;
+
+  SECTION("non-Capella hosts honour the requested mode")
+  {
+    CHECK(effective_tls_verify_mode(tls_verify_mode::peer, false) == tls_verify_mode::peer);
+    CHECK(effective_tls_verify_mode(tls_verify_mode::none, false) == tls_verify_mode::none);
+  }
+
+  SECTION("Capella hosts are always peer-verified, even when none is requested")
+  {
+    CHECK(effective_tls_verify_mode(tls_verify_mode::peer, true) == tls_verify_mode::peer);
+    // The security-relevant case: a requested tls_verify=none is overridden.
+    CHECK(effective_tls_verify_mode(tls_verify_mode::none, true) == tls_verify_mode::peer);
+  }
+}

--- a/test/test_unit_tls_hostname_verification.cxx
+++ b/test/test_unit_tls_hostname_verification.cxx
@@ -1,0 +1,211 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "test_helper.hxx"
+
+#include "core/io/streams.hxx"
+#include "core/tls_context_provider.hxx"
+#include "core/tls_verify_mode.hxx"
+
+#include <asio/io_context.hpp>
+#include <asio/ip/tcp.hpp>
+#include <asio/ssl.hpp>
+
+#include <cstring>
+#include <memory>
+#include <string>
+
+namespace
+{
+// Self-signed certificate (also acts as its own trust anchor) whose only
+// subjectAltName is DNS:correct.example. Test fixture only. The validity window
+// is deliberately very wide (2000-2099) so the test does not depend on the wall
+// clock or fail on machines with skewed clocks.
+constexpr const char* server_cert = R"(-----BEGIN CERTIFICATE-----
+MIIDMzCCAhugAwIBAgIULstz/HoRnjCkbtarc8M1y1COtUwwDQYJKoZIhvcNAQEL
+BQAwGjEYMBYGA1UEAwwPY29ycmVjdC5leGFtcGxlMCAXDTAwMDEwMTAwMDAwMFoY
+DzIwOTkxMjMxMjM1OTU5WjAaMRgwFgYDVQQDDA9jb3JyZWN0LmV4YW1wbGUwggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDjVLUmfrjLbEiWOR9p4WrGmjdo
+cXLYy01I1Dkcw50pPEtg2lTlgZ2ctB9mlHdborFOQwdSP8KRA5TZCHc793IcICrS
+sG2OESAsbVwYWpJH5vB+bGJqvM3xAOBjsEH1UkIv1+yDjnZ54XOQv/6C2YQHj7xS
+Kd7xCuNmoUfyli8MI/gocOtnWoCW1vwaUs2BYO3cvbuNmvWjadYWFn++1gQKek5X
++z920+sM7mP1/3rZAyooFhdVhFkzJBfy176kRS6/9XUF5iHWEi42nZ7XnUubKwFn
+NI0fgvdXtkMfans1pTOyN/Zzq6Lf2MgrFOt7rq/KCCwaSqht1949W0kgqccZAgMB
+AAGjbzBtMB0GA1UdDgQWBBRXenifLMKCVfYbArW04sssiF3q2zAfBgNVHSMEGDAW
+gBRXenifLMKCVfYbArW04sssiF3q2zAaBgNVHREEEzARgg9jb3JyZWN0LmV4YW1w
+bGUwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAfr/eT84yqwPD
+Xa7IthMFUkqmUBVOqjOMaNvgUVS33DEHsseke8HJkT9nKMcmxzEHXiqeRxwjVDcV
+TDnEOC5MQs9eOwATU4ZNyAYsCxwf1jgqiyX3kKqjVriB5B1JdfWcxfTldpEkcsNM
+Z5bm5K2QndhCidFK4/zAZF3p4FxlY6J2G22QI3WDER3sA6lt/IiUYM/N3wb8rlG8
+b1PzHPsHE437O5L5RuZt51DXxEcIUrv8oTIg/4kkzbD7sQVN59myt4n+ef2+5MDs
+RhdSXCpuXr04sNbyw//wxf53l4/qTj2lJ4EQZqDPckxKhtIyM2C2z6ju+M6DXknn
+omL1F449Qw==
+-----END CERTIFICATE-----
+)";
+
+constexpr const char* server_key = R"(-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDjVLUmfrjLbEiW
+OR9p4WrGmjdocXLYy01I1Dkcw50pPEtg2lTlgZ2ctB9mlHdborFOQwdSP8KRA5TZ
+CHc793IcICrSsG2OESAsbVwYWpJH5vB+bGJqvM3xAOBjsEH1UkIv1+yDjnZ54XOQ
+v/6C2YQHj7xSKd7xCuNmoUfyli8MI/gocOtnWoCW1vwaUs2BYO3cvbuNmvWjadYW
+Fn++1gQKek5X+z920+sM7mP1/3rZAyooFhdVhFkzJBfy176kRS6/9XUF5iHWEi42
+nZ7XnUubKwFnNI0fgvdXtkMfans1pTOyN/Zzq6Lf2MgrFOt7rq/KCCwaSqht1949
+W0kgqccZAgMBAAECggEALqys790rVGrkYWGTk1HqsiGmOC242o2tTcNzAXahTT7Z
+rCZPsXqCEZNC8jUP55LZDBxDg83fBRai6EeucXO97EvndvAt4jIedLi0ZLSt3ZDr
+Nk3LDCa9MtsO9zDQbg3IVJnk7+LfbOlO6LyexR9jVgkbLZR2t29YnrEE/Gf8+2UB
+EhVSHxzVzhi7ajx/Fv3xkLavnrgxSarTcSl4Hp9YVI6LS0GAxnUbT9qsEQRoCVFk
+j6NkEoQdUn820WCAO9bxIvEgO9mGfnr7ylNaKi71opUGBXFhnnyqpwVceWd1kaWD
+qBemnLN5vCTMIlpu3S33zNOKVedAVIa/kafkaoUnPQKBgQD6+X/1ApargGDYBHxI
+08+gfhJqDjrMn0gfNbKngAHzH+/VfljWDPm9e9WLSDea0t8+piGmwP4iBHwy/nIQ
+vbKqjlR99Gj24Pkvmq0FZ1ou9FjtZGXV7aNMG6kshbKPegP1EII5bwHYZMJiaKIq
+ckzCCbSK66Qm/WXWt2ul/0K+tQKBgQDn4gJ55KY2JY/n4VlJkkBX9/rhcyB7eXy7
+86ZsWKfrMNn0BOWpM45lHxj9mAfT5B1n9NmFCfbL1aGCl46a/N8VkY3hHkm9leGN
+68gaqaA65XfOSKa7krnn3V3YmyzWMvISnou9phxIJAvH5OIAIJKl8Hkp20GJ3e9G
+qlFoMRLBVQKBgEKmF3D9av3Ibe9v4YGFnlHEqSc4+Cx28DQ5kmQg/mOOS6aqkvTl
+JT1IsYD3gKzA60A75hvejJ6ECmeQYsJHXjck7RM14NoPDJ2zudcBh1WI1kTUsKaL
+IR6JCfgk2TJ4+KwP4kVWUWsh9u0jVE1pZTDyWtu5kDI6gNzwgMnoa9UxAoGAZFjJ
+K4jIaPw+V2GM6yqwT6FP34qbzvNXCFs7dP20xTHh0BjibiOShq47eVr2YDsCgr9R
+9qHGPJWZjFMb8nRl8gaIOJiL3tBiyLD1apxna7Vr8Eg+Z0Pq0a1ZdGhKsfNgELCt
+1odxC8MVmg6xws5VyBvVw0hQB2KUrqb8DbPW4vUCgYBicTMwPN2th81I9gv/QKA/
+OZwqMcnMUzqGRQ1fyr7rWxnw1WkO7y0x8za2U8c9APB2CYM9g5ubDc203DzB1pwM
+/VSERuhUdAzadRW9ax5En7eWUP/ZSvT0qee0B0LrjCbXF/L8uBc5Ia4eIS0eeIKK
++pMEQRYQWT9SSDMZtw1VbQ==
+-----END PRIVATE KEY-----
+)";
+
+struct handshake_outcome {
+  std::error_code client; // client-side handshake result (the behaviour under test)
+  std::error_code server; // server-side handshake result (for cross-checking)
+};
+
+// Drives a real loopback TLS handshake through the production client stream,
+// couchbase::core::io::tls_stream_impl. The client trusts the (correct) server
+// certificate and is configured with `verify_mode`; tls_stream_impl::async_connect()
+// is then asked to reach `request_hostname`, which is the method that wires in
+// SNI and server-identity (SAN/CN) verification before handshaking.
+//
+// The server side is plain Asio because the SDK only implements the TLS client.
+//
+// With tls_verify_mode::peer, a `request_hostname` that does not match the
+// certificate SAN (DNS:correct.example) MUST cause the client handshake to fail
+// (and, as a consequence, the server handshake too). With tls_verify_mode::none,
+// verification is disabled and even a mismatched hostname MUST complete.
+auto
+handshake_with_hostname(const std::string& request_hostname,
+                        couchbase::core::tls_verify_mode verify_mode =
+                          couchbase::core::tls_verify_mode::peer) -> handshake_outcome
+{
+  asio::io_context io;
+
+  asio::ssl::context server_ctx{ asio::ssl::context::tls_server };
+  server_ctx.use_certificate_chain(asio::buffer(server_cert, std::strlen(server_cert)));
+  server_ctx.use_private_key(asio::buffer(server_key, std::strlen(server_key)),
+                             asio::ssl::context::pem);
+
+  // Build the client TLS context the way the SDK does, then hand it to the
+  // production stream class via tls_context_provider so the test exercises the
+  // real tls_stream_impl::async_connect() -> configure_tls_handshake() path.
+  auto client_ctx = std::make_shared<asio::ssl::context>(asio::ssl::context::tls_client);
+  client_ctx->add_certificate_authority(asio::buffer(server_cert, std::strlen(server_cert)));
+  client_ctx->set_verify_mode(verify_mode == couchbase::core::tls_verify_mode::peer
+                                ? asio::ssl::verify_peer
+                                : asio::ssl::verify_none);
+  couchbase::core::tls_context_provider provider{ client_ctx };
+  couchbase::core::io::tls_stream_impl client_stream{ io, provider };
+
+  asio::ip::tcp::acceptor acceptor{
+    io, asio::ip::tcp::endpoint{ asio::ip::make_address("127.0.0.1"), 0 }
+  };
+  const auto port = acceptor.local_endpoint().port();
+
+  std::error_code server_ec{ asio::error::would_block };
+  asio::ssl::stream<asio::ip::tcp::socket> server_stream{ io, server_ctx };
+  acceptor.async_accept(server_stream.lowest_layer(), [&](std::error_code accept_ec) {
+    // A failing accept would make the client result meaningless, so surface it
+    // here rather than letting it masquerade as a client handshake failure.
+    REQUIRE_FALSE(accept_ec);
+    server_stream.async_handshake(asio::ssl::stream_base::server, [&](std::error_code ec) {
+      server_ec = ec;
+    });
+  });
+
+  std::error_code client_ec{ asio::error::would_block };
+  // The behaviour under test: the production connect path resolves SNI and
+  // hostname verification for the name the caller intended to reach and reports
+  // the combined connect/configure/handshake result.
+  client_stream.async_connect(asio::ip::tcp::endpoint{ asio::ip::make_address("127.0.0.1"), port },
+                              request_hostname,
+                              [&](std::error_code ec) {
+                                client_ec = ec;
+                              });
+
+  io.run();
+  return { client_ec, server_ec };
+}
+} // namespace
+
+TEST_CASE("unit: TLS handshake verifies the server hostname against the certificate", "[unit]")
+{
+  SECTION("hostname that matches the certificate SAN is accepted")
+  {
+    const auto outcome = handshake_with_hostname("correct.example");
+    CHECK_FALSE(outcome.client);
+    CHECK_FALSE(outcome.server); // both sides complete the handshake
+  }
+
+  SECTION("hostname that does NOT match the certificate SAN is rejected (CWE-297)")
+  {
+    const auto outcome = handshake_with_hostname("not-the-real-node.example");
+    CHECK(outcome.client); // a name-mismatched certificate must not be accepted
+  }
+}
+
+TEST_CASE("unit: tls_verify=none disables server-identity verification", "[unit]")
+{
+  // tls_verify=none maps to asio::ssl::verify_none. This is the documented
+  // (insecure) escape hatch: certificate and hostname verification are switched
+  // off, so even a hostname that does NOT match the certificate SAN must still
+  // complete the handshake. This complements the verify_peer cases above and
+  // guards against the verify-none branch silently breaking.
+  SECTION("a mismatched hostname is accepted when verification is disabled")
+  {
+    const auto outcome =
+      handshake_with_hostname("not-the-real-node.example", couchbase::core::tls_verify_mode::none);
+    CHECK_FALSE(outcome.client); // verification disabled => handshake succeeds
+    CHECK_FALSE(outcome.server);
+  }
+
+  SECTION("a matching hostname is also accepted when verification is disabled")
+  {
+    const auto outcome =
+      handshake_with_hostname("correct.example", couchbase::core::tls_verify_mode::none);
+    CHECK_FALSE(outcome.client);
+    CHECK_FALSE(outcome.server);
+  }
+}
+
+TEST_CASE("unit: TLS handshake configuration rejects an empty hostname", "[unit]")
+{
+  // An empty hostname must fail closed rather than silently skipping SNI and
+  // hostname verification (which would regress to CA-only validation, CWE-297).
+  asio::io_context io;
+  asio::ssl::context client_ctx{ asio::ssl::context::tls_client };
+  asio::ssl::stream<asio::ip::tcp::socket> client_stream{ io, client_ctx };
+
+  const auto ec = couchbase::core::io::configure_tls_handshake(client_stream, "");
+  CHECK(ec);
+}


### PR DESCRIPTION
Outgoing TLS connections drove the OpenSSL/asio handshake without ever verifying that the server certificate identifies the host being contacted, and without sending SNI. asio::ssl::verify_peer (the default for couchbases://) only validates that the certificate chains to a trusted CA; it does NOT check the certificate CN/SAN. Combined with the default trust store (system CAs + bundled Capella CA + full Mozilla bundle), this let an on-path attacker present any CA-issued certificate for any name and complete the handshake — a man-in-the-middle on the secure-by-default path (CWE-297). For Capella (trust_only_capella), any Capella-CA-signed node certificate was accepted for any Capella hostname, enabling cross-tenant interception.

Fix:
- Add core::io::configure_tls_handshake(stream, hostname): sets SNI (SSL_set_tlsext_host_name) and installs asio::ssl::host_name_verification so the leaf certificate's SAN/CN must match the requested hostname.
- Thread the canonical hostname through stream_impl::async_connect (the per-attempt connect, which is the correct granularity: the mcbp bootstrap session reuses one stream across rotating bootstrap addresses). Callers pass the intended name: mcbp_session (bootstrap_hostname_), http_session (hostname_), app_telemetry_reporter (address_.hostname). plain streams ignore the parameter.
- The verifier is installed unconditionally; in verify_none mode OpenSSL ignores the callback result, so behaviour there is unchanged.

Also harden the tls_verify=none kill switch (was applied silently):
- Log a prominent warning when certificate verification is disabled.
- Refuse to disable verification for *.cloud.couchbase.com hosts; enforce verify_peer instead.

Test: test_unit_tls_hostname_verification drives a real loopback TLS handshake with a certificate whose only SAN is correct.example and asserts the matching hostname is accepted while a mismatched hostname is rejected. With the verification absent the mismatch case fails (reproducing the bug), and passes once the verifier is installed.