### PR TITLE
CXXCBC-878: fit_performer: fix transaction-stream completion hang

### DIFF
--- a/tools/fit_performer/src/service.cxx
+++ b/tools/fit_performer/src/service.cxx
@@ -1328,7 +1328,7 @@ TxnService::clientRecordProcess(grpc::ServerContext* /*context*/,
 
 grpc::Status
 TxnService::transactionStream(
-  grpc::ServerContext* /*context*/,
+  grpc::ServerContext* context,
   grpc::ServerReaderWriter<protocol::transactions::TransactionStreamPerformerToDriver,
                            protocol::transactions::TransactionStreamDriverToPerformer>* stream)
 {
@@ -1394,6 +1394,7 @@ TxnService::transactionStream(
         auto worker_request = request;
         auto worker_conn = conn;
         worker = std::thread([this,
+                              context,
                               stream,
                               worker_request,
                               worker_conn,
@@ -1452,6 +1453,18 @@ TxnService::transactionStream(
             stream->Write(final_result);
           }
           spdlog::trace("{} done, wrote final result", worker_request.name());
+
+          // The transaction is finished, but the read loop below is still parked in a blocking
+          // stream->Read() waiting for the next driver message. The driver (RunningTransaction in
+          // the FIT test-driver) only stops blocking when it observes the stream close - receiving
+          // the final result message alone does not release blockOnResult(), and the driver never
+          // half-closes its outbound side. With nothing left to exchange, proactively end the RPC
+          // so the stream closes and the driver unblocks. TryCancel() is the only way to wake a
+          // synchronous gRPC reader from another thread; the final result was already written
+          // above, and gRPC delivers it before the cancellation, so the driver sees the result then
+          // treats the close as completion. This mirrors the reference .NET performer, whose
+          // end-of-stream likewise surfaces as onError(CANCELLED) on the driver.
+          context->TryCancel();
         });
       } else if (d2p.has_start()) {
         spdlog::info("{} got start", request.name());


### PR DESCRIPTION
The `transactionStream` RPC never closed the server stream after writing the final result, so the Java FIT driver parked in its blocking `Read()` (`blockOnResult()`) until the test timed out.

## Change

- Capture the `grpc::ServerContext` into the worker thread and, after writing the final result, call `context->TryCancel()` to close the stream so the driver's blocking read unblocks.

`TryCancel()` surfaces as `CANCELLED` on the driver; this mirrors the reference .NET performer and is intended (see the explaining comment in the code).

Extracted from the CXXCBC-810 stack (PR #930); single commit, `tools/fit_performer/src/service.cxx` only, no dependency on the other extracted changes.
