### PR TITLE
CXXCBC-842: mcbp_session: use-after-free in message_handler::handle() when reauthentication fails

### DIFF
--- a/core/io/mcbp_session.cxx
+++ b/core/io/mcbp_session.cxx
@@ -324,10 +324,6 @@ class mcbp_session_impl
 
     void handle(mcbp_message&& msg)
     {
-      // A nested stop() (e.g. on reauth failure) can release the session's last
-      // strong ref to this handler, which would otherwise free `this` mid-call.
-      // Holding a local ref keeps this handler alive for the duration (CXXCBC-842).
-      auto self = shared_from_this();
       if (stopped_ || !session_) {
         return;
       }
@@ -704,10 +700,6 @@ class mcbp_session_impl
 
     void handle(mcbp_message&& msg)
     {
-      // A nested stop() (e.g. on reauth failure) can release the session's last
-      // strong ref to this handler, which would otherwise free `this` mid-call.
-      // Holding a local ref keeps this handler alive for the duration (CXXCBC-842).
-      auto self = shared_from_this();
       if (stopped_ || !session_) {
         return;
       }
@@ -2214,11 +2206,9 @@ private:
               CB_LOG_TRACE(
                 "{} MCBP recv {}", self->log_prefix_, mcbp_header_view(msg.header_data()));
               if (self->bootstrapped_) {
-                if (auto h = self->handler_; h) {
-                  h->handle(std::move(msg));
-                }
-              } else if (auto h = self->bootstrap_handler_; h) {
-                h->handle(std::move(msg));
+                self->handler_->handle(std::move(msg));
+              } else if (self->bootstrap_handler_) {
+                self->bootstrap_handler_->handle(std::move(msg));
               }
               if (self->stopped_) {
                 return;

--- a/core/io/mcbp_session.cxx
+++ b/core/io/mcbp_session.cxx
@@ -2205,10 +2205,17 @@ private:
               }
               CB_LOG_TRACE(
                 "{} MCBP recv {}", self->log_prefix_, mcbp_header_view(msg.header_data()));
+              // Copy the handler's shared_ptr into a local before dispatching.
+              // handle() can trigger a nested stop() (e.g. reauth failure) that
+              // releases the session's own strong ref to the handler; the local
+              // copy keeps it alive for the duration of the call so it is not
+              // freed mid-dispatch (CXXCBC-842).
               if (self->bootstrapped_) {
-                self->handler_->handle(std::move(msg));
-              } else if (self->bootstrap_handler_) {
-                self->bootstrap_handler_->handle(std::move(msg));
+                if (auto h = self->handler_; h) {
+                  h->handle(std::move(msg));
+                }
+              } else if (auto h = self->bootstrap_handler_; h) {
+                h->handle(std::move(msg));
               }
               if (self->stopped_) {
                 return;

--- a/core/io/mcbp_session.cxx
+++ b/core/io/mcbp_session.cxx
@@ -324,6 +324,10 @@ class mcbp_session_impl
 
     void handle(mcbp_message&& msg)
     {
+      // A nested stop() (e.g. on reauth failure) can release the session's last
+      // strong ref to this handler, which would otherwise free `this` mid-call.
+      // Holding a local ref keeps this handler alive for the duration (CXXCBC-842).
+      auto self = shared_from_this();
       if (stopped_ || !session_) {
         return;
       }
@@ -700,6 +704,10 @@ class mcbp_session_impl
 
     void handle(mcbp_message&& msg)
     {
+      // A nested stop() (e.g. on reauth failure) can release the session's last
+      // strong ref to this handler, which would otherwise free `this` mid-call.
+      // Holding a local ref keeps this handler alive for the duration (CXXCBC-842).
+      auto self = shared_from_this();
       if (stopped_ || !session_) {
         return;
       }
@@ -2206,9 +2214,11 @@ private:
               CB_LOG_TRACE(
                 "{} MCBP recv {}", self->log_prefix_, mcbp_header_view(msg.header_data()));
               if (self->bootstrapped_) {
-                self->handler_->handle(std::move(msg));
-              } else if (self->bootstrap_handler_) {
-                self->bootstrap_handler_->handle(std::move(msg));
+                if (auto h = self->handler_; h) {
+                  h->handle(std::move(msg));
+                }
+              } else if (auto h = self->bootstrap_handler_; h) {
+                h->handle(std::move(msg));
               }
               if (self->stopped_) {
                 return;


### PR DESCRIPTION
Changes
-------
* Keep a local strong reference (`shared_from_this()`) across `message_handler::handle()` and `bootstrap_handler::handle()` so a re-entrant `stop()` cannot free the handler mid-call
* In `do_read()`, take a local copy of the handler before dispatching so the call is skipped when the handler is null and the handler stays alive for the duration of `handle()`