### PR TITLE
CXXCBC-866: remove the redundant transactions_config move constructor

### DIFF
--- a/core/transactions/transactions_config.cxx
+++ b/core/transactions/transactions_config.cxx
@@ -32,17 +32,6 @@ transactions_config::transactions_config()
 
 transactions_config::~transactions_config() = default;
 
-transactions_config::transactions_config(transactions_config&& c) noexcept
-  : level_(c.level_)
-  , timeout_(c.timeout_)
-  , attempt_context_hooks_(c.attempt_context_hooks_)
-  , cleanup_hooks_(c.cleanup_hooks_)
-  , metadata_collection_(std::move(c.metadata_collection_))
-  , query_config_(c.query_config_)
-  , cleanup_config_(std::move(c.cleanup_config_))
-{
-}
-
 transactions_config::transactions_config(const transactions_config& config)
   : level_(config.durability_level())
   , timeout_(config.timeout())

--- a/couchbase/transactions/transactions_config.hxx
+++ b/couchbase/transactions/transactions_config.hxx
@@ -48,9 +48,11 @@ public:
 
   transactions_config(const transactions_config& c);
 
-  transactions_config(transactions_config&& c) noexcept;
-
   auto operator=(const transactions_config& c) -> transactions_config&;
+
+  // No move operations are declared: they fall back to the copy operations, which is sufficient for
+  // this configuration object (copied once during transaction setup) and keeps a moved-from source
+  // valid -- the hook accessors dereference their pointers, so a nulled-out source would be unsafe.
 
   /**
    * @brief Get the default durability level for all transaction operations


### PR DESCRIPTION
Removes the redundant custom move constructor from `transactions_config`.

CXXCBC-866 originally proposed adding a matching move-assignment operator, but neither is warranted. The class already declares a copy-constructor, copy-assignment, and destructor, so the move-assignment operator was never implicitly declared — `dst = std::move(src)` already resolved to the user copy-assignment, which copies the members and leaves the source valid. The custom move constructor only copied the two hook `shared_ptr`s (so a moved-from source would not leave the accessors dereferencing null) and copied `query_config_` under a `noexcept` its copy does not guarantee — machinery for no real gain on a config that is copied once at transaction setup.

With the custom move constructor removed, both move operations fall back to the copy operations (deep-copy on construction, shallow-share on assignment), which leave the source valid. This drops the null-dereference and `noexcept`/terminate hazards with no functional change.

- Source-compatible: `std::move`-ing a `transactions_config` still works via the copy operations; nothing in the tree requires a `noexcept` move of the type.
- ABI: the out-of-line move-constructor symbol is removed; acceptable in the 1.4.0-rc window.
