### PR TITLE
CXXCBC-875: fit_performer: forward named and positional query parameters independently

### DIFF
--- a/tools/fit_performer/src/commands/query.cxx
+++ b/tools/fit_performer/src/commands/query.cxx
@@ -64,34 +64,14 @@ to_query_options(const protocol::sdk::query::Command& cmd, observability::span_o
   if (cmd.options().has_readonly()) {
     options.readonly(cmd.options().readonly());
   }
-  // Named and positional parameters are mutually exclusive; named takes precedence (matches the
-  // reference Java performer, which uses positional only when there are no named parameters).
-  if (cmd.options().parameters_named_size() == 0 &&
-      cmd.options().parameters_positional_size() > 0) {
-#ifdef COUCHBASE_CXX_CLIENT_QUERY_OPTIONS_HAVE_ADD_PARAMETER
-    for (const auto& param : cmd.options().parameters_positional()) {
-      options.add_positional_parameter(param);
-    }
-#else
-    std::vector<std::vector<std::byte>> positional_params{};
-    for (const auto& param : cmd.options().parameters_positional()) {
-      positional_params.emplace_back(couchbase::codec::tao_json_serializer::serialize(param));
-    }
-    options.encoded_positional_parameters(positional_params);
-#endif
+  // Named and positional parameters are independent: a statement may use both at once (named
+  // values become $name body fields, positional values populate the args array). Each block is a
+  // no-op when its parameter set is empty, so both are forwarded unconditionally.
+  for (const auto& param : cmd.options().parameters_positional()) {
+    options.add_positional_parameter(param);
   }
-  if (cmd.options().parameters_named_size() > 0) {
-#ifdef COUCHBASE_CXX_CLIENT_QUERY_OPTIONS_HAVE_ADD_PARAMETER
-    for (const auto& [key, val] : cmd.options().parameters_named()) {
-      options.add_named_parameter(key, val);
-    }
-#else
-    std::map<std::string, std::vector<std::byte>, std::less<>> named_params{};
-    for (const auto& [key, val] : cmd.options().parameters_named()) {
-      named_params.emplace(key, couchbase::codec::tao_json_serializer::serialize(val));
-    }
-    options.encoded_named_parameters(named_params);
-#endif
+  for (const auto& [key, val] : cmd.options().parameters_named()) {
+    options.add_named_parameter(key, val);
   }
   if (cmd.options().has_flex_index()) {
     options.flex_index(cmd.options().flex_index());
@@ -125,7 +105,7 @@ to_query_options(const protocol::sdk::query::Command& cmd, observability::span_o
   }
   if (cmd.options().has_consistent_with()) {
     couchbase::mutation_state state{};
-    for (auto& t : cmd.options().consistent_with().tokens()) {
+    for (const auto& t : cmd.options().consistent_with().tokens()) {
       // Create a dummy mutation result to add the token to the state
       couchbase::mutation_token token{ static_cast<std::uint64_t>(t.partition_uuid()),
                                        static_cast<std::uint64_t>(t.sequence_number()),


### PR DESCRIPTION
The `fit_performer` query command forwarded positional parameters only when no named parameters were present:

```
if (named_size == 0 && positional_size > 0) { /* forward positional */ }
if (named_size > 0)                          { /* forward named */ }
```

So a statement supplying **both** named and positional parameters silently dropped the positional set. This removes the mutual-exclusion gate and forwards both unconditionally — each loop is a no-op when its set is empty, and the `add_positional_parameter` / `add_named_parameter` / `encoded_*_parameters` calls are unchanged.

**Reviewer note — behavioural change to confirm.** This reverses the previously-documented "named parameters win" parity with the Java performer. Please confirm that "forward both independently" is the intended current FIT protocol / reference-performer contract before merging.

Extracted from the CXXCBC-810 stack (PR #930); single commit, `tools/fit_performer/src/commands/query.cxx` only, no dependency on the other extracted changes.
