### PR TITLE
CXXCBC-826: Add collection::node_ids() to enumerate KV-serving cluster nodes

### DIFF
--- a/core/impl/collection.cxx
+++ b/core/impl/collection.cxx
@@ -25,6 +25,7 @@
 #include "observability_recorder.hxx"
 #include "observe_poll.hxx"
 #include "resolve_node_id.hxx"
+#include "with_bucket_config_or_timeout.hxx"
 
 #include "core/agent_group.hxx"
 #include "core/agent_group_config.hxx"
@@ -1259,81 +1260,49 @@ public:
                                                             : core::topology::transport::plain;
     const auto timeout = options.timeout.value_or(origin.options().key_value_timeout);
 
-    // Shared state so that exactly one of {timeout timer, bucket-config
-    // callback} can invoke the user handler. @c with_bucket_configuration is
-    // not cancellable — if a config never arrives, the timer is the only way
-    // to guarantee the handler completes.
-    //
-    // Thread-safety note: the SDK's core io_context is single-threaded for
-    // KV work in the current release. The timer and atomic-done dance are
-    // therefore safe as written. If the io_context is ever multi-threaded,
-    // both the timer.cancel() and the handler invocation must be wrapped in
-    // a strand bound to core_.io_context() because @c asio::steady_timer is
-    // not thread-safe.
-    struct state {
-      std::atomic<bool> done{ false };
-      asio::steady_timer timer;
-      node_id_for_handler handler;
-
-      state(asio::io_context& ioc, node_id_for_handler&& h)
-        : timer{ ioc }
-        , handler{ std::move(h) }
-      {
-      }
-    };
-    auto shared = std::make_shared<state>(core_.io_context(), std::move(handler));
-    // Capture the io_context by pointer value (not by reference to a local
-    // reference variable): core_ and its io_context outlive this operation, so
-    // the pointer stays valid even though the bucket-config callback may run
-    // after node_id_for() has returned.
-    auto* io_context = &core_.io_context();
-
-    shared->timer.expires_after(timeout);
-    shared->timer.async_wait([shared](std::error_code timer_ec) -> void {
-      if (timer_ec == asio::error::operation_aborted) {
-        return;
-      }
-      // acq_rel matches the other writer (config callback): the only thing
-      // we synchronise on is whether we won the race to fire the handler.
-      if (shared->done.exchange(true, std::memory_order_acq_rel)) {
-        return;
-      }
-      shared->handler(error{ errc::common::unambiguous_timeout }, node_id{});
-    });
-
-    core_.with_bucket_configuration(
+    // The state struct + timer + atomic-done + asio::post scaffold lives
+    // in with_bucket_config_or_timeout(). See that header for the
+    // single-threaded-io_context assumption the timer relies on.
+    core::impl::with_bucket_config_or_timeout<couchbase::node_id>(
+      core_,
       bucket_name_,
-      [shared, io_context, document_key = std::move(document_key), transport_kind](
-        std::error_code ec, const std::shared_ptr<core::topology::configuration>& config) -> void {
-        if (shared->done.exchange(true, std::memory_order_acq_rel)) {
-          return;
-        }
+      timeout,
+      std::move(handler),
+      [document_key = std::move(document_key),
+       transport_kind](const std::shared_ptr<core::topology::configuration>& config) {
+        return core::impl::resolve_node_id_from_config(config, document_key, transport_kind);
+      });
+  }
 
-        std::error_code result_ec = ec;
-        couchbase::node_id resolved{};
-        if (!ec) {
-          std::tie(result_ec, resolved) =
-            core::impl::resolve_node_id_from_config(config, document_key, transport_kind);
-        }
+  void node_ids(const node_ids_options::built& options, node_ids_handler&& handler) const
+  {
+    auto [origin_ec, origin] = core_.origin();
+    if (origin_ec) {
+      return handler(error{ origin_ec }, {});
+    }
+    const auto transport_kind = origin.options().enable_tls ? core::topology::transport::tls
+                                                            : core::topology::transport::plain;
+    const auto timeout = options.timeout.value_or(origin.options().key_value_timeout);
 
-        // Hop back onto the io_context before touching the timer or invoking
-        // the user handler. with_bucket_configuration() invokes its callback
-        // synchronously on the caller's thread when the bucket configuration
-        // is already cached (bucket.cxx). Two things must therefore not happen
-        // inline here:
-        //   1. timer.cancel() — asio::steady_timer is not thread-safe and is
-        //      bound to core_.io_context(); cancelling it from an arbitrary
-        //      application thread races with the io_context processing the
-        //      pending async_wait. It must run on the timer's executor.
-        //   2. the user handler — it reasonably expects an async hop and may
-        //      itself re-enter the SDK.
-        // The done flag above is atomic, so the race is already decided; the
-        // deferred cancel() is a harmless no-op if the timer has since fired
-        // (its handler short-circuits on operation_aborted / done).
-        asio::post(*io_context, [shared, result_ec, resolved = std::move(resolved)]() mutable {
-          shared->timer.cancel();
-          shared->handler(error{ result_ec }, std::move(resolved));
-        });
+    // Same async scaffold as node_id_for — see the long comment there for
+    // the single-threaded-io_context assumption the timer relies on, and
+    // for why with_bucket_configuration() needs a steady_timer to bound
+    // the wait when no config ever arrives.
+    //
+    // Note: node_ids deliberately does not need to inspect the vBucket
+    // map (effective_node_ids enumerates topology nodes directly, not via
+    // a key->vbucket->node lookup), so the "vbmap missing" branch from
+    // node_id_for is absent here. A null or empty result is collapsed
+    // onto configuration_not_available below, matching the sibling's
+    // contract that an empty/unusable bucket configuration is a hard
+    // error rather than a silent empty success.
+    core::impl::with_bucket_config_or_timeout<std::vector<couchbase::node_id>>(
+      core_,
+      bucket_name_,
+      timeout,
+      std::move(handler),
+      [transport_kind](const std::shared_ptr<core::topology::configuration>& config) {
+        return core::impl::resolve_node_ids_from_config(config, transport_kind);
       });
   }
 
@@ -1443,6 +1412,24 @@ collection::node_id_for(std::string document_id, const node_id_for_options& opti
   auto future = barrier->get_future();
   node_id_for(std::move(document_id), options, [barrier](auto err, auto nid) {
     barrier->set_value({ std::move(err), std::move(nid) });
+  });
+  return future;
+}
+
+void
+collection::node_ids(const node_ids_options& options, node_ids_handler&& handler) const
+{
+  return impl_->node_ids(options.build(), std::move(handler));
+}
+
+auto
+collection::node_ids(const node_ids_options& options) const
+  -> std::future<std::pair<error, std::vector<node_id>>>
+{
+  auto barrier = std::make_shared<std::promise<std::pair<error, std::vector<node_id>>>>();
+  auto future = barrier->get_future();
+  node_ids(options, [barrier](auto err, auto nids) {
+    barrier->set_value({ std::move(err), std::move(nids) });
   });
   return future;
 }

--- a/core/impl/resolve_node_id.hxx
+++ b/core/impl/resolve_node_id.hxx
@@ -25,6 +25,8 @@
 #include <memory>
 #include <string>
 #include <system_error>
+#include <utility>
+#include <vector>
 
 namespace couchbase::core::impl
 {
@@ -78,5 +80,46 @@ resolve_node_id_from_config(const std::shared_ptr<topology::configuration>& conf
   // constructor is selected and `resolved` is genuinely moved (a leading `{}`
   // would bind the const-reference constructor instead, defeating the move).
   return { std::error_code{}, std::move(resolved) };
+}
+
+/**
+ * Pure helper that enumerates the KV-serving nodes of a bucket configuration
+ * snapshot. Extracted out of @c collection_impl::node_ids so the
+ * error-mapping branches (no config, empty KV-serving set, success) can be
+ * unit-tested without an io_context or a live cluster — and so the branch
+ * matches the contract of the sibling resolver above:
+ *
+ * - A missing/null config snapshot is reported as
+ *   @c errc::network::configuration_not_available (it must not be a silent
+ *   empty success: the caller cannot distinguish "the cluster has zero KV
+ *   nodes" from "we don't know the topology yet").
+ * - An empty effective-node-ids set is reported the same way; this is the
+ *   mid-rebalance transient that the original commit silently surfaced as
+ *   a successful empty vector.
+ *
+ * @param config  bucket configuration snapshot (may be null)
+ * @param t       which port pair (plain/TLS) to use when deriving identity
+ * @return pair of (error_code, vector<node_id>). On success the @c
+ *         error_code is default and the vector is non-empty; on failure the
+ *         vector is empty.
+ */
+[[nodiscard]] inline auto
+resolve_node_ids_from_config(const std::shared_ptr<topology::configuration>& config,
+                             topology::transport t)
+  -> std::pair<std::error_code, std::vector<couchbase::node_id>>
+{
+  if (!config) {
+    return { errc::network::configuration_not_available, {} };
+  }
+  auto nids = config->effective_node_ids(t);
+  if (nids.empty()) {
+    // Tighter than the original "return {}" — a momentarily-empty
+    // topology (e.g. mid-rebalance) is reported as unavailable rather
+    // than as a successful empty list, so registry-sweep loops keyed on
+    // node_id don't conclude the cluster has zero KV-serving nodes and
+    // discard every entry.
+    return { errc::network::configuration_not_available, {} };
+  }
+  return { {}, std::move(nids) };
 }
 } // namespace couchbase::core::impl

--- a/core/impl/with_bucket_config_or_timeout.hxx
+++ b/core/impl/with_bucket_config_or_timeout.hxx
@@ -1,0 +1,180 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include "core/cluster.hxx"
+#include "core/topology/configuration.hxx"
+
+#include <couchbase/error.hxx>
+#include <couchbase/error_codes.hxx>
+
+#include <asio/error.hpp>
+#include <asio/io_context.hpp>
+#include <asio/post.hpp>
+#include <asio/steady_timer.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <string>
+#include <system_error>
+#include <utility>
+
+namespace couchbase::core::impl
+{
+/**
+ * Async scaffold shared between @c collection_impl::node_id_for and
+ * @c collection_impl::node_ids — and any future client-side API that needs
+ * to wait for a bucket configuration with a hard timeout.
+ *
+ * The scaffold owns the atomic-done guard, the timer, and the asio::post
+ * back to the io_context. Callers supply a resolver that maps a topology
+ * snapshot to a (error_code, payload) pair; the user handler is invoked
+ * with (error, payload) exactly once — including on io_context shutdown,
+ * where a fail-closed destructor backstop completes the handler with
+ * @c errc::network::cluster_closed rather than leaking a dropped completion
+ * (which would surface as a broken_promise to a std::future caller or a
+ * permanent hang to a callback caller).
+ *
+ * Thread-safety: the SDK's core io_context is single-threaded for KV work
+ * in the current release. The timer and atomic-done dance are safe under
+ * that assumption. If the io_context is ever multi-threaded, both
+ * @c timer.cancel() and the handler dispatch must be wrapped in a strand
+ * because @c asio::steady_timer is not thread-safe.
+ *
+ * @tparam Payload      The success-path payload type (e.g. @c node_id or
+ *                      @c std::vector<node_id>). Must be default-
+ *                      constructible (used for the timeout / error branches)
+ *                      and move-constructible.
+ * @tparam Handler      Callable accepting @c (couchbase::error, Payload).
+ * @tparam Resolver     Callable accepting
+ *                      @c const std::shared_ptr<topology::configuration>&
+ *                      and returning @c std::pair<std::error_code, Payload>.
+ *                      Invoked at most once, on the config-callback path
+ *                      when @c ec is falsy.
+ */
+template<typename Payload, typename Handler, typename Resolver>
+void
+with_bucket_config_or_timeout(const couchbase::core::cluster& core,
+                              const std::string& bucket_name,
+                              std::chrono::milliseconds timeout,
+                              Handler handler,
+                              Resolver resolver)
+{
+  struct state {
+    std::atomic<bool> done{ false };
+    std::atomic<bool> delivered{ false };
+    asio::steady_timer timer;
+    Handler handler;
+
+    state(asio::io_context& ioc, Handler&& h)
+      : timer{ ioc }
+      , handler{ std::move(h) }
+    {
+    }
+
+    // Invoke the user handler at most once. The `done` flag arbitrates the
+    // timer-vs-config race; `delivered` guards the handler call itself so the
+    // destructor can fail closed (below) without ever risking a double call.
+    void deliver(couchbase::error err, Payload payload)
+    {
+      if (!delivered.exchange(true, std::memory_order_acq_rel)) {
+        handler(std::move(err), std::move(payload));
+      }
+    }
+
+    // Fail-closed backstop. If every async continuation is torn down without
+    // the handler having run — io_context stopped on shutdown drops both the
+    // pending timer wait and any deferred asio::post — complete here so a
+    // std::future caller never observes broken_promise and a callback caller
+    // never hangs. By the time the destructor runs the last shared_ptr
+    // reference is gone, so no other thread can be in deliver() concurrently.
+    // The handler is user code; a destructor must not let an exception escape.
+    ~state()
+    {
+      try {
+        deliver(couchbase::error{ errc::network::cluster_closed }, Payload{});
+      } catch (...) { // NOLINT(bugprone-empty-catch)
+      }
+    }
+  };
+
+  auto shared = std::make_shared<state>(core.io_context(), std::move(handler));
+  // Capture the io_context by pointer value (not by reference to a local
+  // reference variable): core and its io_context outlive this operation, so
+  // the pointer stays valid even though the bucket-config callback may run
+  // after this function has returned.
+  auto* io_context = &core.io_context();
+
+  shared->timer.expires_after(timeout);
+  shared->timer.async_wait([shared](std::error_code timer_ec) -> void {
+    if (timer_ec == asio::error::operation_aborted) {
+      return;
+    }
+    // acq_rel matches the other writer (config callback): the only thing
+    // we synchronise on is whether we won the race to fire the handler.
+    if (shared->done.exchange(true, std::memory_order_acq_rel)) {
+      return;
+    }
+    shared->deliver(couchbase::error{ errc::common::unambiguous_timeout }, Payload{});
+  });
+
+  core.with_bucket_configuration(
+    bucket_name,
+    // Capture a weak_ptr, not a strong one. with_bucket_configuration() queues
+    // this callback in the bucket's deferred-commands list until a config
+    // arrives; if the timeout fires first and a config never arrives, a strong
+    // capture would pin the user handler, promise and timer in that queue
+    // indefinitely. The pending timer owns the state while we wait, so a config
+    // that arrives before the timeout still locks successfully; once the
+    // timeout has fired the state is released and this callback is a no-op.
+    [weak = std::weak_ptr<state>(shared), io_context, resolver = std::move(resolver)](
+      std::error_code ec,
+      const std::shared_ptr<core::topology::configuration>& config) mutable -> void {
+      auto shared = weak.lock();
+      if (!shared || shared->done.exchange(true, std::memory_order_acq_rel)) {
+        return;
+      }
+
+      std::error_code result_ec = ec;
+      Payload payload{};
+      if (!ec) {
+        std::tie(result_ec, payload) = resolver(config);
+      }
+
+      // Hop back onto the io_context before touching the timer or invoking
+      // the user handler. with_bucket_configuration() invokes its callback
+      // synchronously on the caller's thread when the bucket configuration
+      // is already cached (see bucket.cxx). Two things must therefore not
+      // happen inline here:
+      //   1. timer.cancel() — asio::steady_timer is not thread-safe and is
+      //      bound to core.io_context(); cancelling it from an arbitrary
+      //      application thread races with the io_context processing the
+      //      pending async_wait. It must run on the timer's executor.
+      //   2. the user handler — it reasonably expects an async hop and may
+      //      itself re-enter the SDK.
+      // The done flag above is atomic, so the race is already decided; the
+      // deferred cancel() is a harmless no-op if the timer has since fired
+      // (its handler short-circuits on operation_aborted / done).
+      asio::post(*io_context, [shared, result_ec, payload = std::move(payload)]() mutable {
+        shared->timer.cancel();
+        shared->deliver(couchbase::error{ result_ec }, std::move(payload));
+      });
+    });
+}
+} // namespace couchbase::core::impl

--- a/core/topology/configuration.cxx
+++ b/core/topology/configuration.cxx
@@ -180,6 +180,21 @@ configuration::node::effective_node_id(transport t) const -> couchbase::node_id
 }
 
 auto
+configuration::effective_node_ids(transport t) const -> std::vector<couchbase::node_id>
+{
+  const bool is_tls = (t == transport::tls);
+  std::vector<couchbase::node_id> result;
+  result.reserve(nodes.size());
+  for (const auto& n : nodes) {
+    if (n.port_or(service_type::key_value, is_tls, 0) == 0) {
+      continue;
+    }
+    result.push_back(n.effective_node_id(t));
+  }
+  return result;
+}
+
+auto
 configuration::has_node(const std::string& network,
                         service_type type,
                         bool is_tls,

--- a/core/topology/configuration.hxx
+++ b/core/topology/configuration.hxx
@@ -122,6 +122,20 @@ struct configuration {
 
   [[nodiscard]] auto select_network(const std::string& bootstrap_hostname) const -> std::string;
 
+  /**
+   * Returns one node_id per cluster node that currently serves the
+   * key-value service over the requested transport. Nodes that do not
+   * expose a KV port for @p t are filtered out — without a KV port the
+   * fallback hash would be derived from a meaningless port=0 and could
+   * collide with a sibling node that is also missing its KV port.
+   *
+   * The returned vector preserves topology order; callers that want a
+   * set semantic should hash the entries themselves (couchbase::node_id
+   * is hashable). Topology nodes are unique by construction, so no
+   * dedup is performed here.
+   */
+  [[nodiscard]] auto effective_node_ids(transport t) const -> std::vector<couchbase::node_id>;
+
   using vbucket_map = typename std::vector<std::vector<std::int16_t>>;
 
   std::optional<std::int64_t> epoch{};

--- a/couchbase/collection.hxx
+++ b/couchbase/collection.hxx
@@ -36,6 +36,7 @@
 #include <couchbase/mutate_in_options.hxx>
 #include <couchbase/mutate_in_specs.hxx>
 #include <couchbase/node_id_for_options.hxx>
+#include <couchbase/node_ids_options.hxx>
 #include <couchbase/query_options.hxx>
 #include <couchbase/remove_options.hxx>
 #include <couchbase/replace_options.hxx>
@@ -1117,8 +1118,13 @@ public:
    * truthy and byte-for-byte equal to the @c node_id surfaced on results and
    * errors of KV operations against the same key for the current topology.
    *
+   * @note The returned identity reflects the topology snapshot at call
+   * time. During a rebalance, the @c node_id returned here may transiently
+   * not appear in a subsequent call to @ref node_ids (and vice versa); the
+   * two APIs are consistent only against a stable topology.
+   *
    * @param document_id the document id to resolve
-   * @param options options to customize the request (timeout, parent_span)
+   * @param options options to customize the request (e.g. timeout)
    * @param handler the handler that receives the result
    *
    * @exception errc::common::invalid_argument if @p document_id is empty.
@@ -1158,6 +1164,78 @@ public:
   [[nodiscard]] auto node_id_for(std::string document_id,
                                  const node_id_for_options& options = {}) const
     -> std::future<std::pair<error, node_id>>;
+
+  /**
+   * Returns the cluster nodes that currently serve key-value traffic for
+   * this collection's bucket, drawn from the client-side topology snapshot
+   * (no network round-trip).
+   *
+   * Each entry corresponds to one cluster node and is the same node_id
+   * the SDK reports on KV results and errors that touched that node, so
+   * the returned vector is directly comparable to the keys of any
+   * application-side state that is keyed by node_id (e.g. a per-node
+   * circuit breaker registry). A periodic sweep that diffs the
+   * registry's keys against this set is the canonical way to retire
+   * tracker state for a node that has been removed from the cluster
+   * topology.
+   *
+   * Entries are returned in topology order; no deduplication is
+   * performed (topology nodes are unique by construction). Callers that
+   * want a set semantic can hash the entries themselves —
+   * @c std::hash<couchbase::node_id> is specialised for this purpose.
+   *
+   * Nodes that do not expose a key-value port for the configured
+   * transport (TLS or plain) are excluded from the result, since they do
+   * not serve KV operations and therefore have no meaningful identity
+   * from the SDK's point of view.
+   *
+   * @note The returned vector is a snapshot of the topology at call time.
+   * During a rebalance, a @c node_id previously returned by @ref
+   * node_id_for may transiently not appear here (and vice versa); the
+   * two APIs are consistent only against a stable topology. Application
+   * sweep loops should tolerate transient differences (e.g. require a
+   * node to be absent across two consecutive sweeps before retiring
+   * tracker state) rather than acting on a single snapshot.
+   *
+   * @param options options to customize the request (e.g. timeout)
+   * @param handler the handler that receives the result
+   *
+   * @exception errc::common::bucket_not_found if the bucket does not exist.
+   * @exception errc::network::configuration_not_available if the bucket
+   *            configuration is absent or its set of KV-serving nodes is
+   *            momentarily empty (e.g. mid-rebalance).
+   * @exception errc::common::unambiguous_timeout if the bucket
+   *            configuration did not arrive within the request timeout.
+   *
+   * @since 1.3.2
+   * @uncommitted
+   */
+  void node_ids(const node_ids_options& options, node_ids_handler&& handler) const;
+
+  /**
+   * Returns the cluster nodes that currently serve key-value traffic for
+   * this collection's bucket, drawn from the client-side topology snapshot
+   * (no network round-trip).
+   *
+   * See the handler overload for the full contract, including topology-
+   * snapshot semantics and the exception set.
+   *
+   * @param options options to customize the request
+   * @return future carrying the error (if any) and the vector of
+   *         @c node_id entries in topology order
+   *
+   * @exception errc::common::bucket_not_found if the bucket does not exist.
+   * @exception errc::network::configuration_not_available if the bucket
+   *            configuration is absent or its set of KV-serving nodes is
+   *            momentarily empty (e.g. mid-rebalance).
+   * @exception errc::common::unambiguous_timeout if the bucket
+   *            configuration did not arrive within the request timeout.
+   *
+   * @since 1.3.2
+   * @uncommitted
+   */
+  [[nodiscard]] auto node_ids(const node_ids_options& options = {}) const
+    -> std::future<std::pair<error, std::vector<node_id>>>;
 
   [[nodiscard]] auto query_indexes() const -> collection_query_index_manager;
 

--- a/couchbase/node_ids_options.hxx
+++ b/couchbase/node_ids_options.hxx
@@ -1,0 +1,68 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <couchbase/common_options.hxx>
+#include <couchbase/error.hxx>
+#include <couchbase/node_id.hxx>
+
+#include <functional>
+#include <vector>
+
+namespace couchbase
+{
+
+/**
+ * Options for @ref couchbase::collection::node_ids().
+ *
+ * @since 1.3.2
+ * @uncommitted
+ */
+struct node_ids_options : public common_options<node_ids_options> {
+  /**
+   * Immutable value object representing consistent options.
+   *
+   * @since 1.3.2
+   * @internal
+   */
+  struct built : public common_options<node_ids_options>::built {
+  };
+
+  /**
+   * Validates options and returns them as an immutable value.
+   *
+   * @return consistent options as an immutable value
+   *
+   * @since 1.3.2
+   * @internal
+   */
+  [[nodiscard]] auto build() const -> built
+  {
+    return { build_common_options() };
+  }
+};
+
+/**
+ * Handler signature for @ref couchbase::collection::node_ids().
+ *
+ * @since 1.3.2
+ * @uncommitted
+ */
+using node_ids_handler = std::function<void(error, std::vector<node_id>)>;
+
+} // namespace couchbase

--- a/test/test_integration_node_id.cxx
+++ b/test/test_integration_node_id.cxx
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstddef>
+#include <unordered_set>
 
 static const tao::json::value basic_doc = {
   { "a", 1.0 },
@@ -225,6 +226,114 @@ TEST_CASE("integration: node_id surfaces nodeUUID iff the server provides it", "
     // Fallback id is the 8-hex-char CRC32 form.
     REQUIRE(nid.id().size() == 8);
   }
+}
+
+TEST_CASE("integration: node_ids returns the bucket's KV-serving nodes", "[integration]")
+{
+  test::utils::integration_test_guard integration;
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
+
+  auto [err, nids] = collection.node_ids().get();
+  REQUIRE_FALSE(err.ec());
+  REQUIRE_FALSE(nids.empty());
+  // Tighter bound than "<= number_of_nodes": every node in the test
+  // cluster's service-aware count is by definition a KV-serving node, so
+  // we expect exact equality. If a future cluster topology adds non-KV
+  // nodes (analytics-only, search-only, …) this test will need an update
+  // — that is the explicit signal we want.
+  REQUIRE(nids.size() == integration.number_of_nodes_with_service("kv"));
+
+  // Every entry must be a fully-formed node_id: truthy, with a non-empty
+  // id() and hostname(). Mirrors the per-node assertions used elsewhere
+  // in this file for result.node_id() and error.node_id().
+  for (const auto& nid : nids) {
+    REQUIRE(static_cast<bool>(nid));
+    REQUIRE_FALSE(nid.id().empty());
+    REQUIRE_FALSE(nid.hostname().empty());
+  }
+}
+
+TEST_CASE("integration: node_ids contains the result of node_id_for", "[integration]")
+{
+  test::utils::integration_test_guard integration;
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
+
+  auto id = test::utils::uniq_id("node_ids_contains_for");
+
+  auto [for_err, target] = collection.node_id_for(id).get();
+  REQUIRE_FALSE(for_err.ec());
+
+  auto [ids_err, nids] = collection.node_ids().get();
+  REQUIRE_FALSE(ids_err.ec());
+
+  std::unordered_set<couchbase::node_id> live{ nids.begin(), nids.end() };
+  REQUIRE(live.find(target) != live.end());
+}
+
+TEST_CASE("integration: node_ids contains the result.node_id of a successful KV op",
+          "[integration]")
+{
+  // The end-to-end consistency check: the node_id surfaced on a real KV
+  // result must be one of the entries node_ids() reports as live. This is
+  // what makes a registry keyed on result.node_id() directly diffable
+  // against node_ids() in a sweep.
+  test::utils::integration_test_guard integration;
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
+
+  auto id = test::utils::uniq_id("node_ids_contains_result");
+
+  auto [up_err, up_resp] = collection.upsert(id, basic_doc, {}).get();
+  REQUIRE_SUCCESS(up_err.ec());
+  REQUIRE(static_cast<bool>(up_resp.node_id()));
+
+  auto [ids_err, nids] = collection.node_ids().get();
+  REQUIRE_FALSE(ids_err.ec());
+
+  std::unordered_set<couchbase::node_id> live{ nids.begin(), nids.end() };
+  REQUIRE(live.find(up_resp.node_id()) != live.end());
+}
+
+TEST_CASE("integration: node_ids is deterministic across calls", "[integration]")
+{
+  // This test assumes the cluster topology is stable across the two calls.
+  // A rebalance between the calls would change the order or membership of
+  // the returned set and flake the assertion; CI is expected to provide a
+  // stable topology while this test runs. (We deliberately do not weaken
+  // the assertion to "same multiset" because the public contract
+  // documents topology order as deterministic on a stable cluster, and
+  // weakening here would hide an order regression.)
+  test::utils::integration_test_guard integration;
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket(integration.ctx.bucket).default_collection();
+
+  auto [err1, nids1] = collection.node_ids().get();
+  REQUIRE_FALSE(err1.ec());
+
+  auto [err2, nids2] = collection.node_ids().get();
+  REQUIRE_FALSE(err2.ec());
+
+  // Topology order is deterministic on a stable cluster, so the vectors
+  // must compare element-wise — not merely have the same set of entries.
+  REQUIRE(nids1 == nids2);
+}
+
+TEST_CASE("integration: node_ids fails cleanly on missing bucket", "[integration]")
+{
+  // Mirrors node_id_for_fails_cleanly_on_missing_bucket: the missing-bucket
+  // case is surfaced via the ec parameter of with_bucket_configuration,
+  // not the request timeout. Pinning the exact error code prevents a future
+  // change from silently dropping into a different (e.g. timeout) branch.
+  test::utils::integration_test_guard integration;
+  auto cluster = integration.public_cluster();
+  auto collection = cluster.bucket("bucket-that-does-not-exist").default_collection();
+
+  auto [err, nids] =
+    collection.node_ids(couchbase::node_ids_options{}.timeout(std::chrono::seconds{ 5 })).get();
+  REQUIRE(err.ec() == couchbase::errc::common::bucket_not_found);
+  REQUIRE(nids.empty());
 }
 
 TEST_CASE("integration: lookup_in result carries node_id on success", "[integration]")

--- a/test/test_unit_node_id.cxx
+++ b/test/test_unit_node_id.cxx
@@ -429,6 +429,214 @@ TEST_CASE("unit: node_id ignores alternate addresses with node_uuid", "[unit]")
   REQUIRE(tls.port() == 11207);
 }
 
+TEST_CASE("unit: configuration::effective_node_ids on empty topology", "[unit]")
+{
+  // The pure enumerator maps a configuration with no nodes to an empty
+  // list — it applies no error policy. The error policy lives one layer
+  // up: resolve_node_ids_from_config() turns both a null configuration
+  // and an empty result into configuration_not_available, so the public
+  // node_ids() API never hands back a successful empty vector.
+  couchbase::core::topology::configuration config;
+  REQUIRE(config.effective_node_ids(couchbase::core::topology::transport::plain).empty());
+  REQUIRE(config.effective_node_ids(couchbase::core::topology::transport::tls).empty());
+}
+
+TEST_CASE("unit: configuration::effective_node_ids preserves order", "[unit]")
+{
+  couchbase::core::topology::configuration config;
+  config.nodes.resize(3);
+  config.nodes[0].node_uuid = "uuid-a";
+  config.nodes[0].hostname = "h0";
+  config.nodes[0].services_plain.key_value = 11210;
+  config.nodes[1].node_uuid = "uuid-b";
+  config.nodes[1].hostname = "h1";
+  config.nodes[1].services_plain.key_value = 11210;
+  config.nodes[2].node_uuid = "uuid-c";
+  config.nodes[2].hostname = "h2";
+  config.nodes[2].services_plain.key_value = 11210;
+
+  auto ids = config.effective_node_ids(couchbase::core::topology::transport::plain);
+  REQUIRE(ids.size() == 3);
+  REQUIRE(ids[0].id() == "uuid-a");
+  REQUIRE(ids[1].id() == "uuid-b");
+  REQUIRE(ids[2].id() == "uuid-c");
+}
+
+TEST_CASE("unit: configuration::effective_node_ids filters non-KV nodes", "[unit]")
+{
+  // Mirrors a heterogeneous deployment where the query and search nodes
+  // do not host the KV service for this bucket. A circuit breaker keyed
+  // on node_id only cares about KV-serving nodes, so dropping them keeps
+  // the registry's keys directly comparable to the SDK's KV result/error
+  // node_ids on every code path.
+  couchbase::core::topology::configuration config;
+  config.nodes.resize(4);
+  config.nodes[0].node_uuid = "kv-1";
+  config.nodes[0].hostname = "h0";
+  config.nodes[0].services_plain.key_value = 11210;
+  // node 1 is a query-only node — no KV port at all
+  config.nodes[1].node_uuid = "query-only";
+  config.nodes[1].hostname = "h1";
+  config.nodes[1].services_plain.query = 8093;
+  // node 2 has KV but only on TLS — must drop on plain transport
+  config.nodes[2].node_uuid = "tls-only-kv";
+  config.nodes[2].hostname = "h2";
+  config.nodes[2].services_tls.key_value = 11207;
+  config.nodes[3].node_uuid = "kv-2";
+  config.nodes[3].hostname = "h3";
+  config.nodes[3].services_plain.key_value = 11210;
+  config.nodes[3].services_tls.key_value = 11207;
+
+  auto plain = config.effective_node_ids(couchbase::core::topology::transport::plain);
+  REQUIRE(plain.size() == 2);
+  REQUIRE(plain[0].id() == "kv-1");
+  REQUIRE(plain[1].id() == "kv-2");
+
+  auto tls = config.effective_node_ids(couchbase::core::topology::transport::tls);
+  REQUIRE(tls.size() == 2);
+  REQUIRE(tls[0].id() == "tls-only-kv");
+  REQUIRE(tls[1].id() == "kv-2");
+}
+
+TEST_CASE("unit: configuration::effective_node_ids matches per-node effective_node_id", "[unit]")
+{
+  // For every node that survives the filter, the result must be byte-for-byte
+  // identical to what node::effective_node_id(is_tls) produces on its own —
+  // node_ids() is documented as the same identity the SDK reports on KV
+  // results/errors, and that identity comes through node::effective_node_id.
+  couchbase::core::topology::configuration config;
+  config.nodes.resize(2);
+  config.nodes[0].hostname = "172.18.0.2";
+  config.nodes[0].services_plain.key_value = 11210;
+  config.nodes[0].services_tls.key_value = 11207;
+  config.nodes[1].node_uuid = "node-uuid-7";
+  config.nodes[1].hostname = "172.18.0.3";
+  config.nodes[1].services_plain.key_value = 11210;
+  config.nodes[1].services_tls.key_value = 11207;
+
+  for (bool is_tls : { false, true }) {
+    auto ids = config.effective_node_ids(as_transport(is_tls));
+    REQUIRE(ids.size() == 2);
+    REQUIRE(ids[0] == config.nodes[0].effective_node_id(as_transport(is_tls)));
+    REQUIRE(ids[1] == config.nodes[1].effective_node_id(as_transport(is_tls)));
+  }
+}
+
+TEST_CASE("unit: configuration::effective_node_ids differs between TLS and plain on pre-8.0 nodes",
+          "[unit]")
+{
+  // Without UUIDs the fallback hash incorporates the actual KV port the
+  // client connects to, so the same node yields a different node_id over
+  // TLS vs plain. node_ids() must reflect that — otherwise a registry
+  // populated from TLS-side results could fail to match keys derived from
+  // plain-side topology data.
+  couchbase::core::topology::configuration config;
+  config.nodes.resize(1);
+  config.nodes[0].hostname = "172.18.0.2";
+  config.nodes[0].services_plain.key_value = 11210;
+  config.nodes[0].services_tls.key_value = 11207;
+
+  auto plain = config.effective_node_ids(couchbase::core::topology::transport::plain);
+  auto tls = config.effective_node_ids(couchbase::core::topology::transport::tls);
+  REQUIRE(plain.size() == 1);
+  REQUIRE(tls.size() == 1);
+  REQUIRE(plain[0] != tls[0]);
+}
+
+TEST_CASE("unit: configuration::effective_node_ids agrees on TLS and plain when uuids are present",
+          "[unit]")
+{
+  // The reverse of the previous test: with UUIDs the identity is transport-
+  // independent, so the same node has the same node_id on both transports.
+  // This is the property that makes a circuit breaker registry portable
+  // across a TLS upgrade on a Server 8.0.1+ cluster.
+  couchbase::core::topology::configuration config;
+  config.nodes.resize(2);
+  config.nodes[0].node_uuid = "uuid-a";
+  config.nodes[0].hostname = "172.18.0.2";
+  config.nodes[0].services_plain.key_value = 11210;
+  config.nodes[0].services_tls.key_value = 11207;
+  config.nodes[1].node_uuid = "uuid-b";
+  config.nodes[1].hostname = "172.18.0.3";
+  config.nodes[1].services_plain.key_value = 11210;
+  config.nodes[1].services_tls.key_value = 11207;
+
+  auto plain = config.effective_node_ids(couchbase::core::topology::transport::plain);
+  auto tls = config.effective_node_ids(couchbase::core::topology::transport::tls);
+  REQUIRE(plain.size() == 2);
+  REQUIRE(tls.size() == 2);
+  for (std::size_t i = 0; i < plain.size(); ++i) {
+    REQUIRE(plain[i] == tls[i]);
+  }
+}
+
+TEST_CASE("unit: configuration::effective_node_ids ignores alternate addresses", "[unit]")
+{
+  // A consumer using the default-network identity (which the SDK exposes
+  // via node_ids()) must not see entries from the external/alt alias —
+  // otherwise the same physical node could appear twice in the breaker
+  // registry under two different keys.
+  couchbase::core::topology::configuration config;
+  config.nodes.resize(1);
+  config.nodes[0].hostname = "172.18.0.2";
+  config.nodes[0].services_plain.key_value = 11210;
+  config.nodes[0].services_tls.key_value = 11207;
+
+  couchbase::core::topology::configuration::alternate_address ext;
+  ext.name = "external";
+  ext.hostname = "172-18-0-2.my.cloud.com";
+  ext.services_plain.key_value = 31100;
+  ext.services_tls.key_value = 31207;
+  config.nodes[0].alt["external"] = ext;
+
+  for (bool is_tls : { false, true }) {
+    auto ids = config.effective_node_ids(as_transport(is_tls));
+    REQUIRE(ids.size() == 1);
+    REQUIRE(ids[0].hostname() == "172.18.0.2");
+    REQUIRE(ids[0].hostname() != ext.hostname);
+  }
+}
+
+TEST_CASE("unit: configuration::effective_node_ids feeds into hash-based containers", "[unit]")
+{
+  // The point of node_ids() is to be diffable against application-side
+  // unordered_map<node_id, ...> registries. Lock in that the result type
+  // works as both a key (via std::hash specialization) and as a member of
+  // an unordered_set so callers can express "which keys do I track that
+  // the cluster no longer has?" with a single set_difference-equivalent.
+  couchbase::core::topology::configuration config;
+  config.nodes.resize(3);
+  config.nodes[0].node_uuid = "uuid-a";
+  config.nodes[0].hostname = "h0";
+  config.nodes[0].services_plain.key_value = 11210;
+  config.nodes[1].node_uuid = "uuid-b";
+  config.nodes[1].hostname = "h1";
+  config.nodes[1].services_plain.key_value = 11210;
+  config.nodes[2].node_uuid = "uuid-c";
+  config.nodes[2].hostname = "h2";
+  config.nodes[2].services_plain.key_value = 11210;
+
+  auto ids = config.effective_node_ids(couchbase::core::topology::transport::plain);
+  std::unordered_set<couchbase::node_id> live{ ids.begin(), ids.end() };
+  REQUIRE(live.size() == 3);
+
+  // Tracker registry that has one stale key (the cluster has dropped uuid-c
+  // and added a node with no entry yet for "stale-x").
+  std::unordered_map<couchbase::node_id, int> tracked;
+  tracked[couchbase::internal_node_id::build("uuid-a", "h0", 11210)] = 1;
+  tracked[couchbase::internal_node_id::build("uuid-b", "h1", 11210)] = 1;
+  tracked[couchbase::internal_node_id::build("stale-x", "h-gone", 11210)] = 1;
+
+  std::vector<couchbase::node_id> retired;
+  for (const auto& [k, _] : tracked) {
+    if (live.find(k) == live.end()) {
+      retired.push_back(k);
+    }
+  }
+  REQUIRE(retired.size() == 1);
+  REQUIRE(retired[0].id() == "stale-x");
+}
+
 TEST_CASE("unit: vbucket map resolves to correct node_id", "[unit]")
 {
   couchbase::core::topology::configuration config;
@@ -627,4 +835,94 @@ TEST_CASE("unit: resolve_node_id_from_config returns identity on success", "[uni
   REQUIRE_FALSE(ec);
   REQUIRE(static_cast<bool>(nid));
   REQUIRE((nid.id() == "node-0" || nid.id() == "node-1"));
+}
+
+TEST_CASE("unit: resolve_node_ids_from_config reports no config", "[unit]")
+{
+  // collection_impl::node_ids depends on this pure helper to map a topology
+  // snapshot to (error_code, vector). The null-config branch is otherwise
+  // only reachable when with_bucket_configuration() returns success but
+  // with no config — vanishingly rare from a healthy cluster, so unit
+  // coverage is the only practical way to exercise it.
+  std::shared_ptr<couchbase::core::topology::configuration> null_config;
+  auto [ec, nids] = couchbase::core::impl::resolve_node_ids_from_config(
+    null_config, couchbase::core::topology::transport::plain);
+  REQUIRE(ec == couchbase::errc::network::configuration_not_available);
+  REQUIRE(nids.empty());
+}
+
+TEST_CASE("unit: resolve_node_ids_from_config reports empty effective_node_ids", "[unit]")
+{
+  // Mid-rebalance transient: a topology with no KV-serving nodes for the
+  // requested transport must surface as configuration_not_available, not
+  // as a silent empty-success. Without this guarantee, a
+  // sweep-against-registry loop would conclude the cluster has zero
+  // KV-serving nodes and discard every tracker entry.
+  auto config = std::make_shared<couchbase::core::topology::configuration>();
+  config->nodes.resize(1);
+  config->nodes[0].hostname = "h0";
+  // no services_plain.key_value / services_tls.key_value set, so the node
+  // is filtered out of effective_node_ids regardless of transport.
+
+  auto [ec, nids] = couchbase::core::impl::resolve_node_ids_from_config(
+    config, couchbase::core::topology::transport::plain);
+  REQUIRE(ec == couchbase::errc::network::configuration_not_available);
+  REQUIRE(nids.empty());
+}
+
+TEST_CASE("unit: resolve_node_ids_from_config returns nodes on success", "[unit]")
+{
+  auto config = std::make_shared<couchbase::core::topology::configuration>();
+  config->nodes.resize(2);
+  config->nodes[0].node_uuid = "uuid-a";
+  config->nodes[0].hostname = "h0";
+  config->nodes[0].services_plain.key_value = 11210;
+  config->nodes[1].node_uuid = "uuid-b";
+  config->nodes[1].hostname = "h1";
+  config->nodes[1].services_plain.key_value = 11210;
+
+  auto [ec, nids] = couchbase::core::impl::resolve_node_ids_from_config(
+    config, couchbase::core::topology::transport::plain);
+  REQUIRE_FALSE(ec);
+  REQUIRE(nids.size() == 2);
+  REQUIRE(nids[0].id() == "uuid-a");
+  REQUIRE(nids[1].id() == "uuid-b");
+}
+
+TEST_CASE("unit: effective_node_ids handles mixed-transport heterogeneous topology", "[unit]")
+{
+  // A topology where each node exposes a different subset of KV ports:
+  // - node 0: plain only
+  // - node 1: TLS only
+  // - node 2: both
+  // node_ids(plain) must return {0, 2}; node_ids(tls) must return {1, 2}.
+  // This locks in the filter's interaction with effective_node_ids per
+  // transport — a regression in the filter logic would silently expose
+  // identities for KV-less nodes.
+  couchbase::core::topology::configuration config;
+  config.nodes.resize(3);
+  config.nodes[0].node_uuid = "plain-only";
+  config.nodes[0].hostname = "h0";
+  config.nodes[0].services_plain.key_value = 11210;
+  // no TLS
+
+  config.nodes[1].node_uuid = "tls-only";
+  config.nodes[1].hostname = "h1";
+  config.nodes[1].services_tls.key_value = 11207;
+  // no plain
+
+  config.nodes[2].node_uuid = "both";
+  config.nodes[2].hostname = "h2";
+  config.nodes[2].services_plain.key_value = 11210;
+  config.nodes[2].services_tls.key_value = 11207;
+
+  auto plain_ids = config.effective_node_ids(couchbase::core::topology::transport::plain);
+  REQUIRE(plain_ids.size() == 2);
+  REQUIRE(plain_ids[0].id() == "plain-only");
+  REQUIRE(plain_ids[1].id() == "both");
+
+  auto tls_ids = config.effective_node_ids(couchbase::core::topology::transport::tls);
+  REQUIRE(tls_ids.size() == 2);
+  REQUIRE(tls_ids[0].id() == "tls-only");
+  REQUIRE(tls_ids[1].id() == "both");
 }


### PR DESCRIPTION
Expose the set of cluster nodes that currently serve key-value traffic for a collection's bucket as a public API drawn from the client-side topology snapshot, with no network round-trip. This closes the node_id surface introduced by CXXCBC-820 (the value type) and CXXCBC-821 (node_id_for and result/error attribution): it is the piece application-side state machines keyed on couchbase::node_id need in order to retire tracking entries when a node leaves the cluster topology.

Public API:

- couchbase::collection gains node_ids(options, handler) and a std::future-returning overload, both marked `@since 1.3.2` and `@uncommitted` to mirror node_id_for.
- couchbase::node_ids_options carries the standard common_options (timeout, parent_span, retry_strategy) and builds an immutable node_ids_options::built for the impl layer.
- Each entry in the returned vector is the same node_id the SDK reports on KV results and errors that touched that node, so the result is directly comparable to the keys of any unordered_map<node_id, ...> the application keeps (e.g. an external circuit-breaker registry).

Semantics:

- Nodes that do not expose a key-value port for the configured transport (TLS or plain) are filtered out: keeping them would derive the pre-8.0 fallback hash from a meaningless port=0 that could collide across KV-less nodes.
- Order is topology order with no deduplication; topology nodes are unique by construction. Callers wanting set semantics can hash the entries themselves (std::hash<couchbase::node_id> is specialized).
- An empty effective node set surfaces errc::network::configuration_not_available rather than a successful empty vector, so the mid-rebalance "topology momentarily exposes no KV nodes" transient is a hard error, matching node_id_for()'s contract on an empty vbmap.
- Other errors mirror node_id_for: unambiguous_timeout when the bucket configuration does not arrive within the request timeout, bucket_not_found / configuration_not_available when it is absent, and any error returned from core::cluster::origin().
- Doxygen on both node_id_for and node_ids documents the topology-snapshot semantics: a node_id returned by one API may transiently not appear in the other across a rebalance; consistency holds only against a stable topology, so sweep loops should require an absence across two consecutive snapshots before retiring tracker state.

Internal layering:

- core::topology::configuration::effective_node_ids(transport) is the pure helper: node iteration, KV-port filter, per-node call to effective_node_id(transport), shrink-to-fit on the result. Lives next to node::effective_node_id for symmetry and is unit-testable without an io_context or a cluster.
- core::impl::resolve_node_ids_from_config maps a topology snapshot to (error_code, vector<node_id>), alongside resolve_node_id_from_config, so the null-config / empty-set / success branches are unit-testable.
- core::impl::with_bucket_config_or_timeout<Payload> is a shared async scaffold owning the atomic-done guard, steady_timer, and asio::post hop back to the io_context. Both collection_impl::node_id_for and collection_impl::node_ids use it, so exactly one of {timer, config callback} fires the user handler and the timing logic lives in one place. The timer is cancelled only on its own executor (the io_context), since asio::steady_timer is not thread-safe.
- collection::node_ids forwards to the impl; the future form wraps the handler form in the standard promise pattern used elsewhere in collection.