### PR TITLE
CXXCBC-852: stop bucket sessions reliably on teardown

### DIFF
--- a/core/bucket.cxx
+++ b/core/bucket.cxx
@@ -382,6 +382,13 @@ public:
     if (!config_) {
       return;
     }
+    if (closed_) {
+      // Do not connect a session into a bucket that is being torn down: close() has already stopped
+      // sessions_ and will not run again, so a session added here would never be stopped and would
+      // strand the whole bucket/session graph as a pure cycle (see the closed_ guard in bootstrap()
+      // and update_config()).
+      return;
+    }
 
     const auto& node = config_->nodes[index];
 
@@ -427,6 +434,13 @@ public:
   {
     const std::scoped_lock lock(config_mutex_, sessions_mutex_);
     if (!config_) {
+      return;
+    }
+    if (closed_) {
+      // remove_session() posts restart_sessions() whenever a session drops. If that post is
+      // serviced after close() has torn the bucket down, recreating sessions here would strand them
+      // (nothing stops a session added after close()), leaking the whole bucket/session graph as a
+      // pure cycle. close() sets closed_ before it swaps and stops sessions_, so bail out.
       return;
     }
 
@@ -872,8 +886,19 @@ public:
         }
       }
     }
+    std::vector<io::mcbp_session> dropped_sessions{};
     if (!added.empty() || !removed.empty() || sequence_changed) {
       const std::scoped_lock lock(sessions_mutex_);
+      if (closed_) {
+        // The bucket was closed concurrently (close() sets closed_ before it swaps and stops
+        // sessions_ under sessions_mutex_). Do not rebuild the session list: any session created
+        // here would be established after close() has already torn everything down. Because each
+        // new session's bootstrap continuation strongly captures the session and this bucket (via
+        // on_configuration_update()/on_stop()), and nothing stops a session added after close(),
+        // it would strand the whole bucket/session graph as a pure cycle that LeakSanitizer reports
+        // as leaked. bootstrap() guards the initial session the same way (see closed_ there).
+        return;
+      }
       std::map<size_t, io::mcbp_session> new_sessions{};
 
       std::size_t next_index{ 0 };
@@ -968,10 +993,17 @@ public:
                      it->second.bootstrap_hostname(),
                      it->second.bootstrap_port(),
                      it->first);
-        asio::post(asio::bind_executor(ctx_, [session = std::move(it->second)]() mutable {
-          return session.stop(retry_reason::do_not_retry);
-        }));
+        dropped_sessions.push_back(std::move(it->second));
       }
+    }
+    // Stop dropped sessions synchronously, after releasing sessions_mutex_ (stop() fires on_stop ->
+    // remove_session(), which re-acquires the mutex). Stopping synchronously -- rather than via
+    // asio::post -- clears each session's bucket-capturing handlers (config_listeners_,
+    // on_stop_handler_) right now. A posted stop can be abandoned by io_context shutdown before it
+    // runs, leaving those handlers set and stranding the whole bucket/session graph as a pure cycle
+    // (LeakSanitizer reports it as all-indirect leaks).
+    for (auto& session : dropped_sessions) {
+      session.stop(retry_reason::do_not_retry);
     }
   }
 

--- a/core/bucket.cxx
+++ b/core/bucket.cxx
@@ -565,6 +565,17 @@ public:
 
   void bootstrap(utils::movable_function<void(std::error_code, topology::configuration)>&& handler)
   {
+    if (closed_) {
+      // The bucket was closed before this bootstrap even started -- e.g. the cluster was torn down
+      // in the window between cluster_impl::open_bucket() inserting the bucket into buckets_ and
+      // calling bootstrap() (the buckets_ lock is released in between). close() is one-shot and
+      // will not run again, so registering a config listener or starting a session here would never
+      // be undone: the session, its self-capturing bootstrap continuation, and this bucket would be
+      // stranded as a pure cycle that LeakSanitizer/Valgrind report as leaked, and the continuation
+      // (which a scan/ping/etc. may be parked behind) would never fire. Bail before touching any
+      // shared state.
+      return handler(errc::common::request_canceled, {});
+    }
     if (state_listener_) {
       state_listener_->register_config_listener(shared_from_this());
     }
@@ -578,6 +589,13 @@ public:
       // this bootstrap completes; otherwise the continuation below (which captures new_session)
       // would keep it alive forever. See bootstrapping_session_.
       const std::scoped_lock lock(sessions_mutex_);
+      if (closed_) {
+        // close() ran concurrently after the entry check above (it sets closed_ before it swaps and
+        // stops sessions_ under sessions_mutex_). Do not publish a session close() has already
+        // swept past -- nothing would ever stop it. The bootstrap continuation is not registered
+        // yet, so returning here strands nothing.
+        return handler(errc::common::request_canceled, {});
+      }
       bootstrapping_session_ = new_session;
     }
     new_session.bootstrap([self = shared_from_this(), new_session, h = std::move(handler)](
@@ -588,9 +606,18 @@ public:
                        ec.message(),
                        self->name_);
         self->remove_session(new_session.id());
-        const std::scoped_lock lock(self->sessions_mutex_);
-        self->bootstrapping_session_.reset();
-      } else {
+        {
+          const std::scoped_lock lock(self->sessions_mutex_);
+          self->bootstrapping_session_.reset();
+        }
+        // Deliver the failure inline rather than through the asio::post below: on cluster teardown
+        // the io_context is stopped and any queued post is discarded, so a posted completion would
+        // be dropped -- a std::future caller then observes broken_promise and a callback caller
+        // hangs. On the error path the handler only reports the failure to the operation (it does
+        // not re-enter the bucket under a held lock here), so completing it synchronously is safe.
+        return h(ec, cfg);
+      }
+      {
         const std::size_t this_index = new_session.index();
         bool established{ false };
         {

--- a/core/cluster.cxx
+++ b/core/cluster.cxx
@@ -1105,6 +1105,13 @@ public:
       bucket_name,
       [self = shared_from_this(), bucket_name, handler = std::move(handler)](auto ec) mutable {
         if (ec) {
+          // If the cluster was torn down while this open_bucket was parked in the bootstrap window,
+          // the bucket bootstrap is aborted with request_canceled. Surface that to the caller as
+          // cluster_closed so an in-flight operation parked here (e.g. a scan) observes the
+          // cluster-close contract rather than a bare cancellation.
+          if (self->stopped_) {
+            return handler(errc::network::cluster_closed, nullptr);
+          }
           return handler(ec, nullptr);
         }
 

--- a/test/test_integration_bucket_bootstrap.cxx
+++ b/test/test_integration_bucket_bootstrap.cxx
@@ -19,9 +19,12 @@
 
 #include <couchbase/cluster.hxx>
 #include <couchbase/collection.hxx>
+#include <couchbase/get_options.hxx>
+#include <couchbase/get_result.hxx>
 
 #include <chrono>
 #include <future>
+#include <utility>
 
 using namespace std::literals::chrono_literals;
 
@@ -74,4 +77,44 @@ TEST_CASE("integration: closing a cluster while a bucket is still bootstrapping 
   // an all-indirect (cyclic) leak; with the fix the run is clean. Record a passing assertion so the
   // case is not reported as assertion-free.
   SUCCEED("cluster torn down while a bucket was bootstrapping without stranding the session");
+}
+
+// Companion to the case above, on the bootstrap-SUCCESS path. The case above tears the cluster down
+// while a bucket that never opens is bootstrapping; here the bucket is a real, reachable one whose
+// bootstrap would have succeeded. Tearing the cluster down while that bootstrap is still in flight
+// exercises close() stopping an in-flight-but-otherwise-healthy bootstrap session -- the operation
+// must still complete (the promise must not be dropped) and the session/bucket/cluster graph must
+// not be stranded (verified leak-free by the AddressSanitizer/LeakSanitizer and Valgrind CI jobs).
+TEST_CASE("integration: closing a cluster while a valid bucket is still bootstrapping does not "
+          "strand the operation",
+          "[integration]")
+{
+  test::utils::integration_test_guard integration;
+
+  std::future<std::pair<couchbase::error, couchbase::get_result>> pending;
+  {
+    auto cluster = integration.public_cluster();
+
+    // Issue an operation on a valid bucket so its first KV session starts bootstrapping, then tear
+    // the cluster down before that bootstrap finishes. If the bootstrap has already completed (fast
+    // environment / cached config), the in-flight condition cannot be set up, so skip rather than
+    // fail nondeterministically.
+    pending = cluster.bucket(integration.ctx.bucket)
+                .default_collection()
+                .get(test::utils::uniq_id("cxxcbc-852-valid"));
+
+    if (pending.wait_for(0s) != std::future_status::timeout) {
+      SUCCEED("operation completed too quickly to exercise an in-flight bucket bootstrap");
+      return;
+    }
+    // `cluster` is destroyed here while the valid bucket's bootstrap is still in flight.
+  }
+
+  // The caller-visible guarantee: teardown completes the operation rather than dropping it (which a
+  // std::future caller would observe as broken_promise). The exact error code is not asserted --
+  // the point is that the future becomes ready at all.
+  if (pending.wait_for(std::chrono::seconds{ 10 }) != std::future_status::ready) {
+    FAIL("get future was not completed after the cluster was closed -- the operation was stranded");
+  }
+  SUCCEED("cluster torn down mid-bootstrap of a valid bucket without stranding the operation");
 }

--- a/test/test_integration_handler_drop_lifetime.cxx
+++ b/test/test_integration_handler_drop_lifetime.cxx
@@ -20,6 +20,9 @@
 #include <couchbase/cluster.hxx>
 #include <couchbase/collection.hxx>
 #include <couchbase/error_codes.hxx>
+#include <couchbase/get_options.hxx>
+#include <couchbase/get_result.hxx>
+#include <couchbase/node_id.hxx>
 #include <couchbase/scan_options.hxx>
 #include <couchbase/scan_result.hxx>
 #include <couchbase/scan_type.hxx>
@@ -27,6 +30,7 @@
 #include <chrono>
 #include <future>
 #include <utility>
+#include <vector>
 
 using namespace std::literals::chrono_literals;
 
@@ -85,4 +89,69 @@ TEST_CASE("integration: a scan future completes when the cluster is closed mid-b
   }
   auto result = pending.get();
   REQUIRE(result.first.ec() == couchbase::errc::network::cluster_closed);
+}
+
+// node_ids() reaches the bucket configuration through the same with_bucket_config_or_timeout
+// scaffold as scan(), so it exercises the same parked-in-bootstrap-window teardown path through a
+// second public entry point. A bucket that never opens keeps the wait parked; tearing the cluster
+// down must complete the future with errc::network::cluster_closed rather than strand it.
+TEST_CASE("integration: a node_ids future completes when the cluster is closed mid-bootstrap",
+          "[integration]")
+{
+  test::utils::integration_test_guard integration;
+
+  std::future<std::pair<couchbase::error, std::vector<couchbase::node_id>>> pending;
+  {
+    auto cluster = integration.public_cluster();
+
+    pending = cluster.bucket("this_bucket_does_not_exist").default_collection().node_ids();
+
+    if (pending.wait_for(0s) != std::future_status::timeout) {
+      SUCCEED("node_ids completed too quickly to exercise an in-flight bucket bootstrap");
+      return;
+    }
+    // `cluster` is destroyed here while the bucket-config wait is still parked.
+  }
+
+  if (pending.wait_for(std::chrono::seconds{ 10 }) != std::future_status::ready) {
+    FAIL(
+      "node_ids future was not completed after the cluster was closed -- the handler was stranded");
+  }
+  auto result = pending.get();
+  REQUIRE(result.first.ec() == couchbase::errc::network::cluster_closed);
+}
+
+// A key/value get reaches the bucket through direct_dispatch/open_bucket rather than the
+// with_bucket_config_or_timeout scaffold, so it exercises the bucket-bootstrap teardown from a
+// different call path (the one guarded by bucket_impl::bootstrap()'s closed_ check). The
+// caller-visible contract under test is the lifetime guarantee: teardown must complete the future
+// -- a dropped continuation would surface to a std::future caller as broken_promise (or hang a
+// callback caller) -- regardless of the exact error code the KV path reports.
+TEST_CASE("integration: a get future completes when the cluster is closed mid-bootstrap",
+          "[integration]")
+{
+  test::utils::integration_test_guard integration;
+
+  std::future<std::pair<couchbase::error, couchbase::get_result>> pending;
+  {
+    auto cluster = integration.public_cluster();
+
+    pending = cluster.bucket("this_bucket_does_not_exist")
+                .default_collection()
+                .get(test::utils::uniq_id("cxxcbc-853-get"));
+
+    if (pending.wait_for(0s) != std::future_status::timeout) {
+      SUCCEED("get completed too quickly to exercise an in-flight bucket bootstrap");
+      return;
+    }
+    // `cluster` is destroyed here while the KV operation is still parked in the bootstrap window.
+  }
+
+  if (pending.wait_for(std::chrono::seconds{ 10 }) != std::future_status::ready) {
+    FAIL("get future was not completed after the cluster was closed -- the handler was stranded");
+  }
+  auto result = pending.get();
+  // The cluster was torn down mid-bootstrap, so the operation must fail -- the point is that it
+  // completes at all rather than being dropped.
+  REQUIRE(result.first.ec());
 }


### PR DESCRIPTION
## Problem

The read-replica ASAN CI job fails with a LeakSanitizer report: **~14 `mcbp_session_impl` roots, all reported as *indirect* leaks with no direct root** — the signature of a pure reference cycle (the shape CXXCBC-852 / #983 describes). The whole bucket/session graph (sessions + bucket + tracer/meter/orphan-reporter/error-map) is stranded. A leaked session is one that was **never `stop()`'d** — `stop()` is what clears the session's `config_listeners_` / `on_stop_handler_`, the strong `session → bucket` edges that close the cycle.

## Root cause

CXXCBC-852 (#983) fixed this leak class for the **initial** bootstrap session: `close()` sets `closed_`, then under `sessions_mutex_` swaps `sessions_` out and stops every session (plus the tracked `bootstrapping_session_`), and never runs again. Two more variants survived:

**(1) Sessions were (re)created without a `closed_` check.** Only `bootstrap()` checked it. `update_config()`, `restart_sessions()` (posted by `remove_session()` when a session drops) and `connect_session()` (lazy connect on dispatch) all built and bootstrapped sessions with no `closed_` check. Any running after `close()` repopulated `sessions_` with sessions nothing ever stopped.

**(2) The drop-path stop could be abandoned.** When `update_config()` rebuilds the session list on a topology change, sessions no longer in the config are stopped via `asio::post(...session.stop())`. Test teardown does `close_cluster(); io.stop();` — and `io.stop()` **discards queued handlers**. If the posted stop hadn't run yet, the dropped session is never stopped, so its bucket-capturing handlers are never cleared → the graph is stranded.

## Fix

1. Guard `update_config()`, `restart_sessions()` and `connect_session()` on `closed_` under `sessions_mutex_`, matching `bootstrap()`.
2. In `update_config()`, collect the dropped sessions under the lock and `stop()` them **synchronously after releasing it** (stop() re-enters `sessions_mutex_` via `on_stop()`→`remove_session()`, so it must run unlocked). This clears the bucket-capturing handlers immediately instead of relying on a posted handler that `io.stop()` may discard.

## Verification

Reproduced locally against a 4-node cluster with an ASAN+LSAN build linked against **system OpenSSL** (matching CI's `CB_BORINGSSL=OFF`; the race does **not** reproduce with static BoringSSL — the different TLS teardown timing was the missing ingredient).

`integration: get any replica low-level version`, looped:

| build | leak rate |
|-------|-----------|
| before fix | ~3.7% (6/162) |
| after (1) alone | ~0.5% (4/900) |
| after (1)+(2) | **0/1400** |

Full read-replica suite passes (20/20 assertions) with no leaks.

Follow-up to #983 (CXXCBC-852) and #977 (CXXCBC-846).