### PR TITLE
CXXCBC-879: fit_performer: propagate parallelize batch sub-command errors

### DIFF
--- a/tools/fit_performer/src/service.cxx
+++ b/tools/fit_performer/src/service.cxx
@@ -1215,6 +1215,12 @@ TxnService::execute_command(ConnectionPtr conn,
     uint32_t in_flight = 0;
     std::mutex mtx;
     std::condition_variable cv;
+    // A parallel sub-command can return a (non-throwing) operation error just like a serial one.
+    // The serial path propagates it to fail/roll back the transaction (see the run loop); mirror
+    // that here by keeping the first such error and returning it once all workers finish. This
+    // matches the reference Java performer's BatchExecutor, which stores the first thrown error and
+    // rethrows it after the batch completes.
+    couchbase::error batch_error{};
     // since we are fed the _synchronous_ transaction context, lets make N threads, have each of the
     // threads eat commands off the list of commands and perform them synchronously.   That insures
     // if we make the number of threads equal to the parallelism requested, we will always have that
@@ -1236,8 +1242,9 @@ TxnService::execute_command(ConnectionPtr conn,
         in_flight++;
         spdlog::trace("async executing command, {} now in-flight", in_flight);
         lock.unlock();
+        couchbase::error op_err{};
         try {
-          execute_command(conn, ctx, c, logger_prefix, txn_ctx, true);
+          op_err = execute_command(conn, ctx, c, logger_prefix, txn_ctx, true);
         } catch (...) {
           // Release the in-flight slot and wake a waiter even on exception; otherwise the other
           // workers can block forever in cv.wait() and f.get() below would deadlock. The exception
@@ -1250,6 +1257,9 @@ TxnService::execute_command(ConnectionPtr conn,
         }
         lock.lock();
         in_flight--;
+        if (op_err && !batch_error) {
+          batch_error = op_err;
+        }
         lock.unlock();
         cv.notify_one();
         lock.lock();
@@ -1263,6 +1273,7 @@ TxnService::execute_command(ConnectionPtr conn,
     for (auto& f : futures) {
       f.get();
     }
+    return batch_error;
   } else {
     throw performer_exception::unimplemented("Do not understand transaction command " +
                                              cmd.DebugString());


### PR DESCRIPTION
`execute_command` returns a `couchbase::error`, and the **serial** command path already propagates it (`if (op_err) { return op_err; }`). The **parallel** (`parallelize`) path discarded the result and ended with `return {}`, so a non-throwing operation error inside a parallel batch was silently swallowed — the transaction was neither failed nor rolled back, unlike the serial path.

## Change

- In the parallelize block, capture each sub-command's `couchbase::error`, keep the first non-empty one (under the existing batch lock), and return it so the batch fails/rolls back consistently with the serial path.

Extracted from the CXXCBC-810 stack (PR #930); single commit, `tools/fit_performer/src/service.cxx` only, no dependency on the other extracted changes.
