### PR TITLE
CXXCBC-872: fix replica-read leak of mcbp_command on io_context teardown

### DIFF
--- a/core/bucket.hxx
+++ b/core/bucket.hxx
@@ -88,8 +88,21 @@ public:
     }
     auto cmd = std::make_shared<operations::mcbp_command<bucket, Request>>(
       ctx_, shared_from_this(), request, default_timeout());
-    cmd->start([cmd, handler = std::forward<Handler>(handler)](
+    // Capture the command weakly. The completion is stored as cmd->handler_, so a strong capture
+    // forms a cmd -> handler_ -> cmd cycle that is only broken when the handler runs. For
+    // cancellable (replica fan-out) operations the completion is dispatched onto the command strand
+    // and can be discarded by io_context teardown (close() followed by io_context::stop()) before
+    // it runs, which would leak the command and everything it transitively holds (the bucket, its
+    // topology configuration, error map and session buffers). The command's lifetime is anchored
+    // independently by its deadline timer and session registration, so on any real completion the
+    // weak pointer still locks; when it does not, the command has already been torn down and the
+    // caller's response was going to be dropped regardless.
+    cmd->start([weak_cmd = cmd->weak_from_this(), handler = std::forward<Handler>(handler)](
                  std::error_code ec, std::optional<io::mcbp_message>&& msg) mutable {
+      auto cmd = weak_cmd.lock();
+      if (!cmd) {
+        return;
+      }
       using encoded_response_type = typename Request::encoded_response_type;
       std::uint16_t status_code = msg ? msg->header.status() : 0xffffU;
       auto resp = msg ? encoded_response_type(std::move(*msg)) : encoded_response_type{};


### PR DESCRIPTION
Fixes a memory leak in the replica-read path.

`bucket::execute()` stores its completion as `cmd->handler_` while capturing the command by `shared_ptr`, forming a `cmd -> handler_ -> cmd` self-cycle that is broken only when the completion runs. For cancellable (replica fan-out) operations the completion is dispatched onto the command strand and can be discarded by teardown (`close()` followed by `io_context::stop()`) before it runs, so the cycle is never broken and the command — plus the bucket, its topology configuration, error map and session buffers it transitively holds — leaks. LeakSanitizer reports ~174 KB behind a single `mcbp_command` in the any-replica read path (`integration: subdoc any replica reads`, and `get any replica` on other branches). Non-cancellable ops don't leak because `session::stop` completes them synchronously.

Capture the command weakly in the completion. Its lifetime is anchored independently by the deadline timer and session registration, so on any real completion the weak pointer still locks; on teardown, when nothing else holds it, the command is freed rather than pinned by its own stored handler. This is the generic `bucket::execute` path (all ops); it only leaked for cancellable ops today.

**Testing.** `test_integration_subdoc` passes (no regression; replica reads complete). Verified under LeakSanitizer (clang, `-DENABLE_SANITIZER_LEAK=ON`, BoringSSL off): 4 clean full-binary runs, no LeakSanitizer report (previously ~174 KB leaked).
