### PR TITLE
CXXCBC-881: fit_performer: serialize concurrent cleanup-hook RPCs (fix double-free)

### DIFF
--- a/tools/fit_performer/src/service.cxx
+++ b/tools/fit_performer/src/service.cxx
@@ -434,6 +434,9 @@ TxnService::transactionCleanup(grpc::ServerContext* /*context*/,
   try {
     auto txn =
       couchbase::core::transactions::get_core_transactions(conn->cluster()->transactions());
+    // Serialize the shared-config mutation and the cleanup that reads it (see
+    // cleanup_config_mutex_).
+    const std::scoped_lock<std::mutex> cleanup_lock(cleanup_config_mutex_);
     txn->cleanup().config().cleanup_hooks = std::move(hook_pair.second);
     auto id = to_couchbase_docid(request->atr());
     couchbase::core::transactions::atr_cleanup_entry entry(
@@ -467,6 +470,9 @@ TxnService::transactionCleanupATR(
   try {
     auto txn =
       couchbase::core::transactions::get_core_transactions(conn->cluster()->transactions());
+    // Serialize the shared-config mutation and the cleanup that reads it (see
+    // cleanup_config_mutex_).
+    const std::scoped_lock<std::mutex> cleanup_lock(cleanup_config_mutex_);
     txn->config().attempt_context_hooks = std::move(hook_pair.first);
     txn->cleanup().config().cleanup_hooks = std::move(hook_pair.second);
 
@@ -1286,6 +1292,9 @@ TxnService::clientRecordProcess(grpc::ServerContext* /*context*/,
 
   auto hook_pair = fit_cxx::TxnSvcHook::convert_hooks(request->hook(), hooks, conn);
   auto txn = couchbase::core::transactions::get_core_transactions(conn->cluster()->transactions());
+  // Serialize the shared-config mutation and the cleanup that reads it (see cleanup_config_mutex_).
+  // The lock is held across run_with_timeout so get_active_clients observes the hooks set here.
+  const std::scoped_lock<std::mutex> cleanup_lock(cleanup_config_mutex_);
   txn->config().attempt_context_hooks = std::move(hook_pair.first);
   txn->cleanup().config().cleanup_hooks = std::move(hook_pair.second);
   return conn->run_with_timeout<grpc::Status>(

--- a/tools/fit_performer/src/service.hxx
+++ b/tools/fit_performer/src/service.hxx
@@ -65,6 +65,15 @@ private:
   std::mt19937 generator_;
   fit_cxx::observability::span_owner spans_{};
 
+  // The core transactions object returned by get_core_transactions() is shared per connection
+  // across all concurrent gRPC worker threads. The test-only cleanup RPCs (transactionCleanup,
+  // transactionCleanupATR, clientRecordProcess) inject per-request hooks by overwriting the shared
+  // config's hook shared_ptrs and then immediately run a cleanup operation that reads them.
+  // Serialize those critical sections: concurrent RPCs would otherwise move-assign the same
+  // shared_ptr instance from multiple threads, releasing its control block twice (double-free /
+  // heap corruption).
+  std::mutex cleanup_config_mutex_;
+
   // Thread-safe accessors for the stashed-result state, which is shared across all concurrent
   // transactions/worker threads. Getters return copies so the value can be used safely (e.g. in a
   // blocking transaction op) after the lock is released.


### PR DESCRIPTION
The test-only cleanup RPCs (`transactionCleanup`, `transactionCleanupATR`, `clientRecordProcess`) inject per-request hooks by overwriting the shared per-connection core-transactions config's hook `shared_ptr`s (`txn->cleanup().config().cleanup_hooks = …`, `txn->config().attempt_context_hooks = …`) and then immediately run a cleanup operation that reads them. The core transactions object is shared across all concurrent gRPC worker threads on a connection, so concurrent cleanup RPCs move-assign the same `shared_ptr` from multiple threads, releasing its control block twice — double-free / heap corruption.

## Change

- Add a performer-side `cleanup_config_mutex_` and hold it across each set-hooks-then-cleanup critical section (the three RPC handlers). In `clientRecordProcess` the lock is held across `run_with_timeout` so `get_active_clients` observes the hooks set for that request.

Notes: performer-only — uses `main`'s direct `config().cleanup_hooks = …` assignment, so it does not depend on any core change. The unrelated `get_multi_replicas` clang-format reflow from the original branch draft is dropped.

Extracted from the CXXCBC-810 stack (PR #930); single commit, `tools/fit_performer/src/service.{cxx,hxx}` only, no dependency on the other extracted changes.
