### PR TITLE
Build and test on Windows ARM64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,10 +39,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2025, windows-2022]
+        os: [windows-2025, windows-2022, windows-11-arm]
     runs-on: ${{ matrix.os }}
     steps:
+      # BoringSSL's x86/x64 assembly is assembled with nasm; the ARM64 leg
+      # builds with OPENSSL_NO_ASM and therefore does not need it.
       - name: Install dependencies
+        if: matrix.os != 'windows-11-arm'
         run: |
           choco install --no-progress nasm
       - uses: actions/checkout@v4
@@ -59,6 +62,9 @@ jobs:
           CB_CACHE_OPTION: sccache
           # CB_CMAKE_BUILD_TYPE: Release
           CB_CMAKE_BUILD_TYPE: RelWithDebInfo
+          # No BoringSSL assembly exists for the Windows ARM64 target, so build
+          # the crypto sources in portable C-only mode on that leg.
+          CB_OPENSSL_NO_ASM: ${{ matrix.os == 'windows-11-arm' && '1' || '' }}
           # CB_NUMBER_OF_JOBS deliberately unset: build-tests.rb now autodetects
           # the runner's processor count via Etc.nprocessors (4 on windows-2022/2025).
           # Combined with /MP added in CMakeLists.txt this enables both axes of

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,17 @@ if(WIN32)
   message(STATUS "Windows SDK: ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
 endif()
 
+# On Windows ARM64, MSVC's <winbase.h> defines C++ overloads for the
+# _Interlocked* intrinsics that clash with the intrinsic declarations pulled
+# in transitively (e.g. via asio/BoringSSL), breaking the build. Disabling
+# the C++ overloads restores the plain intrinsic declarations. Match both the
+# native case (CMAKE_SYSTEM_PROCESSOR) and the cross-compile case
+# (-A ARM64 sets CMAKE_GENERATOR_PLATFORM).
+if(MSVC AND (CMAKE_SYSTEM_PROCESSOR MATCHES "ARM64" OR CMAKE_GENERATOR_PLATFORM STREQUAL "ARM64"))
+  message(STATUS "Applying WinBase Interlocked macro for Windows ARM64")
+  add_compile_definitions(MICROSOFT_WINDOWS_WINBASE_H_DEFINE_INTERLOCKED_CPLUSPLUS_OVERLOADS=0)
+endif()
+
 # Multi-process compile for MSVC. With the Visual Studio generator each
 # .vcxproj invokes a single cl.exe that processes its source files
 # serially; /MP turns each invocation into a parallel batch driven by

--- a/bin/build-tests.rb
+++ b/bin/build-tests.rb
@@ -99,6 +99,13 @@ when /msan|memory/
   CB_CMAKE_EXTRAS << "-DENABLE_SANITIZER_MEMORY=ON"
 end
 
+# BoringSSL ships no hand-written assembly for the Windows ARM64 target, so
+# the crypto sources must be built in the portable C-only mode. The Windows
+# ARM64 CI leg sets CB_OPENSSL_NO_ASM=1 (see .github/workflows/build.yml).
+if ENV["CB_OPENSSL_NO_ASM"] == "1"
+  CB_CMAKE_EXTRAS << "-DOPENSSL_NO_ASM=1"
+end
+
 BUILD_DIR = if CB_SANITIZER.empty?
               File.join(PROJECT_ROOT, "cmake-build-tests")
             else

--- a/core/platform/random.cc
+++ b/core/platform/random.cc
@@ -25,7 +25,7 @@
 #include <mutex>
 #include <system_error>
 
-#ifdef WIN32
+#ifdef _WIN32
 // We need to include windows.h _before_ wincrypt.h
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
@@ -45,7 +45,7 @@ class RandomGeneratorProvider
 public:
   RandomGeneratorProvider()
   {
-#ifdef WIN32
+#ifdef _WIN32
     if (!CryptAcquireContext(
           &handle, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT | CRYPT_SILENT)) {
       throw std::system_error(int(GetLastError()),
@@ -69,7 +69,7 @@ public:
 
   virtual ~RandomGeneratorProvider()
   {
-#ifdef WIN32
+#ifdef _WIN32
     CryptReleaseContext(handle, 0);
 #else
     close(handle);
@@ -79,7 +79,7 @@ public:
   auto getBytes(void* dest, std::size_t size) -> bool
   {
     const std::scoped_lock<std::mutex> lock(mutex);
-#ifdef WIN32
+#ifdef _WIN32
     return CryptGenRandom(handle, (DWORD)size, static_cast<BYTE*>(dest));
 #else
 #if defined(__clang__) && defined(__clang_analyzer__)
@@ -92,7 +92,7 @@ public:
   }
 
 private:
-#ifdef WIN32
+#ifdef _WIN32
   HCRYPTPROV handle{};
 #else
   int handle = -1;


### PR DESCRIPTION
Adds Windows ARM64 (aarch64) support and a native CI leg. Reworks the approach attempted in PR #844 onto current main (that PR patched .github/workflows/windows.yml, which has since been merged into build.yml's `windows` job).

Changes:
- core/platform/random.cc: guard the Win32 CryptoAPI paths on the compiler-guaranteed `_WIN32` instead of `WIN32`. All five guards are converted for consistency so correctness no longer depends on <windows.h> back-filling `WIN32` after the first include.
- CMakeLists.txt: on MSVC ARM64 define MICROSOFT_WINDOWS_WINBASE_H_DEFINE_INTERLOCKED_CPLUSPLUS_OVERLOADS=0 to avoid the <winbase.h> _Interlocked* C++ overload clash. The guard matches both native (CMAKE_SYSTEM_PROCESSOR) and cross builds (-A ARM64 -> CMAKE_GENERATOR_PLATFORM).
- bin/build-tests.rb: honor CB_OPENSSL_NO_ASM=1 -> -DOPENSSL_NO_ASM=1, since BoringSSL ships no assembly for the Windows ARM64 target.
- .github/workflows/build.yml: add the windows-11-arm hosted runner to the matrix, set CB_OPENSSL_NO_ASM on that leg, and skip the nasm install there (only x86/x64 BoringSSL assembly needs it).

Fixes #843. Closes #844.