### PR TITLE
test: gate integration_test_guard on cluster+replica readiness

### DIFF
--- a/test/utils/integration_shortcuts.cxx
+++ b/test/utils/integration_shortcuts.cxx
@@ -19,6 +19,7 @@
 
 #include <couchbase/build_config.hxx>
 
+#include "core/impl/wait_until_ready.hxx"
 #include "core/logger/logger.hxx"
 #include "core/utils/join_strings.hxx"
 
@@ -85,5 +86,25 @@ close_bucket(const couchbase::core::cluster& cluster, const std::string& bucket_
     CB_LOG_CRITICAL("unable to close bucket: {}, name={}", rc.message(), bucket_name);
     throw std::system_error(rc);
   }
+}
+
+auto
+wait_until_ready(const couchbase::core::cluster& cluster,
+                 std::optional<std::string> bucket_name,
+                 std::chrono::milliseconds timeout,
+                 couchbase::cluster_state desired_state,
+                 std::set<couchbase::core::service_type> services) -> std::error_code
+{
+  auto barrier = std::make_shared<std::promise<std::error_code>>();
+  auto f = barrier->get_future();
+  couchbase::core::impl::wait_until_ready(cluster,
+                                          std::move(bucket_name),
+                                          timeout,
+                                          desired_state,
+                                          std::move(services),
+                                          [barrier](std::error_code ec) mutable {
+                                            barrier->set_value(ec);
+                                          });
+  return f.get();
 }
 } // namespace test::utils

--- a/test/utils/integration_shortcuts.hxx
+++ b/test/utils/integration_shortcuts.hxx
@@ -18,8 +18,17 @@
 #pragma once
 
 #include "core/cluster.hxx"
+#include "core/service_type.hxx"
 
+#include <couchbase/cluster_state.hxx>
+
+#include <chrono>
 #include <future>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <system_error>
 
 namespace test::utils
 {
@@ -47,4 +56,14 @@ open_bucket(const couchbase::core::cluster& cluster, const std::string& bucket_n
 
 void
 close_bucket(const couchbase::core::cluster& cluster, const std::string& bucket_name);
+
+// Block until the cluster (or, when bucket_name is set, the bucket) reaches desired_state or
+// timeout elapses, returning the resulting error code. Wraps the core's async wait_until_ready with
+// a promise, mirroring open_cluster/open_bucket above. The bucket variant opens the bucket itself.
+auto
+wait_until_ready(const couchbase::core::cluster& cluster,
+                 std::optional<std::string> bucket_name,
+                 std::chrono::milliseconds timeout,
+                 couchbase::cluster_state desired_state,
+                 std::set<couchbase::core::service_type> services) -> std::error_code;
 } // namespace test::utils

--- a/test/utils/integration_test_guard.cxx
+++ b/test/utils/integration_test_guard.cxx
@@ -59,6 +59,32 @@ spawn_io_threads(asio::io_context& io, std::size_t number_of_threads) -> std::ve
   return threads;
 }
 
+// Wait once for the default bucket to be fully placed (active + all replica copies assigned) and
+// its KV endpoints online, so replica reads and durable writes issued by tests do not race a
+// freshly provisioned cluster. Best-effort: deployments that do not support it (e.g. the gocaves
+// mock) proceed with a warning rather than aborting the whole test binary.
+static void
+gate_on_readiness(const couchbase::core::cluster& cluster, const std::string& bucket_name)
+{
+#ifndef COUCHBASE_CXX_CLIENT_COLUMNAR
+  if (bucket_name.empty()) {
+    return;
+  }
+  if (auto ec = wait_until_ready(cluster,
+                                 bucket_name,
+                                 std::chrono::seconds{ 30 },
+                                 couchbase::cluster_state::online,
+                                 { couchbase::core::service_type::key_value });
+      ec) {
+    CB_LOG_WARNING(
+      "integration guard: bucket \"{}\" did not reach online state: {}", bucket_name, ec.message());
+  }
+#else
+  (void)cluster;
+  (void)bucket_name;
+#endif
+}
+
 static auto
 build_origin(const test_context& ctx,
              const couchbase::core::cluster_credentials& auth,
@@ -93,6 +119,7 @@ integration_test_guard::integration_test_guard()
   io_threads = spawn_io_threads(io, ctx.number_of_io_threads);
   origin = build_origin(ctx, auth, connstr);
   open_cluster(cluster, origin);
+  gate_on_readiness(cluster, ctx.bucket);
 }
 
 integration_test_guard::integration_test_guard(const couchbase::core::cluster_options& opts)
@@ -110,6 +137,7 @@ integration_test_guard::integration_test_guard(const couchbase::core::cluster_op
   origin = build_origin(ctx, auth, connstr);
   io_threads = spawn_io_threads(io, ctx.number_of_io_threads);
   open_cluster(cluster, origin);
+  gate_on_readiness(cluster, ctx.bucket);
 }
 
 integration_test_guard::~integration_test_guard()


### PR DESCRIPTION
Integration tests race a freshly provisioned cluster: replica vbuckets may not be placed yet when a test fires an all-replica read, so it comes back with fewer entries and the test flakes (e.g. `subdoc all replica reads` asserting `entries.size() == number_of_replicas() + 1`, seen recently on CI).

Gate the guard on readiness once, centrally: after opening the cluster, `integration_test_guard` waits `wait_until_ready(online, {key_value})` on the default bucket, which the core now backs with `vbucket_map_ready` (every vbucket has its active and all replica copies assigned). A new `test::utils::wait_until_ready()` helper wraps the async core call with a promise, mirroring the existing `open_cluster`/`open_bucket` helpers.

Best-effort: on timeout or error (e.g. the gocaves mock) it logs a warning and proceeds, and it is compiled out under `COUCHBASE_CXX_CLIENT_COLUMNAR`, so those paths are unaffected.

Verified against a 6-node cluster: the previously-flaky `subdoc all replica reads` passes repeatedly, the full subdoc suite is green, and the `wait_until_ready` integration self-tests (which use a separate public cluster) are unaffected.