### PR TITLE
CXXCBC-840: FIT performer - add support for CounterEq bounds

### DIFF
--- a/tools/fit_performer/CMakeLists.txt
+++ b/tools/fit_performer/CMakeLists.txt
@@ -52,6 +52,7 @@ endif()
 
 set(FIT_PERFORMER_SOURCES
     src/batcher.hxx
+    src/bounds.cxx
     src/bounds.hxx
     src/commands/bucket_management.cxx
     src/commands/bucket_management.hxx
@@ -71,6 +72,7 @@ set(FIT_PERFORMER_SOURCES
     src/commands/search_index_management.hxx
     src/connection.cxx
     src/connection.hxx
+    src/counters.cxx
     src/counters.hxx
     src/exceptions.hxx
     src/fit.cxx

--- a/tools/fit_performer/src/bounds.cxx
+++ b/tools/fit_performer/src/bounds.cxx
@@ -56,6 +56,9 @@ create_bounds(counters& global_counters,
       return std::make_unique<counter_equality_bounds>(
         global_counters.get_counter(proto_bounds->counter_eq()), initial_value);
     }
+    case protocol::shared::Bounds::BOUNDS_NOT_SET:
+      // A present-but-empty bounds message means "no bounds": execute each command exactly once.
+      return std::make_unique<counter_bounds>(static_cast<std::int32_t>(command_count));
 
     default:
       throw performer_exception::invalid_argument(

--- a/tools/fit_performer/src/bounds.cxx
+++ b/tools/fit_performer/src/bounds.cxx
@@ -1,0 +1,127 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "bounds.hxx"
+
+#include <spdlog/fmt/fmt.h>
+
+#include <optional>
+
+namespace fit_cxx
+{
+namespace
+{
+auto
+get_initial_counter_value(const protocol::shared::Counter& proto_counter) -> std::int32_t
+{
+  if (!proto_counter.has_global()) {
+    throw performer_exception::invalid_argument(
+      fmt::format("unknown counter type: {}", proto_counter.DebugString()));
+  }
+
+  return proto_counter.global().count();
+}
+
+auto
+create_bounds(counters& global_counters,
+              const std::optional<protocol::shared::Bounds>& proto_bounds,
+              const std::size_t command_count) -> std::unique_ptr<bounds>
+{
+  if (!proto_bounds.has_value()) {
+    return std::make_unique<counter_bounds>(static_cast<std::int32_t>(command_count));
+  }
+
+  switch (proto_bounds->bounds_case()) {
+    case protocol::shared::Bounds::kCounter:
+      return std::make_unique<counter_bounds>(global_counters.get_counter(proto_bounds->counter()));
+    case protocol::shared::Bounds::kForTime:
+      return std::make_unique<timer_bounds>(
+        std::chrono::seconds(proto_bounds->for_time().seconds()));
+    case protocol::shared::Bounds::kCounterEq: {
+      const auto initial_value = get_initial_counter_value(proto_bounds->counter_eq());
+      return std::make_unique<counter_equality_bounds>(
+        global_counters.get_counter(proto_bounds->counter_eq()), initial_value);
+    }
+
+    default:
+      throw performer_exception::invalid_argument(
+        fmt::format("unknown bounds type: {}", proto_bounds->DebugString()));
+  }
+}
+} // namespace
+
+auto
+bounds::from_sdk_workload(counters& global_counters, const protocol::sdk::Workload& proto_workload)
+  -> std::unique_ptr<bounds>
+{
+  return create_bounds(global_counters,
+                       proto_workload.has_bounds() ? std::make_optional(proto_workload.bounds())
+                                                   : std::nullopt,
+                       proto_workload.command_size());
+}
+
+auto
+bounds::from_transactions_workload(counters& global_counters,
+                                   const protocol::transactions::Workload& proto_workload)
+  -> std::unique_ptr<bounds>
+{
+  return create_bounds(global_counters,
+                       proto_workload.has_bounds() ? std::make_optional(proto_workload.bounds())
+                                                   : std::nullopt,
+                       proto_workload.command_size());
+}
+
+counter_bounds::counter_bounds(const std::int32_t initial_value)
+  : counter_{ counter::create(initial_value) }
+{
+}
+
+counter_bounds::counter_bounds(std::shared_ptr<counter> global_counter)
+  : counter_{ std::move(global_counter) }
+{
+}
+
+auto
+counter_bounds::can_execute() -> bool
+{
+  return counter_->decrement() >= 0;
+}
+
+timer_bounds::timer_bounds(const std::chrono::seconds duration)
+  : deadline_{ std::chrono::steady_clock::now() + duration }
+{
+}
+
+auto
+timer_bounds::can_execute() -> bool
+{
+  return std::chrono::steady_clock::now() <= deadline_;
+}
+
+counter_equality_bounds::counter_equality_bounds(std::shared_ptr<counter> global_counter,
+                                                 const std::int32_t target_value)
+  : counter_{ std::move(global_counter) }
+  , target_value_{ target_value }
+{
+}
+
+auto
+counter_equality_bounds::can_execute() -> bool
+{
+  return counter_->get() == target_value_;
+}
+} // namespace fit_cxx

--- a/tools/fit_performer/src/bounds.hxx
+++ b/tools/fit_performer/src/bounds.hxx
@@ -17,90 +17,73 @@
 
 #pragma once
 
+#include "counters.hxx"
 #include "exceptions.hxx"
 
-#include <spdlog/fmt/fmt.h>
 #include <spdlog/spdlog.h>
 
 #include <chrono>
-#include <map>
-#include <mutex>
-#include <optional>
+
+#include "sdk.workload.pb.h"
+#include "transactions.workload.pb.h"
 
 namespace fit_cxx
 {
-class Bounds
+class bounds
 {
 public:
-  Bounds() = default;
+  virtual ~bounds() = default;
+  [[nodiscard]] virtual auto can_execute() -> bool = 0;
 
-  void add_timer(int seconds)
-  {
-    std::scoped_lock<std::mutex> lock(mut_);
-    if (timer_) {
-      return;
-    }
-    // steady_clock (monotonic) so the bound is unaffected by wall-clock jumps (NTP, manual time
-    // changes), which could otherwise end a bounded run early or let it run too long.
-    timer_ = std::chrono::steady_clock::now() + std::chrono::seconds(seconds);
-  }
-  bool check_timer()
-  {
-    std::scoped_lock<std::mutex> lock(mut_);
-    if (timer_) {
-      return std::chrono::steady_clock::now() <= timer_.value();
-    }
-    // if no timer, it can run forever, so return true.
-    return true;
-  }
-  void add_counter(const std::string& key, int value)
-  {
-    std::scoped_lock<std::mutex> lock(mut_);
-    if (auto it = counters_.find(key); it == counters_.end()) {
-      counters_[key] = value;
-      return;
-    }
-    spdlog::info("add_bound found key {} already present, ignoring...", key);
-  }
-
-  bool decrement(const std::string& key)
-  {
-    if (key.empty()) {
-      // happens when there is no bounds (or at least, not a counter)
-      return true;
-    }
-    std::scoped_lock<std::mutex> lock(mut_);
-    if (auto it = counters_.find(key); it != counters_.end()) {
-      if (it->second > 0) {
-        it->second--;
-        return true;
-      }
-      return false;
-    }
-    throw performer_exception::internal(fmt::format("decrement called for unknown key {}", key));
-  }
-
-  bool can_run(const std::string& counter_key, int executed_cmd_count, int cmd_count)
-  {
-    bool has_timer = false;
-    {
-      std::scoped_lock<std::mutex> lock(mut_);
-      has_timer = timer_.has_value();
-    }
-    if (has_timer) {
-      return check_timer();
-    }
-    if (!counter_key.empty()) {
-      return decrement(counter_key);
-    }
-    // No bounds are set - all commands should be executed exactly once
-    return executed_cmd_count < cmd_count;
-  }
-
-private:
-  std::mutex mut_;
-  std::map<std::string, int> counters_;
-  std::optional<std::chrono::steady_clock::time_point> timer_;
+  static auto from_sdk_workload(counters& global_counters,
+                                const protocol::sdk::Workload& proto_workload)
+    -> std::unique_ptr<bounds>;
+  static auto from_transactions_workload(counters& global_counters,
+                                         const protocol::transactions::Workload& proto_workload)
+    -> std::unique_ptr<bounds>;
 };
 
+class counter_bounds final : public bounds
+{
+public:
+  /**
+   * Creates a counter_bounds instance with a local counter.
+   */
+  explicit counter_bounds(std::int32_t initial_value);
+
+  /**
+   * Creates a counter_bounds instances with the provided global counter, that may be shared by
+   * multiple bounds instances.
+   */
+  explicit counter_bounds(std::shared_ptr<counter> global_counter);
+
+  auto can_execute() -> bool override;
+
+private:
+  std::shared_ptr<counter> counter_;
+};
+
+class timer_bounds final : public bounds
+{
+public:
+  explicit timer_bounds(std::chrono::seconds duration);
+
+  auto can_execute() -> bool override;
+
+private:
+  std::chrono::steady_clock::time_point deadline_;
+};
+
+class counter_equality_bounds final : public bounds
+{
+public:
+  explicit counter_equality_bounds(std::shared_ptr<counter> global_counter,
+                                   std::int32_t target_value);
+
+  auto can_execute() -> bool override;
+
+private:
+  std::shared_ptr<counter> counter_;
+  std::int32_t target_value_;
+};
 } // namespace fit_cxx

--- a/tools/fit_performer/src/counters.cxx
+++ b/tools/fit_performer/src/counters.cxx
@@ -78,8 +78,10 @@ counters::get_counter(const std::string& counter_id, std::int32_t initial_value)
   }
   {
     const std::unique_lock lock{ mutex_ };
-    const auto& [it, _] =
-      counters_.try_emplace(counter_id, std::make_shared<counter>(initial_value));
+    auto [it, inserted] = counters_.try_emplace(counter_id, nullptr);
+    if (inserted) {
+      it->second = std::make_shared<counter>(initial_value);
+    }
     return it->second;
   }
 }

--- a/tools/fit_performer/src/counters.cxx
+++ b/tools/fit_performer/src/counters.cxx
@@ -1,0 +1,114 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "counters.hxx"
+
+#include <mutex>
+#include <shared_mutex>
+
+#include "exceptions.hxx"
+
+namespace fit_cxx
+{
+counter::counter(const std::int32_t initial_value)
+  : value_{ initial_value }
+{
+}
+
+auto
+counter::increment() -> std::int32_t
+{
+  return ++value_;
+}
+
+auto
+counter::decrement() -> std::int32_t
+{
+  return --value_;
+}
+
+void
+counter::set(const std::int32_t value)
+{
+  value_ = value;
+}
+
+auto
+counter::get() const -> std::int32_t
+{
+  return value_.load();
+}
+
+auto
+counter::create(const std::int32_t initial_value) -> std::shared_ptr<counter>
+{
+  return std::make_shared<counter>(initial_value);
+}
+
+void
+counters::clear()
+{
+  const std::unique_lock lock{ mutex_ };
+  counters_.clear();
+}
+
+auto
+counters::get_counter(const std::string& counter_id, std::int32_t initial_value)
+  -> std::shared_ptr<counter>
+{
+  {
+    const std::shared_lock lock{ mutex_ };
+    if (const auto& it = counters_.find(counter_id); it != counters_.end()) {
+      return it->second;
+    }
+  }
+  {
+    const std::unique_lock lock{ mutex_ };
+    const auto& [it, _] =
+      counters_.try_emplace(counter_id, std::make_shared<counter>(initial_value));
+    return it->second;
+  }
+}
+
+auto
+counters::get_counter(const protocol::shared::Counter& proto_counter) -> std::shared_ptr<counter>
+{
+  if (!proto_counter.has_global()) {
+    throw performer_exception::invalid_argument("counter type not recognized: " +
+                                                proto_counter.DebugString());
+  }
+  return get_counter(proto_counter.counter_id(), proto_counter.global().count());
+}
+
+void
+counters::set_counter_value(const std::string& counter_id, const std::int32_t value)
+{
+  const auto counter = get_counter(counter_id, value);
+  counter->set(value);
+}
+
+void
+counters::set_counter_value(const protocol::shared::Counter& proto_counter)
+{
+  if (!proto_counter.has_global()) {
+    throw performer_exception::invalid_argument("counter type not recognized: " +
+                                                proto_counter.DebugString());
+  }
+  set_counter_value(proto_counter.counter_id(), proto_counter.global().count());
+}
+
+} // namespace fit_cxx

--- a/tools/fit_performer/src/counters.hxx
+++ b/tools/fit_performer/src/counters.hxx
@@ -50,7 +50,7 @@ public:
   [[nodiscard]] static auto create(std::int32_t initial_value) -> std::shared_ptr<counter>;
 
 private:
-  std::atomic_int32_t value_;
+  std::atomic<std::int32_t> value_;
 };
 
 class counters

--- a/tools/fit_performer/src/counters.hxx
+++ b/tools/fit_performer/src/counters.hxx
@@ -16,23 +16,66 @@
  */
 
 #pragma once
+
+#include "shared.bounds.pb.h"
+
+#include <atomic>
 #include <cstdint>
 #include <map>
-#include <mutex>
+#include <memory>
+#include <shared_mutex>
 #include <string>
 
-class Counters
+namespace fit_cxx
 {
-private:
-  std::mutex mutex_;
-  std::map<std::string, std::uint32_t> counters_;
-
+class counter
+{
 public:
-  // Returns the current value of the counter and then increments it, so the
-  // first call for a given id returns 0, the next returns 1, and so on.
-  std::uint32_t get_and_increment_counter(const std::string& counter_id)
-  {
-    const std::scoped_lock<std::mutex> lock(mutex_);
-    return counters_[counter_id]++;
-  }
+  explicit counter(std::int32_t initial_value);
+
+  /**
+   * Increments the counter and returns the resulting value
+   */
+  [[nodiscard]] auto increment() -> std::int32_t;
+
+  /**
+   * Decrements the counter and returns the resulting value
+   */
+  [[nodiscard]] auto decrement() -> std::int32_t;
+
+  void set(std::int32_t value);
+
+  [[nodiscard]] auto get() const -> std::int32_t;
+
+  [[nodiscard]] static auto create(std::int32_t initial_value) -> std::shared_ptr<counter>;
+
+private:
+  std::atomic_int32_t value_;
 };
+
+class counters
+{
+public:
+  counters() = default;
+
+  void clear();
+
+  /**
+   * Returns the counter with the provided counter_id. If the counter does not exist,
+   * the counter is created with the provided initial_value and returned.
+   */
+  [[nodiscard]] auto get_counter(const std::string& counter_id, std::int32_t initial_value)
+    -> std::shared_ptr<counter>;
+
+  [[nodiscard]] auto get_counter(const protocol::shared::Counter& proto_counter)
+    -> std::shared_ptr<counter>;
+
+  void set_counter_value(const std::string& counter_id, std::int32_t value);
+
+  void set_counter_value(const protocol::shared::Counter& proto_counter);
+
+private:
+  std::shared_mutex mutex_;
+  std::map<std::string, std::shared_ptr<counter>> counters_{};
+};
+} // namespace fit_cxx

--- a/tools/fit_performer/src/service.cxx
+++ b/tools/fit_performer/src/service.cxx
@@ -106,7 +106,6 @@ TxnService::startTxn(ConnectionPtr conn,
                      const protocol::transactions::TransactionCreateRequest* request,
                      protocol::transactions::TransactionResult* response,
                      std::atomic<bool>& timed_out,
-                     Counters& counters,
                      fit_cxx::transaction_context& txn_ctx)
 {
   // Guard against an empty attempts list: the per-attempt index below is computed as
@@ -150,7 +149,7 @@ TxnService::startTxn(ConnectionPtr conn,
       for (const protocol::transactions::TransactionCommand& command : attempt.commands()) {
         spdlog::trace("{} executing command: {}", request->name(), command.DebugString());
         try {
-          auto op_err = execute_command(conn, ctx, command, request->name(), counters, txn_ctx);
+          auto op_err = execute_command(conn, ctx, command, request->name(), txn_ctx);
           if (timed_out) {
             // this means we wrapped this in a call that limited the duration of the transaction,
             // and now we have exceeded that.   The "timeout hack" was done previously when we
@@ -209,7 +208,6 @@ TxnService::transactionCreate(grpc::ServerContext* /*context*/,
              fmt::format("no connection with ID={}", request->cluster_connection_id()) };
   }
   std::atomic<bool> timed_out{ false };
-  Counters counters;
   // Unary transactions have no concurrent peers, so the context has no broadcaster; latches still
   // get registered for parity with the streaming path.
   fit_cxx::transaction_context txn_ctx;
@@ -219,7 +217,7 @@ TxnService::transactionCreate(grpc::ServerContext* /*context*/,
   return conn->run_with_timeout<grpc::Status>(
     std::chrono::seconds(TXN_TIMEOUT),
     [&]() {
-      return startTxn(conn, request, response, timed_out, counters, txn_ctx);
+      return startTxn(conn, request, response, timed_out, txn_ctx);
     },
     [&]() -> grpc::Status {
       timed_out = true;
@@ -295,7 +293,7 @@ to_bucket(ConnectionPtr conn, std::string name)
 }
 
 std::string
-TxnService::to_key(const protocol::shared::DocLocation& loc, Counters& counters)
+TxnService::to_key(const protocol::shared::DocLocation& loc)
 {
   if (loc.has_specific()) {
     return loc.specific().id();
@@ -320,8 +318,10 @@ TxnService::to_key(const protocol::shared::DocLocation& loc, Counters& counters)
       return id_preface + std::to_string(random_number);
     }
     if (loc.pool().has_counter()) {
-      auto counter_id = loc.pool().counter().counter().counter_id();
-      auto counter_value = counters.get_and_increment_counter(counter_id);
+      const auto counter_value =
+        counters_.get_counter(loc.pool().counter().counter())->increment() -
+        1; // Using the pre-increment value, ensuring that the first key always has the initial
+           // value as suffix.
       return id_preface + std::to_string(counter_value % pool_size);
     }
     throw performer_exception::unimplemented(
@@ -571,15 +571,14 @@ check_for_wait(const Cmd& cmd)
 
 auto
 TxnService::to_get_multi_specs(ConnectionPtr conn,
-                               const protocol::transactions::TransactionCommand& cmd,
-                               Counters& counters)
+                               const protocol::transactions::TransactionCommand& cmd)
   -> std::vector<couchbase::transactions::transaction_get_multi_spec>
 {
   std::vector<couchbase::transactions::transaction_get_multi_spec> specs;
   specs.reserve(static_cast<std::size_t>(cmd.get_multi().specs_size()));
 
   for (const auto& spec : cmd.get_multi().specs()) {
-    specs.emplace_back(to_collection(conn, spec.location()), to_key(spec.location(), counters));
+    specs.emplace_back(to_collection(conn, spec.location()), to_key(spec.location()));
   }
 
   return specs;
@@ -614,8 +613,7 @@ TxnService::to_get_multi_options(const protocol::transactions::TransactionComman
 auto
 TxnService::to_get_multi_replicas_from_preferred_server_group_specs(
   ConnectionPtr conn,
-  const protocol::transactions::TransactionCommand& cmd,
-  Counters& counters)
+  const protocol::transactions::TransactionCommand& cmd)
   -> std::vector<
     couchbase::transactions::transaction_get_multi_replicas_from_preferred_server_group_spec>
 {
@@ -625,7 +623,7 @@ TxnService::to_get_multi_replicas_from_preferred_server_group_specs(
   specs.reserve(static_cast<std::size_t>(cmd.get_multi().specs_size()));
 
   for (const auto& spec : cmd.get_multi().specs()) {
-    specs.emplace_back(to_collection(conn, spec.location()), to_key(spec.location(), counters));
+    specs.emplace_back(to_collection(conn, spec.location()), to_key(spec.location()));
   }
   return specs;
 }
@@ -667,7 +665,6 @@ TxnService::execute_command(ConnectionPtr conn,
                             std::shared_ptr<couchbase::transactions::attempt_context> ctx,
                             const protocol::transactions::TransactionCommand& cmd,
                             const std::string& logger_prefix,
-                            Counters& counters,
                             fit_cxx::transaction_context& txn_ctx,
                             bool is_batch)
 {
@@ -732,7 +729,7 @@ TxnService::execute_command(ConnectionPtr conn,
         false,
         [&](std::shared_ptr<couchbase::transactions::attempt_context> c) {
           auto [err, result] = c->get_multi_replicas_from_preferred_server_group(
-            to_get_multi_replicas_from_preferred_server_group_specs(conn, cmd, counters),
+            to_get_multi_replicas_from_preferred_server_group_specs(conn, cmd),
             to_get_multi_replicas_from_preferred_server_group_options(cmd));
           spdlog::debug("get_multi_replicas: err.message: {}, err.ec.message: {}",
                         err.message(),
@@ -747,8 +744,8 @@ TxnService::execute_command(ConnectionPtr conn,
                       false,
                       false,
                       [&](std::shared_ptr<couchbase::transactions::attempt_context> c) {
-                        auto [err, result] = c->get_multi(to_get_multi_specs(conn, cmd, counters),
-                                                          to_get_multi_options(cmd));
+                        auto [err, result] =
+                          c->get_multi(to_get_multi_specs(conn, cmd), to_get_multi_options(cmd));
                         spdlog::debug("get_multi: err.message: {}, err.ec.message: {}",
                                       err.message(),
                                       err.ec().message());
@@ -983,7 +980,7 @@ TxnService::execute_command(ConnectionPtr conn,
   if (cmd.has_get_v2()) {
     auto req = cmd.get_v2();
     auto coll = to_collection(conn, req.location());
-    auto id = to_key(req.location(), counters);
+    auto id = to_key(req.location());
     return execute_op(req,
                       ctx,
                       cmd.do_not_propagate_error(),
@@ -1008,7 +1005,7 @@ TxnService::execute_command(ConnectionPtr conn,
   if (cmd.has_replace_v2()) {
     auto req = cmd.replace_v2();
     auto coll = to_collection(conn, req.location());
-    auto id = to_key(req.location(), counters);
+    auto id = to_key(req.location());
     auto content_str = content_as_string(req.content());
     auto content = couchbase::core::utils::json::parse(std::string_view{ content_str });
     return execute_op(req,
@@ -1035,7 +1032,7 @@ TxnService::execute_command(ConnectionPtr conn,
   if (cmd.has_remove_v2()) {
     auto req = cmd.remove_v2();
     auto coll = to_collection(conn, req.location());
-    auto id = to_key(req.location(), counters);
+    auto id = to_key(req.location());
     return execute_op(
       req,
       ctx,
@@ -1058,7 +1055,7 @@ TxnService::execute_command(ConnectionPtr conn,
   if (cmd.has_insert_v2()) {
     auto req = cmd.insert_v2();
     auto coll = to_collection(conn, req.location());
-    auto id = to_key(req.location(), counters);
+    auto id = to_key(req.location());
     auto insert_content_str = content_as_string(req.content());
     auto content = couchbase::core::utils::json::parse(std::string_view{ insert_content_str });
     return execute_op(req,
@@ -1177,7 +1174,7 @@ TxnService::execute_command(ConnectionPtr conn,
         spdlog::trace("async executing command, {} now in-flight", in_flight);
         lock.unlock();
         try {
-          execute_command(conn, ctx, c, logger_prefix, counters, txn_ctx, true);
+          execute_command(conn, ctx, c, logger_prefix, txn_ctx, true);
         } catch (...) {
           // Release the in-flight slot and wake a waiter even on exception; otherwise the other
           // workers can block forever in cv.wait() and f.get() below would deadlock. The exception
@@ -1343,7 +1340,6 @@ TxnService::transactionStream(
                               &start_cv,
                               &ready_to_start,
                               &aborted]() {
-          Counters counters;
           protocol::transactions::TransactionStreamPerformerToDriver created;
           created.set_allocated_created(
             protocol::transactions::TransactionCreated::default_instance().New());
@@ -1372,8 +1368,7 @@ TxnService::transactionStream(
             worker_conn->run_with_timeout<grpc::Status>(
               std::chrono::seconds(TXN_TIMEOUT),
               [&]() {
-                return startTxn(
-                  worker_conn, &worker_request, result, timed_out, counters, *txn_ctx);
+                return startTxn(worker_conn, &worker_request, result, timed_out, *txn_ctx);
               },
               [&]() -> grpc::Status {
                 timed_out = true;
@@ -1667,7 +1662,6 @@ TxnService::run(grpc::ServerContext* /*context*/,
   spdlog::info("got run with {}", request->DebugString());
   std::string run_id{ couchbase::core::uuid::to_string(couchbase::core::uuid::random()) };
   constexpr auto cmd_timeout = std::chrono::seconds(60);
-  fit_cxx::Bounds workload_bounds;
   auto conn = getConn(request->workloads().cluster_connection_id());
   if (!conn) {
     return { ::grpc::CANCELLED,
@@ -1696,7 +1690,7 @@ TxnService::run(grpc::ServerContext* /*context*/,
   // Declaration order matters because, on the exception path, the catch blocks below return without
   // joining still-running tasks, so the joins happen in the ~future destructors. Locals destruct in
   // reverse declaration order, so:
-  //   * counters and stream_mut are declared FIRST (destruct last): workload/stream tasks capture
+  //   * stream_mut is declared FIRST (destruct last): workload/stream tasks capture
   //     them by reference, so they must outlive every task join.
   //   * stream_futures is declared before workload_futures so that workload_futures destructs
   //   FIRST.
@@ -1705,34 +1699,28 @@ TxnService::run(grpc::ServerContext* /*context*/,
   //     half-destroyed stream_futures.
   // Without this ordering, a sibling task still running when another task throws would read and
   // lock already-destroyed objects (use-after-free / data race).
-  Counters counters;
   std::mutex stream_mut;
   std::list<std::future<void>> stream_futures;
   std::list<std::future<void>> workload_futures;
   try {
-    for (auto& horiz : request->workloads().horizontal_scaling()) {
-      for (auto& work : horiz.workloads()) {
+    for (const auto& horiz : request->workloads().horizontal_scaling()) {
+      for (const auto& work : horiz.workloads()) {
         // Capture `work` by value: it is a per-iteration loop variable, so capturing it by
         // reference would let the async task observe a later iteration's workload (or a destroyed
         // reference). Everything else captured by reference outlives these futures.
         workload_futures.push_back(std::async(std::launch::async, [&, work]() -> void {
           if (work.has_sdk()) {
-            int cmd_count = work.sdk().command_size();
-            std::string bounds_key;
-            if (work.has_transaction()) {
-              bounds_key = configure_bounds(
-                workload_bounds, work.transaction().has_bounds(), work.transaction().bounds());
-            } else {
-              bounds_key =
-                configure_bounds(workload_bounds, work.sdk().has_bounds(), work.sdk().bounds());
+            const auto cmd_count = work.sdk().command_size();
+            if (cmd_count == 0) {
+              throw performer_exception::invalid_argument("The SDK workload has no commands");
             }
-
+            const auto bounds = fit_cxx::bounds::from_sdk_workload(counters_, work.sdk());
             int counter = 0;
-            while (workload_bounds.can_run(bounds_key, counter, cmd_count)) {
-              auto& cmd = work.sdk().command(counter % cmd_count);
-              auto [cmd_fut, stream_fut] = execute_sdk_command(conn, cmd, batcher, counters);
+            while (bounds->can_execute()) {
+              const auto& cmd = work.sdk().command(counter % cmd_count);
+              auto [cmd_fut, stream_fut] = execute_sdk_command(conn, cmd, batcher);
               if (stream_fut) {
-                std::scoped_lock<std::mutex> lock(stream_mut);
+                const std::scoped_lock<std::mutex> lock(stream_mut);
                 stream_futures.push_back(std::move(stream_fut.value()));
               }
               if (cmd_fut.wait_for(cmd_timeout) != std::future_status::ready) {
@@ -1743,13 +1731,17 @@ TxnService::run(grpc::ServerContext* /*context*/,
               counter++;
             }
           } else if (work.has_transaction()) {
-            int cmd_count = work.transaction().command_size();
-            std::string bounds_key = configure_bounds(
-              workload_bounds, work.transaction().has_bounds(), work.transaction().bounds());
+            const auto cmd_count = work.transaction().command_size();
+            if (cmd_count == 0) {
+              throw performer_exception::invalid_argument(
+                "The transaction workload has no commands");
+            }
+            const auto bounds =
+              fit_cxx::bounds::from_transactions_workload(counters_, work.transaction());
 
             int counter = 0;
-            while (workload_bounds.can_run(bounds_key, counter, cmd_count)) {
-              auto& cmd = work.transaction().command(counter % cmd_count);
+            while (bounds->can_execute()) {
+              const auto& cmd = work.transaction().command(counter % cmd_count);
               // Declared in the loop scope so the timeout handler below can set it and startTxn()
               // (which polls it) can observe the timeout and short-circuit cooperatively.
               std::atomic<bool> timed_out{ false };
@@ -1764,8 +1756,7 @@ TxnService::run(grpc::ServerContext* /*context*/,
                   auto start = std::chrono::high_resolution_clock::now();
                   res.mutable_initiated()->CopyFrom(
                     google::protobuf::util::TimeUtil::GetCurrentTime());
-                  auto result =
-                    startTxn(conn, &cmd, res.mutable_transaction(), timed_out, counters, txn_ctx);
+                  auto result = startTxn(conn, &cmd, res.mutable_transaction(), timed_out, txn_ctx);
                   spdlog::debug("transaction finished with result {} {}",
                                 result.error_message(),
                                 res.DebugString());
@@ -1818,28 +1809,10 @@ TxnService::run(grpc::ServerContext* /*context*/,
   }
 }
 
-std::string
-TxnService::configure_bounds(fit_cxx::Bounds& workload_bounds,
-                             bool has_bounds,
-                             const protocol::shared::Bounds& bounds)
-{
-  std::string bounds_key;
-  if (has_bounds) {
-    if (bounds.has_counter()) {
-      bounds_key = bounds.counter().counter_id();
-      workload_bounds.add_counter(bounds_key, bounds.counter().global().count());
-    } else if (bounds.has_for_time()) {
-      workload_bounds.add_timer(bounds.for_time().seconds());
-    }
-  }
-  return bounds_key;
-}
-
 CmdFutures
 TxnService::execute_sdk_command(ConnectionPtr conn,
                                 const protocol::sdk::Command cmd,
-                                std::shared_ptr<fit_cxx::Batcher> batcher,
-                                Counters& counters)
+                                std::shared_ptr<fit_cxx::Batcher> batcher)
 {
   auto barrier = std::make_shared<std::promise<void>>();
   auto cmd_fut = barrier->get_future();
@@ -1855,7 +1828,7 @@ TxnService::execute_sdk_command(ConnectionPtr conn,
   }
   if (cmd.has_get()) {
     auto coll = to_collection(conn, cmd.get().location());
-    auto key = to_key(cmd.get().location(), counters);
+    auto key = to_key(cmd.get().location());
     auto cmd_args = fit_cxx::commands::key_value::command_args{
       /* .collection = */ coll,
       /* .key = */ key,
@@ -1867,7 +1840,7 @@ TxnService::execute_sdk_command(ConnectionPtr conn,
   }
   if (cmd.has_replace()) {
     auto coll = to_collection(conn, cmd.replace().location());
-    auto key = to_key(cmd.replace().location(), counters);
+    auto key = to_key(cmd.replace().location());
     auto cmd_args = fit_cxx::commands::key_value::command_args{
       /* .collection = */ coll,
       /* .key = */ key,
@@ -1879,7 +1852,7 @@ TxnService::execute_sdk_command(ConnectionPtr conn,
   }
   if (cmd.has_insert()) {
     auto coll = to_collection(conn, cmd.insert().location());
-    auto key = to_key(cmd.insert().location(), counters);
+    auto key = to_key(cmd.insert().location());
     auto cmd_args = fit_cxx::commands::key_value::command_args{
       /* .collection = */ coll,
       /* .key = */ key,
@@ -1892,7 +1865,7 @@ TxnService::execute_sdk_command(ConnectionPtr conn,
 
   if (cmd.has_upsert()) {
     auto coll = to_collection(conn, cmd.upsert().location());
-    auto key = to_key(cmd.upsert().location(), counters);
+    auto key = to_key(cmd.upsert().location());
     auto cmd_args = fit_cxx::commands::key_value::command_args{
       /* .collection = */ coll,
       /* .key = */ key,
@@ -1904,7 +1877,7 @@ TxnService::execute_sdk_command(ConnectionPtr conn,
   }
   if (cmd.has_remove()) {
     auto coll = to_collection(conn, cmd.remove().location());
-    auto key = to_key(cmd.remove().location(), counters);
+    auto key = to_key(cmd.remove().location());
     auto cmd_args = fit_cxx::commands::key_value::command_args{
       /* .collection = */ coll,
       /* .key = */ key,
@@ -2115,7 +2088,7 @@ TxnService::execute_sdk_command(ConnectionPtr conn,
     if (collection_cmd.has_lookup_in()) {
       auto cmd_args = fit_cxx::commands::key_value::command_args{
         /* .collection = */ to_collection(conn, collection_cmd.lookup_in().location()),
-        /* .key = */ to_key(collection_cmd.lookup_in().location(), counters),
+        /* .key = */ to_key(collection_cmd.lookup_in().location()),
         /* .spans = */ &spans_,
         /* .return_result = */ return_result,
       };
@@ -2125,7 +2098,7 @@ TxnService::execute_sdk_command(ConnectionPtr conn,
     } else if (collection_cmd.has_get_and_lock()) {
       auto cmd_args = fit_cxx::commands::key_value::command_args{
         /* .collection = */ to_collection(conn, collection_cmd.get_and_lock().location()),
-        /* .key = */ to_key(collection_cmd.get_and_lock().location(), counters),
+        /* .key = */ to_key(collection_cmd.get_and_lock().location()),
         /* .spans = */ &spans_,
         /* .return_result = */ return_result,
       };
@@ -2135,7 +2108,7 @@ TxnService::execute_sdk_command(ConnectionPtr conn,
     } else if (collection_cmd.has_unlock()) {
       auto cmd_args = fit_cxx::commands::key_value::command_args{
         /* .collection = */ to_collection(conn, collection_cmd.unlock().location()),
-        /* .key = */ to_key(collection_cmd.unlock().location(), counters),
+        /* .key = */ to_key(collection_cmd.unlock().location()),
         /* .spans = */ &spans_,
       };
       auto res = fit_cxx::commands::key_value::execute_command(collection_cmd.unlock(), cmd_args);
@@ -2143,7 +2116,7 @@ TxnService::execute_sdk_command(ConnectionPtr conn,
     } else if (collection_cmd.has_get_and_touch()) {
       auto cmd_args = fit_cxx::commands::key_value::command_args{
         /* .collection = */ to_collection(conn, collection_cmd.get_and_touch().location()),
-        /* .key = */ to_key(collection_cmd.get_and_touch().location(), counters),
+        /* .key = */ to_key(collection_cmd.get_and_touch().location()),
         /* .spans = */ &spans_,
         /* .return_result = */ return_result,
       };
@@ -2153,7 +2126,7 @@ TxnService::execute_sdk_command(ConnectionPtr conn,
     } else if (collection_cmd.has_exists()) {
       auto cmd_args = fit_cxx::commands::key_value::command_args{
         /* .collection = */ to_collection(conn, collection_cmd.exists().location()),
-        /* .key = */ to_key(collection_cmd.exists().location(), counters),
+        /* .key = */ to_key(collection_cmd.exists().location()),
         /* .spans = */ &spans_,
         /* .return_result = */ return_result,
       };
@@ -2162,7 +2135,7 @@ TxnService::execute_sdk_command(ConnectionPtr conn,
     } else if (collection_cmd.has_touch()) {
       auto cmd_args = fit_cxx::commands::key_value::command_args{
         /* .collection = */ to_collection(conn, collection_cmd.touch().location()),
-        /* .key = */ to_key(collection_cmd.touch().location(), counters),
+        /* .key = */ to_key(collection_cmd.touch().location()),
         /* .spans = */ &spans_,
         /* .return_result = */ return_result,
       };
@@ -2171,7 +2144,7 @@ TxnService::execute_sdk_command(ConnectionPtr conn,
     } else if (collection_cmd.has_mutate_in()) {
       auto cmd_args = fit_cxx::commands::key_value::command_args{
         /* .collection = */ to_collection(conn, collection_cmd.mutate_in().location()),
-        /* .key = */ to_key(collection_cmd.mutate_in().location(), counters),
+        /* .key = */ to_key(collection_cmd.mutate_in().location()),
         /* .spans = */ &spans_,
         /* .return_result = */ return_result,
       };
@@ -2181,7 +2154,7 @@ TxnService::execute_sdk_command(ConnectionPtr conn,
     } else if (collection_cmd.has_get_any_replica()) {
       auto cmd_args = fit_cxx::commands::key_value::command_args{
         /* .collection = */ to_collection(conn, collection_cmd.get_any_replica().location()),
-        /* .key = */ to_key(collection_cmd.get_any_replica().location(), counters),
+        /* .key = */ to_key(collection_cmd.get_any_replica().location()),
         /* .spans = */ &spans_,
         /* .return_result = */ return_result,
       };
@@ -2191,7 +2164,7 @@ TxnService::execute_sdk_command(ConnectionPtr conn,
     } else if (collection_cmd.has_get_all_replicas()) {
       auto cmd_args = fit_cxx::commands::key_value::command_args{
         /* .collection = */ to_collection(conn, collection_cmd.get_all_replicas().location()),
-        /* .key = */ to_key(collection_cmd.get_all_replicas().location(), counters),
+        /* .key = */ to_key(collection_cmd.get_all_replicas().location()),
         /* .spans = */ &spans_,
         /* .return_result = */ return_result,
       };
@@ -2214,7 +2187,7 @@ TxnService::execute_sdk_command(ConnectionPtr conn,
       if (binary_cmd.has_append()) {
         auto cmd_args = fit_cxx::commands::key_value::command_args{
           /* .collection = */ to_collection(conn, binary_cmd.append().location()),
-          /* .key = */ to_key(binary_cmd.append().location(), counters),
+          /* .key = */ to_key(binary_cmd.append().location()),
           /* .spans = */ &spans_,
           /* .return_result = */ return_result,
         };
@@ -2223,7 +2196,7 @@ TxnService::execute_sdk_command(ConnectionPtr conn,
       } else if (binary_cmd.has_prepend()) {
         auto cmd_args = fit_cxx::commands::key_value::command_args{
           /* .collection = */ to_collection(conn, binary_cmd.prepend().location()),
-          /* .key = */ to_key(binary_cmd.prepend().location(), counters),
+          /* .key = */ to_key(binary_cmd.prepend().location()),
           /* .spans = */ &spans_,
           /* .return_result = */ return_result,
         };
@@ -2232,7 +2205,7 @@ TxnService::execute_sdk_command(ConnectionPtr conn,
       } else if (binary_cmd.has_increment()) {
         auto cmd_args = fit_cxx::commands::key_value::command_args{
           /* .collection = */ to_collection(conn, binary_cmd.increment().location()),
-          /* .key = */ to_key(binary_cmd.increment().location(), counters),
+          /* .key = */ to_key(binary_cmd.increment().location()),
           /* .spans = */ &spans_,
           /* .return_result = */ return_result,
         };
@@ -2241,7 +2214,7 @@ TxnService::execute_sdk_command(ConnectionPtr conn,
       } else if (binary_cmd.has_decrement()) {
         auto cmd_args = fit_cxx::commands::key_value::command_args{
           /* .collection = */ to_collection(conn, binary_cmd.decrement().location()),
-          /* .key = */ to_key(binary_cmd.decrement().location(), counters),
+          /* .key = */ to_key(binary_cmd.decrement().location()),
           /* .spans = */ &spans_,
           /* .return_result = */ return_result,
         };
@@ -2252,7 +2225,7 @@ TxnService::execute_sdk_command(ConnectionPtr conn,
       auto lookup_in_cmd = collection_cmd.lookup_in_any_replica();
       auto cmd_args = fit_cxx::commands::key_value::command_args{
         /* .collection = */ to_collection(conn, lookup_in_cmd.location()),
-        /* .key = */ to_key(lookup_in_cmd.location(), counters),
+        /* .key = */ to_key(lookup_in_cmd.location()),
         /* .spans = */ &spans_,
         /* .return_result = */ return_result,
       };
@@ -2261,7 +2234,7 @@ TxnService::execute_sdk_command(ConnectionPtr conn,
     } else if (collection_cmd.has_lookup_in_all_replicas()) {
       auto lookup_in_cmd = collection_cmd.lookup_in_all_replicas();
       collection = to_collection(conn, lookup_in_cmd.location());
-      auto key = to_key(lookup_in_cmd.location(), counters);
+      auto key = to_key(lookup_in_cmd.location());
       auto cmd_args = fit_cxx::commands::key_value::command_args{
         /* .collection = */ collection,
         /* .key = */ key,
@@ -2381,5 +2354,31 @@ TxnService::spanFinish(grpc::ServerContext* /*context*/,
     return { ::grpc::CANCELLED, e.what() };
   }
 
+  return grpc::Status::OK;
+}
+
+grpc::Status
+TxnService::setCounter(grpc::ServerContext* /*context*/,
+                       const protocol::shared::Counter* request,
+                       protocol::shared::SetCounterResponse* /*response*/)
+{
+  spdlog::info("setCounter called with {}", request->DebugString());
+
+  try {
+    counters_.set_counter_value(*request);
+  } catch (const performer_exception& e) {
+    return e.to_grpc_status();
+  }
+  return grpc::Status::OK;
+}
+
+grpc::Status
+TxnService::clearAllCounters(grpc::ServerContext* /*context*/,
+                             const protocol::shared::ClearAllCountersRequest* /*request*/,
+                             protocol::shared::ClearAllCountersResponse* /*response*/)
+{
+  spdlog::info("clearAllCounters called");
+
+  counters_.clear();
   return grpc::Status::OK;
 }

--- a/tools/fit_performer/src/service.cxx
+++ b/tools/fit_performer/src/service.cxx
@@ -2368,6 +2368,8 @@ TxnService::setCounter(grpc::ServerContext* /*context*/,
     counters_.set_counter_value(*request);
   } catch (const performer_exception& e) {
     return e.to_grpc_status();
+  } catch (const std::exception& e) {
+    return { ::grpc::CANCELLED, e.what() };
   }
   return grpc::Status::OK;
 }
@@ -2379,6 +2381,10 @@ TxnService::clearAllCounters(grpc::ServerContext* /*context*/,
 {
   spdlog::info("clearAllCounters called");
 
-  counters_.clear();
+  try {
+    counters_.clear();
+  } catch (const std::exception& e) {
+    return { ::grpc::CANCELLED, e.what() };
+  }
   return grpc::Status::OK;
 }

--- a/tools/fit_performer/src/service.hxx
+++ b/tools/fit_performer/src/service.hxx
@@ -60,6 +60,7 @@ private:
   std::optional<couchbase::transactions::transaction_get_result> stashed_result_{};
   std::map<std::uint32_t, couchbase::transactions::transaction_get_result> stashed_result_slots_{};
   fit_cxx::run_result_streams streams_;
+  fit_cxx::counters counters_;
   std::mutex rng_mutex_;
   std::mt19937 generator_;
   fit_cxx::observability::span_owner spans_{};
@@ -107,14 +108,12 @@ private:
 
   CmdFutures execute_sdk_command(ConnectionPtr conn,
                                  protocol::sdk::Command cmd,
-                                 std::shared_ptr<fit_cxx::Batcher> batcher,
-                                 Counters& counters);
+                                 std::shared_ptr<fit_cxx::Batcher> batcher);
 
   couchbase::error execute_command(ConnectionPtr conn,
                                    std::shared_ptr<couchbase::transactions::attempt_context> ctx,
                                    const protocol::transactions::TransactionCommand& cmd,
                                    const std::string& logger_prefix,
-                                   Counters& counters,
                                    fit_cxx::transaction_context& txn_ctx,
                                    bool is_batch = false);
 
@@ -122,25 +121,17 @@ private:
                         const protocol::transactions::TransactionCreateRequest* request,
                         protocol::transactions::TransactionResult* response,
                         std::atomic<bool>& timed_out,
-                        Counters& counters,
                         fit_cxx::transaction_context& txn_ctx);
 
-  std::string configure_bounds(fit_cxx::Bounds& workload_bounds,
-                               bool has_bounds,
-                               const protocol::shared::Bounds& bounds);
+  std::string to_key(const protocol::shared::DocLocation& loc);
 
-  std::string to_key(const protocol::shared::DocLocation& loc, Counters& counters);
-
-  auto to_get_multi_specs(ConnectionPtr conn,
-                          const protocol::transactions::TransactionCommand& cmd,
-                          Counters& counters)
+  auto to_get_multi_specs(ConnectionPtr conn, const protocol::transactions::TransactionCommand& cmd)
     -> std::vector<couchbase::transactions::transaction_get_multi_spec>;
   auto to_get_multi_options(const protocol::transactions::TransactionCommand& cmd)
     -> couchbase::transactions::transaction_get_multi_options;
   auto to_get_multi_replicas_from_preferred_server_group_specs(
     ConnectionPtr conn,
-    const protocol::transactions::TransactionCommand& cmd,
-    Counters& counters)
+    const protocol::transactions::TransactionCommand& cmd)
     -> std::vector<
       couchbase::transactions::transaction_get_multi_replicas_from_preferred_server_group_spec>;
   auto to_get_multi_replicas_from_preferred_server_group_options(
@@ -219,4 +210,12 @@ public:
   grpc::Status spanFinish(grpc::ServerContext* context,
                           const protocol::observability::SpanFinishRequest* request,
                           protocol::observability::SpanFinishResponse* response) override;
+
+  grpc::Status setCounter(grpc::ServerContext* context,
+                          const protocol::shared::Counter* request,
+                          protocol::shared::SetCounterResponse* response) override;
+
+  grpc::Status clearAllCounters(grpc::ServerContext* context,
+                                const protocol::shared::ClearAllCountersRequest* request,
+                                protocol::shared::ClearAllCountersResponse* response) override;
 };


### PR DESCRIPTION
## Motivation

There has been a breaking change in the FIT driver for FIT/SIT, as it assumes that performers now support the `CounterEq` bounds. Counters are now also assumed to be global, at the performer-level rather than per-run.

## Changes

* Introduce a new `counters` class containing all global counters which are now kept by the `TxnService`.
* Refactor bounds to create a base class that has a `can_execute` method, which is then specialised by child classes for each type of bounds. This includes support for the new `CounterEq` bounds (`fit_cxx::counter_equality_bounds`).
* Counters are now stored as atomic integers, wrapped in the new `counter` class. This avoids the need for locking when changing the counter's value.