### PR TITLE
[Backport] CXXCBC-841: bucket_update fails on Couchbase Server 8.1 due to leading "&" in form-encoded request body

### DIFF
--- a/core/operations/management/bucket_create.cxx
+++ b/core/operations/management/bucket_create.cxx
@@ -30,104 +30,101 @@ namespace couchbase::core::operations::management
 {
 
 auto
-bucket_create_request::encode_to(encoded_request_type& encoded,
-                                 http_context& /* context */) const -> std::error_code
+bucket_create_request::encode_to(encoded_request_type& encoded, http_context& /* context */) const
+  -> std::error_code
 {
   encoded.method = "POST";
   encoded.path = "/pools/default/buckets";
 
   encoded.headers["content-type"] = "application/x-www-form-urlencoded";
-  encoded.body.append(fmt::format("name={}", utils::string_codec::form_encode(bucket.name)));
+
+  std::map<std::string, std::string> values{};
+  values["name"] = bucket.name;
   switch (bucket.bucket_type) {
     case couchbase::core::management::cluster::bucket_type::couchbase:
-      encoded.body.append("&bucketType=couchbase");
+      values["bucketType"] = "couchbase";
       break;
     case couchbase::core::management::cluster::bucket_type::memcached:
-      encoded.body.append("&bucketType=memcached");
+      values["bucketType"] = "memcached";
       break;
     case couchbase::core::management::cluster::bucket_type::ephemeral:
-      encoded.body.append("&bucketType=ephemeral");
+      values["bucketType"] = "ephemeral";
       break;
     case couchbase::core::management::cluster::bucket_type::unknown:
       break;
   }
   if (bucket.ram_quota_mb == 0) {
-    encoded.body.append(fmt::format(
-      "&ramQuotaMB={}", 100)); // If not explicitly set, set to prior default value of 100
+    values["ramQuotaMB"] = "100"; // If not explicitly set, set to prior default value of 100
   } else {
-    encoded.body.append(fmt::format("&ramQuotaMB={}", bucket.ram_quota_mb));
+    values["ramQuotaMB"] = std::to_string(bucket.ram_quota_mb);
   }
 
   if (bucket.bucket_type != couchbase::core::management::cluster::bucket_type::memcached &&
       bucket.num_replicas.has_value()) {
-    encoded.body.append(fmt::format("&replicaNumber={}", bucket.num_replicas.value()));
+    values["replicaNumber"] = std::to_string(bucket.num_replicas.value());
   }
   if (bucket.max_expiry.has_value()) {
-    encoded.body.append(fmt::format("&maxTTL={}", bucket.max_expiry.value()));
+    values["maxTTL"] = std::to_string(bucket.max_expiry.value());
   }
   if (bucket.bucket_type != couchbase::core::management::cluster::bucket_type::ephemeral &&
       bucket.replica_indexes.has_value()) {
-    encoded.body.append(
-      fmt::format("&replicaIndex={}", bucket.replica_indexes.value() ? "1" : "0"));
+    values["replicaIndex"] = bucket.replica_indexes.value() ? "1" : "0";
   }
   if (bucket.history_retention_collection_default.has_value()) {
-    encoded.body.append(
-      fmt::format("&historyRetentionCollectionDefault={}",
-                  bucket.history_retention_collection_default.value() ? "true" : "false"));
+    values["historyRetentionCollectionDefault"] =
+      bucket.history_retention_collection_default.value() ? "true" : "false";
   }
   if (bucket.history_retention_bytes.has_value()) {
-    encoded.body.append(
-      fmt::format("&historyRetentionBytes={}", bucket.history_retention_bytes.value()));
+    values["historyRetentionBytes"] = std::to_string(bucket.history_retention_bytes.value());
   }
   if (bucket.history_retention_duration.has_value()) {
-    encoded.body.append(
-      fmt::format("&historyRetentionSeconds={}", bucket.history_retention_duration.value()));
+    values["historyRetentionSeconds"] = std::to_string(bucket.history_retention_duration.value());
   }
   if (bucket.flush_enabled.has_value()) {
-    encoded.body.append(fmt::format("&flushEnabled={}", bucket.flush_enabled.value() ? "1" : "0"));
+    values["flushEnabled"] = bucket.flush_enabled.value() ? "1" : "0";
   }
   if (bucket.num_vbuckets.has_value()) {
-    encoded.body.append(fmt::format("&numVBuckets={}", bucket.num_vbuckets.value()));
+    values["numVBuckets"] = std::to_string(bucket.num_vbuckets.value());
   }
 
   switch (bucket.eviction_policy) {
     case couchbase::core::management::cluster::bucket_eviction_policy::full:
-      encoded.body.append("&evictionPolicy=fullEviction");
+      values["evictionPolicy"] = "fullEviction";
       break;
     case couchbase::core::management::cluster::bucket_eviction_policy::value_only:
-      encoded.body.append("&evictionPolicy=valueOnly");
+      values["evictionPolicy"] = "valueOnly";
       break;
     case couchbase::core::management::cluster::bucket_eviction_policy::no_eviction:
-      encoded.body.append("&evictionPolicy=noEviction");
+      values["evictionPolicy"] = "noEviction";
       break;
     case couchbase::core::management::cluster::bucket_eviction_policy::not_recently_used:
-      encoded.body.append("&evictionPolicy=nruEviction");
+      values["evictionPolicy"] = "nruEviction";
       break;
     case couchbase::core::management::cluster::bucket_eviction_policy::unknown:
       break;
   }
   switch (bucket.compression_mode) {
     case couchbase::core::management::cluster::bucket_compression::off:
-      encoded.body.append("&compressionMode=off");
+      values["compressionMode"] = "off";
       break;
     case couchbase::core::management::cluster::bucket_compression::active:
-      encoded.body.append("&compressionMode=active");
+      values["compressionMode"] = "active";
       break;
     case couchbase::core::management::cluster::bucket_compression::passive:
-      encoded.body.append("&compressionMode=passive");
+      values["compressionMode"] = "passive";
       break;
     case couchbase::core::management::cluster::bucket_compression::unknown:
       break;
   }
   switch (bucket.conflict_resolution_type) {
     case couchbase::core::management::cluster::bucket_conflict_resolution::timestamp:
-      encoded.body.append("&conflictResolutionType=lww");
+      values["conflictResolutionType"] = "lww";
       break;
     case couchbase::core::management::cluster::bucket_conflict_resolution::sequence_number:
-      encoded.body.append("&conflictResolutionType=seqno");
+      values["conflictResolutionType"] = "seqno";
       break;
     case couchbase::core::management::cluster::bucket_conflict_resolution::custom:
-      encoded.body.append("&conflictResolutionType=custom");
+      values["conflictResolutionType"] = "custom";
       break;
     case couchbase::core::management::cluster::bucket_conflict_resolution::unknown:
       break;
@@ -135,16 +132,16 @@ bucket_create_request::encode_to(encoded_request_type& encoded,
   if (bucket.minimum_durability_level.has_value()) {
     switch (bucket.minimum_durability_level.value()) {
       case durability_level::none:
-        encoded.body.append("&durabilityMinLevel=none");
+        values["durabilityMinLevel"] = "none";
         break;
       case durability_level::majority:
-        encoded.body.append("&durabilityMinLevel=majority");
+        values["durabilityMinLevel"] = "majority";
         break;
       case durability_level::majority_and_persist_to_active:
-        encoded.body.append("&durabilityMinLevel=majorityAndPersistActive");
+        values["durabilityMinLevel"] = "majorityAndPersistActive";
         break;
       case durability_level::persist_to_majority:
-        encoded.body.append("&durabilityMinLevel=persistToMajority");
+        values["durabilityMinLevel"] = "persistToMajority";
         break;
     }
   }
@@ -152,12 +149,14 @@ bucket_create_request::encode_to(encoded_request_type& encoded,
     case couchbase::core::management::cluster::bucket_storage_backend::unknown:
       break;
     case couchbase::core::management::cluster::bucket_storage_backend::couchstore:
-      encoded.body.append("&storageBackend=couchstore");
+      values["storageBackend"] = "couchstore";
       break;
     case couchbase::core::management::cluster::bucket_storage_backend::magma:
-      encoded.body.append("&storageBackend=magma");
+      values["storageBackend"] = "magma";
       break;
   }
+
+  encoded.body = utils::string_codec::v2::form_encode(values);
   return {};
 }
 auto

--- a/core/operations/management/bucket_update.cxx
+++ b/core/operations/management/bucket_update.cxx
@@ -30,8 +30,8 @@
 namespace couchbase::core::operations::management
 {
 auto
-bucket_update_request::encode_to(encoded_request_type& encoded,
-                                 http_context& /* context */) const -> std::error_code
+bucket_update_request::encode_to(encoded_request_type& encoded, http_context& /* context */) const
+  -> std::error_code
 {
   encoded.method = "POST";
   encoded.path =
@@ -39,65 +39,61 @@ bucket_update_request::encode_to(encoded_request_type& encoded,
 
   encoded.headers["content-type"] = "application/x-www-form-urlencoded";
 
+  std::map<std::string, std::string> values{};
   if (bucket.ram_quota_mb > 0) {
-    encoded.body.append(fmt::format("&ramQuotaMB={}", bucket.ram_quota_mb));
+    values["ramQuotaMB"] = std::to_string(bucket.ram_quota_mb);
   }
   if (bucket.num_replicas.has_value()) {
-    encoded.body.append(fmt::format("&replicaNumber={}", bucket.num_replicas.value()));
+    values["replicaNumber"] = std::to_string(bucket.num_replicas.value());
   }
-
   if (bucket.max_expiry.has_value()) {
-    encoded.body.append(fmt::format("&maxTTL={}", bucket.max_expiry.value()));
+    values["maxTTL"] = std::to_string(bucket.max_expiry.value());
   }
   if (bucket.history_retention_collection_default.has_value()) {
-    encoded.body.append(
-      fmt::format("&historyRetentionCollectionDefault={}",
-                  bucket.history_retention_collection_default.value() ? "true" : "false"));
+    values["historyRetentionCollectionDefault"] =
+      bucket.history_retention_collection_default.value() ? "true" : "false";
   }
   if (bucket.history_retention_bytes.has_value()) {
-    encoded.body.append(
-      fmt::format("&historyRetentionBytes={}", bucket.history_retention_bytes.value()));
+    values["historyRetentionBytes"] = std::to_string(bucket.history_retention_bytes.value());
   }
   if (bucket.history_retention_duration.has_value()) {
-    encoded.body.append(
-      fmt::format("&historyRetentionSeconds={}", bucket.history_retention_duration.value()));
+    values["historyRetentionSeconds"] = std::to_string(bucket.history_retention_duration.value());
   }
   if (bucket.replica_indexes.has_value()) {
-    encoded.body.append(
-      fmt::format("&replicaIndex={}", bucket.replica_indexes.value() ? "1" : "0"));
+    values["replicaIndex"] = bucket.replica_indexes.value() ? "1" : "0";
   }
   if (bucket.flush_enabled.has_value()) {
-    encoded.body.append(fmt::format("&flushEnabled={}", bucket.flush_enabled.value() ? "1" : "0"));
+    values["flushEnabled"] = bucket.flush_enabled.value() ? "1" : "0";
   }
   if (bucket.num_vbuckets.has_value()) {
-    encoded.body.append(fmt::format("&numVBuckets={}", bucket.num_vbuckets.value()));
+    values["numVBuckets"] = std::to_string(bucket.num_vbuckets.value());
   }
 
   switch (bucket.eviction_policy) {
     case couchbase::core::management::cluster::bucket_eviction_policy::full:
-      encoded.body.append("&evictionPolicy=fullEviction");
+      values["evictionPolicy"] = "fullEviction";
       break;
     case couchbase::core::management::cluster::bucket_eviction_policy::value_only:
-      encoded.body.append("&evictionPolicy=valueOnly");
+      values["evictionPolicy"] = "valueOnly";
       break;
     case couchbase::core::management::cluster::bucket_eviction_policy::no_eviction:
-      encoded.body.append("&evictionPolicy=noEviction");
+      values["evictionPolicy"] = "noEviction";
       break;
     case couchbase::core::management::cluster::bucket_eviction_policy::not_recently_used:
-      encoded.body.append("&evictionPolicy=nruEviction");
+      values["evictionPolicy"] = "nruEviction";
       break;
     case couchbase::core::management::cluster::bucket_eviction_policy::unknown:
       break;
   }
   switch (bucket.compression_mode) {
     case couchbase::core::management::cluster::bucket_compression::off:
-      encoded.body.append("&compressionMode=off");
+      values["compressionMode"] = "off";
       break;
     case couchbase::core::management::cluster::bucket_compression::active:
-      encoded.body.append("&compressionMode=active");
+      values["compressionMode"] = "active";
       break;
     case couchbase::core::management::cluster::bucket_compression::passive:
-      encoded.body.append("&compressionMode=passive");
+      values["compressionMode"] = "passive";
       break;
     case couchbase::core::management::cluster::bucket_compression::unknown:
       break;
@@ -105,19 +101,21 @@ bucket_update_request::encode_to(encoded_request_type& encoded,
   if (bucket.minimum_durability_level) {
     switch (bucket.minimum_durability_level.value()) {
       case durability_level::none:
-        encoded.body.append("&durabilityMinLevel=none");
+        values["durabilityMinLevel"] = "none";
         break;
       case durability_level::majority:
-        encoded.body.append("&durabilityMinLevel=majority");
+        values["durabilityMinLevel"] = "majority";
         break;
       case durability_level::majority_and_persist_to_active:
-        encoded.body.append("&durabilityMinLevel=majorityAndPersistActive");
+        values["durabilityMinLevel"] = "majorityAndPersistActive";
         break;
       case durability_level::persist_to_majority:
-        encoded.body.append("&durabilityMinLevel=persistToMajority");
+        values["durabilityMinLevel"] = "persistToMajority";
         break;
     }
   }
+
+  encoded.body = utils::string_codec::v2::form_encode(values);
   return {};
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,6 +45,7 @@ unit_test(crypto)
 unit_test(orphan_reporter)
 unit_test(node_id)
 unit_test(management_collection)
+unit_test(management_bucket)
 target_link_libraries(test_unit_jsonsl PRIVATE jsonsl)
 
 integration_benchmark(get)

--- a/test/test_unit_management_bucket.cxx
+++ b/test/test_unit_management_bucket.cxx
@@ -1,0 +1,145 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "test_helper.hxx"
+
+#include "core/cluster_options.hxx"
+#include "core/io/http_context.hxx"
+#include "core/io/http_message.hxx"
+#include "core/io/query_cache.hxx"
+#include "core/operations/management/bucket_create.hxx"
+#include "core/operations/management/bucket_update.hxx"
+#include "core/topology/configuration.hxx"
+
+#include <couchbase/durability_level.hxx>
+
+#include <map>
+#include <string>
+
+namespace
+{
+auto
+make_http_context() -> couchbase::core::http_context
+{
+  static couchbase::core::topology::configuration config{};
+  static couchbase::core::query_cache query_cache{};
+  static couchbase::core::cluster_options cluster_options{};
+  std::string hostname{};
+  std::uint16_t port{};
+  std::string canonical_hostname{};
+  std::uint16_t canonical_port{};
+  return {
+    config, cluster_options, query_cache, hostname, port, canonical_hostname, canonical_port
+  };
+}
+
+/**
+ * Parse an application/x-www-form-urlencoded body into a key->value map. Values used in these
+ * tests do not require percent-decoding, so the raw value is kept as-is.
+ */
+auto
+parse_form_body(const std::string& body) -> std::map<std::string, std::string>
+{
+  std::map<std::string, std::string> values{};
+  std::size_t pos{ 0 };
+  while (pos < body.size()) {
+    auto amp = body.find('&', pos);
+    auto pair = body.substr(pos, amp == std::string::npos ? std::string::npos : amp - pos);
+    auto eq = pair.find('=');
+    if (eq != std::string::npos) {
+      values[pair.substr(0, eq)] = pair.substr(eq + 1);
+    }
+    if (amp == std::string::npos) {
+      break;
+    }
+    pos = amp + 1;
+  }
+  return values;
+}
+} // namespace
+
+TEST_CASE("unit: bucket_update::encode_to form body", "[unit]")
+{
+  couchbase::core::io::http_request http_req;
+  auto ctx = make_http_context();
+
+  couchbase::core::operations::management::bucket_update_request req{};
+  req.bucket.name = "my_bucket";
+  req.bucket.ram_quota_mb = 256;
+  req.bucket.num_replicas = 2;
+  req.bucket.flush_enabled = true;
+  req.bucket.minimum_durability_level = couchbase::durability_level::majority;
+
+  auto ec = req.encode_to(http_req, ctx);
+  REQUIRE_SUCCESS(ec);
+
+  // The body must be a well-formed form-urlencoded string: no leading '&' (which Couchbase
+  // Server 8.1+ via MB-61655 rejects as an empty parameter) and no empty tokens.
+  REQUIRE_FALSE(http_req.body.empty());
+  REQUIRE(http_req.body.front() != '&');
+  REQUIRE(http_req.body.find("&&") == std::string::npos);
+  REQUIRE(http_req.body.back() != '&');
+
+  auto values = parse_form_body(http_req.body);
+  CHECK(values["ramQuotaMB"] == "256");
+  CHECK(values["replicaNumber"] == "2");
+  CHECK(values["flushEnabled"] == "1");
+  CHECK(values["durabilityMinLevel"] == "majority");
+  // bucket name is carried in the path, not the body
+  CHECK(values.count("name") == 0);
+}
+
+TEST_CASE("unit: bucket_create::encode_to form body", "[unit]")
+{
+  couchbase::core::io::http_request http_req;
+  auto ctx = make_http_context();
+
+  couchbase::core::operations::management::bucket_create_request req{};
+  req.bucket.name = "my_bucket";
+  req.bucket.ram_quota_mb = 512;
+  req.bucket.bucket_type = couchbase::core::management::cluster::bucket_type::couchbase;
+  req.bucket.num_replicas = 1;
+
+  auto ec = req.encode_to(http_req, ctx);
+  REQUIRE_SUCCESS(ec);
+
+  REQUIRE_FALSE(http_req.body.empty());
+  REQUIRE(http_req.body.front() != '&');
+  REQUIRE(http_req.body.find("&&") == std::string::npos);
+  REQUIRE(http_req.body.back() != '&');
+
+  auto values = parse_form_body(http_req.body);
+  CHECK(values["name"] == "my_bucket");
+  CHECK(values["bucketType"] == "couchbase");
+  CHECK(values["ramQuotaMB"] == "512");
+  CHECK(values["replicaNumber"] == "1");
+}
+
+TEST_CASE("unit: bucket_create::encode_to defaults ram quota to 100", "[unit]")
+{
+  couchbase::core::io::http_request http_req;
+  auto ctx = make_http_context();
+
+  couchbase::core::operations::management::bucket_create_request req{};
+  req.bucket.name = "my_bucket";
+
+  auto ec = req.encode_to(http_req, ctx);
+  REQUIRE_SUCCESS(ec);
+
+  auto values = parse_form_body(http_req.body);
+  CHECK(values["ramQuotaMB"] == "100");
+}


### PR DESCRIPTION
Changes
--------
* Convert bucket_create/bucket_update to build request body using v2::form_encode() instead of append "&"-prefixed fragments
* Add unit tests to confirm bucket_create/bucket_update request building behavior prevents any leading "&" in the request