### PR TITLE
CXXCBC-817: Fix template injection in GitHub Action

### DIFF
--- a/.github/actions/remove-cluster/action.yml
+++ b/.github/actions/remove-cluster/action.yml
@@ -9,5 +9,8 @@ runs:
   steps:
     - name: Remove cbdinocluster cluster
       shell: bash
+      env:
+        # Map input.id to an environment variable to prevent shell injection
+        CLUSTER_ID: ${{ inputs.id }}
       run: |
-        cbdinocluster -v rm ${{ inputs.id }}
+        cbdinocluster -v rm "$CLUSTER_ID"


### PR DESCRIPTION
Aikido flagged a potential template injection vulnerability in the remove-cluster GitHub Action at line 12. The shell step interpolated inputs.id directly into the command, enabling shell injection.

To mitigate this, map inputs.id to the CLUSTER_ID environment variable and reference it as "$CLUSTER_ID" inside the shell script. This prevents arbitrary shell commands from executing.