### PR TITLE
CXXCBC-852: Stop the in-flight bootstrap session when a bucket is closed

### DIFF
--- a/core/bucket.cxx
+++ b/core/bucket.cxx
@@ -554,6 +554,13 @@ public:
         ? io::mcbp_session(
             client_id_, {}, ctx_, tls_, origin_, state_listener_, name_, known_features_)
         : io::mcbp_session(client_id_, {}, ctx_, origin_, state_listener_, name_, known_features_);
+    {
+      // Publish the in-flight session so close() can stop it if the cluster is torn down before
+      // this bootstrap completes; otherwise the continuation below (which captures new_session)
+      // would keep it alive forever. See bootstrapping_session_.
+      const std::scoped_lock lock(sessions_mutex_);
+      bootstrapping_session_ = new_session;
+    }
     new_session.bootstrap([self = shared_from_this(), new_session, h = std::move(handler)](
                             std::error_code ec, topology::configuration cfg) mutable {
       if (ec) {
@@ -562,20 +569,37 @@ public:
                        ec.message(),
                        self->name_);
         self->remove_session(new_session.id());
+        const std::scoped_lock lock(self->sessions_mutex_);
+        self->bootstrapping_session_.reset();
       } else {
         const std::size_t this_index = new_session.index();
-        new_session.on_configuration_update(self);
-        new_session.on_stop([id = new_session.id(), self]() {
-          self->remove_session(id);
-        });
-
+        bool established{ false };
         {
+          // Establish the session and stop tracking it as bootstrapping in one critical section, so
+          // a concurrent close() finds it in exactly one of the two containers (never neither).
           const std::scoped_lock lock(self->sessions_mutex_);
-          self->sessions_.insert_or_assign(this_index, std::move(new_session));
+          self->bootstrapping_session_.reset();
+          if (self->closed_) {
+            // The bucket was closed while this session was still bootstrapping (close() sets
+            // closed_ before it swaps the session maps). Do not register callbacks or add it to
+            // sessions_: a session established after close() would be stranded, and its on_stop
+            // handler could post restart_sessions() during shutdown. Stop it here instead -- no
+            // on_stop is registered, so stopping under the lock cannot re-enter remove_session().
+            new_session.stop(retry_reason::do_not_retry);
+          } else {
+            new_session.on_configuration_update(self);
+            new_session.on_stop([id = new_session.id(), self]() {
+              self->remove_session(id);
+            });
+            self->sessions_.insert_or_assign(this_index, std::move(new_session));
+            established = true;
+          }
         }
-        self->update_config(cfg);
-        self->drain_deferred_queue({});
-        self->poll_config({});
+        if (established) {
+          self->update_config(cfg);
+          self->drain_deferred_queue({});
+          self->poll_config({});
+        }
       }
       asio::post(
         asio::bind_executor(self->ctx_, [h = std::move(h), ec, cfg = std::move(cfg)]() mutable {
@@ -719,12 +743,19 @@ public:
     }
 
     std::map<size_t, io::mcbp_session> old_sessions;
+    std::optional<io::mcbp_session> bootstrapping_session;
     {
       const std::scoped_lock lock(sessions_mutex_);
       std::swap(old_sessions, sessions_);
+      std::swap(bootstrapping_session, bootstrapping_session_);
     }
     for (auto& [index, session] : old_sessions) {
       session.stop(retry_reason::do_not_retry);
+    }
+    // Stop the session that is still bootstrapping (if any): this completes its bootstrap with an
+    // error, releasing the continuation that would otherwise strand the session and this bucket.
+    if (bootstrapping_session) {
+      bootstrapping_session->stop(retry_reason::do_not_retry);
     }
   }
 
@@ -1112,6 +1143,13 @@ private:
   std::mutex deferred_commands_mutex_{};
 
   std::map<size_t, io::mcbp_session> sessions_{};
+  // The very first session is only moved into sessions_ once it finishes bootstrapping; until then
+  // it lives solely inside its own bootstrap continuation (which captures a copy of the session and
+  // this bucket). If the cluster is closed while that bootstrap is in flight (e.g. a bucket that
+  // never opens), close() would otherwise never see the session, so its self-capture would strand
+  // the session, the bucket, and the whole cluster graph. Track it here so close() can stop it and
+  // let the continuation fire. Guarded by sessions_mutex_.
+  std::optional<io::mcbp_session> bootstrapping_session_{};
   mutable std::mutex sessions_mutex_{};
   std::atomic_size_t round_robin_next_{ 0 };
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,7 @@ integration_test(management_eventing)
 integration_test(management_search_index)
 integration_test(http_session_manager)
 integration_test(node_id)
+integration_test(bucket_bootstrap)
 
 unit_test(connection_string)
 unit_test(capella)

--- a/test/test_integration_bucket_bootstrap.cxx
+++ b/test/test_integration_bucket_bootstrap.cxx
@@ -1,0 +1,77 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "test_helper_integration.hxx"
+
+#include <couchbase/cluster.hxx>
+#include <couchbase/collection.hxx>
+
+#include <chrono>
+#include <future>
+
+using namespace std::literals::chrono_literals;
+
+// Regression test for CXXCBC-852.
+//
+// Opening a bucket starts bootstrapping its first key/value session, and that session is only moved
+// into the bucket's session list once it finishes connecting. While it is still bootstrapping it
+// lives solely inside its own bootstrap continuation, which captures a copy of the session and the
+// bucket. If the cluster is closed before that bootstrap completes, close() -- which stops only the
+// already-established sessions -- never stops the in-flight one, so its self-capture strands the
+// session, the bucket, and the whole cluster graph.
+//
+// There is no caller-visible symptom (the pending operation fails either way); the leak is only
+// observable to AddressSanitizer/LeakSanitizer, which reports it as an all-indirect (cyclic) leak.
+// This test therefore reproduces the teardown-while-bootstrapping scenario and is verified by the
+// sanitizer CI job: it leaks without the fix and is clean with it.
+TEST_CASE("integration: closing a cluster while a bucket is still bootstrapping does not leak",
+          "[integration]")
+{
+  test::utils::integration_test_guard integration;
+
+  {
+    auto cluster = integration.public_cluster();
+
+    // An operation on a bucket that never becomes reachable starts a KV session bootstrapping and
+    // leaves it in flight: the bucket never opens, so the operation stays pending and the session
+    // is never moved into the established-sessions list. The future is intentionally not awaited --
+    // we tear the cluster down while the bootstrap is still going.
+    auto pending = cluster.bucket("this_bucket_does_not_exist")
+                     .default_collection()
+                     .exists(test::utils::uniq_id("cxxcbc-852"));
+
+    // The regression requires the bucket bootstrap to still be in flight when the cluster is torn
+    // down. If the operation has already completed (e.g. against a mock, or an unusually fast
+    // environment), the in-flight condition cannot be set up, so skip rather than fail
+    // nondeterministically.
+    if (pending.wait_for(0s) != std::future_status::timeout) {
+      SUCCEED("operation completed too quickly to exercise an in-flight bucket bootstrap");
+      return;
+    }
+
+    // `cluster` is destroyed here, tearing down the io_context while the bucket bootstrap is still
+    // in flight. close() must stop the bootstrapping session so its continuation runs and the
+    // self-capture is released.
+  }
+
+  // The regression is a memory leak with no caller-visible symptom, so the real check is performed
+  // by the AddressSanitizer/LeakSanitizer CI job: without the fix the in-flight session (and,
+  // reachable only through it, the bucket and the whole cluster graph) is stranded and reported as
+  // an all-indirect (cyclic) leak; with the fix the run is clean. Record a passing assertion so the
+  // case is not reported as assertion-free.
+  SUCCEED("cluster torn down while a bucket was bootstrapping without stranding the session");
+}


### PR DESCRIPTION
open_bucket() puts the bucket in the cluster's map and starts bootstrapping its first KV session, but that session is only moved into the bucket's session list once it finishes connecting. Until then it lives solely inside its own bootstrap continuation, which captures a copy of the session and the bucket. If the cluster is closed before that bootstrap completes -- for example a bucket that never opens -- close() only stops the already-established sessions, so the in-flight session, and through it the bucket and the whole cluster graph, is stranded and leaked (reachable only via the self-capture, so it shows up as a pure cycle under LeakSanitizer).

Track the bootstrapping session on the bucket and stop it in close() so its continuation runs, the self-capture is released, and the graph is freed.