### PR TITLE
chore: adopt LLVM 22 toolchain in CI and satisfy its linters

### DIFF
--- a/.cppcheck_suppressions.txt
+++ b/.cppcheck_suppressions.txt
@@ -21,6 +21,9 @@ unusedVariable:*
 useStlAlgorithm:*
 unusedPrivateFunction:*
 
+# jsonsl uses integer-to-pointer casts for state tagging
+intToPointerCast:*/core/utils/json_streaming_lexer.cxx
+
 # these are not very useful
 checkersReport:*
 internalAstError:*
@@ -36,5 +39,6 @@ variableScope:*/test/test_*
 
 # do not scan third-party code
 *:*/_deps/*
+*:*/CPM/*
 *:*/generated/third_party/*
 

--- a/.github/workflows/columnar.yml
+++ b/.github/workflows/columnar.yml
@@ -32,7 +32,8 @@ jobs:
         with:
           key: ${{ github.job }}
       - name: Build
-        timeout-minutes: 40
+        timeout-minutes: 90
         env:
           CB_COLUMNAR: ON
+          CB_NUMBER_OF_JOBS: 4
         run: ./bin/build-tests

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -12,7 +12,7 @@ on:
       - release-*
 
 env:
-  LLVM_VERSION: 20
+  LLVM_VERSION: 22
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/bin/build-tests.rb
+++ b/bin/build-tests.rb
@@ -20,6 +20,12 @@ require "fileutils"
 require "rbconfig"
 require "English"
 
+class Object
+  def to_b
+    ![nil, false, 0, "", "0", "f", "F", "false", "FALSE", "off", "OFF", "no", "NO"].include?(self)
+  end
+end
+
 def which(name, extra_location = [])
   ENV.fetch("PATH", "")
      .split(File::PATH_SEPARATOR)
@@ -99,7 +105,7 @@ BUILD_DIR = if CB_SANITIZER.empty?
               File.join(PROJECT_ROOT, "cmake-build-tests-#{CB_SANITIZER}")
             end
 
-FileUtils.rm_rf(BUILD_DIR, verbose: true)
+FileUtils.rm_rf(BUILD_DIR, verbose: true) unless ENV["CB_PRESERVE_BUILD_DIR"].to_b
 FileUtils.mkdir_p(BUILD_DIR, verbose: true)
 
 Dir.chdir(BUILD_DIR) do

--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -29,7 +29,7 @@ function(set_project_options target_name)
 
   target_compile_features(${target_name} PRIVATE cxx_std_17)
   if(MSVC)
-    target_compile_options(${target_name} PRIVATE /bigobj)
+    target_compile_options(${target_name} PRIVATE /bigobj /FS)
     target_link_libraries(${target_name} PRIVATE iphlpapi)
   endif()
 

--- a/core/app_telemetry_meter.cxx
+++ b/core/app_telemetry_meter.cxx
@@ -599,7 +599,7 @@ public:
   auto value_recorder(const std::string& node_uuid, const std::string& bucket_name)
     -> std::shared_ptr<app_telemetry_value_recorder> override
   {
-    const std::lock_guard<std::mutex> lock(mutex_);
+    const std::scoped_lock<std::mutex> lock(mutex_);
 
     if (auto node = recorders_.find(node_uuid); node != recorders_.end()) {
       if (auto bucket = node->second.find(bucket_name); bucket != node->second.end()) {
@@ -636,7 +636,7 @@ public:
 
   auto nothing_to_report() -> bool override
   {
-    const std::lock_guard<std::mutex> lock(mutex_);
+    const std::scoped_lock<std::mutex> lock(mutex_);
     return recorders_.empty();
   }
 

--- a/core/bucket.cxx
+++ b/core/bucket.cxx
@@ -245,7 +245,7 @@ public:
   {
     auto handle_error = [is_retry, req](std::error_code ec) {
       // We only want to log an error on retries if the error isn't cancelled.
-      if (!is_retry || (is_retry && ec != errc::common::request_canceled)) {
+      if (!is_retry || ec != errc::common::request_canceled) {
         CB_LOG_ERROR("reschedule failed, failing request ({})", ec.message());
       }
 

--- a/core/cluster.cxx
+++ b/core/cluster.cxx
@@ -281,6 +281,7 @@ is_feature_supported(const operations::analytics_request& /*request*/,
                      const configuration_capabilities& capabilities,
                      const cluster_options& options) -> bool
 {
+  // cppcheck-suppress knownConditionTrueFalse
   if (operations::analytics_request::allow_enterprise_analytics) {
     return true;
   }
@@ -732,6 +733,7 @@ public:
     if (stopped_) {
       return handler(request.make_response({ errc::network::cluster_closed }, response_type{}));
     }
+    // cppcheck-suppress knownConditionTrueFalse
     if (!is_feature_supported(
           request, session_manager_->configuration_capabilities(), origin_.options())) {
       return handler(

--- a/core/config_profiles.cxx
+++ b/core/config_profiles.cxx
@@ -64,7 +64,7 @@ config_profiles::config_profiles() noexcept
 void
 config_profiles::apply(std::string_view profile_name, couchbase::core::cluster_options& opts)
 {
-  const std::lock_guard<std::mutex> lock(mut_);
+  const std::scoped_lock<std::mutex> lock(mut_);
   auto it = profiles_.find(profile_name);
   if (it != profiles_.end()) {
     it->second->apply(opts);

--- a/core/impl/with_cancellation.hxx
+++ b/core/impl/with_cancellation.hxx
@@ -35,7 +35,7 @@ class cancellation_token
 public:
   void setup(utils::movable_function<void()> cancel_fn)
   {
-    const std::lock_guard lock(mutex_);
+    const std::scoped_lock lock(mutex_);
     if (cancelled_) {
       cancel_fn();
       return;
@@ -47,7 +47,7 @@ public:
   {
     utils::movable_function<void()> fn{};
     {
-      const std::lock_guard lock(mutex_);
+      const std::scoped_lock lock(mutex_);
       cancelled_ = true;
       fn = std::move(cancel_fn_);
     }

--- a/core/io/mcbp_session.cxx
+++ b/core/io/mcbp_session.cxx
@@ -2127,6 +2127,7 @@ private:
         const std::scoped_lock lock(output_buffer_mutex_);
         output_buffer_.clear();
       }
+      // cppcheck-suppress knownConditionTrueFalse
       if (stopped_) {
         return;
       }

--- a/core/platform/random.cc
+++ b/core/platform/random.cc
@@ -78,7 +78,7 @@ public:
 
   auto getBytes(void* dest, std::size_t size) -> bool
   {
-    const std::lock_guard<std::mutex> lock(mutex);
+    const std::scoped_lock<std::mutex> lock(mutex);
 #ifdef WIN32
     return CryptGenRandom(handle, (DWORD)size, static_cast<BYTE*>(dest));
 #else
@@ -107,7 +107,7 @@ RandomGenerator::RandomGenerator()
 {
   if (!shared_provider) {
     // This might be the first one, lets lock and create
-    const std::lock_guard<std::mutex> guard(shared_provider_lock);
+    const std::scoped_lock<std::mutex> guard(shared_provider_lock);
     if (!shared_provider) { // cppcheck-suppress identicalInnerCondition; DCLP
       shared_provider = std::make_unique<RandomGeneratorProvider>();
     }

--- a/core/range_scan_load_balancer.cxx
+++ b/core/range_scan_load_balancer.cxx
@@ -36,7 +36,7 @@ range_scan_node_state::range_scan_node_state(std::queue<std::uint16_t> vbuckets)
 auto
 range_scan_node_state::fetch_vbucket_id() -> std::optional<std::uint16_t>
 {
-  const std::lock_guard<std::mutex> lock{ mutex_ };
+  const std::scoped_lock<std::mutex> lock{ mutex_ };
   if (pending_vbuckets_.empty()) {
     return {};
   }
@@ -49,28 +49,28 @@ range_scan_node_state::fetch_vbucket_id() -> std::optional<std::uint16_t>
 void
 range_scan_node_state::notify_stream_ended()
 {
-  const std::lock_guard<std::mutex> lock{ mutex_ };
+  const std::scoped_lock<std::mutex> lock{ mutex_ };
   active_stream_count_--;
 }
 
 void
 range_scan_node_state::enqueue_vbucket(std::uint16_t vbucket_id)
 {
-  const std::lock_guard<std::mutex> lock{ mutex_ };
+  const std::scoped_lock<std::mutex> lock{ mutex_ };
   pending_vbuckets_.push(vbucket_id);
 }
 
 auto
 range_scan_node_state::active_stream_count() -> std::uint16_t
 {
-  const std::lock_guard<std::mutex> lock{ mutex_ };
+  const std::scoped_lock<std::mutex> lock{ mutex_ };
   return active_stream_count_;
 }
 
 auto
 range_scan_node_state::pending_vbucket_count() -> std::size_t
 {
-  const std::lock_guard<std::mutex> lock{ mutex_ };
+  const std::scoped_lock<std::mutex> lock{ mutex_ };
   return pending_vbuckets_.size();
 }
 
@@ -98,7 +98,7 @@ range_scan_load_balancer::seed(std::uint64_t seed)
 auto
 range_scan_load_balancer::select_vbucket() -> std::optional<std::uint16_t>
 {
-  const std::lock_guard<std::mutex> lock{ select_vbucket_mutex_ };
+  const std::scoped_lock<std::mutex> lock{ select_vbucket_mutex_ };
 
   auto min_stream_count = std::numeric_limits<std::uint16_t>::max();
   std::optional<std::int16_t> selected_node_id{};

--- a/core/range_scan_orchestrator.cxx
+++ b/core/range_scan_orchestrator.cxx
@@ -510,7 +510,7 @@ public:
           } else {
             // Empty signal means that stream has completed
             {
-              const std::lock_guard<std::mutex> lock{ self->stream_map_mutex_ };
+              const std::scoped_lock<std::mutex> lock{ self->stream_map_mutex_ };
               self->streams_.erase(signal.vbucket_id);
             }
             return asio::post(asio::bind_executor(
@@ -540,7 +540,7 @@ public:
       auto v = vbucket_id.value();
       std::shared_ptr<range_scan_stream> stream{};
       {
-        const std::lock_guard<std::mutex> lock{ stream_map_mutex_ };
+        const std::scoped_lock<std::mutex> lock{ stream_map_mutex_ };
         stream = streams_.at(v);
       }
       CB_LOG_TRACE("scanning vbucket {} at node {}", vbucket_id.value(), stream->node_id());

--- a/core/row_streamer.cxx
+++ b/core/row_streamer.cxx
@@ -126,7 +126,7 @@ public:
         if (std::holds_alternative<row_stream_end_signal>(row)) {
           auto signal = std::get<row_stream_end_signal>(row);
           if (!signal.metadata.empty()) {
-            std::lock_guard<std::mutex> const lock{ self->metadata_mutex_ };
+            const std::scoped_lock<std::mutex> lock{ self->metadata_mutex_ };
             self->metadata_ = std::move(signal.metadata);
           }
           return handler({}, signal.ec);
@@ -149,7 +149,7 @@ public:
 
   auto metadata() -> std::optional<std::string>
   {
-    std::lock_guard<std::mutex> const lock{ metadata_mutex_ };
+    const std::scoped_lock<std::mutex> lock{ metadata_mutex_ };
     return metadata_;
   }
 
@@ -181,7 +181,7 @@ private:
         return;
       }
       {
-        const std::lock_guard<std::mutex> lock{ self->data_feed_mutex_ };
+        const std::scoped_lock<std::mutex> lock{ self->data_feed_mutex_ };
         self->lexer_.feed(data);
       }
 

--- a/core/transactions/error_list.hxx
+++ b/core/transactions/error_list.hxx
@@ -39,7 +39,7 @@ public:
   }
   void push_back(const transaction_operation_failed& ex)
   {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock<std::mutex> lock(mutex_);
     list_.push_back(ex);
     size_ = list_.size();
   }
@@ -47,7 +47,7 @@ public:
   {
     assert(size_.load() > 0);
     // merge the errors, throw a composite
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock<std::mutex> lock(mutex_);
     transaction_operation_failed::merge_errors(list_, cause);
   }
 };

--- a/core/transactions/internal/transactions_cleanup.hxx
+++ b/core/transactions/internal/transactions_cleanup.hxx
@@ -118,7 +118,7 @@ public:
   void add_collection(const couchbase::transactions::transaction_keyspace& keyspace);
   auto collections() -> std::list<couchbase::transactions::transaction_keyspace>
   {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock<std::mutex> lock(mutex_);
     return collections_;
   }
 

--- a/core/transactions/internal/utils.hxx
+++ b/core/transactions/internal/utils.hxx
@@ -175,7 +175,7 @@ jitter()
   static std::mt19937 gen(rd());
   static std::uniform_real_distribution<> dist(1 - RETRY_OP_JITTER, 1 + RETRY_OP_JITTER);
 
-  std::lock_guard<std::mutex> lock(mtx);
+  std::scoped_lock<std::mutex> lock(mtx);
   return dist(gen);
 }
 

--- a/core/transactions/staged_mutation.cxx
+++ b/core/transactions/staged_mutation.cxx
@@ -149,7 +149,7 @@ unstaging_state::wait_until_unstage_possible() -> bool
 void
 unstaging_state::notify_unstage_complete()
 {
-  const std::lock_guard lock(mutex_);
+  const std::scoped_lock lock(mutex_);
   in_flight_count_--;
   cv_.notify_one();
 }
@@ -157,7 +157,7 @@ unstaging_state::notify_unstage_complete()
 void
 unstaging_state::notify_unstage_error()
 {
-  const std::lock_guard lock(mutex_);
+  const std::scoped_lock lock(mutex_);
   abort_ = true;
   in_flight_count_--;
   cv_.notify_all();
@@ -166,14 +166,14 @@ unstaging_state::notify_unstage_error()
 auto
 staged_mutation_queue::empty() -> bool
 {
-  const std::lock_guard<std::mutex> lock(mutex_);
+  const std::scoped_lock<std::mutex> lock(mutex_);
   return queue_.empty();
 }
 
 void
 staged_mutation_queue::add(staged_mutation&& mutation)
 {
-  const std::lock_guard<std::mutex> lock(mutex_);
+  const std::scoped_lock<std::mutex> lock(mutex_);
   // Can only have one staged mutation per document.
   queue_.erase(std::remove_if(queue_.begin(),
                               queue_.end(),
@@ -188,7 +188,7 @@ void
 staged_mutation_queue::extract_to(const std::string& prefix,
                                   core::operations::mutate_in_request& req)
 {
-  const std::lock_guard<std::mutex> lock(mutex_);
+  const std::scoped_lock<std::mutex> lock(mutex_);
   tao::json::value inserts = tao::json::empty_array;
   tao::json::value replaces = tao::json::empty_array;
   tao::json::value removes = tao::json::empty_array;
@@ -232,7 +232,7 @@ staged_mutation_queue::extract_to(const std::string& prefix,
 void
 staged_mutation_queue::remove_any(const core::document_id& id)
 {
-  const std::lock_guard<std::mutex> lock(mutex_);
+  const std::scoped_lock<std::mutex> lock(mutex_);
   auto new_end = std::remove_if(queue_.begin(), queue_.end(), [&id](const staged_mutation& item) {
     return document_ids_equal(item.id(), id);
   });
@@ -242,7 +242,7 @@ staged_mutation_queue::remove_any(const core::document_id& id)
 auto
 staged_mutation_queue::find_any(const core::document_id& id) -> staged_mutation*
 {
-  const std::lock_guard<std::mutex> lock(mutex_);
+  const std::scoped_lock<std::mutex> lock(mutex_);
   for (auto& item : queue_) {
     if (document_ids_equal(item.id(), id)) {
       return &item;
@@ -254,7 +254,7 @@ staged_mutation_queue::find_any(const core::document_id& id) -> staged_mutation*
 auto
 staged_mutation_queue::find_replace(const core::document_id& id) -> staged_mutation*
 {
-  const std::lock_guard<std::mutex> lock(mutex_);
+  const std::scoped_lock<std::mutex> lock(mutex_);
   for (auto& item : queue_) {
     if (item.type() == staged_mutation_type::REPLACE && document_ids_equal(item.id(), id)) {
       return &item;
@@ -266,7 +266,7 @@ staged_mutation_queue::find_replace(const core::document_id& id) -> staged_mutat
 auto
 staged_mutation_queue::find_insert(const core::document_id& id) -> staged_mutation*
 {
-  const std::lock_guard<std::mutex> lock(mutex_);
+  const std::scoped_lock<std::mutex> lock(mutex_);
   for (auto& item : queue_) {
     if (item.type() == staged_mutation_type::INSERT && document_ids_equal(item.id(), id)) {
       return &item;
@@ -278,7 +278,7 @@ staged_mutation_queue::find_insert(const core::document_id& id) -> staged_mutati
 auto
 staged_mutation_queue::find_remove(const core::document_id& id) -> staged_mutation*
 {
-  const std::lock_guard<std::mutex> lock(mutex_);
+  const std::scoped_lock<std::mutex> lock(mutex_);
   for (auto& item : queue_) {
     if (item.type() == staged_mutation_type::REMOVE && document_ids_equal(item.id(), id)) {
       return &item;
@@ -289,7 +289,7 @@ staged_mutation_queue::find_remove(const core::document_id& id) -> staged_mutati
 void
 staged_mutation_queue::iterate(const std::function<void(staged_mutation&)>& op)
 {
-  const std::lock_guard<std::mutex> lock(mutex_);
+  const std::scoped_lock<std::mutex> lock(mutex_);
   for (auto& item : queue_) {
     op(item);
   }
@@ -299,7 +299,7 @@ void
 staged_mutation_queue::commit(const std::shared_ptr<attempt_context_impl>& ctx)
 {
   CB_ATTEMPT_CTX_LOG_TRACE(ctx, "committing staged mutations...");
-  const std::lock_guard<std::mutex> lock(mutex_);
+  const std::scoped_lock<std::mutex> lock(mutex_);
 
   unstaging_state state{ ctx };
   std::vector<std::future<void>> futures{};
@@ -390,7 +390,7 @@ void
 staged_mutation_queue::rollback(const std::shared_ptr<attempt_context_impl>& ctx)
 {
   CB_ATTEMPT_CTX_LOG_TRACE(ctx, "rolling back staged mutations...");
-  const std::lock_guard<std::mutex> lock(mutex_);
+  const std::scoped_lock<std::mutex> lock(mutex_);
 
   unstaging_state state{ ctx };
   std::vector<std::future<void>> futures{};

--- a/core/transactions/transaction_context.cxx
+++ b/core/transactions/transaction_context.cxx
@@ -77,7 +77,7 @@ void
 transaction_context::add_attempt()
 {
   const transaction_attempt attempt{};
-  const std::lock_guard<std::mutex> lock(mutex_);
+  const std::scoped_lock<std::mutex> lock(mutex_);
   attempts_.push_back(attempt);
 }
 
@@ -408,7 +408,7 @@ transaction_context::finalize(txn_complete_callback&& cb)
 void
 transaction_context::current_attempt_state(attempt_state s)
 {
-  const std::lock_guard<std::mutex> lock(mutex_);
+  const std::scoped_lock<std::mutex> lock(mutex_);
   if (attempts_.empty()) {
     throw std::runtime_error("transaction_context has no attempts yet");
   }
@@ -488,7 +488,7 @@ transaction_context::new_attempt_context()
 auto
 transaction_context::current_attempt() const -> const transaction_attempt&
 {
-  const std::lock_guard<std::mutex> lock(mutex_);
+  const std::scoped_lock<std::mutex> lock(mutex_);
   if (attempts_.empty()) {
     throw std::runtime_error("transaction context has no attempts yet");
   }
@@ -498,7 +498,7 @@ transaction_context::current_attempt() const -> const transaction_attempt&
 auto
 transaction_context::num_attempts() const -> std::size_t
 {
-  const std::lock_guard<std::mutex> lock(mutex_);
+  const std::scoped_lock<std::mutex> lock(mutex_);
   return attempts_.size();
 }
 

--- a/core/transactions/transactions_cleanup.cxx
+++ b/core/transactions/transactions_cleanup.cxx
@@ -108,7 +108,7 @@ transactions_cleanup::clean_collection(
   // first make sure the collection is in the list
   while (is_running()) {
     {
-      const std::lock_guard<std::mutex> lock(mutex_);
+      const std::scoped_lock<std::mutex> lock(mutex_);
       if (collections_.end() == std::find(collections_.begin(), collections_.end(), keyspace)) {
         CB_LOST_ATTEMPT_CLEANUP_LOG_DEBUG(
           "cleanup for {} ending, no longer in collection cleanup list", keyspace);

--- a/core/transactions/waitable_op_list.hxx
+++ b/core/transactions/waitable_op_list.hxx
@@ -158,7 +158,7 @@ public:
   }
   void decrement_in_flight()
   {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock<std::mutex> lock(mutex_);
     in_flight_--;
     CB_TXN_LOG_TRACE("in_flight decremented to {}", in_flight_);
     assert(in_flight_ >= 0);
@@ -170,7 +170,7 @@ public:
 private:
   void change_count(int32_t val)
   {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock<std::mutex> lock(mutex_);
     if (allow_ops_) {
       count_ += val;
       if (val > 0) {

--- a/test/test_integration_meter.cxx
+++ b/test/test_integration_meter.cxx
@@ -32,7 +32,7 @@ public:
   }
   void record_value(std::int64_t value) override
   {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock<std::mutex> lock(mutex_);
     values_.emplace_back(value);
   }
   std::map<std::string, std::string> tags() const
@@ -41,12 +41,12 @@ public:
   }
   std::list<std::uint64_t> values()
   {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock<std::mutex> lock(mutex_);
     return values_;
   }
   void reset()
   {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock<std::mutex> lock(mutex_);
     values_.clear();
   }
 
@@ -68,7 +68,7 @@ public:
     const std::string& name,
     const std::map<std::string, std::string>& tags) override
   {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock<std::mutex> lock(mutex_);
     auto it = value_recorders_.equal_range(name);
     if (it.first != it.second) {
 
@@ -83,14 +83,14 @@ public:
 
   void reset()
   {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock<std::mutex> lock(mutex_);
     value_recorders_.clear();
   }
 
   std::list<std::shared_ptr<test_value_recorder>> get_recorders(const std::string& name)
   {
     std::list<std::shared_ptr<test_value_recorder>> retval;
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock<std::mutex> lock(mutex_);
     auto it = value_recorders_.equal_range(name);
     for (auto itr = it.first; itr != it.second; itr++) {
       retval.push_back(itr->second);

--- a/test/test_integration_tracer.cxx
+++ b/test/test_integration_tracer.cxx
@@ -128,7 +128,7 @@ public:
   {
     fmt::println("Creating span {} with parent {}", name, parent ? parent->name() : "<none>");
 
-    const std::lock_guard<std::mutex> lock(mutex_);
+    const std::scoped_lock<std::mutex> lock(mutex_);
     spans_.push_back(std::make_shared<test_span>(name, parent));
 
     if (parent != nullptr) {
@@ -141,13 +141,13 @@ public:
 
   auto spans() -> std::vector<std::shared_ptr<test_span>>
   {
-    const std::lock_guard<std::mutex> lock(mutex_);
+    const std::scoped_lock<std::mutex> lock(mutex_);
     return spans_;
   }
 
   void reset()
   {
-    const std::lock_guard<std::mutex> lock(mutex_);
+    const std::scoped_lock<std::mutex> lock(mutex_);
     spans_.clear();
   }
 

--- a/test/test_unit_transaction_logging.cxx
+++ b/test/test_unit_transaction_logging.cxx
@@ -34,7 +34,7 @@ public:
   std::string output()
   {
     // prevent data race if sink_it_ is called
-    std::lock_guard<std::mutex> lock(mut_);
+    std::scoped_lock<std::mutex> lock(mut_);
     return out_.str();
   }
 
@@ -44,7 +44,7 @@ protected:
     spdlog::memory_buf_t formatted;
     base_sink<std::mutex>::formatter_->format(msg, formatted);
     // prevent data race when calling output()
-    std::lock_guard<std::mutex> lock(mut_);
+    std::scoped_lock<std::mutex> lock(mut_);
     out_.write(formatted.data(), static_cast<std::streamsize>(formatted.size()));
   }
   void flush_() override


### PR DESCRIPTION
Bump the linters workflow from LLVM 20 to 22 and apply the resulting clang-tidy / cppcheck cleanups across the existing codebase, separated out from the fit_performer migration (PR #933) so it can land on its own.

- linters.yml: LLVM_VERSION 20 -> 22
- core/, test/: std::lock_guard -> std::scoped_lock; cppcheck-suppress annotations (cluster.cxx, mcbp_session.cxx); redundant-condition simplification (bucket.cxx)
- .cppcheck_suppressions.txt: suppress jsonsl int-to-pointer casts in json_streaming_lexer.cxx; skip the CPM cache when scanning
- cmake/CompilerOptions.cmake: add MSVC /FS for parallel PDB writes
- columnar.yml: raise build timeout 40 -> 90 min, CB_NUMBER_OF_JOBS=4
- bin/build-tests.rb: CB_PRESERVE_BUILD_DIR env gate (+ to_b helper)