### PR TITLE
CXXCBC-862: Re-resolve collection id on unknown_collection on the queue_request KV path

### DIFF
--- a/core/bucket.cxx
+++ b/core/bucket.cxx
@@ -162,6 +162,47 @@ public:
       reason = retry_reason::key_value_error_map_retry_indicated;
     } else {
       switch (status) {
+        case key_value_status_code::unknown_collection:
+          /**
+           * The server does not recognise the collection id we sent. This covers two cases:
+           *
+           *   1. The collection was dropped and recreated, so its id changed. The cached id we sent
+           *      is now stale and re-sending it would loop forever. We must invalidate the cache
+           *      and re-resolve the id via GetCollectionID before retrying.
+           *   2. The node's collection manifest simply lags ns_server's view: the id is still valid
+           *      but has not propagated to this particular KV node yet. Here re-sending the same id
+           *      succeeds once the manifest catches up, bounded by the operation timeout.
+           *
+           * Prefer re-resolution: if the request was dispatched through the collection-id cache the
+           * hook invalidates the cached id and schedules a re-resolution retry (covering case 1,
+           * and case 2 too since GetCollectionID re-fetches). This matches the legacy mcbp_command
+           * path, which handled both via handle_unknown_collection(); when KV ops were migrated to
+           * this path that handling was dropped and the status surfaced directly as
+           * collection_not_found, which consumers such as the range scan orchestrator treat as
+           * fatal.
+           *
+           * If there is no hook (request bypassed the cid cache) or re-resolution gave up, fall
+           * back to a bounded collection-outdated retry with the same id, which still recovers
+           * case 2.
+           */
+          if (req->on_unknown_collection_ && req->on_unknown_collection_()) {
+            return;
+          }
+          reason = retry_reason::key_value_collection_outdated;
+          break;
+        case key_value_status_code::config_only:
+          /**
+           * The node has a configuration but is not serving data operations yet (e.g. during
+           * warmup or rebalance). Mirror the legacy path: fetch a fresh configuration and retry so
+           * the request is routed to a node that can serve it.
+           */
+          CB_LOG_DEBUG(
+            "{} server returned config_only status, meaning that the node does not serve "
+            "data operations, requesting new configuration and retrying",
+            log_prefix_);
+          fetch_config();
+          reason = retry_reason::service_response_code_indicated;
+          break;
         case key_value_status_code::locked:
           if (req->command_ != protocol::client_opcode::unlock) {
             /**

--- a/core/collections_component.cxx
+++ b/core/collections_component.cxx
@@ -311,6 +311,20 @@ public:
   auto dispatch(std::shared_ptr<mcbp::queue_request> request)
     -> tl::expected<std::shared_ptr<pending_operation>, std::error_code>
   {
+    // Give the KV response path a way to invalidate the cached collection id and re-resolve it
+    // when the server reports unknown_collection (e.g. after a drop/recreate assigns a new id).
+    // Capture weak pointers to both the manager and the request: storing a shared_ptr to the
+    // request inside a std::function held ON that same request would form a self-referential cycle
+    // and leak it. GetCollectionID resolution requests do not pass through here, so they never get
+    // the hook and cannot recurse.
+    request->on_unknown_collection_ = [weak_mgr = weak_from_this(),
+                                       weak_req =
+                                         std::weak_ptr<mcbp::queue_request>(request)]() -> bool {
+      auto mgr = weak_mgr.lock();
+      auto req = weak_req.lock();
+      return (mgr && req) ? mgr->handle_collection_unknown(req) : false;
+    };
+
     if ((request->collection_id_ > 0) // collection id present
         || (request->collection_name_.empty() && request->scope_name_.empty()) // no collection
         || (request->collection_name_ == collection::default_name &&

--- a/core/mcbp/queue_request.hxx
+++ b/core/mcbp/queue_request.hxx
@@ -27,6 +27,7 @@
 #include <asio/steady_timer.hpp>
 
 #include <atomic>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <set>
@@ -78,6 +79,13 @@ public:
   std::string collection_name_{};
   std::string scope_name_{};
   std::size_t replica_index_{ 0 };
+
+  // Set by collections_component when a request is dispatched through the collection-id cache.
+  // Invoked by the KV response path on an unknown_collection status to invalidate the cached id,
+  // re-resolve it (GetCollectionID) and retry the request. Returns true if a retry was scheduled.
+  // Left empty for requests that bypass the cache (e.g. the GetCollectionID resolution requests
+  // themselves), which must not recurse.
+  std::function<bool()> on_unknown_collection_{};
   // This tracks when the request was dispatched so that we can properly prioritize older requests
   // to try and meet timeout requirements.
   std::chrono::steady_clock::time_point dispatched_time_{};

--- a/test/test_integration_range_scan.cxx
+++ b/test/test_integration_range_scan.cxx
@@ -20,6 +20,7 @@
 #include "core/agent_group.hxx"
 #include "core/agent_unit_test_api.hxx"
 #include "core/collections_component_unit_test_api.hxx"
+#include "core/operations/management/collections.hxx"
 #include "core/range_scan_orchestrator.hxx"
 #include "core/topology/configuration.hxx"
 
@@ -1751,4 +1752,114 @@ TEST_CASE("integration: range scan public API", "[integration]")
     fut.get();
     REQUIRE(item_count == 100);
   }
+}
+
+TEST_CASE("integration: range scan re-resolves recreated collection id", "[integration]")
+{
+  // Exercises the new KV (queue_request / crud_component) path, which range scan dispatches
+  // through collections_component. Dropping and recreating a collection with the same name assigns
+  // it a new collection id, so the id cached by the first scan is stale. The second scan sends the
+  // stale id, the server replies unknown_collection, and the on_unknown_collection_ hook must
+  // invalidate the cache, re-resolve via GetCollectionID and retry — succeeding instead of failing
+  // with collection_not_found. The seam itself is unit-tested in test_unit_mcbp_queue_request.cxx.
+  test::utils::integration_test_guard integration;
+
+  if (!integration.has_bucket_capability("range_scan")) {
+    SKIP("cluster does not support range_scan");
+  }
+  if (integration.cluster_version().is_mock()) {
+    SKIP("GOCAVES does not reassign collection ids when a collection is recreated");
+  }
+
+  const auto scope_name = std::string{ couchbase::scope::default_name };
+  const auto collection_name = test::utils::uniq_id("recreate");
+
+  auto create_collection = [&]() {
+    couchbase::core::operations::management::collection_create_request req{ integration.ctx.bucket,
+                                                                            scope_name,
+                                                                            collection_name };
+    auto resp = test::utils::execute(integration.cluster, req);
+    REQUIRE_SUCCESS(resp.ctx.ec);
+    REQUIRE(test::utils::wait_until_collection_manifest_propagated(
+      integration.cluster, integration.ctx.bucket, resp.uid));
+  };
+  auto drop_collection = [&]() {
+    couchbase::core::operations::management::collection_drop_request req{ integration.ctx.bucket,
+                                                                          scope_name,
+                                                                          collection_name };
+    auto resp = test::utils::execute(integration.cluster, req);
+    REQUIRE_SUCCESS(resp.ctx.ec);
+    REQUIRE(test::utils::wait_until_collection_manifest_propagated(
+      integration.cluster, integration.ctx.bucket, resp.uid));
+  };
+
+  create_collection();
+
+  auto cluster = integration.public_cluster();
+  auto collection =
+    cluster.bucket(integration.ctx.bucket).scope(scope_name).collection(collection_name);
+
+  // These ids are chosen (as in the collection-retry test above) so they all map to vbucket 12,
+  // which do_range_scan scans; recreating the collection does not change key-to-vbucket mapping.
+  const std::vector<std::string> ids{
+    "rangecollectionretry-9695",   "rangecollectionretry-24520",  "rangecollectionretry-90825",
+    "rangecollectionretry-119677", "rangecollectionretry-150939", "rangecollectionretry-170176",
+    "rangecollectionretry-199557", "rangecollectionretry-225568", "rangecollectionretry-231302",
+    "rangecollectionretry-245898",
+  };
+  const auto value = make_binary_value(128);
+
+  auto ag = couchbase::core::agent_group(integration.io, { { integration.cluster } });
+  ag.open_bucket(integration.ctx.bucket);
+  auto agent = ag.get_agent(integration.ctx.bucket);
+  REQUIRE(agent.has_value());
+
+  auto scan = [&]() {
+    auto mutations = populate_documents_for_range_scan(collection, ids, value);
+    auto highest = std::max_element(mutations.begin(), mutations.end(), [](auto a, auto b) {
+      return a.second.sequence_number() < b.second.sequence_number();
+    });
+
+    couchbase::core::range_scan_create_options create_options{
+      scope_name,
+      collection_name,
+      couchbase::core::range_scan{
+        couchbase::core::scan_term{ "rangecollectionretry" },
+        couchbase::core::scan_term{ "rangecollectionretry\xff" },
+      },
+    };
+    create_options.snapshot_requirements = couchbase::core::range_snapshot_requirements{
+      highest->second.partition_uuid(),
+      highest->second.sequence_number(),
+    };
+
+    couchbase::core::range_scan_continue_options continue_options{};
+    continue_options.batch_time_limit = std::chrono::seconds{ 10 };
+
+    return do_range_scan(agent.value(), 12, create_options, continue_options);
+  };
+
+  // First scan resolves and caches the current collection id.
+  {
+    auto data = scan();
+    REQUIRE_FALSE(data.empty());
+  }
+
+  // Drop and recreate: the recreated collection gets a new id, invalidating the cached id.
+  drop_collection();
+  create_collection();
+
+  // Second scan sends the now-stale cached id, receives unknown_collection, and must re-resolve
+  // and retry rather than fail. Success (non-empty, correct data) proves the re-resolution path.
+  {
+    auto data = scan();
+    REQUIRE_FALSE(data.empty());
+    for (const auto& item : data) {
+      REQUIRE(item.body.has_value());
+      REQUIRE(item.body->value == value);
+    }
+  }
+
+  // Drop the collection we created so the test bucket is not left polluted.
+  drop_collection();
 }

--- a/test/test_unit_mcbp_queue_request.cxx
+++ b/test/test_unit_mcbp_queue_request.cxx
@@ -204,6 +204,48 @@ TEST_CASE("unit: queue_request span fields default to null", "[unit]")
   REQUIRE(req->dispatch_span_ == nullptr);
 }
 
+TEST_CASE("unit: queue_request on_unknown_collection_ seam", "[unit]")
+{
+  // This covers only the seam itself: the KV response path in bucket_impl::resolve_response
+  // consults req->on_unknown_collection_ and, when it is set and returns true, treats the
+  // unknown_collection status as handled (re-resolution scheduled by collections_component).
+  // The wiring of the hook to handle_collection_unknown, and the actual cid invalidation +
+  // re-resolution, require a network-bound dispatcher and are covered by the integration test
+  // "integration: range scan re-resolves recreated collection id" in
+  // test_integration_range_scan.cxx.
+  auto req = make_get_request([](auto /*resp*/, auto /*req*/, auto /*ec*/) {
+  });
+
+  SECTION("defaults to empty so the response path falls back to a bounded retry")
+  {
+    REQUIRE_FALSE(static_cast<bool>(req->on_unknown_collection_));
+  }
+
+  SECTION("once set, it is invoked and its result is observed by the caller")
+  {
+    int invocations = 0;
+    req->on_unknown_collection_ = [&invocations]() -> bool {
+      ++invocations;
+      return true;
+    };
+
+    REQUIRE(static_cast<bool>(req->on_unknown_collection_));
+    // Mirror the guard in resolve_response: only invoke when the hook is present.
+    const bool handled = req->on_unknown_collection_ && req->on_unknown_collection_();
+    REQUIRE(handled);
+    REQUIRE(invocations == 1);
+  }
+
+  SECTION("a hook that declines forces the fallback path")
+  {
+    req->on_unknown_collection_ = []() -> bool {
+      return false;
+    };
+    const bool handled = req->on_unknown_collection_ && req->on_unknown_collection_();
+    REQUIRE_FALSE(handled);
+  }
+}
+
 TEST_CASE("unit: queue_request persistent — callback invoked for each successful response",
           "[unit]")
 {


### PR DESCRIPTION
Extracted from #930 (CXXCBC-810) as an independent, self-contained fix.

The crud_component/queue_request response handler (bucket_impl::resolve_response)
was migrated from the legacy mcbp_command path but never received that path's
handling for the unknown_collection and config_only server statuses:
unknown_collection surfaced directly as collection_not_found (fatal for range
scan) and config_only failed the operation.

Restore parity with mcbp_command's handle_unknown_collection(): on
unknown_collection, invalidate the cached collection id and re-resolve it via
GetCollectionID before retrying, so a dropped/recreated collection (new id)
self-heals instead of looping on a stale id, while a lagging manifest still
recovers. The response path reaches the collections layer through an
on_unknown_collection_ hook stamped on the request at dispatch, keeping
bucket_impl unaware of the collections component. On config_only, fetch a fresh
configuration and retry. Retries remain bounded by the operation timeout.

**Testing.** `test_unit_mcbp_queue_request` (unit, seam) — 229 assertions pass. New `test_integration_range_scan` case *"range scan re-resolves recreated collection id"* run against a live cluster (drop+recreate → new cid → re-resolve + retry) — 81 assertions pass. Library builds clean.
