### PR TITLE
CXXCBC-877: regression guard for auto-rollback error surfacing (+ log-format fix)

### DIFF
--- a/core/transactions/transaction_context.cxx
+++ b/core/transactions/transaction_context.cxx
@@ -320,9 +320,15 @@ transaction_context::handle_error(const std::exception_ptr& err, txn_complete_ca
         current_attempt_context_->rollback();
       } catch (const std::exception& er_rollback) {
         cleanup().add_attempt(current_attempt_context_);
+        // A failed auto-rollback (including one that runs out of time and expires) re-raises the
+        // ORIGINAL error that provoked the rollback, with retry suppressed - the application cares
+        // about what made the rollback happen, not that the rollback then also failed. The
+        // reference SDKs surface EXPIRED only for an application-driven rollback, which this SDK
+        // does not expose (design doc "The Core Loop": propagate the original
+        // TransactionOperationFailed with retry set to false).
         CB_ATTEMPT_CTX_LOG_TRACE(
           current_attempt_context_,
-          "got error \"{}\" while auto rolling back, throwing original error",
+          "got error \"{}\" while auto rolling back, throwing original error \"{}\"",
           er_rollback.what(),
           er.what());
         auto final = er.get_final_exception(*this);

--- a/test/test_transaction_context.cxx
+++ b/test/test_transaction_context.cxx
@@ -20,8 +20,13 @@
 
 #include "core/operations.hxx"
 #include "core/transactions.hxx"
+#include "core/transactions/attempt_context_testing_hooks.hxx"
+#include "core/transactions/cleanup_testing_hooks.hxx"
+#include "core/transactions/exceptions.hxx"
+#include "core/transactions/internal/exceptions_internal.hxx"
 #include "core/transactions/internal/transaction_context.hxx"
 #include "core/transactions/internal/utils.hxx"
+#include "core/utils/movable_function.hxx"
 
 #include <exception>
 #include <spdlog/spdlog.h>
@@ -597,4 +602,59 @@ TEST_CASE("transactions: can not per transactions config", "[transactions]")
   REQUIRE(tx->config().timeout == txns->config().timeout);
   REQUIRE(tx->config().query_config.scan_consistency ==
           txns->config().query_config.scan_consistency);
+}
+
+// Regression guard for the FIT scenario
+// states.SetATRAbortedTest/SetATRRolledBackTest.failOtherRepeatedly_ShouldExpire (and
+// errorDuringExpiryOvertimeModeShouldBailOut): when an auto-rollback cannot complete because the
+// attempt has entered expiry-overtime, the user-facing error must remain the ORIGINAL failure that
+// provoked the rollback (surfaced here as failure_type::FAIL), not the rollback's own expiry
+// (failure_type::EXPIRY). Surfacing the rollback's expiry here is the regression that previously
+// broke these tests.
+TEST_CASE("transactions: auto-rollback that expires raises the original failure, not expiry",
+          "[transactions]")
+{
+  test::utils::integration_test_guard integration;
+  test::utils::open_bucket(integration.cluster, integration.ctx.bucket);
+
+  auto hooks = std::make_shared<attempt_context_testing_hooks>();
+  // Drop into expiry-overtime mode the moment the rollback reaches the ATR-abort stage...
+  hooks->has_expired_client_side = [](std::shared_ptr<attempt_context>,
+                                      const std::string& place,
+                                      std::optional<const std::string>) {
+    return place == STAGE_ATR_ABORT;
+  };
+  // ...and keep the ATR-abort failing so the rollback bails out while in overtime.
+  hooks->before_atr_aborted =
+    [](std::shared_ptr<attempt_context>,
+       couchbase::core::utils::movable_function<void(std::optional<error_class>)>&& cb) {
+      cb(error_class::FAIL_OTHER);
+    };
+
+  couchbase::transactions::transactions_config cfg{};
+  cfg.timeout(std::chrono::seconds(2));
+  cfg.test_factories(hooks, std::make_shared<cleanup_testing_hooks>());
+  auto [ec, txns] =
+    couchbase::core::transactions::transactions::create(integration.cluster, cfg).get();
+  REQUIRE_FALSE(ec);
+
+  couchbase::core::document_id id{
+    integration.ctx.bucket, "_default", "_default", test::utils::uniq_id("txn")
+  };
+
+  std::optional<failure_type> raised{};
+  try {
+    txns->run([&id](const std::shared_ptr<attempt_context>& ctx) {
+      ctx->insert(id, tx_content_json);
+      // The application raises a rollback-able failure. In ExtSDKIntegration there is no
+      // app-rollback, so this is an auto-rollback: the original failure must survive the rollback's
+      // own expiry-overtime bailout.
+      throw transaction_operation_failed(FAIL_OTHER, "force auto-rollback");
+    });
+  } catch (const transaction_exception& e) {
+    raised = e.type();
+  }
+
+  REQUIRE(raised.has_value());
+  REQUIRE(raised.value() == failure_type::FAIL);
 }


### PR DESCRIPTION
When a KV- or query-mode **auto**-rollback itself fails or runs out of time (expiry-overtime), the transaction must surface the **original** `TransactionOperationFailed` that provoked the rollback, not the rollback's own `FAIL_EXPIRY` (spec "The Core Loop": propagate the original failure with retry disabled; an `EXPIRED` result is reserved for an application-driven rollback, which this SDK does not expose).

**Honest framing:** this behaviour is *already correct* on `main` — `handle_error` re-raises the original error via the generic rollback catch. This PR is a **regression guard**, not a bug fix:

- Adds a cluster/integration test that forces expiry-overtime at `STAGE_ATR_ABORT` and asserts the surfaced failure is the original (`failure_type::FAIL`), not `EXPIRY`. It is green today (verified against a live cluster); its value is preventing a future regression.
- Fixes the auto-rollback failure log format string — it had one `{}` placeholder for two arguments, so the original error's message was dropped from the log.
- Documents the contract on the existing handler.

The dedicated `catch (const transaction_operation_failed&)` clause from the original branch draft is intentionally **not** included: it is behaviourally identical to the existing generic `catch (const std::exception&)` (which already catches and re-raises the original error), so it would be dead-equivalent code.

Extracted from the CXXCBC-810 stack (PR #930); single commit, standalone.
