### PR TITLE
CXXCBC-853: Fix handler-drop lifetime in async public-API operations

### DIFF
--- a/core/cluster.cxx
+++ b/core/cluster.cxx
@@ -1149,11 +1149,21 @@ public:
             if (auto bucket = cluster->find_bucket_by_name(bucket_name.value()); bucket) {
               return bucket->ping(collector, timeout);
             }
+            // Capture a weak_ptr, not a strong cluster: open_bucket parks this callback in the
+            // bucket-bootstrap queue, which close() does not drain. A strong self-capture would
+            // form a cluster<->parked-callback cycle that pins the ping collector past cluster
+            // close, so its destructor -- the backstop that reports the ping result -- would never
+            // run and the caller would hang. With a weak capture the callback is released when the
+            // cluster is torn down, the collector is destroyed, and its destructor delivers the
+            // report.
             cluster->open_bucket(
-              bucket_name.value(), [collector, cluster, bucket_name, timeout](std::error_code ec) {
+              bucket_name.value(),
+              [collector, weak = std::weak_ptr(cluster), bucket_name, timeout](std::error_code ec) {
                 if (!ec) {
-                  if (auto bucket = cluster->find_bucket_by_name(bucket_name.value()); bucket) {
-                    return bucket->ping(collector, timeout);
+                  if (auto cluster = weak.lock()) {
+                    if (auto bucket = cluster->find_bucket_by_name(bucket_name.value()); bucket) {
+                      return bucket->ping(collector, timeout);
+                    }
                   }
                 }
               });

--- a/core/impl/collection.cxx
+++ b/core/impl/collection.cxx
@@ -1157,86 +1157,91 @@ public:
         break;
     }
 
-    return core_.open_bucket(
+    // Fetch the bucket configuration through the shared async scaffold rather than nesting
+    // open_bucket + with_bucket_configuration directly: the latter parks its continuation in the
+    // core (in the bucket-bootstrap window it is not drained on close), so capturing the moved
+    // scan_handler there would strand it -- a std::future caller would observe broken_promise and a
+    // callback caller would hang -- if the cluster is torn down mid-scan. The scaffold anchors the
+    // wait on an io_context timer and fails closed with errc::network::cluster_closed. Everything
+    // the continuation needs is captured by value (not `this`): the scan handler outlives
+    // collection_impl when the caller drops the collection but keeps the future, so a raw-`this`
+    // capture would be a use-after-free.
+    core::impl::with_bucket_config_or_timeout<std::shared_ptr<core::topology::configuration>>(
+      core_,
       bucket_name_,
-      [this,
-       obs_rec = std::move(obs_rec),
-       handler = std::move(handler),
+      orchestrator_opts.timeout,
+      [core = core_,
+       bucket_name = bucket_name_,
+       scope_name = scope_name_,
+       name = name_,
+       crypto_manager = crypto_manager_,
        orchestrator_opts,
-       core_scan_type](std::error_code ec) mutable {
-        if (ec) {
-          obs_rec->finish(ec);
-          return handler(error(ec), {});
+       core_scan_type,
+       obs_rec = std::move(obs_rec),
+       handler = std::move(handler)](
+        couchbase::error err, std::shared_ptr<core::topology::configuration> config) mutable {
+        if (err.ec()) {
+          obs_rec->finish(err.ec());
+          return handler(
+            error(err.ec(), "An error occurred when attempting to fetch the bucket configuration."),
+            {});
         }
-        return core_.with_bucket_configuration(
-          bucket_name_,
-          [this,
-           obs_rec = std::move(obs_rec),
-           handler = std::move(handler),
-           orchestrator_opts,
-           core_scan_type](std::error_code ec,
-                           const std::shared_ptr<core::topology::configuration>& config) mutable {
-            if (ec) {
-              obs_rec->finish(ec);
-              return handler(
-                error(ec, "An error occurred when attempting to fetch the bucket configuration."),
-                {});
-            }
-            if (!config->capabilities.supports_range_scan()) {
-              obs_rec->finish(ec);
-              return handler(error(errc::common::feature_not_available,
-                                   "This bucket does not support range scan."),
-                             {});
-            }
-            auto agent_group =
-              core::agent_group(core_.io_context(), core::agent_group_config{ { core_ } });
-            ec = agent_group.open_bucket(bucket_name_);
-            if (ec) {
-              obs_rec->finish(ec);
-              return handler(error(ec,
-                                   fmt::format("An error occurred while opening the `{}` bucket.",
-                                               bucket_name_)),
-                             {});
-            }
-            auto agent = agent_group.get_agent(bucket_name_);
-            if (!agent.has_value()) {
-              obs_rec->finish(ec);
-              return handler(
-                error(agent.error(),
-                      fmt::format(
-                        "An error occurred while getting an operation agent for the `{}` bucket",
-                        bucket_name_)),
-                {});
-            }
-            if (!config->vbmap.has_value() || config->vbmap->empty()) {
-              CB_LOG_WARNING("Unable to get vbucket map for `{}` - cannot perform scan operation",
-                             bucket_name_);
-              obs_rec->finish(ec);
-              return handler(error(errc::common::request_canceled,
-                                   "No vbucket map included with the bucket config"),
-                             {});
-            }
+        if (!config->capabilities.supports_range_scan()) {
+          obs_rec->finish(errc::common::feature_not_available);
+          return handler(
+            error(errc::common::feature_not_available, "This bucket does not support range scan."),
+            {});
+        }
+        auto agent_group =
+          core::agent_group(core.io_context(), core::agent_group_config{ { core } });
+        if (auto ec = agent_group.open_bucket(bucket_name); ec) {
+          obs_rec->finish(ec);
+          return handler(
+            error(ec, fmt::format("An error occurred while opening the `{}` bucket.", bucket_name)),
+            {});
+        }
+        auto agent = agent_group.get_agent(bucket_name);
+        if (!agent.has_value()) {
+          obs_rec->finish(agent.error());
+          return handler(
+            error(
+              agent.error(),
+              fmt::format("An error occurred while getting an operation agent for the `{}` bucket.",
+                          bucket_name)),
+            {});
+        }
+        if (!config->vbmap.has_value() || config->vbmap->empty()) {
+          CB_LOG_WARNING("Unable to get vbucket map for `{}` - cannot perform scan operation",
+                         bucket_name);
+          obs_rec->finish(errc::common::request_canceled);
+          return handler(error(errc::common::request_canceled,
+                               "No vbucket map included with the bucket config."),
+                         {});
+        }
 
-            auto orchestrator = core::range_scan_orchestrator(core_.io_context(),
-                                                              agent.value(),
-                                                              config->vbmap.value(),
-                                                              scope_name_,
-                                                              name_,
-                                                              core_scan_type,
-                                                              orchestrator_opts);
-            return orchestrator.scan(
-              [obs_rec = std::move(obs_rec),
-               crypto_manager = crypto_manager_,
-               handler = std::move(handler)](auto ec, auto core_scan_result) mutable {
-                obs_rec->finish(ec);
-                if (ec) {
-                  return handler(error(ec, "Error while starting the range scan"), {});
-                }
-                auto internal_result = std::make_shared<internal_scan_result>(
-                  std::move(core_scan_result), std::move(crypto_manager));
-                return handler({}, scan_result{ internal_result });
-              });
-          });
+        auto orchestrator = core::range_scan_orchestrator(core.io_context(),
+                                                          agent.value(),
+                                                          config->vbmap.value(),
+                                                          scope_name,
+                                                          name,
+                                                          core_scan_type,
+                                                          orchestrator_opts);
+        return orchestrator.scan([obs_rec = std::move(obs_rec),
+                                  crypto_manager = std::move(crypto_manager),
+                                  handler = std::move(handler)](auto ec,
+                                                                auto core_scan_result) mutable {
+          obs_rec->finish(ec);
+          if (ec) {
+            return handler(error(ec, "Error while starting the range scan"), {});
+          }
+          auto internal_result = std::make_shared<internal_scan_result>(std::move(core_scan_result),
+                                                                        std::move(crypto_manager));
+          return handler({}, scan_result{ internal_result });
+        });
+      },
+      [](const std::shared_ptr<core::topology::configuration>& config)
+        -> std::pair<std::error_code, std::shared_ptr<core::topology::configuration>> {
+        return { {}, config };
       });
   }
 

--- a/core/impl/observe_poll.cxx
+++ b/core/impl/observe_poll.cxx
@@ -169,20 +169,21 @@ private:
 
 class observe_context;
 void
-observe_poll(const cluster& core, std::shared_ptr<observe_context> ctx);
+observe_poll(const std::shared_ptr<observe_context>& ctx);
 
 class observe_context : public std::enable_shared_from_this<observe_context>
 {
 public:
-  observe_context(asio::io_context& io,
+  observe_context(cluster core,
                   document_id id,
                   mutation_token token,
                   std::optional<std::chrono::milliseconds> timeout,
                   couchbase::persist_to persist_to,
                   couchbase::replicate_to replicate_to,
                   observe_handler&& handler)
-    : poll_deadline_{ io }
-    , poll_backoff_{ io }
+    : poll_deadline_{ core.io_context() }
+    , poll_backoff_{ core.io_context() }
+    , core_{ std::move(core) }
     , id_{ std::move(id) }
     , status_{ std::move(token) }
     , timeout_{ timeout }
@@ -190,6 +191,38 @@ public:
     , replicate_to_{ replicate_to }
     , handler_{ std::move(handler) }
   {
+  }
+
+  observe_context(const observe_context&) = delete;
+  observe_context(observe_context&&) = delete;
+  auto operator=(const observe_context&) -> observe_context& = delete;
+  auto operator=(observe_context&&) -> observe_context& = delete;
+
+  ~observe_context()
+  {
+    // Fail closed. The context is anchored on the io_context by poll_deadline_ for the whole
+    // operation, while the config wait captures a weak_ptr and the seqno requests are cancellable
+    // core operations. If the io_context is torn down mid-poll, every continuation is dropped and
+    // the context is destroyed here with handler_ still set. Deliver an error so a std::future
+    // caller never observes broken_promise and a callback caller never hangs -- this is the
+    // backstop for every legacy-durability mutation (persist_to / replicate_to), which routes its
+    // handler through the observe poll.
+    observe_handler handler{};
+    {
+      const std::scoped_lock lock(handler_mutex_);
+      std::swap(handler_, handler);
+    }
+    if (handler) {
+      try {
+        handler(errc::network::cluster_closed);
+      } catch (...) { // NOLINT(bugprone-empty-catch)
+      }
+    }
+  }
+
+  [[nodiscard]] auto core() const -> const cluster&
+  {
+    return core_;
   }
 
   void start()
@@ -294,27 +327,30 @@ public:
     on_last_response_ = std::move(handler);
   }
 
-  void execute(const cluster& core)
+  void execute()
   {
     auto requests = std::move(requests_);
     status_.reset();
-    on_last_response(requests.size(), [core, ctx = shared_from_this()](std::error_code ec) mutable {
+    on_last_response(requests.size(), [weak = weak_from_this()](std::error_code ec) mutable {
       if (ec == asio::error::operation_aborted) {
         return;
       }
-      observe_poll(core, std::move(ctx));
+      if (auto ctx = weak.lock()) {
+        observe_poll(ctx);
+      }
     });
     for (auto&& request : requests) {
-      core.execute(std::move(request),
-                   [ctx = shared_from_this()](observe_seqno_response&& response) {
-                     ctx->handle_response(std::move(response));
-                   });
+      core_.execute(std::move(request),
+                    [ctx = shared_from_this()](observe_seqno_response&& response) {
+                      ctx->handle_response(std::move(response));
+                    });
     }
   }
 
 private:
   asio::steady_timer poll_deadline_;
   asio::steady_timer poll_backoff_;
+  cluster core_;
   const document_id id_;
   observe_status status_;
   std::optional<std::chrono::milliseconds> timeout_;
@@ -330,13 +366,22 @@ private:
 };
 
 void
-observe_poll(const cluster& core, std::shared_ptr<observe_context> ctx)
+observe_poll(const std::shared_ptr<observe_context>& ctx)
 {
   const std::string bucket_name = ctx->bucket_name();
-  core.with_bucket_configuration(
+  // Capture a weak_ptr, not the context or a core copy: with_bucket_configuration parks this
+  // callback in the core (in the bucket-bootstrap window it is not drained on close). The context
+  // is kept alive meanwhile by poll_deadline_ on the io_context, and it owns the core through its
+  // core_ member -- capturing either strongly here would form a cycle that survives cluster close
+  // and strand the handler.
+  ctx->core().with_bucket_configuration(
     bucket_name,
-    [core, ctx = std::move(ctx)](
+    [weak = std::weak_ptr<observe_context>(ctx)](
       std::error_code ec, const std::shared_ptr<core::topology::configuration>& config) mutable {
+      auto ctx = weak.lock();
+      if (!ctx) {
+        return;
+      }
       if (ec) {
         return ctx->finish(ec);
       }
@@ -360,7 +405,7 @@ observe_poll(const cluster& core, std::shared_ptr<observe_context> ctx)
             observe_seqno_request{ replica_id, false, ctx->partition_uuid(), ctx->timeout() });
         }
       }
-      ctx->execute(core);
+      ctx->execute();
     });
 }
 } // namespace
@@ -374,14 +419,9 @@ initiate_observe_poll(const cluster& core,
                       couchbase::replicate_to replicate_to,
                       observe_handler&& handler)
 {
-  auto ctx = std::make_shared<observe_context>(core.io_context(),
-                                               std::move(id),
-                                               std::move(token),
-                                               timeout,
-                                               persist_to,
-                                               replicate_to,
-                                               std::move(handler));
+  auto ctx = std::make_shared<observe_context>(
+    core, std::move(id), std::move(token), timeout, persist_to, replicate_to, std::move(handler));
   ctx->start();
-  return observe_poll(core, std::move(ctx));
+  return observe_poll(ctx);
 }
 } // namespace couchbase::core::impl

--- a/core/impl/query_index_manager.cxx
+++ b/core/impl/query_index_manager.cxx
@@ -84,7 +84,27 @@ public:
   watch_context(const watch_context&) = delete;
   auto operator=(const watch_context&) -> watch_context& = delete;
   auto operator=(watch_context&&) -> watch_context& = delete;
-  ~watch_context() = default;
+
+  ~watch_context()
+  {
+    // Fail closed. During the polling-interval backoff the context is kept alive only by its own
+    // timer on the io_context; if the io_context is torn down then, that pending wait is dropped
+    // without running and the context is destroyed here with handler_ still set. Deliver an error
+    // so a std::future caller never observes broken_promise and a callback caller never hangs. (The
+    // GET-ALL request phase already fails closed -- core_.execute delivers request_canceled on
+    // close.) A moved-from context has an empty handler_, so this is a no-op there. Mirror
+    // finish(): move the handler out before invoking it and end the observability span, so the
+    // watch metrics are not left dangling on shutdown.
+    if (handler_) {
+      watch_query_indexes_handler handler{};
+      std::swap(handler, handler_);
+      try {
+        observability_recorder_->finish(errc::network::cluster_closed);
+        handler(couchbase::error{ errc::network::cluster_closed });
+      } catch (...) { // NOLINT(bugprone-empty-catch)
+      }
+    }
+  }
 
   void execute()
   {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,7 @@ integration_test(management_search_index)
 integration_test(http_session_manager)
 integration_test(node_id)
 integration_test(bucket_bootstrap)
+integration_test(handler_drop_lifetime)
 
 unit_test(connection_string)
 unit_test(capella)

--- a/test/test_integration_handler_drop_lifetime.cxx
+++ b/test/test_integration_handler_drop_lifetime.cxx
@@ -1,0 +1,88 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "test_helper_integration.hxx"
+
+#include <couchbase/cluster.hxx>
+#include <couchbase/collection.hxx>
+#include <couchbase/error_codes.hxx>
+#include <couchbase/scan_options.hxx>
+#include <couchbase/scan_result.hxx>
+#include <couchbase/scan_type.hxx>
+
+#include <chrono>
+#include <future>
+#include <utility>
+
+using namespace std::literals::chrono_literals;
+
+// Regression test for the handler-drop lifetime fixes in the async public-API operations.
+//
+// Several self-owning operations wait for a bucket configuration by parking a completion
+// continuation in the core's bucket-bootstrap queue. close() does not drain that queue, so tearing
+// the cluster down while such an operation is in flight used to drop the continuation without ever
+// running it: a std::future caller observed broken_promise and a callback caller hung forever.
+//
+// A collection scan is the representative path that can be driven into that state deterministically
+// through the public API: scanning a bucket that never opens leaves scan()'s with_bucket_config
+// wait parked in the bootstrap window, with no dependency on any server-side service being present.
+// The sibling paths fixed in the same change (observe-based legacy durability, bucket-level ping,
+// watch_query_indexes) share the with_bucket_config_or_timeout scaffold but each needs a successful
+// precursor operation or a specific service, so they cannot be forced in-flight-at-teardown without
+// a race; this case exercises the shared mechanism through the one deterministic entry point.
+//
+// Unlike a pure leak (which is only visible to the sanitizer), the fix here restores a
+// caller-visible contract, so the test asserts it directly: the future must complete with
+// errc::network::cluster_closed rather than be dropped.
+TEST_CASE("integration: a scan future completes when the cluster is closed mid-bootstrap",
+          "[integration]")
+{
+  test::utils::integration_test_guard integration;
+
+  std::future<std::pair<couchbase::error, couchbase::scan_result>> pending;
+  {
+    auto cluster = integration.public_cluster();
+
+    // A scan of a bucket that never becomes reachable parks its bucket-config wait in the
+    // bootstrap window: the bucket never opens, so the wait never resolves on its own. The future
+    // is intentionally not awaited -- the cluster is torn down while the wait is still parked.
+    pending = cluster.bucket("this_bucket_does_not_exist")
+                .default_collection()
+                .scan(couchbase::range_scan{}, {});
+
+    // The regression requires the scan to still be in flight when the cluster is torn down. If it
+    // has already completed (e.g. against a mock, or an unusually fast environment), the in-flight
+    // condition cannot be set up, so skip rather than fail nondeterministically.
+    if (pending.wait_for(0s) != std::future_status::timeout) {
+      SUCCEED("scan completed too quickly to exercise an in-flight bucket bootstrap");
+      return;
+    }
+
+    // `cluster` is destroyed here, stopping the io_context while the scan's bucket-config wait is
+    // still parked. The fail-closed backstop must complete the parked handler.
+  }
+
+  // With the fix the fail-closed backstop completes the future shortly after teardown. Bound the
+  // wait so a regression (the parked handler stranded, so the future never becomes ready) fails
+  // this test in seconds instead of hanging the whole integration run. Once ready, get() surfaces
+  // the outcome -- and a dropped-rather-than-stranded promise still fails fast via broken_promise.
+  if (pending.wait_for(std::chrono::seconds{ 10 }) != std::future_status::ready) {
+    FAIL("scan future was not completed after the cluster was closed -- the handler was stranded");
+  }
+  auto result = pending.get();
+  REQUIRE(result.first.ec() == couchbase::errc::network::cluster_closed);
+}


### PR DESCRIPTION
Several self-owning async operations register a completion continuation that the core parks in a bucket-bootstrap queue (open_bucket / with_bucket_configuration) while also holding a strong reference to the core, or rely on a self-owned timer with no fail-closed path. Because close() does not drain the bootstrap queue, tearing the cluster down while such an operation is in flight neither invokes nor releases the continuation: the caller's handler never runs -- a std::future caller observes broken_promise, or blocks forever when the dropped continuation is also leaked, and a callback caller hangs.

Affected: observe-based legacy durability (persist_to / replicate_to on every mutation), collection scan (which also captured a raw this), watch_query_indexes during its polling backoff, and bucket-level ping.

Adopt the with_bucket_config_or_timeout pattern: capture a weak_ptr into the core-parked callback, anchor the operation's lifetime on an io_context timer, and deliver errc::network::cluster_closed from a fail-closed destructor when the operation is dropped.