### PR TITLE
CXXCBC-864: Close thread-safety races in KV op routing and finalization

### DIFF
--- a/core/transactions/attempt_context_impl.cxx
+++ b/core/transactions/attempt_context_impl.cxx
@@ -42,6 +42,7 @@
 #include "internal/utils.hxx"
 #include "staged_mutation.hxx"
 
+#include <cassert>
 #include <optional>
 
 namespace couchbase::core::transactions
@@ -233,10 +234,12 @@ attempt_context_impl::get(const core::document_id& id) -> transaction_get_result
 void
 attempt_context_impl::get(const core::document_id& id, Callback&& cb)
 {
-  if (op_list_.get_mode().is_query()) {
-    return get_with_query(id, false, std::move(cb));
-  }
   cache_error_async(cb, [self = shared_from_this(), id, cb]() mutable {
+    // Mode is read after cache_error_async incremented the op count, closing the
+    // race with set_query_mode() -- see the comment in insert() for the rationale.
+    if (self->op_list_.get_mode().is_query()) {
+      return self->get_with_query(id, false, std::move(cb));
+    }
     self->check_if_done(cb);
     self->do_get(
       id,
@@ -323,10 +326,12 @@ void
 attempt_context_impl::get_optional(const core::document_id& id, Callback&& cb)
 {
 
-  if (op_list_.get_mode().is_query()) {
-    return get_with_query(id, true, std::move(cb));
-  }
   cache_error_async(cb, [self = shared_from_this(), id, cb]() mutable {
+    // Mode is read after cache_error_async incremented the op count, closing the
+    // race with set_query_mode() -- see the comment in insert() for the rationale.
+    if (self->op_list_.get_mode().is_query()) {
+      return self->get_with_query(id, true, std::move(cb));
+    }
     self->ensure_open_bucket(
       id.bucket(), [self, id, cb = std::move(cb)](std::error_code ec) mutable {
         if (ec) {
@@ -886,11 +891,13 @@ attempt_context_impl::replace(const transaction_get_result& document,
                               Callback&& cb)
 {
 
-  if (op_list_.get_mode().is_query()) {
-    return replace_raw_with_query(document, std::move(content), std::move(cb));
-  }
   return cache_error_async(
     cb, [self = shared_from_this(), cb, document, content = std::move(content)]() mutable {
+      // Mode is read after cache_error_async incremented the op count, closing the
+      // race with set_query_mode() -- see the comment in insert() for the rationale.
+      if (self->op_list_.get_mode().is_query()) {
+        return self->replace_raw_with_query(document, std::move(content), std::move(cb));
+      }
       self->ensure_open_bucket(
         document.bucket(),
         [self, cb = std::move(cb), document, content = std::move(content)](
@@ -1026,6 +1033,13 @@ attempt_context_impl::create_staged_replace(
   const std::optional<document_metadata>& document_metadata,
   Handler&& cb)
 {
+  // ExtThreadSafety invariant -- see create_staged_insert() for the full rationale and
+  // the spec reference (couchbase-transactions-specs/transactions-extensions.md,
+  // "ExtThreadSafety").  replace() reads the mode after this op is counted, so reaching
+  // this staging point in query mode means that ordering has regressed.
+  assert(!op_list_.query_mode_entered() &&
+         "ExtThreadSafety: KV replace staged after query mode entered -- would be missing "
+         "from BEGIN WORK and lost at commit");
   operations::mutate_in_request req{ id };
   const bool binary =
     codec::codec_flags::has_common_flags(content.flags, codec::codec_flags::binary_common_flags);
@@ -1274,11 +1288,20 @@ attempt_context_impl::insert(const core::document_id& id,
                              codec::encoded_value content,
                              Callback&& cb)
 {
-  if (op_list_.get_mode().is_query()) {
-    return insert_raw_with_query(id, std::move(content), std::move(cb));
-  }
   return cache_error_async(
     cb, [self = shared_from_this(), id, cb, content = std::move(content)]() mutable {
+      // The op count was incremented by cache_error_async before this lambda runs.
+      // Reading the mode here -- after the increment -- closes a race with
+      // set_query_mode(): a query switching to query mode first waits for all
+      // in-flight KV ops to drain before issuing BEGIN WORK, so once this op is
+      // counted, either we observe KV mode and our staged mutation is guaranteed to
+      // be part of BEGIN WORK, or we observe query mode and route through query.
+      // Checking the mode before the increment (as the code used to) left a window
+      // where a query could flip the mode in the gap, after which this op would
+      // stage a KV mutation that BEGIN WORK had already missed -- silently losing it.
+      if (self->op_list_.get_mode().is_query()) {
+        return self->insert_raw_with_query(id, std::move(content), std::move(cb));
+      }
       self->ensure_open_bucket(
         id.bucket(),
         [self, id, content = std::move(content), cb = std::move(cb)](std::error_code ec) mutable {
@@ -1452,10 +1475,12 @@ void
 attempt_context_impl::remove(const transaction_get_result& document, VoidCallback&& cb)
 {
 
-  if (op_list_.get_mode().is_query()) {
-    return remove_with_query(document, std::move(cb));
-  }
   return cache_error_async(cb, [self = shared_from_this(), document, cb]() mutable {
+    // Mode is read after cache_error_async incremented the op count, closing the
+    // race with set_query_mode() -- see the comment in insert() for the rationale.
+    if (self->op_list_.get_mode().is_query()) {
+      return self->remove_with_query(document, std::move(cb));
+    }
     self->check_if_done(cb);
     self->ensure_open_bucket(
       document.bucket(), [self, document, cb = std::move(cb)](std::error_code ec) mutable {
@@ -1539,6 +1564,15 @@ attempt_context_impl::remove(const transaction_get_result& document, VoidCallbac
                       return error_handler(
                         *ec, "before_staged_remove hook raised error", std::move(cb));
                     }
+                    // ExtThreadSafety invariant -- see create_staged_insert() for the
+                    // full rationale and spec reference
+                    // (couchbase-transactions-specs/transactions-extensions.md,
+                    // "ExtThreadSafety").  remove() reads the mode after this op is
+                    // counted, so reaching this staging point in query mode means that
+                    // ordering has regressed.
+                    assert(!self->op_list_.query_mode_entered() &&
+                           "ExtThreadSafety: KV remove staged after query mode entered -- "
+                           "would be missing from BEGIN WORK and lost at commit");
                     CB_ATTEMPT_CTX_LOG_TRACE(self,
                                              "about to remove doc {} with cas {}",
                                              document.id(),
@@ -2203,59 +2237,69 @@ make_kv_txdata(std::optional<transaction_get_result> doc = std::nullopt) -> tao:
 void
 attempt_context_impl::get_with_query(const core::document_id& id, bool optional, Callback&& cb)
 {
-  cache_error_async(cb, [self = shared_from_this(), id, optional, cb]() mutable {
-    couchbase::transactions::transaction_query_options opts;
-    opts.readonly(true);
-    return self->wrap_query(
-      KV_GET,
-      opts,
-      make_params(id, {}),
-      make_kv_txdata(),
-      STAGE_QUERY_KV_GET,
-      true,
-      {},
-      [self, id, optional, cb = std::move(cb)](std::exception_ptr err,
-                                               core::operations::query_response resp) mutable {
-        if (resp.ctx.ec == couchbase::errc::key_value::document_not_found) {
+  // Called only from get()/get_optional(), already within their cache_error_async()
+  // (op counted, existing_error() checked); see insert_raw_with_query() for why we do
+  // not re-wrap.
+  auto self = shared_from_this();
+  couchbase::transactions::transaction_query_options opts;
+  opts.readonly(true);
+  return self->wrap_query(
+    KV_GET,
+    opts,
+    make_params(id, {}),
+    make_kv_txdata(),
+    STAGE_QUERY_KV_GET,
+    true,
+    {},
+    [self, id, optional, cb = std::move(cb)](std::exception_ptr err,
+                                             core::operations::query_response resp) mutable {
+      if (resp.ctx.ec == couchbase::errc::key_value::document_not_found) {
+        // A non-optional get() must fail rather than report an empty result: its callback contract
+        // (and the synchronous get() wrapper) dereferences the returned optional, so err==nullptr
+        // with res==nullopt would be a null dereference. Mirror the rows-empty handling below and
+        // the KV get() path.
+        if (optional) {
           return self->op_completed_with_callback(std::move(cb),
                                                   std::optional<transaction_get_result>());
         }
-        if (!err) {
-          // make a transaction_get_result from the row...
-          try {
-            if (resp.rows.empty()) {
-              if (optional) {
-                return self->op_completed_with_callback(std::move(cb),
-                                                        std::optional<transaction_get_result>());
-              }
-              return self->op_completed_with_error(
-                std::move(cb),
-                transaction_operation_failed(FAIL_DOC_NOT_FOUND, "document not found"));
+        return self->op_completed_with_error(
+          std::move(cb), transaction_operation_failed(FAIL_DOC_NOT_FOUND, "document not found"));
+      }
+      if (!err) {
+        // make a transaction_get_result from the row...
+        try {
+          if (resp.rows.empty()) {
+            if (optional) {
+              return self->op_completed_with_callback(std::move(cb),
+                                                      std::optional<transaction_get_result>());
             }
-            CB_ATTEMPT_CTX_LOG_TRACE(self, "get_with_query got: {}", resp.rows.front());
-            transaction_get_result doc(id, core::utils::json::parse(resp.rows.front()));
-            return self->op_completed_with_callback(std::move(cb),
-                                                    std::optional<transaction_get_result>(doc));
-          } catch (const std::exception& e) {
-            // TODO(SA): unsure what to do here, but this is pretty fatal, so
             return self->op_completed_with_error(
-              std::move(cb), transaction_operation_failed(FAIL_OTHER, e.what()));
+              std::move(cb),
+              transaction_operation_failed(FAIL_DOC_NOT_FOUND, "document not found"));
           }
+          CB_ATTEMPT_CTX_LOG_TRACE(self, "get_with_query got: {}", resp.rows.front());
+          transaction_get_result doc(id, core::utils::json::parse(resp.rows.front()));
+          return self->op_completed_with_callback(std::move(cb),
+                                                  std::optional<transaction_get_result>(doc));
+        } catch (const std::exception& e) {
+          // Unexpected error here: fail with FAIL_OTHER so the transaction rolls back.
+          return self->op_completed_with_error(std::move(cb),
+                                               transaction_operation_failed(FAIL_OTHER, e.what()));
         }
-        // for get_optional.   <sigh>
-        if (optional) {
-          try {
-            std::rethrow_exception(err);
-          } catch (const document_not_found&) {
-            return self->op_completed_with_callback(std::move(cb),
-                                                    std::optional<transaction_get_result>());
-          } catch (...) {
-            return self->op_completed_with_error(std::move(cb), std::current_exception());
-          }
+      }
+      // for get_optional.   <sigh>
+      if (optional) {
+        try {
+          std::rethrow_exception(err);
+        } catch (const document_not_found&) {
+          return self->op_completed_with_callback(std::move(cb),
+                                                  std::optional<transaction_get_result>());
+        } catch (...) {
+          return self->op_completed_with_error(std::move(cb), std::current_exception());
         }
-        return self->op_completed_with_error(std::move(cb), std::move(err));
-      });
-  });
+      }
+      return self->op_completed_with_error(std::move(cb), std::move(err));
+    });
 }
 
 void
@@ -2263,46 +2307,55 @@ attempt_context_impl::insert_raw_with_query(const core::document_id& id,
                                             codec::encoded_value content,
                                             Callback&& cb)
 {
-  cache_error_async(
-    cb, [self = shared_from_this(), id, content = std::move(content), cb]() mutable {
-      const couchbase::transactions::transaction_query_options opts;
-      return self->wrap_query(
-        KV_INSERT,
-        opts,
-        make_params(id, std::move(content)),
-        make_kv_txdata(),
-        STAGE_QUERY_KV_INSERT,
-        true,
-        {},
-        [self, id, cb = std::move(cb)](const std::exception_ptr& err,
-                                       core::operations::query_response resp) mutable {
-          if (err) {
-            try {
-              std::rethrow_exception(err);
-            } catch (const transaction_operation_failed& e) {
-              return self->op_completed_with_error(std::move(cb), e);
-            } catch (const op_exception& ex) {
-              return self->op_completed_with_error(std::move(cb), ex);
-            } catch (const std::exception& e) {
-              return self->op_completed_with_error(
-                std::move(cb), transaction_operation_failed(FAIL_OTHER, e.what()));
-            } catch (...) {
-              return self->op_completed_with_error(
-                std::move(cb), transaction_operation_failed(FAIL_OTHER, "unexpected error"));
-            }
-          }
-          // make a transaction_get_result from the row...
-          try {
-            CB_ATTEMPT_CTX_LOG_TRACE(self, "insert_raw_with_query got: {}", resp.rows.front());
-            transaction_get_result doc(id, core::utils::json::parse(resp.rows.front()));
-            return self->op_completed_with_callback(std::move(cb),
-                                                    std::optional<transaction_get_result>(doc));
-          } catch (const std::exception& e) {
-            // TODO(SA): unsure what to do here, but this is pretty fatal, so
-            return self->op_completed_with_error(
-              std::move(cb), transaction_operation_failed(FAIL_OTHER, e.what()));
-          }
-        });
+  // Called only from insert(), already within its cache_error_async(): the op has
+  // been counted in the wait-group and existing_error() has been checked, so we must
+  // not wrap again here -- double-counting would leave the op permanently in-flight
+  // and deadlock the commit/rollback wait.
+  auto self = shared_from_this();
+  const couchbase::transactions::transaction_query_options opts;
+  return self->wrap_query(
+    KV_INSERT,
+    opts,
+    make_params(id, std::move(content)),
+    make_kv_txdata(),
+    STAGE_QUERY_KV_INSERT,
+    true,
+    {},
+    [self, id, cb = std::move(cb)](const std::exception_ptr& err,
+                                   core::operations::query_response resp) mutable {
+      if (err) {
+        try {
+          std::rethrow_exception(err);
+        } catch (const transaction_operation_failed& e) {
+          return self->op_completed_with_error(std::move(cb), e);
+        } catch (const op_exception& ex) {
+          return self->op_completed_with_error(std::move(cb), ex);
+        } catch (const std::exception& e) {
+          return self->op_completed_with_error(std::move(cb),
+                                               transaction_operation_failed(FAIL_OTHER, e.what()));
+        } catch (...) {
+          return self->op_completed_with_error(
+            std::move(cb), transaction_operation_failed(FAIL_OTHER, "unexpected error"));
+        }
+      }
+      // make a transaction_get_result from the row...
+      try {
+        if (resp.rows.empty()) {
+          // A successful insert query must return the staged document row; no rows is an
+          // unexpected protocol condition. front() on an empty vector is UB, so guard explicitly.
+          return self->op_completed_with_error(
+            std::move(cb),
+            transaction_operation_failed(FAIL_OTHER, "insert query returned no rows"));
+        }
+        CB_ATTEMPT_CTX_LOG_TRACE(self, "insert_raw_with_query got: {}", resp.rows.front());
+        transaction_get_result doc(id, core::utils::json::parse(resp.rows.front()));
+        return self->op_completed_with_callback(std::move(cb),
+                                                std::optional<transaction_get_result>(doc));
+      } catch (const std::exception& e) {
+        // Unexpected error here: fail with FAIL_OTHER so the transaction rolls back.
+        return self->op_completed_with_error(std::move(cb),
+                                             transaction_operation_failed(FAIL_OTHER, e.what()));
+      }
     });
 }
 
@@ -2311,91 +2364,103 @@ attempt_context_impl::replace_raw_with_query(const transaction_get_result& docum
                                              codec::encoded_value content,
                                              Callback&& cb)
 {
-  cache_error_async(
-    cb, [self = shared_from_this(), document, content = std::move(content), cb]() mutable {
-      const couchbase::transactions::transaction_query_options opts;
-      return self->wrap_query(
-        KV_REPLACE,
-        opts,
-        make_params(document.id(), std::move(content)),
-        make_kv_txdata(document),
-        STAGE_QUERY_KV_REPLACE,
-        true,
-        {},
-        [self, id = document.id(), cb = std::move(cb)](
-          const std::exception_ptr& err, core::operations::query_response resp) mutable {
-          if (err) {
-            try {
-              std::rethrow_exception(err);
-            } catch (const query_cas_mismatch& e) {
-              return self->op_completed_with_error(
-                std::move(cb), transaction_operation_failed(FAIL_CAS_MISMATCH, e.what()).retry());
-            } catch (const document_not_found& e) {
-              return self->op_completed_with_error(
-                std::move(cb), transaction_operation_failed(FAIL_DOC_NOT_FOUND, e.what()).retry());
-            } catch (const transaction_operation_failed& e) {
-              return self->op_completed_with_error(std::move(cb), e);
-            } catch (std::exception& e) {
-              return self->op_completed_with_error(
-                std::move(cb), transaction_operation_failed(FAIL_OTHER, e.what()));
-            } catch (...) {
-              return self->op_completed_with_error(
-                std::move(cb), transaction_operation_failed(FAIL_OTHER, "unexpected exception"));
-            }
-          }
-          // make a transaction_get_result from the row...
-          try {
-            CB_ATTEMPT_CTX_LOG_TRACE(self, "replace_raw_with_query got: {}", resp.rows.front());
-            transaction_get_result doc(id, core::utils::json::parse(resp.rows.front()));
-            return self->op_completed_with_callback(std::move(cb),
-                                                    std::optional<transaction_get_result>(doc));
-          } catch (const std::exception& e) {
-            // TODO(SA): unsure what to do here, but this is pretty fatal, so
-            return self->op_completed_with_error(
-              std::move(cb), transaction_operation_failed(FAIL_OTHER, e.what()));
-          }
-        });
+  // Called only from replace(), already within its cache_error_async() (op counted,
+  // existing_error() checked); see insert_raw_with_query() for why we do not re-wrap.
+  auto self = shared_from_this();
+  const couchbase::transactions::transaction_query_options opts;
+  return self->wrap_query(
+    KV_REPLACE,
+    opts,
+    make_params(document.id(), std::move(content)),
+    make_kv_txdata(document),
+    STAGE_QUERY_KV_REPLACE,
+    true,
+    {},
+    [self, id = document.id(), cb = std::move(cb)](const std::exception_ptr& err,
+                                                   core::operations::query_response resp) mutable {
+      if (err) {
+        try {
+          std::rethrow_exception(err);
+        } catch (const query_cas_mismatch& e) {
+          return self->op_completed_with_error(
+            std::move(cb), transaction_operation_failed(FAIL_CAS_MISMATCH, e.what()).retry());
+        } catch (const document_not_found& e) {
+          return self->op_completed_with_error(
+            std::move(cb), transaction_operation_failed(FAIL_DOC_NOT_FOUND, e.what()).retry());
+        } catch (const transaction_operation_failed& e) {
+          return self->op_completed_with_error(std::move(cb), e);
+        } catch (const op_exception& ex) {
+          return self->op_completed_with_error(std::move(cb), ex);
+        } catch (std::exception& e) {
+          return self->op_completed_with_error(std::move(cb),
+                                               transaction_operation_failed(FAIL_OTHER, e.what()));
+        } catch (...) {
+          return self->op_completed_with_error(
+            std::move(cb), transaction_operation_failed(FAIL_OTHER, "unexpected exception"));
+        }
+      }
+      // make a transaction_get_result from the row...
+      try {
+        if (resp.rows.empty()) {
+          // A successful replace query must return the staged document row; no rows is an
+          // unexpected protocol condition. front() on an empty vector is UB, so guard explicitly.
+          return self->op_completed_with_error(
+            std::move(cb),
+            transaction_operation_failed(FAIL_OTHER, "replace query returned no rows"));
+        }
+        CB_ATTEMPT_CTX_LOG_TRACE(self, "replace_raw_with_query got: {}", resp.rows.front());
+        transaction_get_result doc(id, core::utils::json::parse(resp.rows.front()));
+        return self->op_completed_with_callback(std::move(cb),
+                                                std::optional<transaction_get_result>(doc));
+      } catch (const std::exception& e) {
+        // Unexpected error here: fail with FAIL_OTHER so the transaction rolls back.
+        return self->op_completed_with_error(std::move(cb),
+                                             transaction_operation_failed(FAIL_OTHER, e.what()));
+      }
     });
 }
 
 void
 attempt_context_impl::remove_with_query(const transaction_get_result& document, VoidCallback&& cb)
 {
-  cache_error_async(cb, [self = shared_from_this(), document, cb]() {
-    const couchbase::transactions::transaction_query_options opts;
-    return self->wrap_query(
-      KV_REMOVE,
-      opts,
-      make_params(document.id(), {}),
-      make_kv_txdata(document),
-      STAGE_QUERY_KV_REMOVE,
-      true,
-      {},
-      [self, id = document.id(), cb](const std::exception_ptr& err,
-                                     const core::operations::query_response& /* resp */) mutable {
-        if (err) {
-          try {
-            std::rethrow_exception(err);
-          } catch (const transaction_operation_failed& e) {
-            return self->op_completed_with_error(std::move(cb), e);
-          } catch (const document_not_found& e) {
-            return self->op_completed_with_error(
-              std::move(cb), transaction_operation_failed(FAIL_DOC_NOT_FOUND, e.what()).retry());
-          } catch (const query_cas_mismatch& e) {
-            return self->op_completed_with_error(
-              std::move(cb), transaction_operation_failed(FAIL_CAS_MISMATCH, e.what()).retry());
-          } catch (const std::exception& e) {
-            return self->op_completed_with_error(
-              std::move(cb), transaction_operation_failed(FAIL_OTHER, e.what()));
-          } catch (...) {
-            return self->op_completed_with_error(
-              std::move(cb), transaction_operation_failed(FAIL_OTHER, "unexpected exception"));
-          }
+  // Called only from remove(), already within its cache_error_async() (op counted,
+  // existing_error() checked); see insert_raw_with_query() for why we do not re-wrap.
+  auto self = shared_from_this();
+  const couchbase::transactions::transaction_query_options opts;
+  return self->wrap_query(
+    KV_REMOVE,
+    opts,
+    make_params(document.id(), {}),
+    make_kv_txdata(document),
+    STAGE_QUERY_KV_REMOVE,
+    true,
+    {},
+    [self, id = document.id(), cb = std::move(cb)](
+      const std::exception_ptr& err, const core::operations::query_response& /* resp */) mutable {
+      if (err) {
+        try {
+          std::rethrow_exception(err);
+        } catch (const transaction_operation_failed& e) {
+          return self->op_completed_with_error(std::move(cb), e);
+        } catch (const document_not_found& e) {
+          return self->op_completed_with_error(
+            std::move(cb), transaction_operation_failed(FAIL_DOC_NOT_FOUND, e.what()).retry());
+        } catch (const query_cas_mismatch& e) {
+          return self->op_completed_with_error(
+            std::move(cb), transaction_operation_failed(FAIL_CAS_MISMATCH, e.what()).retry());
+        } catch (const op_exception& ex) {
+          return self->op_completed_with_error(std::move(cb), ex);
+        } catch (const std::exception& e) {
+          return self->op_completed_with_error(std::move(cb),
+                                               transaction_operation_failed(FAIL_OTHER, e.what()));
+        } catch (...) {
+          return self->op_completed_with_error(
+            std::move(cb), transaction_operation_failed(FAIL_OTHER, "unexpected exception"));
         }
-        // make a transaction_get_result from the row...
-        return self->op_completed_with_callback(std::move(cb));
-      });
-  });
+      }
+      // make a transaction_get_result from the row...
+      return self->op_completed_with_callback(std::move(cb));
+    });
 }
 
 void
@@ -3798,6 +3863,17 @@ attempt_context_impl::create_staged_insert(const core::document_id& id,
                                               UNKNOWN,
                                               "before_staged_insert hook threw error");
   }
+  // ExtThreadSafety invariant (couchbase-transactions-specs/transactions-extensions.md,
+  // "ExtThreadSafety"): "no KV operations are staged but not sent in the BEGIN WORK" and
+  // "no KV operations are performed regularly after queryMode is entered".  insert()
+  // reads the mode only after this op is counted in the wait-group, and set_query_mode()
+  // drains all in-flight KV ops before issuing BEGIN WORK -- so reaching this staging
+  // point with query mode already entered means that ordering has regressed and the
+  // mutation would be silently lost at commit.  Fires loudly in debug/FIT builds;
+  // compiled out in release.
+  assert(!op_list_.query_mode_entered() &&
+         "ExtThreadSafety: KV insert staged after query mode entered -- would be missing "
+         "from BEGIN WORK and lost at commit");
   CB_ATTEMPT_CTX_LOG_DEBUG(this, "about to insert staged doc {} with cas {}", id, cas);
   core::operations::mutate_in_request req{ id };
   const bool binary =

--- a/core/transactions/attempt_context_impl.hxx
+++ b/core/transactions/attempt_context_impl.hxx
@@ -289,7 +289,11 @@ private:
           err.cause(TRANSACTION_ALREADY_COMMITTED);
           break;
         default:
-          err.cause(UNKNOWN);
+          // Ops are only blocked once commit or rollback has begun (wait_and_block_ops), but the
+          // attempt state is published later -- and the empty-commit fast path never reaches
+          // COMMITTED at all. So a racing op can land here with the state still PENDING: report it
+          // as a concurrent operation rather than an opaque unknown cause.
+          err.cause(CONCURRENT_OPERATIONS_DETECTED_ON_SAME_DOCUMENT);
       }
       op_completed_with_error_no_cache(std::forward<Handler>(cb), std::make_exception_ptr(err));
     } catch (const transaction_operation_failed& e) {

--- a/core/transactions/waitable_op_list.hxx
+++ b/core/transactions/waitable_op_list.hxx
@@ -79,6 +79,15 @@ public:
     // we have the lock.  Block all further ops
     allow_ops_ = false;
   }
+  // Peek at whether query mode has already been entered.  Briefly acquires mutex_ but, unlike
+  // get_mode(), never waits on cv_query_ for the query node to be set, so it returns immediately.
+  // Used by defensive invariant checks: a KV mutation must never be staged once query mode is
+  // entered.
+  auto query_mode_entered() const -> bool
+  {
+    const std::scoped_lock lock(mutex_);
+    return mode_.mode == attempt_mode::modes::QUERY;
+  }
   auto get_mode() -> attempt_mode
   {
     std::unique_lock<std::mutex> lock(mutex_);
@@ -143,8 +152,10 @@ public:
   {
     // when begin work errors out, it is fatal, so reset to kv mode here, allowing
     // rollback to function properly.
-    std::unique_lock<std::mutex> lock;
+    const std::scoped_lock lock(mutex_);
     mode_.mode = attempt_mode::modes::KV;
+    // query_node is intentionally left populated: a retry runs with a fresh waitable_op_list, and
+    // get_mode()'s wait predicate keys on query_node, so clearing it here would serve no purpose.
     cv_query_.notify_all();
   }
 
@@ -199,6 +210,6 @@ private:
   std::condition_variable cv_ops_;
   std::condition_variable cv_query_;
   std::condition_variable cv_in_flight_;
-  std::mutex mutex_;
+  mutable std::mutex mutex_;
 };
 } // namespace couchbase::core::transactions

--- a/test/test_unit_waitable_op_list.cxx
+++ b/test/test_unit_waitable_op_list.cxx
@@ -145,3 +145,106 @@ TEST_CASE("transactions: get mode waits", "[unit]")
   CHECK(mode.query_node == NODE);
   CHECK(mode.mode == couchbase::core::transactions::attempt_mode::modes::QUERY);
 }
+
+TEST_CASE("transactions: reset_query_mode returns to KV mode", "[unit]")
+{
+  couchbase::core::transactions::waitable_op_list op_list;
+  op_list.increment_ops();
+  op_list.set_query_mode(
+    [&op_list]() {
+      op_list.set_query_node(NODE);
+    },
+    []() {
+    });
+  REQUIRE(op_list.query_mode_entered());
+
+  op_list.reset_query_mode();
+  REQUIRE_FALSE(op_list.query_mode_entered());
+}
+
+TEST_CASE("transactions: reset_query_mode is synchronized against readers", "[unit]")
+{
+  // Regression guard for the unsynchronized write in reset_query_mode(): it must hold mutex_ while
+  // mutating mode_ and notifying, otherwise it races the locked readers get_mode()/
+  // query_mode_entered(). The data race is surfaced by ThreadSanitizer; this test drives both sides
+  // concurrently so a TSan build can observe it, and asserts the functional outcome (mode reset to
+  // KV) on any build.
+  for (int i = 0; i < 100; ++i) {
+    couchbase::core::transactions::waitable_op_list op_list;
+    op_list.increment_ops();
+    op_list.set_query_mode(
+      [&op_list]() {
+        op_list.set_query_node(NODE);
+      },
+      []() {
+      });
+
+    std::thread reader([&op_list]() {
+      for (int j = 0; j < 100; ++j) {
+        (void)op_list.query_mode_entered();
+      }
+    });
+    op_list.reset_query_mode();
+    reader.join();
+
+    REQUIRE_FALSE(op_list.query_mode_entered());
+  }
+}
+
+TEST_CASE("transactions: query_mode_entered reflects the current mode", "[unit]")
+{
+  couchbase::core::transactions::waitable_op_list op_list;
+  REQUIRE_FALSE(op_list.query_mode_entered());
+
+  op_list.increment_ops();
+  op_list.set_query_mode(
+    [&op_list]() {
+      op_list.set_query_node(NODE);
+    },
+    []() {
+    });
+  REQUIRE(op_list.query_mode_entered());
+}
+
+TEST_CASE("transactions: query_mode_entered stays false until in-flight ops drain into query mode",
+          "[unit]")
+{
+  // The register-then-check invariant behind the KV-op routing fix: a counted (in-flight) KV op can
+  // safely observe KV mode while a concurrent set_query_mode() is blocked waiting for in-flight ops
+  // to drain. Query mode only becomes observable once that drain completes -- so a KV op that sees
+  // KV mode is guaranteed to be part of BEGIN WORK rather than stranded after it.
+  couchbase::core::transactions::waitable_op_list op_list;
+  op_list.increment_ops(); // the op that calls set_query_mode
+  op_list.increment_ops(); // a second in-flight op that must drain before query mode is entered
+
+  auto f = std::async(std::launch::async, [&op_list] {
+    op_list.set_query_mode(
+      [&op_list]() {
+        op_list.set_query_node(NODE);
+      },
+      []() {
+      });
+  });
+
+  // set_query_mode() is blocked waiting for the second op to drain; the mode is still KV.
+  CHECK(std::future_status::timeout == f.wait_for(std::chrono::milliseconds(100)));
+  CHECK_FALSE(op_list.query_mode_entered());
+
+  // draining the second op lets set_query_mode() complete and enter query mode.
+  op_list.decrement_in_flight();
+  f.get();
+  CHECK(op_list.query_mode_entered());
+}
+
+TEST_CASE("transactions: operations after commit/rollback are rejected with a conflict", "[unit]")
+{
+  // Once commit/rollback has blocked operations (wait_and_block_ops), a racing operation must be
+  // rejected: increment_ops() throws async_operation_conflict. Mapping that conflict to the
+  // CONCURRENT_OPERATIONS_DETECTED_ON_SAME_DOCUMENT cause happens in attempt_context_impl and is
+  // covered by the FIT ThreadSafety suite, not here.
+  couchbase::core::transactions::waitable_op_list op_list;
+  op_list.wait_and_block_ops(); // no ops in flight, so this returns immediately and blocks new ops
+
+  REQUIRE_THROWS_AS(op_list.increment_ops(),
+                    couchbase::core::transactions::async_operation_conflict);
+}


### PR DESCRIPTION
Extracted from #930 (CXXCBC-810) as an independent, self-contained fix.

Two races surfaced intermittently in the ThreadSafety suite:

KV op mode check vs op registration. Each KV operation (get/insert/replace/
remove) read the attempt mode at function entry, before cache_error_async
registered the operation in the wait-group. The mode read and the registration
were separate waitable_op_list lock acquisitions, so a concurrent query could
switch to query mode and issue BEGIN WORK in the gap. The KV op then stayed on
the KV path and staged a mutation that BEGIN WORK had already missed, leaving
an orphaned client ATR and a mutation lost at commit. Read the mode inside
cache_error_async, after the op is counted: once registered, set_query_mode
waits for in-flight KV ops to drain before BEGIN WORK, so observing KV mode
guarantees the staged mutation is part of BEGIN WORK; otherwise the op routes
through query. This matches the atomic register-then-check used by the Go and
Java implementations. The redundant cache_error_async wrapper is dropped from
the *_with_query helpers, which are now always invoked from an already-counted
context. A non-blocking waitable_op_list::query_mode_entered() backs an assert
of the invariant at each KV staging point.

Concurrent-op conflict reported as unknown cause. An operation racing a commit
or rollback throws async_operation_conflict, and the resulting
transaction_operation_failed took its cause from the attempt state. But ops are
blocked at the start of commit/rollback (wait_and_block_ops) while the state is
published later -- and the empty-commit fast path never reaches COMMITTED -- so
a racing op could observe state PENDING and surface an opaque UNKNOWN cause.
Since this conflict only arises once finalization has begun, report the default
case as CONCURRENT_OPERATIONS_DETECTED_ON_SAME_DOCUMENT, keeping the precise
already-committed/already-aborted causes when the state is known.

**Testing.** Library builds clean; `test_unit_waitable_op_list` passes. The definitive oracle is the ThreadSafety FIT suite under TSan (CI). Note: the `query_mode_entered()` invariant assert is compiled out under `-DNDEBUG`, so it guards debug/FIT builds only; correctness rests on the register-then-check drain ordering.
