### PR TITLE
Fix ThreadSanitizer integration suite: real replica-cancel race, instrumented libc++, suppression wiring

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -38,7 +38,7 @@ jobs:
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor --output /etc/apt/keyrings/llvm-snapshot.gpg
           sudo bash -c "echo 'deb [signed-by=/etc/apt/keyrings/llvm-snapshot.gpg] https://apt.llvm.org/noble/ llvm-toolchain-noble-${LLVM_VERSION} main' >> /etc/apt/sources.list"
           sudo apt-get update -y
-          sudo apt-get install -y clang-${LLVM_VERSION} clang-tools-${LLVM_VERSION} libc++-${LLVM_VERSION}-dev libc++abi-${LLVM_VERSION}-dev
+          sudo apt-get install -y clang-${LLVM_VERSION} clang-tools-${LLVM_VERSION} libc++-${LLVM_VERSION}-dev libc++abi-${LLVM_VERSION}-dev libclang-rt-${LLVM_VERSION}-dev
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -82,7 +82,7 @@ jobs:
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor --output /etc/apt/keyrings/llvm-snapshot.gpg
           sudo bash -c "echo 'deb [signed-by=/etc/apt/keyrings/llvm-snapshot.gpg] https://apt.llvm.org/noble/ llvm-toolchain-noble-${LLVM_VERSION} main' >> /etc/apt/sources.list"
           sudo apt-get update -y
-          sudo apt-get install -y clang-${LLVM_VERSION} clang-tools-${LLVM_VERSION} libc++-${LLVM_VERSION}-dev libc++abi-${LLVM_VERSION}-dev
+          sudo apt-get install -y clang-${LLVM_VERSION} clang-tools-${LLVM_VERSION} libc++-${LLVM_VERSION}-dev libc++abi-${LLVM_VERSION}-dev libclang-rt-${LLVM_VERSION}-dev
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -139,7 +139,7 @@ jobs:
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor --output /etc/apt/keyrings/llvm-snapshot.gpg
           sudo bash -c "echo 'deb [signed-by=/etc/apt/keyrings/llvm-snapshot.gpg] https://apt.llvm.org/noble/ llvm-toolchain-noble-${LLVM_VERSION} main' >> /etc/apt/sources.list"
           sudo apt-get update -y
-          sudo apt-get install -y clang-${LLVM_VERSION} clang-tools-${LLVM_VERSION} libc++-${LLVM_VERSION}-dev libc++abi-${LLVM_VERSION}-dev
+          sudo apt-get install -y clang-${LLVM_VERSION} clang-tools-${LLVM_VERSION} libc++-${LLVM_VERSION}-dev libc++abi-${LLVM_VERSION}-dev libclang-rt-${LLVM_VERSION}-dev
       - uses: actions/checkout@v4
         with:
           submodules: recursive

--- a/bin/build-tests
+++ b/bin/build-tests
@@ -74,7 +74,12 @@ case "${CB_SANITIZER}" in
         CB_CMAKE_EXTRAS="${CB_CMAKE_EXTRAS} -DCOUCHBASE_CXX_CLIENT_BUILD_OPENTELEMETRY=OFF"
         CB_STDLIB_FLAGS="-stdlib=libc++ -Wno-unused-result"
         CB_LINK_FLAGS="-stdlib=libc++ -lc++abi"
-        export TSAN_OPTIONS="second_deadlock_stack=1,suppressions=${PROJECT_ROOT}/.tsan_suppressions"
+        # The distro libc++ is not built with -fsanitize=thread, so TSan cannot see the
+        # happens-before edges inside its shared_ptr/promise/future internals and reports
+        # phantom races. ignore_noninstrumented_modules=1 makes TSan disregard accesses that
+        # occur entirely inside uninstrumented modules (libc++, the libclang_rt runtime),
+        # keeping only races that involve our own instrumented code.
+        export TSAN_OPTIONS="second_deadlock_stack=1,ignore_noninstrumented_modules=1,suppressions=${PROJECT_ROOT}/.tsan_suppressions"
         ;;
 
     msan | memory)

--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -65,12 +65,13 @@ macro(integration_test name)
   endif()
   set(_catch_extra_args "")
   if(DEFINED COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS AND EXISTS "${COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS}")
-    set(_catch_extra_args ENVIRONMENT "TSAN_OPTIONS=halt_on_error=0,suppressions=${COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS}")
+    set(_catch_extra_args ENVIRONMENT
+                          "TSAN_OPTIONS=halt_on_error=0,second_deadlock_stack=1,ignore_noninstrumented_modules=1,suppressions=${COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS}")
   endif()
   catch_discover_tests(
     test_integration_${name}
-    ${_catch_extra_args}
     PROPERTIES
+    ${_catch_extra_args}
     SKIP_REGULAR_EXPRESSION
     "SKIP"
     LABELS
@@ -113,12 +114,13 @@ macro(transaction_test name)
   endif()
   set(_catch_extra_args "")
   if(DEFINED COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS AND EXISTS "${COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS}")
-    set(_catch_extra_args ENVIRONMENT "TSAN_OPTIONS=halt_on_error=0,suppressions=${COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS}")
+    set(_catch_extra_args ENVIRONMENT
+                          "TSAN_OPTIONS=halt_on_error=0,second_deadlock_stack=1,ignore_noninstrumented_modules=1,suppressions=${COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS}")
   endif()
   catch_discover_tests(
     test_transaction_${name}
-    ${_catch_extra_args}
     PROPERTIES
+    ${_catch_extra_args}
     SKIP_REGULAR_EXPRESSION
     "SKIP"
     LABELS
@@ -160,12 +162,13 @@ macro(unit_test name)
   endif()
   set(_catch_extra_args "")
   if(DEFINED COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS AND EXISTS "${COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS}")
-    set(_catch_extra_args ENVIRONMENT "TSAN_OPTIONS=halt_on_error=0,suppressions=${COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS}")
+    set(_catch_extra_args ENVIRONMENT
+                          "TSAN_OPTIONS=halt_on_error=0,second_deadlock_stack=1,ignore_noninstrumented_modules=1,suppressions=${COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS}")
   endif()
   catch_discover_tests(
     test_unit_${name}
-    ${_catch_extra_args}
     PROPERTIES
+    ${_catch_extra_args}
     SKIP_REGULAR_EXPRESSION
     "SKIP"
     LABELS

--- a/core/bucket.hxx
+++ b/core/bucket.hxx
@@ -23,6 +23,7 @@
 #include "tls_context_provider.hxx"
 
 #include <asio/bind_executor.hpp>
+#include <asio/dispatch.hpp>
 #include <asio/io_context.hpp>
 #include <asio/post.hpp>
 #include <asio/ssl.hpp>
@@ -111,6 +112,17 @@ public:
   template<typename Request>
   void map_and_send(std::shared_ptr<operations::mcbp_command<bucket, Request>> cmd)
   {
+    if constexpr (operations::is_cancellable_operation_v<Request>) {
+      // Confine the dispatch path of cancellable (replica fan-out) commands to
+      // the command strand, so writes to session_/opaque_ here cannot race a
+      // sibling-triggered cancellation arriving on an IO thread. This covers
+      // both the initial dispatch and retry re-entry via schedule_for_retry.
+      if (!cmd->strand_.running_in_this_thread()) {
+        return asio::dispatch(cmd->strand_, [self = shared_from_this(), cmd]() {
+          self->map_and_send(cmd);
+        });
+      }
+    }
     if (is_closed()) {
       return cmd->cancel(retry_reason::do_not_retry);
     }

--- a/core/io/mcbp_command.hxx
+++ b/core/io/mcbp_command.hxx
@@ -37,10 +37,14 @@
 #include <couchbase/durability_level.hxx>
 #include <couchbase/error_codes.hxx>
 
+#include <asio/dispatch.hpp>
+#include <asio/io_context.hpp>
 #include <asio/steady_timer.hpp>
+#include <asio/strand.hpp>
 #include <spdlog/fmt/bundled/chrono.h>
 
 #include <functional>
+#include <type_traits>
 #include <utility>
 
 namespace couchbase::core::operations
@@ -57,6 +61,18 @@ struct mcbp_command : public std::enable_shared_from_this<mcbp_command<Manager, 
   using encoded_response_type = typename Request::encoded_response_type;
   asio::steady_timer deadline;
   asio::steady_timer retry_backoff;
+  // Only cancellable operations (replica fan-out) need a strand: their dispatch
+  // path can run on the caller thread while a sibling's completion cancels them
+  // from an IO thread, so all access to session_/opaque_/handler_ is confined to
+  // it. Non-cancellable operations get an empty placeholder instead, so they pay
+  // neither the strand_impl allocation nor any access on the hot path; the strand
+  // is referenced only inside `if constexpr (is_cancellable_operation_v<...>)`.
+  struct unused_strand {
+  };
+  using command_strand = std::conditional_t<is_cancellable_operation_v<Request>,
+                                            asio::strand<asio::io_context::executor_type>,
+                                            unused_strand>;
+  command_strand strand_;
   Request request;
   encoded_request_type encoded;
   std::optional<std::uint32_t> opaque_{};
@@ -76,12 +92,22 @@ struct mcbp_command : public std::enable_shared_from_this<mcbp_command<Manager, 
   std::chrono::time_point<std::chrono::steady_clock> started_at_{};
   std::vector<std::chrono::microseconds> server_durations_{};
 
+  static auto make_command_strand(asio::io_context& ctx) -> command_strand
+  {
+    if constexpr (is_cancellable_operation_v<Request>) {
+      return command_strand{ ctx.get_executor() };
+    } else {
+      return command_strand{};
+    }
+  }
+
   mcbp_command(asio::io_context& ctx,
                std::shared_ptr<Manager> manager,
                Request req,
                std::chrono::milliseconds default_timeout)
     : deadline(ctx)
     , retry_backoff(ctx)
+    , strand_(make_command_strand(ctx))
     , request(req)
     , manager_(manager)
     , timeout_(request.timeout.value_or(default_timeout))
@@ -133,6 +159,16 @@ struct mcbp_command : public std::enable_shared_from_this<mcbp_command<Manager, 
 
   void cancel(retry_reason reason, bool is_timeout = true)
   {
+    if constexpr (is_cancellable_operation_v<Request>) {
+      // Confine cancellation to the command strand so it cannot race the
+      // dispatch path (map_and_send/send_to/send) of a replica sibling that is
+      // still being set up on another thread.
+      if (!strand_.running_in_this_thread()) {
+        return asio::dispatch(strand_, [self = this->shared_from_this(), reason, is_timeout]() {
+          self->cancel(reason, is_timeout);
+        });
+      }
+    }
     if (opaque_ && session_) {
       if (session_->cancel(opaque_.value(), asio::error::operation_aborted, reason)) {
         handler_ = nullptr;
@@ -146,6 +182,36 @@ struct mcbp_command : public std::enable_shared_from_this<mcbp_command<Manager, 
       );
     } else {
       invoke_handler(errc::common::request_canceled);
+    }
+  }
+
+  // Re-dispatch a session completion handler onto the command strand for
+  // cancellable operations, so the response/timeout path (which mcbp_session
+  // invokes on its own IO thread) cannot run concurrently with a strand-confined
+  // cancel(). A no-op passthrough for non-cancellable operations.
+  template<typename Handler>
+  auto on_strand(Handler&& handler)
+  {
+    if constexpr (is_cancellable_operation_v<Request>) {
+      return [self = this->shared_from_this(), handler = std::forward<Handler>(handler)](
+               std::error_code ec,
+               retry_reason reason,
+               io::mcbp_message&& msg,
+               std::optional<key_value_error_map_info> error_info) mutable {
+        if (self->strand_.running_in_this_thread()) {
+          return handler(ec, reason, std::move(msg), std::move(error_info));
+        }
+        asio::dispatch(self->strand_,
+                       [handler = std::move(handler),
+                        ec,
+                        reason,
+                        msg = std::move(msg),
+                        error_info = std::move(error_info)]() mutable {
+                         handler(ec, reason, std::move(msg), std::move(error_info));
+                       });
+      };
+    } else {
+      return std::forward<Handler>(handler);
     }
   }
 
@@ -185,6 +251,15 @@ struct mcbp_command : public std::enable_shared_from_this<mcbp_command<Manager, 
 
   void request_collection_id()
   {
+    if constexpr (is_cancellable_operation_v<Request>) {
+      // Reached from the unknown-collection retry timer on an arbitrary IO
+      // thread; hop onto the strand before touching session_/opaque_.
+      if (!strand_.running_in_this_thread()) {
+        return asio::dispatch(strand_, [self = this->shared_from_this()]() {
+          self->request_collection_id();
+        });
+      }
+    }
     if (session_->is_stopped()) {
       return manager_->map_and_send(this->shared_from_this());
     }
@@ -194,11 +269,11 @@ struct mcbp_command : public std::enable_shared_from_this<mcbp_command<Manager, 
     session_->write_and_subscribe(
       req.opaque(),
       req.data(session_->supports_feature(protocol::hello_feature::snappy)),
-      [self = this->shared_from_this()](
-        std::error_code ec,
-        retry_reason /* reason */,
-        io::mcbp_message&& msg,
-        std::optional<key_value_error_map_info> /* error_info */) mutable {
+      on_strand([self = this->shared_from_this()](
+                  std::error_code ec,
+                  retry_reason /* reason */,
+                  io::mcbp_message&& msg,
+                  std::optional<key_value_error_map_info> /* error_info */) mutable {
         if (ec == asio::error::operation_aborted) {
           return self->invoke_handler(errc::common::ambiguous_timeout);
         }
@@ -216,7 +291,7 @@ struct mcbp_command : public std::enable_shared_from_this<mcbp_command<Manager, 
                                               resp.body().collection_uid());
         self->request.id.collection_uid(resp.body().collection_uid());
         return self->send();
-      });
+      }));
   }
 
   void handle_unknown_collection()
@@ -283,13 +358,13 @@ struct mcbp_command : public std::enable_shared_from_this<mcbp_command<Manager, 
     session_->write_and_subscribe(
       request.opaque,
       encoded.data(session_->supports_feature(protocol::hello_feature::snappy)),
-      [self = this->shared_from_this(),
-       start = std::chrono::steady_clock::now(),
-       dispatch_span = std::move(dispatch_span)](
-        std::error_code ec,
-        retry_reason reason,
-        io::mcbp_message&& msg,
-        std::optional<key_value_error_map_info> /* error_info */) mutable {
+      on_strand([self = this->shared_from_this(),
+                 start = std::chrono::steady_clock::now(),
+                 dispatch_span = std::move(dispatch_span)](
+                  std::error_code ec,
+                  retry_reason reason,
+                  io::mcbp_message&& msg,
+                  std::optional<key_value_error_map_info> /* error_info */) mutable {
         {
           const auto server_duration_us =
             static_cast<std::uint64_t>(protocol::parse_server_duration_us(msg));
@@ -411,7 +486,7 @@ struct mcbp_command : public std::enable_shared_from_this<mcbp_command<Manager, 
         } else {
           io::retry_orchestrator::maybe_retry(self->manager_, self, reason, ec);
         }
-      });
+      }));
   }
 
   void send_to(io::mcbp_session session)

--- a/test/test_integration_range_scan.cxx
+++ b/test/test_integration_range_scan.cxx
@@ -586,11 +586,21 @@ TEST_CASE("integration: range scan cancel during streaming using protocol cancel
     scan_uuid = res.scan_uuid;
   }
 
-  auto execute_protocol_cancel = [agent, scan_uuid, vbid = vbucket_id]() {
-    auto op = agent->range_scan_cancel(scan_uuid, vbid, {}, [](auto /* res */, auto ec) {
-      REQUIRE_SUCCESS(ec);
-    });
-    EXPECT_SUCCESS(op);
+  // The cancellation is triggered from the range_scan_continue item callback, which runs on an
+  // IO thread. Catch2 assertion macros mutate shared state on the main thread's stack and are not
+  // thread-safe, so the cancel outcome is handed back to the main thread through a promise and
+  // asserted there instead of inside the callback.
+  auto cancel_barrier = std::make_shared<std::promise<std::error_code>>();
+  auto cancel_future = cancel_barrier->get_future();
+
+  auto execute_protocol_cancel = [agent, scan_uuid, vbid = vbucket_id, cancel_barrier]() {
+    auto op =
+      agent->range_scan_cancel(scan_uuid, vbid, {}, [cancel_barrier](auto /* res */, auto ec) {
+        cancel_barrier->set_value(ec);
+      });
+    if (!op) {
+      cancel_barrier->set_value(op.error());
+    }
   };
 
   std::vector<couchbase::core::range_scan_item> data;
@@ -633,6 +643,10 @@ TEST_CASE("integration: range scan cancel during streaming using protocol cancel
   } while (true);
 
   REQUIRE(data.size() == 3);
+
+  // Wait for the cancellation issued from the IO thread to complete and assert its outcome on the
+  // main thread.
+  REQUIRE_SUCCESS(cancel_future.get());
 }
 
 TEST_CASE("integration: range scan cancel during streaming using pending_operation cancel",


### PR DESCRIPTION
## Summary

The TSan integration job was failing with a large number of `data race` reports. Triage split the failures into three causes, all addressed here:

1. **Most reports were false positives from an uninstrumented libc++.** The build uses `-stdlib=libc++`, but the distro libc++ is not compiled with `-fsanitize=thread`, so TSan cannot see the happens-before edges inside `shared_ptr`/`promise`/`future`/`condition_variable` and reports phantom races (mostly `operator delete` during cluster teardown). These are silenced with `ignore_noninstrumented_modules=1` — no instrumented libc++ is built.

2. **One genuine product race** in the replica fan-out, fixed here.

3. **A Catch2 harness race** in a range-scan test, plus a cmake wiring bug that left the suppressions file inert.

## Changes

### Serialize replica command dispatch and cancellation on a per-command strand `core/io/mcbp_command.hxx`, `core/bucket.hxx`

`get_any_replica` / `lookup_in_any_replica` / `get_all_replicas` dispatch sibling `mcbp_command`s on the caller thread and share one `cancellation_token` per command. When the first sibling's response arrives on an IO thread it cancels the remaining siblings inline, reading and writing their `session_`/`opaque_`/ `handler_` fields while the caller thread is still inside `core->execute()` writing those same fields. TSan reports this across `mcbp_command::cancel`, `send_to`, error-context construction, and `mcbp_session::cancel`.

Confine the entire mutable lifecycle of cancellable commands to a per-command `asio::strand`: `cancel()`, `bucket::map_and_send()` and `request_collection_id()` self-dispatch onto the strand when not already running on it, and the `write_and_subscribe` completion handlers are re-dispatched onto it, so initial dispatch, retry re-entry, collection-id resolution, the response/timeout path and token-triggered cancellation are all serialized — `invoke_handler` can no longer race a strand-dispatched `cancel()`. Gated on `is_cancellable_operation_v`, so the non-replica KV path is unchanged.

### Run TSan against the prebuilt libclang-rt runtime and ignore uninstrumented libc++ `.github/workflows/sanitizers.yml`, `bin/build-tests`, `cmake/Testing.cmake`

Install the prebuilt `libclang-rt-${LLVM_VERSION}-dev` package (LLVM's sanitizer runtime) alongside the existing clang/libc++ apt packages so `-fsanitize=thread` links against it. Because the distro libc++ is not instrumented, run the tests with `ignore_noninstrumented_modules=1`, which makes TSan disregard accesses that occur entirely inside uninstrumented modules (libc++, the runtime) and keep only races that involve our own code. The option is set both in `bin/build-tests` (`TSAN_OPTIONS`) and in the per-test ctest environment (`cmake/Testing.cmake`).

`cmake/Testing.cmake` also carried a wiring bug: the `ENVIRONMENT` entry holding `TSAN_OPTIONS` (and the suppressions file path) was passed to `catch_discover_tests` before the `PROPERTIES` keyword, where it is silently ignored. As a result no suppression reached any test — the Catch2 `RunContext` and signal-handler entries were inert, so tests that legitimately call `REQUIRE` from IO-thread callbacks failed under TSan. Move the entry after `PROPERTIES` so it becomes a real per-test property (integration, transaction and unit macros).

### Fix the range-scan cancel test data race `test/test_integration_range_scan.cxx`

`integration: range scan cancel during streaming using protocol cancel` triggered the cancellation from the `range_scan_continue` item callback — which runs on an IO thread — and called Catch2 assertion macros there. Catch2's `RunContext` lives on the main thread's stack and is not thread-safe, so this raced the main thread. (The `race:Catch::RunContext` suppression does not always save it: TSan matches suppressions by symbolized frame name, and the CI symbolizer can fail.) Hand the cancel outcome back to the main thread through a `std::promise` and assert it there after the scan loop.

## Verification

Built with stock libc++ + the prebuilt libclang-rt TSan runtime (no instrumented libc++) and run against a real cluster:

- `range scan cancel during streaming using protocol cancel`: **0 races, 31 assertions pass** (previously 8 `data race` reports + `SIGABRT`).
- Replica repro `enable external tracer - KV operations`: the strand fix takes the cancel race from 14 warnings to **0 across 15 runs**; `read_replica`, `subdoc` and `tracer` suites pass with no functional regression.

## Notes for reviewers

- No instrumented libc++ is built from source; the from-source toolchain machinery was dropped. The trade-off of `ignore_noninstrumented_modules=1` is that genuine races living entirely inside libc++ are not reported — acceptable here, since the races we care about all involve our own instrumented code.
- Remaining integration `example:` failures under TSan are environmental (they require the `travel-sample` bucket) and are out of scope for this change.
