### PR TITLE
CXXCBC-858: capture dispatch local_id/peer/server_duration via typed span setters

### DIFF
--- a/core/io/mcbp_command.hxx
+++ b/core/io/mcbp_command.hxx
@@ -566,7 +566,11 @@ private:
         dispatch_span->add_tag(tracing::attributes::dispatch::operation_id,
                                fmt::format("0x{:x}", request.opaque));
       }
-      dispatch_span->add_tag(tracing::attributes::dispatch::local_id, session_->id());
+      // Prefer the typed capability so the local id is not string-tagged on the hot path; external
+      // tracers fall back to the string tag.
+      if (!dispatch_span->try_set_dispatch_local_id(session_->id())) {
+        dispatch_span->add_tag(tracing::attributes::dispatch::local_id, session_->id());
+      }
     }
     return dispatch_span;
   }
@@ -575,14 +579,21 @@ private:
                            const std::uint64_t server_duration_us) const
   {
     if (dispatch_span->uses_tags()) {
-      dispatch_span->add_tag(tracing::attributes::dispatch::server_duration, server_duration_us);
+      // Prefer the typed capability so the server duration and peer socket are not string-tagged on
+      // the hot path; external tracers fall back to the string tags.
+      if (!dispatch_span->try_set_dispatch_result(
+            server_duration_us, session_->remote_hostname(), session_->remote_port())) {
+        dispatch_span->add_tag(tracing::attributes::dispatch::server_duration, server_duration_us);
+        dispatch_span->add_tag(tracing::attributes::dispatch::peer_address,
+                               session_->remote_hostname());
+        dispatch_span->add_tag(tracing::attributes::dispatch::peer_port, session_->remote_port());
+      }
+      // The built-in span does not keep the server (canonical) address; only external tracers
+      // consume these, and their SSO-sized tag names do not allocate.
       dispatch_span->add_tag(tracing::attributes::dispatch::server_address,
                              session_->canonical_hostname());
       dispatch_span->add_tag(tracing::attributes::dispatch::server_port,
                              session_->canonical_port_number());
-      dispatch_span->add_tag(tracing::attributes::dispatch::peer_address,
-                             session_->remote_hostname());
-      dispatch_span->add_tag(tracing::attributes::dispatch::peer_port, session_->remote_port());
     }
     dispatch_span->end();
   }

--- a/core/tracing/threshold_logging_tracer.cxx
+++ b/core/tracing/threshold_logging_tracer.cxx
@@ -129,6 +129,32 @@ public:
     return true;
   }
 
+  [[nodiscard]] auto try_set_dispatch_local_id(const std::string& local_id) -> bool override
+  {
+    // Capture directly, bypassing the tag-name string that add_tag() would materialize on the hot
+    // path (see request_span::try_set_dispatch_local_id).
+    last_local_id_ = local_id;
+    return true;
+  }
+
+  [[nodiscard]] auto try_set_dispatch_result(std::uint64_t server_duration_us,
+                                             const std::string& peer_address,
+                                             std::uint16_t peer_port) -> bool override
+  {
+    // Mirror the add_tag() bookkeeping without materializing any tag-name strings, including the
+    // same rule for the running total: it is accumulated only on non-dispatch spans, so a dispatch
+    // span records last_server_duration_us_ and leaves the total to be rolled up on its parent in
+    // end(). (In current wiring this setter only runs on the dispatch span, but the guard is kept
+    // so the two paths stay behaviourally identical.)
+    last_server_duration_us_ = server_duration_us;
+    if (name() != tracing::operation::step_dispatch) {
+      total_server_duration_us_ += server_duration_us;
+    }
+    peer_hostname_ = peer_address;
+    peer_port_ = peer_port;
+    return true;
+  }
+
   void end() override;
 
   void set_last_local_id(const std::string& id)
@@ -139,6 +165,11 @@ public:
   void set_operation_id(const std::string& id)
   {
     operation_id_ = id;
+  }
+
+  void set_operation_id_opaque(std::uint32_t opaque)
+  {
+    operation_id_opaque_ = opaque;
   }
 
   void set_peer_hostname(const std::string& hostname)
@@ -409,6 +440,10 @@ threshold_logging_span::end()
       }
       if (operation_id_.has_value()) {
         p->set_operation_id(operation_id_.value());
+      } else if (operation_id_opaque_.has_value()) {
+        // Propagate the raw opaque so the parent still reports the operation id, while keeping the
+        // (rarely needed) formatting deferred to the parent's reporting path.
+        p->set_operation_id_opaque(operation_id_opaque_.value());
       }
       if (peer_hostname_.has_value()) {
         p->set_peer_hostname(peer_hostname_.value());

--- a/couchbase/tracing/request_span.hxx
+++ b/couchbase/tracing/request_span.hxx
@@ -77,6 +77,36 @@ public:
     return false;
   }
 
+  /**
+   * Efficiently record the local connection identifier of a dispatch span without materializing a
+   * tag-name string on the hot path.
+   *
+   * Like try_set_dispatch_operation_id(), the default returns false so the SDK records the value as
+   * a regular string tag and external tracer implementations are unaffected.
+   *
+   * @return true if the span captured the identifier; false to request the string-tag fallback.
+   */
+  [[nodiscard]] virtual auto try_set_dispatch_local_id(const std::string& /* local_id */) -> bool
+  {
+    return false;
+  }
+
+  /**
+   * Efficiently record the result metadata of a dispatch span (server processing time and the peer
+   * socket) in a single call, without materializing tag-name strings on the hot path.
+   *
+   * The default returns false so the SDK records the values as regular string tags and external
+   * tracer implementations are unaffected.
+   *
+   * @return true if the span captured the metadata; false to request the string-tag fallback.
+   */
+  [[nodiscard]] virtual auto try_set_dispatch_result(std::uint64_t /* server_duration_us */,
+                                                     const std::string& /* peer_address */,
+                                                     std::uint16_t /* peer_port */) -> bool
+  {
+    return false;
+  }
+
 private:
   std::string name_{};
   std::shared_ptr<request_span> parent_{ nullptr };

--- a/test/test_unit_request_span.cxx
+++ b/test/test_unit_request_span.cxx
@@ -17,16 +17,27 @@
 
 #include "test_helper.hxx"
 
+#include "core/tracing/constants.hxx"
 #include "core/tracing/threshold_logging_tracer.hxx"
 
 #include <couchbase/tracing/request_span.hxx>
 
+#include <atomic>
 #include <cstdint>
+#include <cstdlib>
+#include <new>
 #include <optional>
 #include <string>
 
 namespace
 {
+// Sanitizer builds intercept allocation and provide their own operator new/delete, so this counter
+// and the overrides below are compiled out under sanitizers (COUCHBASE_CXX_CLIENT_BUILD_SANITIZED),
+// along with the two allocation-count tests; the functional capture behaviour is covered elsewhere.
+#ifndef COUCHBASE_CXX_CLIENT_BUILD_SANITIZED
+std::atomic<long> g_alloc_count{ 0 };
+#endif
+
 // A span that implements only the required interface — it does not opt into typed dispatch capture,
 // so it must behave like any external tracer's span.
 class minimal_span : public couchbase::tracing::request_span
@@ -43,19 +54,87 @@ public:
   }
 };
 
-// A span that opts into typed dispatch capture.
+// A span that opts into typed dispatch capture and records the captured values so the test can
+// assert the SDK routed them through the typed path.
 class capturing_span : public minimal_span
 {
 public:
   std::optional<std::uint32_t> captured_operation_id{};
+  std::optional<std::string> captured_local_id{};
+  std::optional<std::uint64_t> captured_server_duration_us{};
+  std::optional<std::string> captured_peer_address{};
+  std::optional<std::uint16_t> captured_peer_port{};
 
   auto try_set_dispatch_operation_id(std::uint32_t opaque) -> bool override
   {
     captured_operation_id = opaque;
     return true;
   }
+
+  auto try_set_dispatch_local_id(const std::string& local_id) -> bool override
+  {
+    captured_local_id = local_id;
+    return true;
+  }
+
+  auto try_set_dispatch_result(std::uint64_t server_duration_us,
+                               const std::string& peer_address,
+                               std::uint16_t peer_port) -> bool override
+  {
+    captured_server_duration_us = server_duration_us;
+    captured_peer_address = peer_address;
+    captured_peer_port = peer_port;
+    return true;
+  }
+};
+
+// A span whose typed setters record nothing but a flag — used to isolate the cost of the call
+// itself (the tag-name temporary) from any value copy the capture would otherwise perform.
+class flag_only_span : public minimal_span
+{
+public:
+  bool touched{ false };
+
+  auto try_set_dispatch_local_id(const std::string& /* local_id */) -> bool override
+  {
+    touched = true;
+    return true;
+  }
+
+  auto try_set_dispatch_result(std::uint64_t /* server_duration_us */,
+                               const std::string& /* peer_address */,
+                               std::uint16_t /* peer_port */) -> bool override
+  {
+    touched = true;
+    return true;
+  }
 };
 } // namespace
+
+#ifndef COUCHBASE_CXX_CLIENT_BUILD_SANITIZED
+void*
+operator new(std::size_t n)
+{
+  g_alloc_count.fetch_add(1, std::memory_order_relaxed);
+  void* p = std::malloc(n != 0 ? n : 1);
+  if (p == nullptr) {
+    throw std::bad_alloc{};
+  }
+  return p;
+}
+
+void
+operator delete(void* p) noexcept
+{
+  std::free(p);
+}
+
+void
+operator delete(void* p, std::size_t) noexcept
+{
+  std::free(p);
+}
+#endif
 
 TEST_CASE("unit: a span does not capture the typed dispatch operation id by default", "[unit]")
 {
@@ -82,3 +161,76 @@ TEST_CASE("unit: a captured dispatch operation id formats to the reported string
   REQUIRE(format_dispatch_operation_id(0) == "0x0");
   REQUIRE(format_dispatch_operation_id(0xffffffff) == "0xffffffff");
 }
+
+TEST_CASE("unit: a span does not capture typed dispatch metadata by default", "[unit]")
+{
+  minimal_span span;
+  // External tracers rely on these defaults being false so the SDK falls back to string tags.
+  REQUIRE_FALSE(span.try_set_dispatch_local_id("66388CF5BFCF7522/18CC8791579B567C"));
+  REQUIRE_FALSE(span.try_set_dispatch_result(120, "192.168.1.5", 11210));
+}
+
+TEST_CASE("unit: a span may opt into capturing typed dispatch metadata", "[unit]")
+{
+  capturing_span span;
+
+  REQUIRE(span.try_set_dispatch_local_id("66388CF5BFCF7522/18CC8791579B567C"));
+  REQUIRE(span.captured_local_id == "66388CF5BFCF7522/18CC8791579B567C");
+
+  REQUIRE(span.try_set_dispatch_result(120, "192.168.1.5", 11210));
+  REQUIRE(span.captured_server_duration_us == 120);
+  REQUIRE(span.captured_peer_address == "192.168.1.5");
+  REQUIRE(span.captured_peer_port == 11210);
+}
+
+#ifndef COUCHBASE_CXX_CLIENT_BUILD_SANITIZED
+TEST_CASE("unit: the typed local_id setter avoids the tag-name allocation on the hot path",
+          "[unit]")
+{
+  flag_only_span span;
+
+  // The string tag path materializes a std::string for the tag name from the const char* constant,
+  // which may heap-allocate; the typed setter takes the value directly and never constructs a
+  // tag-name temporary. Assert the invariant -- the typed path allocates nothing and is never worse
+  // than the tag path -- rather than an absolute tag-path count: whether "couchbase.local_id"
+  // heap-allocates depends on the standard library's SSO capacity (libc++'s larger SSO keeps it
+  // inline) and on allocation instrumentation being active, so a fixed ">= 1" is not portable.
+  const long before_tag = g_alloc_count.load(std::memory_order_relaxed);
+  span.add_tag(couchbase::core::tracing::attributes::dispatch::local_id, "x");
+  const long tag_allocs = g_alloc_count.load(std::memory_order_relaxed) - before_tag;
+
+  const long before_typed = g_alloc_count.load(std::memory_order_relaxed);
+  const bool captured = span.try_set_dispatch_local_id("x");
+  const long typed_allocs = g_alloc_count.load(std::memory_order_relaxed) - before_typed;
+
+  REQUIRE(captured);
+  REQUIRE(typed_allocs == 0);
+  REQUIRE(typed_allocs <= tag_allocs);
+}
+
+TEST_CASE("unit: the typed result setter avoids the tag-name allocations on the hot path", "[unit]")
+{
+  flag_only_span span;
+
+  // Each of the three string-tag names (server_duration/peer_address/peer_port) may allocate a
+  // temporary std::string for the name; the single typed call captures all three with no tag-name
+  // temporaries. As above, assert the invariant (typed path allocates nothing and is never worse
+  // than the tag path) rather than an absolute count, since how many of the three names exceed the
+  // SSO limit depends on the standard library and instrumentation.
+  const long before_tags = g_alloc_count.load(std::memory_order_relaxed);
+  span.add_tag(couchbase::core::tracing::attributes::dispatch::server_duration,
+               static_cast<std::uint64_t>(120));
+  span.add_tag(couchbase::core::tracing::attributes::dispatch::peer_address, "p");
+  span.add_tag(couchbase::core::tracing::attributes::dispatch::peer_port,
+               static_cast<std::uint64_t>(11210));
+  const long tag_allocs = g_alloc_count.load(std::memory_order_relaxed) - before_tags;
+
+  const long before_typed = g_alloc_count.load(std::memory_order_relaxed);
+  const bool captured = span.try_set_dispatch_result(120, "p", 11210);
+  const long typed_allocs = g_alloc_count.load(std::memory_order_relaxed) - before_typed;
+
+  REQUIRE(captured);
+  REQUIRE(typed_allocs == 0);
+  REQUIRE(typed_allocs <= tag_allocs);
+}
+#endif


### PR DESCRIPTION
> [!WARNING]
> Merge after #989  (does not depend on the code, just stacked PR for convenience)

With the default threshold_logging_tracer, mcbp_command recorded the dispatch span's local_id, peer address/port and server_duration as string tags on every operation. The tag-name constants are const char*, so each add_tag call materialized a temporary std::string for the name; the four names all exceed the SSO limit and heap-allocate, only to be string-compared and -- for operations under the reporting threshold -- discarded.

Extend the additive request_span capability introduced for the operation id with try_set_dispatch_local_id and try_set_dispatch_result (the three close-time values grouped into a single call). Both default to false so external and OpenTelemetry tracers keep the string-tag path unchanged; threshold_logging_span overrides them to store the values directly, and mcbp_command prefers the typed setter with an add_tag fallback. server_address/server_port keep the string tag: the built-in span ignores them and their names fit in SSO.

Also fix a gap left when the operation id became opaque-only: the dispatch span is never reported itself, so end() transfers its fields to the parent operation span -- but it still copied the now-empty operation_id string and dropped last_operation_id from threshold reports. end() now propagates the raw opaque via a dedicated internal setter (set_operation_id_opaque), uniform with the other field-transfer setters, so the parent formats and reports it lazily.

