### PR TITLE
[Backport] CXXCBC-839: Filter push configuration notifications strictly by session bucket binding

### DIFF
--- a/core/io/configuration_belongs_to_session.hxx
+++ b/core/io/configuration_belongs_to_session.hxx
@@ -1,0 +1,67 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-2021 Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace couchbase::core::io
+{
+/**
+ * Decide whether a freshly received cluster map belongs to this session and must
+ * therefore be accepted.
+ *
+ * A session's bucket binding is fixed for its entire lifetime (set once in the
+ * constructor, never reassigned), so the rule reduces to a single invariant:
+ * the bucket identity carried by the configuration must match the bucket identity
+ * of the session.
+ *
+ *   - a cluster-level (bucket-less) session accepts only cluster-level configs;
+ *   - a bucket-level session accepts only configs for *its own* bucket.
+ *
+ * @param config_bucket   bucket name embedded in the configuration payload
+ *                        (std::nullopt  =>  cluster-level / GCCCP config)
+ * @param session_bucket  bucket this session is bound to
+ *                        (std::nullopt  =>  cluster-level / GCCCP session)
+ * @return true if the configuration must be accepted, false if it must be ignored
+ */
+[[nodiscard]] inline auto
+configuration_belongs_to_session(const std::optional<std::string>& config_bucket,
+                                 const std::optional<std::string>& session_bucket) -> bool
+{
+  // Stage 1 — cluster-level config for a cluster-level session.
+  // Neither side names a bucket: this is a GCCCP (cluster) map and the session is
+  // not bound to any bucket, so the config belongs here. Accept.
+  if (!config_bucket.has_value() && !session_bucket.has_value()) {
+    return true;
+  }
+
+  // Stage 2 — cardinality mismatch: exactly one side names a bucket. Reject.
+  // Either a bucket-less config arrived on a bucket-bound session, or a bucket
+  // config arrived on a cluster-level session. In both cases the config does not
+  // belong to this session.
+  if (config_bucket.has_value() != session_bucket.has_value()) {
+    return false;
+  }
+
+  // Stage 3 — both sides name a bucket: accept only if it is the *same* bucket.
+  // Reaching here guarantees both optionals are engaged, so value() is safe.
+  // Guards against applying another bucket's map to this session.
+  return config_bucket.value() == session_bucket.value();
+}
+} // namespace couchbase::core::io

--- a/core/io/mcbp_session.cxx
+++ b/core/io/mcbp_session.cxx
@@ -22,6 +22,7 @@
 #ifdef COUCHBASE_CXX_CLIENT_COLUMNAR
 #include "core/columnar/background_bootstrap_listener.hxx"
 #endif
+#include "configuration_belongs_to_session.hxx"
 #include "core/config_listener.hxx"
 #include "core/diagnostics.hxx"
 #include "core/impl/bootstrap_error.hxx"
@@ -634,14 +635,9 @@ class mcbp_session_impl
                 }
               }
               std::optional<topology::configuration> config = req.body().config();
-              if (session_ && config.has_value()) {
-                if ((!config->bucket.has_value() && req.body().bucket().empty()) ||
-                    (session_->bucket_name_.has_value() && !req.body().bucket().empty() &&
-                     // TODO(CXXCBC-549)
-                     // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-                     session_->bucket_name_.value() == req.body().bucket())) {
-                  session_->update_configuration(std::move(config.value()));
-                }
+              if (session_ && config.has_value() &&
+                  configuration_belongs_to_session(config->bucket, session_->bucket_name_)) {
+                session_->update_configuration(std::move(config.value()));
               }
             } break;
             default:
@@ -824,14 +820,9 @@ class mcbp_session_impl
                 }
               }
               std::optional<topology::configuration> config = req.body().config();
-              if (session_ && config.has_value()) {
-                if ((!config->bucket.has_value() && req.body().bucket().empty()) ||
-                    (session_->bucket_name_.has_value() && !req.body().bucket().empty() &&
-                     // TODO(CXXCBC-549)
-                     // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-                     session_->bucket_name_.value() == req.body().bucket())) {
-                  session_->update_configuration(std::move(config.value()));
-                }
+              if (session_ && config.has_value() &&
+                  configuration_belongs_to_session(config->bucket, session_->bucket_name_)) {
+                session_->update_configuration(std::move(config.value()));
               }
             } break;
             default:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,7 @@ integration_test(node_id)
 
 unit_test(connection_string)
 unit_test(contains_string)
+unit_test(configuration_belongs_to_session)
 unit_test(utils)
 unit_test(binary_transcoder)
 unit_test(json_transcoder)

--- a/test/test_unit_configuration_belongs_to_session.cxx
+++ b/test/test_unit_configuration_belongs_to_session.cxx
@@ -1,0 +1,108 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-2021 Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "test_helper.hxx"
+
+#include "core/io/configuration_belongs_to_session.hxx"
+
+#include <optional>
+#include <string>
+
+// The argument order is (config_bucket, session_bucket). These named constants
+// make each call site below read in terms of *what kind* of config arrives on
+// *what kind* of session, rather than as a pair of anonymous optionals.
+namespace
+{
+const std::optional<std::string> cluster_level{}; // std::nullopt => GCCCP / no bucket
+} // namespace
+
+TEST_CASE("unit: configuration_belongs_to_session cluster-level session", "[unit]")
+{
+  using couchbase::core::io::configuration_belongs_to_session;
+
+  // A cluster-level (GCCCP) session is bound to no bucket. It accepts only
+  // cluster-level maps, and must ignore any bucket-scoped map that happens to
+  // arrive on it.
+  SECTION("accepts a cluster-level config")
+  {
+    CHECK(configuration_belongs_to_session(cluster_level, cluster_level));
+  }
+
+  SECTION("ignores a bucket-scoped config")
+  {
+    CHECK_FALSE(configuration_belongs_to_session("default", cluster_level));
+    CHECK_FALSE(configuration_belongs_to_session("travel-sample", cluster_level));
+  }
+}
+
+TEST_CASE("unit: configuration_belongs_to_session bucket-level session", "[unit]")
+{
+  using couchbase::core::io::configuration_belongs_to_session;
+
+  // A session bound to a bucket accepts only maps for that exact bucket.
+  SECTION("accepts a config for its own bucket")
+  {
+    CHECK(configuration_belongs_to_session("default", "default"));
+    CHECK(configuration_belongs_to_session("travel-sample", "travel-sample"));
+  }
+
+  SECTION("ignores a config for a different bucket")
+  {
+    CHECK_FALSE(configuration_belongs_to_session("travel-sample", "default"));
+    CHECK_FALSE(configuration_belongs_to_session("default", "travel-sample"));
+  }
+
+  SECTION("ignores a cluster-level config")
+  {
+    // A bucket-bound session must not be steered by a bucket-less (GCCCP) map.
+    CHECK_FALSE(configuration_belongs_to_session(cluster_level, "default"));
+  }
+}
+
+TEST_CASE("unit: configuration_belongs_to_session bucket-name matching is exact", "[unit]")
+{
+  using couchbase::core::io::configuration_belongs_to_session;
+
+  // Bucket identity is compared by exact string equality: no case-folding, no
+  // trimming, no prefix matching. A near-miss is a different bucket.
+  SECTION("case-sensitive")
+  {
+    CHECK_FALSE(configuration_belongs_to_session("Default", "default"));
+    CHECK_FALSE(configuration_belongs_to_session("DEFAULT", "default"));
+  }
+
+  SECTION("no prefix or substring matching")
+  {
+    CHECK_FALSE(configuration_belongs_to_session("default2", "default"));
+    CHECK_FALSE(configuration_belongs_to_session("default", "default2"));
+  }
+
+  SECTION("whitespace is significant")
+  {
+    CHECK_FALSE(configuration_belongs_to_session("default ", "default"));
+  }
+
+  SECTION("empty bucket name is just another name and matches itself")
+  {
+    // An engaged-but-empty optional is distinct from std::nullopt: both sides
+    // name "a bucket", and that bucket happens to be the empty string, so they
+    // match. (This is a degenerate input, exercised here only to pin behaviour.)
+    CHECK(configuration_belongs_to_session(std::string{}, std::string{}));
+    CHECK_FALSE(configuration_belongs_to_session(std::string{}, cluster_level));
+    CHECK_FALSE(configuration_belongs_to_session(cluster_level, std::string{}));
+  }
+}


### PR DESCRIPTION
Motivation
----------
During node failover or rebalance, a bucket-bound session could be locked out of adopting the correct cluster map, causing stale routing, continuous Not My VBucket (NMVB) loops, and client-side timeouts.

The config push handler in mcbp_session used a guard that let GCCCP (cluster-level, bucket-less) map change notifications leak onto active bucket-bound sessions. Accepting a bucket-less config advanced the session's config revision floor, so when the full map-carrying config for the same or earlier revision later arrived on that session, it was discarded as old or identical.

Changes
-------
* Add configuration_belongs_to_session, a pure helper that accepts a config only when its bucket scope matches the session's: bucket-less configs go to bucket-less sessions, and a bucket config goes only to its own bucket session.
* Apply it as the call-site guard in both the SSL and plain-text cluster_map_change_notification parsers in mcbp_session.cxx.
* Add unit tests covering the cluster-level, bucket-level, and exact-match cases.