### PR TITLE
ci: speed up the clang-tidy job and de-flake integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.job }}-${{ matrix.os }}
-      - name: Build tests
+      - name: Build tests (${{ matrix.os }})
         timeout-minutes: 60
         env:
           CB_NUMBER_OF_JOBS: 8
@@ -53,7 +53,7 @@ jobs:
         with:
           key: ${{ github.job }}-${{ matrix.os }}
           variant: sccache
-      - name: Build tests
+      - name: Build tests (${{ matrix.os }})
         timeout-minutes: 120
         env:
           CB_CACHE_OPTION: sccache

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -92,6 +92,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+          # Need history back to the PR base so the diff-based run can find it.
+          fetch-depth: 0
       - name: Install dependencies
         run: |
           sudo apt-get update -y
@@ -100,8 +102,30 @@ jobs:
           sudo bash -c "echo 'deb [signed-by=/etc/apt/keyrings/llvm-snapshot.gpg] https://apt.llvm.org/noble/ llvm-toolchain-noble-${LLVM_VERSION} main' >> /etc/apt/sources.list"
           sudo apt-get update -y
           sudo apt-get install -y clang-${LLVM_VERSION} clang-tidy-${LLVM_VERSION} clang-tools-${LLVM_VERSION}
-      - name: Run clang-tidy
+      # On pull requests, analyze only the sources changed against the base branch.
+      - name: Run clang-tidy (changed files)
+        if: ${{ github.event_name == 'pull_request' }}
         run: ./bin/check-clang-tidy
         env:
           CB_CC: /usr/bin/clang-${{ env.LLVM_VERSION }}
           CB_CXX: /usr/bin/clang++-${{ env.LLVM_VERSION }}
+          CB_CLANG_TIDY: /usr/bin/clang-tidy-${{ env.LLVM_VERSION }}
+          CB_NUMBER_OF_JOBS: 4
+          CB_TIDY_DIFF_BASE: ${{ github.event.pull_request.base.sha }}
+      # On push to a protected branch, analyze the whole library.
+      - name: Run clang-tidy (full)
+        if: ${{ github.event_name != 'pull_request' }}
+        run: ./bin/check-clang-tidy
+        env:
+          CB_CC: /usr/bin/clang-${{ env.LLVM_VERSION }}
+          CB_CXX: /usr/bin/clang++-${{ env.LLVM_VERSION }}
+          CB_CLANG_TIDY: /usr/bin/clang-tidy-${{ env.LLVM_VERSION }}
+          CB_RUN_CLANG_TIDY: /usr/bin/run-clang-tidy-${{ env.LLVM_VERSION }}
+          CB_NUMBER_OF_JOBS: 4
+      - name: Upload clang-tidy fixes
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: clang-tidy-fixes
+          path: cmake-build-clang-tidy/build/clang-tidy-fixes.yaml
+          if-no-files-found: ignore

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -46,7 +46,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.job }}
-      - name: Build tests
+      - name: Build tests (${{ matrix.sanitizer }})
         env:
           CB_SANITIZER: ${{ matrix.sanitizer }}
           CB_CLANG: /usr/bin/clang-${{ env.LLVM_VERSION }}
@@ -91,7 +91,7 @@ jobs:
         with:
           name: build-${{ matrix.sanitizer }}
           path: ./cmake-build-tests-${{ matrix.sanitizer }}
-      - name: Run tests
+      - name: Run unit tests (${{ matrix.sanitizer }})
         timeout-minutes: 60
         env:
           CB_SANITIZER: ${{ matrix.sanitizer }}
@@ -158,7 +158,7 @@ jobs:
         env:
           HOST: ${{ steps.cbdino.outputs.ip }}
         run: ./bin/check-cluster
-      - name: Run tests
+      - name: Run integration tests (${{ matrix.sanitizer }}, ${{ matrix.tls }})
         timeout-minutes: 120
         env:
           CB_SANITIZER: ${{ matrix.sanitizer }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           name: build
           path: ./cmake-build-tests
-      - name: Run tests
+      - name: Run unit tests
         timeout-minutes: 40
         env:
           TEST_LOG_LEVEL: trace
@@ -113,7 +113,7 @@ jobs:
         env:
           HOST: ${{ steps.cbdino.outputs.ip }}
         run: ./bin/check-cluster
-      - name: Run tests
+      - name: Run ${{ matrix.suite }} tests
         timeout-minutes: 40
         env:
           TEST_SERVER_VERSION: ${{ matrix.server }}

--- a/bin/check-clang-tidy
+++ b/bin/check-clang-tidy
@@ -19,14 +19,20 @@ PROJECT_ROOT="$( cd "$(dirname "$0"/..)" >/dev/null 2>&1 ; pwd -P )"
 CB_CMAKE=${CB_CMAKE:-$(which cmake)}
 CB_CC=${CB_CC:-$(which clang-22)}
 CB_CXX=${CB_CXX:-$(which clang++-22)}
+CB_CLANG_TIDY=${CB_CLANG_TIDY:-$(which clang-tidy-22 || which clang-tidy)}
+CB_RUN_CLANG_TIDY=${CB_RUN_CLANG_TIDY:-$(which run-clang-tidy-22 || which run-clang-tidy)}
 CB_NUMBER_OF_JOBS=${CB_NUMBER_OF_JOBS:-2}
 CB_CMAKE_EXTRAS=${CB_CMAKE_EXTRAS:-}
+# When set to a git ref, only the C++ sources changed relative to that ref are
+# analyzed (pull-request mode); otherwise the whole library is analyzed.
+CB_TIDY_DIFF_BASE=${CB_TIDY_DIFF_BASE:-}
 
 echo "CB_CC=${CB_CC}"
 echo "CB_CXX=${CB_CXX}"
 echo "CB_CMAKE=${CB_CMAKE}"
 
 BUILD_DIR="${PROJECT_ROOT}/cmake-build-clang-tidy"
+FIXES_FILE="${BUILD_DIR}/build/clang-tidy-fixes.yaml"
 
 set -exuo pipefail
 
@@ -34,9 +40,57 @@ rm -rf "${BUILD_DIR}"
 mkdir -p "${BUILD_DIR}"
 cd "${BUILD_DIR}"
 
-${CB_CMAKE} -S "${PROJECT_ROOT}" -B build -DENABLE_CLANG_TIDY=ON -DENABLE_CLANG_TIDY_FIX=ON -DCMAKE_C_COMPILER=${CB_CC} -DCMAKE_CXX_COMPILER=${CB_CXX} ${CB_CMAKE_EXTRAS}
+# Configure with a compilation database but without build-integrated clang-tidy,
+# then build the library once (no tidy) so generated headers exist on disk before
+# analysis. Only the shared library target is built; the static library shares the
+# same source list, so this covers every translation unit once.
+${CB_CMAKE} -S "${PROJECT_ROOT}" -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+  -DCMAKE_C_COMPILER=${CB_CC} -DCMAKE_CXX_COMPILER=${CB_CXX} ${CB_CMAKE_EXTRAS}
+${CB_CMAKE} --build build --parallel "${CB_NUMBER_OF_JOBS}" --target couchbase_cxx_client
+
+if [ -n "${CB_TIDY_DIFF_BASE}" ]; then
+  # Pull-request mode: analyze only the sources changed against the base branch.
+  # A single clang-tidy process handles the (small) changed-file set, so it writes
+  # the exported fixes without contention.
+  mapfile -t changed < <(git -C "${PROJECT_ROOT}" diff --name-only --diff-filter=ACMR \
+    "${CB_TIDY_DIFF_BASE}" -- '*.cxx' '*.cpp' '*.cc')
+  files=()
+  for f in "${changed[@]}"; do
+    # Stay within the same scope as the full run, which only analyzes the
+    # couchbase_cxx_client target: core/ holds the library implementation
+    # (couchbase/ is headers only). Test and tool sources are not part of that
+    # target and are not linted in full mode, so skip them here as well.
+    case "${f}" in
+      core/* | couchbase/*) ;;
+      *) continue ;;
+    esac
+    if grep -qF "\"${PROJECT_ROOT}/${f}\"" build/compile_commands.json; then
+      files+=("${PROJECT_ROOT}/${f}")
+    fi
+  done
+  if [ ${#files[@]} -eq 0 ]; then
+    echo "no changed C++ sources in the compilation database; nothing to analyze"
+    exit 0
+  fi
+  printf 'analyzing changed source: %s\n' "${files[@]}"
+  set +e
+  "${CB_CLANG_TIDY}" -p build -export-fixes="${FIXES_FILE}" \
+    -extra-arg=-Wno-unknown-warning-option -extra-arg=-Wno-c2y-extensions "${files[@]}"
+  STATUS=$?
+  set -e
+  exit ${STATUS}
+fi
+
+# Full mode: analyze every translation unit of the library implementation. Drive
+# clang-tidy through run-clang-tidy rather than CMake's build-integrated clang-tidy:
+# run-clang-tidy analyzes each translation unit in a separate process and merges the
+# per-unit fixes into a single file, whereas CMake's parallel per-unit invocations
+# would all write -- and clobber -- one shared -export-fixes file.
 set +e
-${CB_CMAKE} --build build --parallel ${CB_NUMBER_OF_JOBS} --verbose
+"${CB_RUN_CLANG_TIDY}" -p build -j "${CB_NUMBER_OF_JOBS}" \
+  -clang-tidy-binary "${CB_CLANG_TIDY}" -export-fixes "${FIXES_FILE}" \
+  -extra-arg=-Wno-unknown-warning-option -extra-arg=-Wno-c2y-extensions \
+  "${PROJECT_ROOT}/core/"'.*\.(cxx|cpp|cc)$'
 STATUS=$?
 set -e
 

--- a/cmake/StaticAnalyzers.cmake
+++ b/cmake/StaticAnalyzers.cmake
@@ -51,11 +51,14 @@ if(ENABLE_CLANG_TIDY)
     #   compiler versions (e.g. when mixing clang-tidy-23 with clang-22 headers).
     # -Wno-c2y-extensions: __COUNTER__ is used by Catch2's TEST_CASE macro; clang-23 warns it is a
     #   C2y extension. We cannot modify Catch2, and the warning is irrelevant in a C++17 codebase.
+    # No -export-fixes here: build-integrated clang-tidy runs once per translation unit in
+    #   parallel, so a shared fixes file would be clobbered. CI exports fixes via run-clang-tidy
+    #   in bin/check-clang-tidy instead. -fix (which rewrites sources in place) is opt-in and
+    #   intended for local use only; CI must report, not rewrite.
     set(COUCHBASE_CXX_CLIENT_CLANG_TIDY
         "${CLANGTIDY};-extra-arg=-Wno-unknown-warning-option;-extra-arg=-Wno-c2y-extensions")
     if(ENABLE_CLANG_TIDY_FIX)
-      set(COUCHBASE_CXX_CLIENT_CLANG_TIDY
-          "${COUCHBASE_CXX_CLIENT_CLANG_TIDY};-fix;-export-fixes=${PROJECT_BINARY_DIR}/clang-tidy-fixes.yaml")
+      set(COUCHBASE_CXX_CLIENT_CLANG_TIDY "${COUCHBASE_CXX_CLIENT_CLANG_TIDY};-fix")
     endif()
   else()
     message(SEND_ERROR "clang-tidy requested but executable not found")

--- a/core/transactions/transactions_cleanup.cxx
+++ b/core/transactions/transactions_cleanup.cxx
@@ -144,7 +144,7 @@ transactions_cleanup::clean_collection(
           remaining_in_cleanup_window.count() /
           std::max<decltype(it)::difference_type>(1, atrs_left_for_this_client));
         // clean the ATR entry
-        std::string atr_id = *it;
+        const std::string atr_id = *it;
         if (!is_running()) {
           CB_LOST_ATTEMPT_CLEANUP_LOG_DEBUG("cleanup of {} complete", keyspace);
           return;

--- a/test/test_integration_crud.cxx
+++ b/test/test_integration_crud.cxx
@@ -705,14 +705,30 @@ TEST_CASE("integration: upsert may trigger snappy compression", "[integration]")
 TEST_CASE("integration: multi-threaded open/close bucket", "[integration]")
 {
   test::utils::integration_test_guard integration;
-  constexpr auto number_of_threads{ 100 };
+  constexpr std::size_t number_of_threads{ 100 };
+
+  // This test exercises concurrent open/upsert/close for thread-safety; it does not require
+  // that every operation succeeds. On a busy or still-warming-up CI cluster an individual
+  // operation can legitimately time out, and an exception escaping a std::thread would call
+  // std::terminate and abort the whole test binary. So each worker records its outcome
+  // instead of throwing, and the main thread evaluates the results afterwards, tolerating
+  // timeouts while still failing (cleanly) on any unexpected error.
+  const auto tolerable = [](std::error_code ec) {
+    return !ec || ec == couchbase::errc::common::ambiguous_timeout ||
+           ec == couchbase::errc::common::unambiguous_timeout;
+  };
 
   std::vector<std::thread> threads;
   threads.reserve(number_of_threads);
 
-  for (auto i = 0; i < number_of_threads; ++i) {
-    threads.emplace_back([&integration]() {
-      test::utils::open_bucket(integration.cluster, integration.ctx.bucket);
+  std::vector<std::error_code> open_results(number_of_threads);
+  for (std::size_t i = 0; i < number_of_threads; ++i) {
+    threads.emplace_back([&integration, &open_results, i]() {
+      try {
+        test::utils::open_bucket(integration.cluster, integration.ctx.bucket);
+      } catch (const std::system_error& e) {
+        open_results[i] = e.code();
+      }
     });
   }
   std::for_each(threads.begin(), threads.end(), [](auto& thread) {
@@ -721,18 +737,15 @@ TEST_CASE("integration: multi-threaded open/close bucket", "[integration]")
 
   threads.clear();
 
-  for (auto i = 0; i < number_of_threads; ++i) {
-    threads.emplace_back([&integration]() {
+  std::vector<std::error_code> upsert_results(number_of_threads);
+  for (std::size_t i = 0; i < number_of_threads; ++i) {
+    threads.emplace_back([&integration, &upsert_results, i]() {
       couchbase::core::document_id id{
         integration.ctx.bucket, "_default", "_default", test::utils::uniq_id("foo")
       };
       couchbase::core::operations::upsert_request req{ id, basic_doc_json };
       req.timeout = std::chrono::seconds{ 20 };
-      if (auto resp = test::utils::execute(integration.cluster, req); resp.ctx.ec()) {
-        if (resp.ctx.ec() != couchbase::errc::common::ambiguous_timeout) {
-          throw std::system_error(resp.ctx.ec());
-        }
-      }
+      upsert_results[i] = test::utils::execute(integration.cluster, req).ctx.ec();
     });
   }
 
@@ -742,16 +755,32 @@ TEST_CASE("integration: multi-threaded open/close bucket", "[integration]")
 
   threads.clear();
 
-  for (auto i = 0; i < number_of_threads; ++i) {
-    auto close_bucket = [&integration]() {
-      test::utils::close_bucket(integration.cluster, integration.ctx.bucket);
-    };
-    std::thread closer(std::move(close_bucket));
-    threads.emplace_back(std::move(closer));
+  std::vector<std::error_code> close_results(number_of_threads);
+  for (std::size_t i = 0; i < number_of_threads; ++i) {
+    threads.emplace_back([&integration, &close_results, i]() {
+      try {
+        test::utils::close_bucket(integration.cluster, integration.ctx.bucket);
+      } catch (const std::system_error& e) {
+        close_results[i] = e.code();
+      }
+    });
   }
   std::for_each(threads.begin(), threads.end(), [](auto& thread) {
     thread.join();
   });
+
+  for (const auto& ec : open_results) {
+    INFO("open_bucket: " << ec.message());
+    REQUIRE(tolerable(ec));
+  }
+  for (const auto& ec : upsert_results) {
+    INFO("upsert: " << ec.message());
+    REQUIRE(tolerable(ec));
+  }
+  for (const auto& ec : close_results) {
+    INFO("close_bucket: " << ec.message());
+    REQUIRE(tolerable(ec));
+  }
 }
 
 TEST_CASE("integration: open bucket that does not exist", "[integration]")

--- a/test/test_integration_subdoc.cxx
+++ b/test/test_integration_subdoc.cxx
@@ -149,11 +149,21 @@ assert_single_lookup_all_replica_success(test::utils::integration_test_guard& in
 {
   couchbase::core::operations::lookup_in_all_replicas_request req{ id };
   req.specs = couchbase::lookup_in_specs{ spec }.specs();
-  auto response = test::utils::execute(integration.cluster, req);
   INFO(fmt::format(
     "assert_single_lookup_all_replica_success(\"{}\", \"{}\")", id, req.specs[0].path_));
+  // A freshly written document, even one written durably, may not be readable from every
+  // replica the instant the write returns; an all-replica lookup then comes back with fewer
+  // entries (a replica answers not_found). Poll until every replica reports the document
+  // before asserting full coverage, so replication lag does not flake the test.
+  const auto expected_entries = integration.number_of_replicas() + 1;
+  couchbase::core::operations::lookup_in_all_replicas_response response;
+  auto replicated = test::utils::wait_until([&]() {
+    response = test::utils::execute(integration.cluster, req);
+    return !response.ctx.ec() && response.entries.size() == expected_entries;
+  });
+  REQUIRE(replicated);
   REQUIRE_SUCCESS(response.ctx.ec());
-  REQUIRE(response.entries.size() == integration.number_of_replicas() + 1);
+  REQUIRE(response.entries.size() == expected_entries);
   auto responses_from_active =
     std::count_if(response.entries.begin(), response.entries.end(), [](const auto& r) {
       return !r.is_replica;


### PR DESCRIPTION
Three independent CI and test-stability improvements.

### Run clang-tidy on changed files in pull requests

The linter job re-analyzed the entire library on every PR, which was slow and made the failure output hard to attribute. Pull requests now analyze only the C++ sources changed against the PR base; push to a protected branch still runs the full library analysis. Both modes share the same setup — configure a compile database and build the `couchbase_cxx_client` target once (the static and shared libraries share a source list, so this covers every translation unit) so generated headers exist before analysis. The diff-based mode (`CB_TIDY_DIFF_BASE`) is scoped to `core/` and `couchbase/` so it lints exactly the translation units the full run covers.

CI reports findings as a `clang-tidy-fixes.yaml` artifact instead of rewriting the tree; `-fix` (in-place rewrite) stays opt-in for local use. The full run drives clang-tidy through `run-clang-tidy`, which analyzes each translation unit in a separate process and merges the per-unit fixes into a single file — CMake's build-integrated clang-tidy cannot export fixes safely, since its parallel per-unit invocations would all clobber one shared file. The changed-files run is a single clang-tidy process, so it writes its fixes without contention. One finding surfaced by this is fixed (`const std::string atr_id` in the lost-attempts cleanup loop).

### Harden flaky multi-threaded and replica-read integration tests

The concurrent open/upsert/close thread-safety test now tolerates ambiguous/unambiguous timeouts rather than requiring unconditional success, so it exercises concurrency without flaking under load. The all-replica read tests poll until every replica reports the document before asserting full entry coverage, so replication lag no longer produces a spurious short result.

### Disambiguate matrix job step names

Matrix legs shared identical step names ("Build tests", "Run tests"), making parallel runs indistinguishable in the Actions UI. Step names now carry their matrix dimension (os / sanitizer / tls / suite).
