### PR TITLE
CXXCBC-880: fit_performer: harden content decoding and range-scan error reporting

### DIFF
--- a/tools/fit_performer/src/commands/common.hxx
+++ b/tools/fit_performer/src/commands/common.hxx
@@ -171,6 +171,11 @@ result_to_content(const Result& result,
   std::visit(
     overloaded{
       [&](std::monostate) {
+        // No transcoder specified: use the SDK's default read behaviour for this result type so the
+        // performer exercises the real SDK path. Transaction reads decode leniently (ignoring the
+        // document's common flags, per ExtBinarySupport), while ordinary KV reads use the strict
+        // JSON transcoder; any discrepancy here is an SDK issue to fix rather than to paper over in
+        // the performer.
         switch (proto_content_as.as_case()) {
           case protocol::shared::ContentAs::kAsString: {
             proto_res_content->set_content_as_string(result.template content_as<std::string>());
@@ -286,6 +291,62 @@ result_to_content(const Result& result,
           "unsupported transcoder - content type combination");
       } },
     transcoder);
+}
+
+// result_to_content()/multi_result_to_content() raise performer_exception for a transcoder /
+// content-type pair they cannot render. That pairing is a property of the request, not of the
+// document, so it can be checked before any document is read. Callers that decode inside a
+// streaming producer (e.g. range scan) must validate it up front instead: a performer_exception
+// thrown from the producer cannot be surfaced cleanly (it would abort the run via a blocking future
+// teardown), whereas one thrown here, during command setup, propagates to run() and becomes a
+// non-success gRPC status (UNIMPLEMENTED, the same performer_exception::unimplemented that
+// result_to_content() raises for the pairing). Keep the supported sets in sync with
+// result_to_content().
+inline void
+ensure_content_combo_supported(const transcoder& transcoder,
+                               const protocol::shared::ContentAs& proto_content_as)
+{
+  const auto content_case = proto_content_as.as_case();
+  const auto is_json_family = [&]() {
+    switch (content_case) {
+      case protocol::shared::ContentAs::kAsString:
+      case protocol::shared::ContentAs::kAsByteArray:
+      case protocol::shared::ContentAs::kAsJsonObject:
+      case protocol::shared::ContentAs::kAsJsonArray:
+      case protocol::shared::ContentAs::kAsBoolean:
+      case protocol::shared::ContentAs::kAsInteger:
+      case protocol::shared::ContentAs::kAsFloatingPoint:
+        return true;
+      default:
+        return false;
+    }
+  };
+  const bool supported =
+    std::visit(overloaded{
+                 [&](std::monostate) {
+                   return is_json_family();
+                 },
+                 [&](couchbase::codec::default_json_transcoder) {
+                   return is_json_family();
+                 },
+                 [&](couchbase::codec::raw_binary_transcoder) {
+                   return content_case == protocol::shared::ContentAs::kAsByteArray;
+                 },
+                 [&](couchbase::codec::raw_json_transcoder) {
+                   return content_case == protocol::shared::ContentAs::kAsString ||
+                          content_case == protocol::shared::ContentAs::kAsByteArray;
+                 },
+                 [&](couchbase::codec::raw_string_transcoder) {
+                   return content_case == protocol::shared::ContentAs::kAsString;
+                 },
+                 [&](auto) {
+                   return false;
+                 },
+               },
+               transcoder);
+  if (!supported) {
+    throw performer_exception::unimplemented("unsupported transcoder - content type combination");
+  }
 }
 
 template<typename Result>

--- a/tools/fit_performer/src/commands/key_value.cxx
+++ b/tools/fit_performer/src/commands/key_value.cxx
@@ -2023,6 +2023,11 @@ execute_streaming_command(const protocol::sdk::kv::rangescan::Scan& cmd, const c
     std::optional<protocol::shared::ContentAs> content_as{};
     if (cmd.has_content_as()) {
       content_as = cmd.content_as();
+      // Reject an unsupported transcoder/content-type combination now, while still on the command
+      // setup path: it is a pairing this performer does not support, and throwing here surfaces it
+      // as a non-success gRPC status (UNIMPLEMENTED, via run()). The producer below cannot raise it
+      // cleanly once the stream is running, so it must be caught up front.
+      common::ensure_content_combo_supported(transcoder, content_as.value());
     }
     return [transcoder,
             content_as,
@@ -2040,11 +2045,43 @@ execute_streaming_command(const protocol::sdk::kv::rangescan::Scan& cmd, const c
         spdlog::trace("next_fn has no more scan entries, returning std::nullopt");
         return std::nullopt;
       }
-      from_scan_result_item(stream_id,
-                            item.value(),
-                            transcoder,
-                            content_as,
-                            proto_res.mutable_sdk()->mutable_range_scan_result());
+      try {
+        from_scan_result_item(stream_id,
+                              item.value(),
+                              transcoder,
+                              content_as,
+                              proto_res.mutable_sdk()->mutable_range_scan_result());
+      } catch (const std::system_error& e) {
+        // A per-item SDK decode error carrying a std::error_code: surface it as a typed Couchbase
+        // exception via convert_error_code (as elsewhere in this file) so the driver sees the
+        // error_code/category rather than an opaque message. Still returned as an error result, not
+        // an escaping exception -- an escaping exception unwinds the stream writer task
+        // (stream.hxx) without a terminal stream message and hangs the driver until its test
+        // timeout.
+        spdlog::debug("next_fn failed decoding scan item \"{}\" for stream {}: {} ({})",
+                      item.value().id(),
+                      stream_id,
+                      e.what(),
+                      e.code().message());
+        auto err_res = common::create_new_result();
+        common::convert_error_code(e.code(), err_res.mutable_sdk()->mutable_exception());
+        return err_res;
+      } catch (const std::exception& e) {
+        // Any other per-item decode error: the transcoder/content-type combination was validated
+        // during setup, so result_to_content() no longer raises performer_exception on this path.
+        // Report it as an SDK error result rather than letting it escape the producer (see above).
+        spdlog::debug("next_fn failed decoding scan item \"{}\" for stream {}: {}",
+                      item.value().id(),
+                      stream_id,
+                      e.what());
+        auto err_res = common::create_new_result();
+        err_res.mutable_sdk()->mutable_exception()->mutable_other()->set_name(
+          fmt::format("range-scan decode failed (stream {}, id \"{}\"): {}",
+                      stream_id,
+                      item.value().id(),
+                      e.what()));
+        return err_res;
+      }
       return proto_res;
     };
   }


### PR DESCRIPTION
Two content-path robustness gaps in the performer:

1. There was no up-front validation that the requested transcoder / content-type combination is supported before a command runs, so an unsupported combo failed deep in the operation.
2. The range-scan producer called `from_scan_result_item(...)` with no try/catch; a per-item decode exception escaped the streaming producer and tore down the stream writer without a terminal message, hanging the driver until timeout.

## Changes

- Add `ensure_content_combo_supported()` to validate the transcoder/content-type pairing during command setup.
- Wrap per-item decode in the range-scan producer in a try/catch that converts a decode exception into an SDK error result instead of letting it escape.

Notes: `lenient_json_transcoder` already exists on `main` and is not touched here. The `ensure_content_combo_supported` support set must stay in sync with `result_to_content` (flagged in a code comment).

Extracted from the CXXCBC-810 stack (PR #930); single commit, `tools/fit_performer/src/commands/{common.hxx,key_value.cxx}` only, no dependency on the other extracted changes.
