### PR TITLE
CXXCBC-845: Remove timeout & retry_strategy from wait_until_ready_options

### DIFF
--- a/core/impl/public_bucket.cxx
+++ b/core/impl/public_bucket.cxx
@@ -86,11 +86,6 @@ public:
                         const wait_until_ready_options::built& options,
                         wait_until_ready_handler&& handler) const
   {
-    if (options.timeout.has_value()) {
-      return handler(couchbase::error{ errc::common::invalid_argument,
-                                       "wait_until_ready_options::timeout is ignored; use the "
-                                       "positional timeout argument instead" });
-    }
     return core::impl::wait_until_ready(core_,
                                         name_,
                                         timeout,

--- a/core/impl/public_cluster.cxx
+++ b/core/impl/public_cluster.cxx
@@ -390,11 +390,6 @@ public:
                         const wait_until_ready_options::built& options,
                         wait_until_ready_handler&& handler) const
   {
-    if (options.timeout.has_value()) {
-      return handler(couchbase::error{ errc::common::invalid_argument,
-                                       "wait_until_ready_options::timeout is ignored; use the "
-                                       "positional timeout argument instead" });
-    }
     return core::impl::wait_until_ready(core_,
                                         std::nullopt,
                                         timeout,

--- a/couchbase/wait_until_ready_options.hxx
+++ b/couchbase/wait_until_ready_options.hxx
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <couchbase/cluster_state.hxx>
-#include <couchbase/common_options.hxx>
 #include <couchbase/error.hxx>
 #include <couchbase/service_type.hxx>
 
@@ -34,7 +33,7 @@ namespace couchbase
  * @since 1.4.0
  * @committed
  */
-struct wait_until_ready_options : public common_options<wait_until_ready_options> {
+struct wait_until_ready_options {
   /**
    * Sets the state the cluster (or bucket) has to reach before the wait completes.
    *
@@ -50,7 +49,7 @@ struct wait_until_ready_options : public common_options<wait_until_ready_options
   auto desired_state(cluster_state desired_state) -> wait_until_ready_options&
   {
     desired_state_ = desired_state;
-    return self();
+    return *this;
   }
 
   /**
@@ -66,7 +65,7 @@ struct wait_until_ready_options : public common_options<wait_until_ready_options
   auto service_types(std::set<service_type> service_types) -> wait_until_ready_options&
   {
     service_types_ = std::move(service_types);
-    return self();
+    return *this;
   }
 
   /**
@@ -75,7 +74,7 @@ struct wait_until_ready_options : public common_options<wait_until_ready_options
    * @since 1.4.0
    * @internal
    */
-  struct built : public common_options<wait_until_ready_options>::built {
+  struct built {
     cluster_state desired_state;
     std::set<service_type> service_types;
   };
@@ -93,7 +92,7 @@ struct wait_until_ready_options : public common_options<wait_until_ready_options
    */
   [[nodiscard]] auto build() const -> built
   {
-    return { build_common_options(), desired_state_, service_types_ };
+    return { desired_state_, service_types_ };
   }
 
 private:

--- a/test/test_integration_wait_until_ready.cxx
+++ b/test/test_integration_wait_until_ready.cxx
@@ -62,14 +62,6 @@ TEST_CASE("integration: cluster wait_until_ready", "[integration]")
     REQUIRE(err.ec() == couchbase::errc::common::invalid_argument);
   }
 
-  SECTION("options timeout is rejected in favour of the positional argument")
-  {
-    couchbase::wait_until_ready_options options{};
-    options.timeout(1s);
-    auto err = cluster.wait_until_ready(10s, options).get();
-    REQUIRE(err.ec() == couchbase::errc::common::invalid_argument);
-  }
-
   SECTION("callback overload completes exactly once")
   {
     couchbase::wait_until_ready_options options{};
@@ -123,14 +115,6 @@ TEST_CASE("integration: bucket wait_until_ready", "[integration]")
     options.service_types({ couchbase::service_type::key_value });
     auto err = cluster.bucket(integration.ctx.bucket).wait_until_ready(10s, options).get();
     REQUIRE_SUCCESS(err.ec());
-  }
-
-  SECTION("options timeout is rejected in favour of the positional argument")
-  {
-    couchbase::wait_until_ready_options options{};
-    options.timeout(1s);
-    auto err = cluster.bucket(integration.ctx.bucket).wait_until_ready(10s, options).get();
-    REQUIRE(err.ec() == couchbase::errc::common::invalid_argument);
   }
 
   SECTION("reaches online state for a non-KV service")


### PR DESCRIPTION
Both `timeout` and `retry_strategy` should not be on `wait_until_ready` options. Timeout is provided as a parameter to the function instead, and the one in the options block is already rejected with `invalid_argument`. The `retry_strategy` option is unused.

See https://github.com/couchbase/couchbase-cxx-client/pull/980#discussion_r3597416787