### PR TITLE
CXXCBC-849: format log arguments only when a consumer exists

### DIFF
--- a/core/logger/logger.cxx
+++ b/core/logger/logger.cxx
@@ -62,6 +62,10 @@ std::atomic_int file_logger_version{ 0 };
 std::shared_ptr<couchbase::core::logger::log_callback> log_callback{};
 std::mutex log_callback_mutex;
 std::atomic_int log_callback_version{ 0 };
+// Mirrors "is log_callback set?" so the hot-path predicate can be answered with a single atomic
+// load, without copying the owning shared_ptr. Updated under log_callback_mutex alongside
+// log_callback.
+std::atomic<bool> log_callback_present{ false };
 
 auto
 get_file_logger() -> std::shared_ptr<spdlog::logger>
@@ -94,6 +98,7 @@ update_callback_logger(const std::shared_ptr<couchbase::core::logger::log_callba
 {
   const std::scoped_lock lock(log_callback_mutex);
   log_callback = new_callback;
+  log_callback_present.store(new_callback != nullptr, std::memory_order_relaxed);
   ++log_callback_version;
 }
 
@@ -194,6 +199,14 @@ should_log(level lvl) -> bool
     return get_file_logger()->should_log(translate_level(lvl));
   }
   return false;
+}
+
+auto
+has_custom_callback() -> bool
+{
+  // A log macro asks this on every call; answer it with a single atomic load rather than copying
+  // the owning shared_ptr that get_custom_callback() returns.
+  return log_callback_present.load(std::memory_order_relaxed);
 }
 
 namespace detail

--- a/core/logger/logger.hxx
+++ b/core/logger/logger.hxx
@@ -181,6 +181,14 @@ get_lowest_log_level() -> level;
 auto
 should_log(level lvl) -> bool;
 
+/**
+ * @return true if a custom log callback is currently registered. Used to decide whether log
+ * arguments need to be formatted at all, independently of the severity level (the callback does
+ * its own level filtering).
+ */
+auto
+has_custom_callback() -> bool;
+
 auto
 should_log_protocol() -> bool;
 
@@ -279,10 +287,17 @@ is_initialized() -> bool;
  */
 #define COUCHBASE_LOG(file, line, function, severity, ...)                                         \
   do {                                                                                             \
-    couchbase::core::logger::log_custom_logger(file, line, function, severity, __VA_ARGS__);       \
-                                                                                                   \
-    if (couchbase::core::logger::should_log(severity)) {                                           \
-      couchbase::core::logger::log(file, line, function, severity, __VA_ARGS__);                   \
+    const bool cb_log_to_file_ = couchbase::core::logger::should_log(severity);                    \
+    const bool cb_log_to_custom_ = couchbase::core::logger::has_custom_callback();                 \
+    if (cb_log_to_file_ || cb_log_to_custom_) {                                                    \
+      auto cb_log_message_ = ::fmt::format(__VA_ARGS__);                                           \
+      if (cb_log_to_custom_) {                                                                     \
+        couchbase::core::logger::detail::log_custom_logger(                                        \
+          file, line, function, severity, cb_log_message_);                                        \
+      }                                                                                            \
+      if (cb_log_to_file_) {                                                                       \
+        couchbase::core::logger::detail::log(file, line, function, severity, cb_log_message_);     \
+      }                                                                                            \
     }                                                                                              \
   } while (false)
 
@@ -343,8 +358,10 @@ is_initialized() -> bool;
  */
 #define COUCHBASE_LOG_RAW(file, line, function, severity, msg)                                     \
   do {                                                                                             \
-    couchbase::core::logger::log_custom_logger(file, line, function, severity, msg);               \
-                                                                                                   \
+    /* msg is already a string; deliver it directly (no fmt::format), gated like COUCHBASE_LOG. */ \
+    if (couchbase::core::logger::has_custom_callback()) {                                          \
+      couchbase::core::logger::detail::log_custom_logger(file, line, function, severity, msg);     \
+    }                                                                                              \
     if (couchbase::core::logger::should_log(severity)) {                                           \
       couchbase::core::logger::detail::log(file, line, function, severity, msg);                   \
     }                                                                                              \

--- a/test/test_unit_logger.cxx
+++ b/test/test_unit_logger.cxx
@@ -21,6 +21,31 @@
 
 #include "core/logger/logger.hxx"
 
+#include <spdlog/fmt/bundled/format.h>
+
+#include <atomic>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace
+{
+// Counts how many times its fmt formatter runs, so a test can assert whether the logging macro
+// evaluated (formatted) its arguments at all.
+std::atomic<int> probe_format_count{ 0 };
+struct format_probe {
+};
+} // namespace
+
+template<>
+struct fmt::formatter<format_probe> : fmt::formatter<std::string_view> {
+  auto format(format_probe /*probe*/, fmt::format_context& ctx) const -> decltype(ctx.out())
+  {
+    probe_format_count.fetch_add(1, std::memory_order_relaxed);
+    return fmt::formatter<std::string_view>::format("probe", ctx);
+  }
+};
+
 TEST_CASE("unit: simple callback", "[unit]")
 {
   std::vector<std::string> captured_logs;
@@ -132,4 +157,35 @@ TEST_CASE("unit: reregister custom log callback", "[unit]")
   assert(captured_logs.size() == 2);
   assert(captured_logs[0].find("Test error message") != std::string::npos);
   assert(captured_logs[1].find("Test error message 3") != std::string::npos);
+}
+
+TEST_CASE("unit: no argument formatting when logging disabled and no callback", "[unit]")
+{
+  couchbase::logger::unregister_log_callback();
+  couchbase::logger::set_level(couchbase::logger::log_level::off);
+  probe_format_count.store(0);
+
+  CB_LOG_TRACE("value={}", format_probe{});
+
+  REQUIRE(probe_format_count.load() == 0);
+}
+
+TEST_CASE("unit: arguments formatted and delivered when a callback is registered", "[unit]")
+{
+  std::vector<std::string> captured;
+  couchbase::logger::register_log_callback(
+    [&captured](std::string_view msg,
+                couchbase::logger::log_level /*level*/,
+                couchbase::logger::log_location /*location*/) {
+      captured.emplace_back(msg);
+    });
+  couchbase::logger::set_level(couchbase::logger::log_level::off);
+  probe_format_count.store(0);
+
+  CB_LOG_TRACE("value={}", format_probe{});
+
+  couchbase::logger::unregister_log_callback();
+  REQUIRE(probe_format_count.load() == 1);
+  REQUIRE_FALSE(captured.empty());
+  REQUIRE(captured.back().find("value=probe") != std::string::npos);
 }


### PR DESCRIPTION
The COUCHBASE_LOG macro family formatted its arguments with fmt::format on every invocation, ahead of the severity-level gate, then discarded the string whenever the level was off and no custom callback was registered. On the KV hot path, where trace statements fire once per operation, that formats messages nobody reads.

Compute the two delivery predicates first -- should_log(severity) for the file sink and has_custom_callback() for a registered callback -- and format the arguments once, only if at least one consumer exists, then hand the single formatted string to whichever paths are active. COUCHBASE_LOG_RAW is brought under the same gate; because its message is already a string it is delivered straight to the sinks without fmt::format, which also avoids misparsing a fixed message that happens to contain brace characters.

has_custom_callback() answers the per-call presence question without copying the owning shared_ptr: it caches only the presence bit in a version-gated thread-local, mirroring the existing callback cache, so the common no-callback path is a single version comparison. Call-site signatures and compile-time format-string checking are unchanged.