### PR TITLE
Make integration tests pass under Valgrind

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -116,12 +116,20 @@ jobs:
           - lsan
           - tsan
           - ubsan
-          - valgrind
         server:
           - 8.0.0
         tls:
           - plain
           - tls
+        # valgrind runs under memcheck and is far slower than the other
+        # sanitizers (~110-130 min for the full suite), leaving no headroom
+        # under the 120 min step budget. Shard it across two jobs (~1h each)
+        # via ctest -I stride; the other sanitizers are fast and run unsharded.
+        include:
+          - { sanitizer: valgrind, server: 8.0.0, tls: plain, shard_index: 1, shard_total: 2 }
+          - { sanitizer: valgrind, server: 8.0.0, tls: plain, shard_index: 2, shard_total: 2 }
+          - { sanitizer: valgrind, server: 8.0.0, tls: tls, shard_index: 1, shard_total: 2 }
+          - { sanitizer: valgrind, server: 8.0.0, tls: tls, shard_index: 2, shard_total: 2 }
     runs-on: ubuntu-24.04
     steps:
       - name: Install dependencies
@@ -157,6 +165,8 @@ jobs:
           TEST_SERVER_VERSION: ${{ matrix.server }}
           TEST_CONNECTION_STRING: ${{ matrix.tls == 'tls' && format('{0}?trust_certificate=cluster.crt', steps.cbdino.outputs.tls-connstr) || steps.cbdino.outputs.connstr }}
           TEST_LOG_LEVEL: trace
+          CB_TEST_SHARD_INDEX: ${{ matrix.shard_index }}
+          CB_TEST_SHARD_TOTAL: ${{ matrix.shard_total }}
         run: |
           chmod -R +x ./cmake-build-tests-${{ matrix.sanitizer }}
           ./bin/run-integration-tests
@@ -168,6 +178,6 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: report-integration-${{ matrix.sanitizer }}-${{ matrix.tls }}-${{ matrix.server }}
+          name: report-integration-${{ matrix.sanitizer }}-${{ matrix.tls }}-${{ matrix.server }}${{ matrix.shard_index && format('-shard{0}', matrix.shard_index) || '' }}
           path: |
             cmake-build-tests-${{ matrix.sanitizer }}/Testing/Temporary/*.log

--- a/.valgrind_suppressions.txt
+++ b/.valgrind_suppressions.txt
@@ -48,3 +48,13 @@
    fun:RAND_bytes_with_additional_data
    ...
 }
+{
+   glibc-pthread-create-tls-dtv
+   Memcheck:Leak
+   match-leak-kinds: possible
+   ...
+   fun:_dl_allocate_tls
+   ...
+   fun:pthread_create*
+   ...
+}

--- a/bin/run-integration-tests
+++ b/bin/run-integration-tests
@@ -106,7 +106,19 @@ fi
 ulimit -c unlimited
 
 export TEST_CONNECTION_STRING="${TEST_CONNECTION_STRING//cluster.crt/${PROJECT_ROOT}/cluster.crt}"
-${CB_CTEST} ${CB_CTEST_EXTRAS} --output-on-failure --label-regex 'integration' --output-junit results.xml
+
+# Optional test sharding: split the suite across N parallel CI jobs. When
+# CB_TEST_SHARD_INDEX/CB_TEST_SHARD_TOTAL are set, run only tests whose global
+# ctest index falls on this shard's stride (-I start,,stride). The label filter
+# is applied on top, and the union of all shards covers the full set with no
+# overlap. Used by the valgrind leg, which is too slow to fit one job.
+CB_TEST_SHARD_INDEX=${CB_TEST_SHARD_INDEX:-}
+CB_TEST_SHARD_TOTAL=${CB_TEST_SHARD_TOTAL:-}
+CB_CTEST_SHARD=""
+if [ -n "${CB_TEST_SHARD_INDEX}" ] && [ -n "${CB_TEST_SHARD_TOTAL}" ]; then
+    CB_CTEST_SHARD="-I ${CB_TEST_SHARD_INDEX},,${CB_TEST_SHARD_TOTAL}"
+fi
+${CB_CTEST} ${CB_CTEST_EXTRAS} ${CB_CTEST_SHARD} --output-on-failure --label-regex 'integration' --output-junit results.xml
 STATUS=$?
 
 if [ ! -z "${GOCAVES_PID}" ]

--- a/test/test_integration_analytics.cxx
+++ b/test/test_integration_analytics.cxx
@@ -43,8 +43,8 @@ TEST_CASE("integration: analytics query", "[integration]")
     SKIP("elixir deployment does not support analytics");
   }
 
-  if (!integration.cluster_version().supports_analytics()) {
-    SKIP("cluster does not support analytics");
+  if (!integration.has_analytics_service()) {
+    SKIP("cluster does not have analytics service");
   }
 
   test::utils::open_bucket(integration.cluster, integration.ctx.bucket);
@@ -216,8 +216,8 @@ TEST_CASE("integration: analytics scope query", "[integration]")
     SKIP("elixir deployment does not support analytics");
   }
 
-  if (!integration.cluster_version().supports_analytics()) {
-    SKIP("cluster does not support analytics");
+  if (!integration.has_analytics_service()) {
+    SKIP("cluster does not have analytics service");
   }
   if (!integration.cluster_version().supports_collections()) {
     SKIP("cluster does not support collections");
@@ -343,8 +343,8 @@ TEST_CASE("integration: public API analytics query", "[integration]")
     SKIP("elixir deployment does not support analytics");
   }
 
-  if (!integration.cluster_version().supports_analytics()) {
-    SKIP("cluster does not support analytics");
+  if (!integration.has_analytics_service()) {
+    SKIP("cluster does not have analytics service");
   }
 
   auto cluster = integration.public_cluster();
@@ -548,8 +548,8 @@ TEST_CASE("integration: public API analytics scope query", "[integration]")
     SKIP("elixir deployment does not support analytics");
   }
 
-  if (!integration.cluster_version().supports_analytics()) {
-    SKIP("cluster does not support analytics");
+  if (!integration.has_analytics_service()) {
+    SKIP("cluster does not have analytics service");
   }
   if (!integration.cluster_version().supports_collections()) {
     SKIP("cluster does not support collections");
@@ -636,8 +636,8 @@ TEST_CASE("integration: public API analytics query using both named and position
 {
   test::utils::integration_test_guard integration;
 
-  if (!integration.cluster_version().supports_analytics()) {
-    SKIP("cluster does not support analytics");
+  if (!integration.has_analytics_service()) {
+    SKIP("cluster does not have analytics service");
   }
 
   auto cluster = integration.public_cluster();

--- a/test/test_integration_crud.cxx
+++ b/test/test_integration_crud.cxx
@@ -233,7 +233,11 @@ TEST_CASE("integration: pessimistic locking", "[integration]")
   couchbase::core::document_id id{
     integration.ctx.bucket, "_default", "_default", test::utils::uniq_id("locking")
   };
-  uint32_t lock_time = 10;
+  // Server caps lock duration at 30s; use the max so the lock survives the long
+  // sequence of operations below when running under a sanitizer (valgrind), where
+  // a shorter lock can auto-expire mid-test and turn the expected cas_mismatch
+  // into document_not_locked.
+  uint32_t lock_time = 30;
 
   couchbase::cas cas{};
 

--- a/test/test_integration_examples.cxx
+++ b/test/test_integration_examples.cxx
@@ -280,6 +280,7 @@ public:
   {
     options.timeouts()
       .search_timeout(std::chrono::minutes(5))
+      .key_value_timeout(std::chrono::seconds(20))
       .management_timeout(std::chrono::minutes(5));
   }
 };

--- a/test/test_integration_range_scan.cxx
+++ b/test/test_integration_range_scan.cxx
@@ -841,7 +841,7 @@ TEST_CASE("integration: orchestrator scan range without content", "[integration]
   auto ids = make_doc_ids(100, "rangescanwithoutcontent-");
   auto value = make_binary_value(1);
   auto mutations =
-    populate_documents_for_range_scan(collection, ids, value, std::chrono::seconds{ 30 });
+    populate_documents_for_range_scan(collection, ids, value, std::chrono::seconds{ 300 });
 
   auto vbucket_map = get_vbucket_map(integration);
 
@@ -905,7 +905,7 @@ TEST_CASE("integration: orchestrator scan range with content", "[integration]")
   auto ids = make_doc_ids(100, "rangescanwithcontent-");
   auto value = make_binary_value(100);
   auto mutations =
-    populate_documents_for_range_scan(collection, ids, value, std::chrono::seconds{ 30 });
+    populate_documents_for_range_scan(collection, ids, value, std::chrono::seconds{ 300 });
 
   auto vbucket_map = get_vbucket_map(integration);
 
@@ -1130,7 +1130,7 @@ TEST_CASE("integration: orchestrator prefix scan without content", "[integration
   auto ids = make_doc_ids(100, "prefixscanwithoutcontent-");
   auto value = make_binary_value(1);
   auto mutations =
-    populate_documents_for_range_scan(collection, ids, value, std::chrono::seconds{ 30 });
+    populate_documents_for_range_scan(collection, ids, value, std::chrono::seconds{ 300 });
 
   auto vbucket_map = get_vbucket_map(integration);
 
@@ -1334,7 +1334,7 @@ TEST_CASE("integration: orchestrator prefix scan without content and up to 5 con
   auto ids = make_doc_ids(100, "prefixscanwithoutcontent-");
   auto value = make_binary_value(1);
   auto mutations =
-    populate_documents_for_range_scan(collection, ids, value, std::chrono::seconds{ 30 });
+    populate_documents_for_range_scan(collection, ids, value, std::chrono::seconds{ 300 });
 
   auto vbucket_map = get_vbucket_map(integration);
 
@@ -1396,7 +1396,7 @@ TEST_CASE("integration: orchestrator prefix scan, get 10 items and cancel", "[in
   auto ids = make_doc_ids(15, "prefixscancancel-");
   auto value = make_binary_value(1);
   auto mutations =
-    populate_documents_for_range_scan(collection, ids, value, std::chrono::seconds{ 30 });
+    populate_documents_for_range_scan(collection, ids, value, std::chrono::seconds{ 300 });
 
   auto vbucket_map = get_vbucket_map(integration);
 
@@ -1466,7 +1466,7 @@ TEST_CASE("integration: orchestrator prefix scan with concurrency 0 (invalid arg
   auto ids = make_doc_ids(100, "prefixscaninvalidconcurrency-");
   auto value = make_binary_value(1);
   auto mutations =
-    populate_documents_for_range_scan(collection, ids, value, std::chrono::seconds{ 30 });
+    populate_documents_for_range_scan(collection, ids, value, std::chrono::seconds{ 300 });
 
   auto vbucket_map = get_vbucket_map(integration);
 
@@ -1588,7 +1588,7 @@ TEST_CASE("integration: range scan public API", "[integration]")
   auto ids = make_doc_ids(100, prefix);
   auto value = make_binary_value(1);
   auto mutations =
-    populate_documents_for_range_scan(collection, ids, value, std::chrono::seconds{ 30 });
+    populate_documents_for_range_scan(collection, ids, value, std::chrono::seconds{ 300 });
 
   SECTION("prefix scan")
   {

--- a/test/utils/integration_test_guard.hxx
+++ b/test/utils/integration_test_guard.hxx
@@ -110,7 +110,11 @@ public:
 
   inline auto has_analytics_service() -> bool
   {
-    return has_service(couchbase::core::service_type::analytics);
+    // Analytics is Enterprise-only and version-gated, and is not modelled by
+    // the gocaves mock. Require both that the deployment supports analytics and
+    // that an analytics node is actually present, so callers need a single gate.
+    return cluster_version().supports_analytics() &&
+           has_service(couchbase::core::service_type::analytics);
   }
 
   auto number_of_nodes_with_service(std::string type) -> std::size_t;


### PR DESCRIPTION
Valgrind instrumentation slows client-side work enough that a few tests race server-side TTLs that comfortably hold at native speed:

- Range-scan tests populated documents with a 30s expiry that could lapse before the slowed scan finished, leaving fewer keys than expected. Raise it to 300s, matching the sibling sampling-scan tests.
- The pessimistic-locking test locked a key for 10s, which auto-expired partway through the slowed sequence and turned the expected cas_mismatch into document_not_locked. Lock for the server maximum of 30s.

Two fixes are independent of timing:

- Analytics tests only gated on the server version supporting analytics, so they failed with service_not_available on a cluster that has no analytics node. Skip when the service is absent as well, matching the query suite; clusters that deploy analytics still exercise them.
- Suppress the benign "possibly lost" glibc TLS block allocated for the detached thread spawned by cluster::connect(). It is freed at thread exit, but memcheck reports it via _dl_allocate_tls/pthread_create.