### PR TITLE
CXXCBC-885: hand-rolled test harness for the CNG test tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -637,6 +637,19 @@ if(COUCHBASE_CXX_CLIENT_BUILD_TESTS)
   include(cmake/Testing.cmake)
 endif()
 
+# CNG (Protostellar) tests use a hand-rolled framework (NOT Catch2), so they can be built
+# independently of the main (Catch2) test suite. Individual cases opt into linking the client
+# library via the LINK_CLIENT argument to add_cng_test() in test/cng/CMakeLists.txt; the framework
+# itself does not require it.
+option(COUCHBASE_CXX_CLIENT_BUILD_CNG_TESTS "Build CNG (Protostellar) tests"
+       ${COUCHBASE_CXX_CLIENT_BUILD_TESTS})
+if(COUCHBASE_CXX_CLIENT_BUILD_CNG_TESTS)
+  # Enable testing at the top level so `ctest` from the build root discovers the CNG tests even
+  # when the main (Catch2) suite is disabled and cmake/Testing.cmake was not included.
+  enable_testing()
+  add_subdirectory(test/cng)
+endif()
+
 option(COUCHBASE_CXX_CLIENT_BUILD_DOCS "Build API documentation" ${COUCHBASE_CXX_CLIENT_MASTER_PROJECT})
 if(COUCHBASE_CXX_CLIENT_BUILD_DOCS)
   include(cmake/Documentation.cmake)

--- a/test/cng/CMakeLists.txt
+++ b/test/cng/CMakeLists.txt
@@ -1,0 +1,48 @@
+# CNG (Protostellar) test tree.
+#
+# Uses a small hand-rolled framework (see framework/, CXXCBC-885), deliberately NOT Catch2.
+# See test/cng/README.md to build and run these tests. Enabled via COUCHBASE_CXX_CLIENT_BUILD_CNG_TESTS.
+
+find_package(Threads REQUIRED)
+
+# Shared harness: the runner + the shared main(). Each test executable links this and provides
+# its own tests(). fmt comes from spdlog's bundled copy (header include dirs only).
+add_library(
+  cng_test_main STATIC
+  ${PROJECT_SOURCE_DIR}/test/cng/framework/test_runner.cxx
+  ${PROJECT_SOURCE_DIR}/test/cng/framework/test_main.cxx)
+target_include_directories(cng_test_main PUBLIC ${PROJECT_SOURCE_DIR}/test/cng
+                                                ${PROJECT_SOURCE_DIR})
+target_include_directories(
+  cng_test_main SYSTEM BEFORE
+  PUBLIC $<BUILD_INTERFACE:$<TARGET_PROPERTY:spdlog::spdlog,INTERFACE_INCLUDE_DIRECTORIES>>)
+target_link_libraries(cng_test_main PUBLIC Threads::Threads)
+set_project_options(cng_test_main)
+set_project_warnings(cng_test_main)
+
+# add_cng_test(<relpath>) — relpath is under test/cng/ without extension (e.g.
+# framework/framework_selftest). The executable/ctest name is the file stem prefixed with cng_.
+function(add_cng_test relpath)
+  get_filename_component(stem ${relpath} NAME_WE)
+  set(target cng_${stem}_test)
+  # The name comes from the file stem, not the full relpath, so kv/options.cxx and
+  # query/options.cxx would both want cng_options_test. Fail loudly at configure time instead of
+  # letting the second add_executable() error out cryptically (or worse, silently win).
+  if(TARGET ${target})
+    message(FATAL_ERROR "add_cng_test(${relpath}): target ${target} already exists. Two test files "
+                        "share a stem -- rename one of them.")
+  endif()
+  add_executable(${target} ${PROJECT_SOURCE_DIR}/test/cng/${relpath}.cxx)
+  target_include_directories(${target} PRIVATE ${PROJECT_SOURCE_DIR}/test/cng ${PROJECT_SOURCE_DIR})
+  target_include_directories(
+    ${target} SYSTEM BEFORE
+    PRIVATE $<BUILD_INTERFACE:$<TARGET_PROPERTY:spdlog::spdlog,INTERFACE_INCLUDE_DIRECTORIES>>)
+  target_link_libraries(${target} PRIVATE cng_test_main Threads::Threads)
+  set_project_options(${target})
+  set_project_warnings(${target})
+  add_test(NAME ${target} COMMAND $<TARGET_FILE:${target}>)
+  # The harness returns 77 when every case was skipped; map that to ctest's "Skipped".
+  set_tests_properties(${target} PROPERTIES SKIP_RETURN_CODE 77 LABELS "cng")
+endfunction()
+
+add_cng_test(framework/framework_selftest)

--- a/test/cng/framework/framework_selftest.cxx
+++ b/test/cng/framework/framework_selftest.cxx
@@ -1,0 +1,216 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Self-test for the CNG test framework. It exercises the runner's pass / fail / skip / timeout /
+// env-gating / filter behaviour by driving run() with in-memory sub-suites and asserting on the
+// returned run_result. Because it asserts on the runner's *return value* (rather than letting an
+// inner failure propagate), every case here passes and this binary exits 0.
+
+#include "test_runner.hxx"
+
+#include <chrono>
+#include <cstddef>
+#include <set>
+#include <sstream>
+#include <thread>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+// Case bodies used to build the in-memory sub-suites the runner is tested against.
+void
+body_pass()
+{
+  assert_true(true);
+}
+void
+body_fail()
+{
+  assert_true(false, "intentional failure");
+}
+void
+body_skip()
+{
+  skip("intentional skip");
+}
+void
+body_sleep()
+{
+  std::this_thread::sleep_for(std::chrono::milliseconds{ 200 });
+}
+
+// A sink for the runner's progress output so the self-test stays quiet.
+auto
+run_quiet(const test_suite& suite, const std::set<std::string>& filter, bool real_cluster)
+  -> run_result
+{
+  std::ostringstream sink;
+  return run(suite, filter, real_cluster, sink);
+}
+
+// ── the self-test cases ──────────────────────────────────────────────────────
+
+void
+should_run_gating_is_correct()
+{
+  assert_true(should_run(test_env::agnostic, false), "agnostic runs in mock mode");
+  assert_true(should_run(test_env::agnostic, true), "agnostic runs in real mode");
+  assert_true(should_run(test_env::any_server, false), "any_server runs in mock mode");
+  assert_true(should_run(test_env::any_server, true), "any_server runs in real mode");
+  assert_true(should_run(test_env::mock_only, false), "mock_only runs in mock mode");
+  assert_false(should_run(test_env::mock_only, true), "mock_only skipped in real mode");
+  assert_false(should_run(test_env::cluster_only, false), "cluster_only skipped in mock mode");
+  assert_true(should_run(test_env::cluster_only, true), "cluster_only runs in real mode");
+}
+
+void
+runner_reports_a_passing_case()
+{
+  const test_suite s{ "inner", { { "p", body_pass } } };
+  const auto r = run_quiet(s, {}, false);
+  assert_eq(r.passed, std::size_t{ 1 }, "one pass counted");
+  assert_eq(r.failed, std::size_t{ 0 }, "no failures");
+  assert_eq(exit_code(r), 0, "exit code 0 on success");
+}
+
+void
+runner_detects_a_failing_case()
+{
+  const test_suite s{ "inner", { { "f", body_fail } } };
+  const auto r = run_quiet(s, {}, false);
+  assert_eq(r.failed, std::size_t{ 1 }, "one failure counted");
+  assert_eq(exit_code(r), 1, "exit code 1 on failure");
+}
+
+void
+runner_reports_a_skipped_case()
+{
+  const test_suite s{ "inner", { { "s", body_skip } } };
+  const auto r = run_quiet(s, {}, false);
+  assert_eq(r.skipped, std::size_t{ 1 }, "one skip counted");
+  assert_eq(r.failed, std::size_t{ 0 }, "skip is not a failure");
+}
+
+void
+runner_detects_a_timeout()
+{
+  // 200ms body against a 20ms budget must be reported as a failure.
+  const test_suite s{ "inner", { { "t", body_sleep, std::chrono::milliseconds{ 20 } } } };
+  const auto r = run_quiet(s, {}, false);
+  assert_eq(r.failed, std::size_t{ 1 }, "timeout counted as a failure");
+}
+
+void
+env_gating_skips_cluster_only_without_a_cluster()
+{
+  const test_suite s{ "inner", { { "c", body_pass, default_timeout, test_env::cluster_only } } };
+  const auto without = run_quiet(s, {}, /*real_cluster=*/false);
+  assert_eq(without.skipped, std::size_t{ 1 }, "cluster_only skipped without a cluster");
+  assert_eq(without.passed, std::size_t{ 0 }, "cluster_only did not run without a cluster");
+
+  const auto with = run_quiet(s, {}, /*real_cluster=*/true);
+  assert_eq(with.passed, std::size_t{ 1 }, "cluster_only runs with a cluster");
+}
+
+void
+filter_selects_cases_by_name()
+{
+  const test_suite s{ "inner", { { "a", body_pass }, { "b", body_pass } } };
+  const auto r = run_quiet(s, { "a" }, false);
+  assert_eq(r.passed, std::size_t{ 1 }, "only the filtered case runs");
+}
+
+void
+a_failing_case_does_not_suppress_later_cases()
+{
+  // One ctest test is registered per executable, so abandoning the suite on the first failure
+  // would hide every later regression in the same binary until the first one is fixed.
+  const test_suite s{ "inner", { { "f", body_fail }, { "p", body_pass }, { "s", body_skip } } };
+  const auto r = run_quiet(s, {}, false);
+  assert_eq(r.failed, std::size_t{ 1 }, "the failure is counted");
+  assert_eq(r.passed, std::size_t{ 1 }, "a later case still runs after a failure");
+  assert_eq(r.skipped, std::size_t{ 1 }, "a later skip is still reported after a failure");
+}
+
+void
+slow_cases_run_after_a_failure()
+{
+  test_suite s{ "inner", { { "f", body_fail } } };
+  s.slow_test_cases = { { "p", body_pass } };
+  const auto r = run_quiet(s, {}, false);
+  assert_eq(r.passed, std::size_t{ 1 }, "slow cases are not abandoned by an earlier failure");
+}
+
+void
+a_filter_name_matching_nothing_fails()
+{
+  const test_suite s{ "inner", { { "a", body_pass } } };
+  const auto r = run_quiet(s, { "typo" }, false);
+  assert_eq(r.passed, std::size_t{ 0 }, "nothing ran");
+  assert_eq(r.failed, std::size_t{ 1 }, "an unmatched filter name is a failure");
+  assert_eq(exit_code(r), 1, "exit code 1, not a silent pass");
+}
+
+void
+a_suite_that_runs_nothing_does_not_pass()
+{
+  const test_suite empty{ "inner", {} };
+  const auto r = run_quiet(empty, {}, false);
+  assert_eq(r.passed, std::size_t{ 0 }, "nothing ran");
+  assert_eq(r.skipped, std::size_t{ 0 }, "nothing skipped");
+  assert_eq(exit_code(r), 1, "an empty suite must not report success");
+}
+
+void
+a_timeout_is_reported_as_such()
+{
+  // main() needs to distinguish a timeout from an ordinary failure: only a timeout leaves a
+  // detached worker thread, which dictates how the process exits.
+  const test_suite s{ "inner", { { "t", body_sleep, std::chrono::milliseconds{ 20 } } } };
+  const auto r = run_quiet(s, {}, false);
+  assert_eq(r.timed_out, std::size_t{ 1 }, "the timeout is flagged separately");
+  assert_eq(r.failed, std::size_t{ 1 }, "and still counted as a failure");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "framework_selftest",
+    {
+      { "should_run_gating_is_correct", should_run_gating_is_correct },
+      { "runner_reports_a_passing_case", runner_reports_a_passing_case },
+      { "runner_detects_a_failing_case", runner_detects_a_failing_case },
+      { "runner_reports_a_skipped_case", runner_reports_a_skipped_case },
+      { "runner_detects_a_timeout", runner_detects_a_timeout, timeout::fast },
+      { "env_gating_skips_cluster_only_without_a_cluster",
+        env_gating_skips_cluster_only_without_a_cluster },
+      { "filter_selects_cases_by_name", filter_selects_cases_by_name },
+      { "a_failing_case_does_not_suppress_later_cases",
+        a_failing_case_does_not_suppress_later_cases },
+      { "slow_cases_run_after_a_failure", slow_cases_run_after_a_failure },
+      { "a_filter_name_matching_nothing_fails", a_filter_name_matching_nothing_fails },
+      { "a_suite_that_runs_nothing_does_not_pass", a_suite_that_runs_nothing_does_not_pass },
+      { "a_timeout_is_reported_as_such", a_timeout_is_reported_as_such, timeout::fast },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test

--- a/test/cng/framework/test_framework.hxx
+++ b/test/cng/framework/test_framework.hxx
@@ -1,0 +1,291 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+// A small hand-rolled test framework for the CNG (Protostellar) test tree.
+//
+// This deliberately does NOT use Catch2 (the couchbase-cxx-client default). Its design is
+// ported from the author's stand-alone harness, adapted from C++23 to the C++17 that this
+// library targets: std::print -> fmt, std::move_only_function -> plain function pointers,
+// std::jthread -> std::thread, std::source_location -> the builtin-based shim below.
+//
+// A test file provides `tests()` returning a `test_suite`; the runner (see test_runner.hxx)
+// executes each `test_case` on a worker thread with a per-case timeout and reports the outcome.
+
+#include <chrono>
+#include <cstdint>
+#include <exception>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+// The wrapper (not <spdlog/fmt/bundled/format.h>) is required: it defines FMT_HEADER_ONLY for this
+// standalone test framework, which links spdlog's headers only, not its compiled fmt.
+#include <spdlog/fmt/fmt.h>
+
+namespace couchbase::cng::test
+{
+
+// C++17 stand-in for std::source_location (C++20). Where __builtin_FILE/LINE/FUNCTION exist they
+// evaluate at the call site when used as default arguments, so an assertion helper can capture its
+// caller's location without a macro. On a toolchain that lacks the builtins the shim degrades to an
+// unknown location rather than failing to compile.
+//
+// The probe is deliberately __has_builtin (plus bare __clang__, whose older releases lack the
+// probe). MSVC exposes the builtins from 16.6 but only gained __has_builtin in VS 2022 17.1, so
+// 16.6-17.0 takes the "unknown" branch: correct, just less informative. Not special-cased because
+// no CI leg builds those versions, and an untested #if is worse than a documented limitation.
+#if defined(__has_builtin)
+#define COUCHBASE_CNG_HAS_LOCATION_BUILTINS                                                        \
+  (__has_builtin(__builtin_FILE) && __has_builtin(__builtin_LINE) &&                               \
+   __has_builtin(__builtin_FUNCTION))
+#elif defined(__clang__)
+#define COUCHBASE_CNG_HAS_LOCATION_BUILTINS 1
+#else
+#define COUCHBASE_CNG_HAS_LOCATION_BUILTINS 0
+#endif
+
+class source_location
+{
+public:
+#if COUCHBASE_CNG_HAS_LOCATION_BUILTINS
+  static constexpr auto current(const char* file = __builtin_FILE(),
+                                int line = __builtin_LINE(),
+                                const char* function = __builtin_FUNCTION()) noexcept
+    -> source_location
+#else
+  static constexpr auto current(const char* file = "unknown",
+                                int line = 0,
+                                const char* function = "unknown") noexcept -> source_location
+#endif
+  {
+    source_location loc;
+    loc.file_ = file;
+    loc.line_ = static_cast<std::uint_least32_t>(line);
+    loc.function_ = function;
+    return loc;
+  }
+
+  [[nodiscard]] constexpr auto file_name() const noexcept -> const char*
+  {
+    return file_;
+  }
+  [[nodiscard]] constexpr auto line() const noexcept -> std::uint_least32_t
+  {
+    return line_;
+  }
+  [[nodiscard]] constexpr auto function_name() const noexcept -> const char*
+  {
+    return function_;
+  }
+
+private:
+  const char* file_{ "" };
+  std::uint_least32_t line_{ 0 };
+  const char* function_{ "" };
+};
+
+#undef COUCHBASE_CNG_HAS_LOCATION_BUILTINS
+
+// Timeout presets — use these instead of raw millisecond values so timing expectations are
+// explicit. Mirrors the presets in the source harness.
+namespace timeout
+{
+using namespace std::chrono_literals;
+inline constexpr auto instant = 500ms;   // pure computation, no I/O
+inline constexpr auto fast = 2'000ms;    // minimal I/O
+inline constexpr auto network = 5'000ms; // network operations
+// integration and slow are equal by coincidence, not by definition: they express different
+// intents (waiting on an external system vs. a deliberate in-test delay) and either may be
+// retuned without regard for the other. Pick by what the case is waiting for, not by the value.
+inline constexpr auto integration = 30'000ms; // external processes / real cluster
+inline constexpr auto slow = 30'000ms;        // intentional delays
+} // namespace timeout
+
+inline constexpr auto default_timeout = timeout::network;
+
+// Which server environment a case needs. `real_cluster` encodes exactly one thing -- whether
+// TEST_CONNECTION_STRING is set -- so its false branch means "no cluster configured", NOT "a mock
+// is running": there is no CNG mock gateway, and none is planned. Tests that need a server of
+// their own stand up an in-process gRPC server and are therefore `agnostic`.
+//
+// So today only `agnostic` and `cluster_only` are used. `any_server` and `mock_only` are carried
+// over from the harness this was ported from and are reserved for a mock that does not exist yet.
+// Note `any_server` would run with nothing to talk to if used now -- give it a third state
+// (no server at all) before adopting it.
+//
+//   * no cluster (unset): agnostic + any_server + mock_only; cluster_only is skipped
+//   * real cluster (set): agnostic + any_server + cluster_only; mock_only is skipped
+enum class test_env : std::uint8_t {
+  agnostic,     // no external server needed (pure unit, or brings its own in-process server)
+  any_server,   // reserved: basic ops against whichever server is active
+  mock_only,    // reserved: needs mock-specific behaviour (fault injection)
+  cluster_only, // needs a real Couchbase cluster / gateway.
+};
+
+[[nodiscard]] constexpr auto
+should_run(test_env env, bool real_cluster) noexcept -> bool
+{
+  switch (env) {
+    case test_env::agnostic:
+    case test_env::any_server:
+      return true;
+    case test_env::mock_only:
+      return !real_cluster;
+    case test_env::cluster_only:
+      return real_cluster;
+  }
+  return true;
+}
+
+// Thrown by skip() to mark a case skipped at runtime — for preconditions the coarse env field
+// cannot express. The runner reports it distinctly from a failure.
+class test_skip_exception : public std::exception
+{
+public:
+  explicit test_skip_exception(std::string reason)
+    : reason_{ std::move(reason) }
+  {
+  }
+  [[nodiscard]] auto what() const noexcept -> const char* override
+  {
+    return reason_.c_str();
+  }
+  [[nodiscard]] auto reason() const noexcept -> const std::string&
+  {
+    return reason_;
+  }
+
+private:
+  std::string reason_;
+};
+
+// Thrown by the assert_* helpers on a failed assertion. The runner catches it and marks the
+// case failed (without aborting the process, so a self-test can exercise the failure path).
+class test_assertion_failure : public std::exception
+{
+public:
+  explicit test_assertion_failure(std::string message)
+    : message_{ std::move(message) }
+  {
+  }
+  [[nodiscard]] auto what() const noexcept -> const char* override
+  {
+    return message_.c_str();
+  }
+
+private:
+  std::string message_;
+};
+
+struct test_case {
+  std::string name;
+  void (*func)();
+  std::chrono::milliseconds timeout{ default_timeout };
+  test_env env{ test_env::agnostic };
+};
+
+struct test_suite {
+  std::string name;
+  std::vector<test_case> test_cases;
+  std::vector<test_case> slow_test_cases{};
+};
+
+// Each test file defines this.
+auto
+tests() -> test_suite;
+
+// ── Assertions ────────────────────────────────────────────────────────────────
+
+[[noreturn]] inline void
+skip(std::string reason)
+{
+  throw test_skip_exception(std::move(reason));
+}
+
+inline void
+assert_true(bool value,
+            std::string_view message = "expected true",
+            source_location loc = source_location::current())
+{
+  if (!value) {
+    throw test_assertion_failure(fmt::format("{}:{}: {}", loc.file_name(), loc.line(), message));
+  }
+}
+
+inline void
+assert_false(bool value,
+             std::string_view message = "expected false",
+             source_location loc = source_location::current())
+{
+  assert_true(!value, message, loc);
+}
+
+// Report both operands when they are formattable. Without this the message says only "expected
+// equal", so a failure tells you the values differed but not what they were -- the one place where
+// not using Catch2 (whose expression decomposition prints operands) costs something concrete. The
+// `if constexpr` keeps assert_eq usable with types fmt cannot format.
+template<typename A, typename B>
+inline void
+assert_eq(const A& actual,
+          const B& expected,
+          std::string_view message = "expected equal",
+          source_location loc = source_location::current())
+{
+  if (!(actual == expected)) {
+    if constexpr (fmt::is_formattable<A>::value && fmt::is_formattable<B>::value) {
+      throw test_assertion_failure(fmt::format("{}:{}: {} (actual: {}, expected: {})",
+                                               loc.file_name(),
+                                               loc.line(),
+                                               message,
+                                               actual,
+                                               expected));
+    } else {
+      throw test_assertion_failure(fmt::format("{}:{}: {}", loc.file_name(), loc.line(), message));
+    }
+  }
+}
+
+// Invoke `fn` and require it to throw an exception of type Exc.
+template<typename Exc, typename Fn>
+inline void
+assert_throws(Fn&& fn,
+              std::string_view message = "expected exception",
+              source_location loc = source_location::current())
+{
+  bool threw_expected = false;
+  try {
+    std::forward<Fn>(fn)();
+  } catch (const Exc&) {
+    threw_expected = true;
+  } catch (const test_skip_exception&) {
+    throw; // a skip() inside the callable must reach the runner, not be reported as a wrong type
+  } catch (const test_assertion_failure&) {
+    throw; // ditto for a nested assertion failure, which carries its own location and message
+  } catch (...) {
+    throw test_assertion_failure(fmt::format(
+      "{}:{}: {} (a different exception type was thrown)", loc.file_name(), loc.line(), message));
+  }
+  if (!threw_expected) {
+    throw test_assertion_failure(
+      fmt::format("{}:{}: {} (nothing was thrown)", loc.file_name(), loc.line(), message));
+  }
+}
+
+} // namespace couchbase::cng::test

--- a/test/cng/framework/test_main.cxx
+++ b/test/cng/framework/test_main.cxx
@@ -1,0 +1,76 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Shared entry point for every CNG test executable. A test file provides tests(); this main
+// gathers a name filter from argv, decides mock-vs-real mode from TEST_CONNECTION_STRING, runs
+// the suite, and maps the outcome to a process exit code (0 pass / 1 fail / 77 all-skipped).
+
+#include "test_runner.hxx"
+
+#include <cstdlib> // std::_Exit
+#include <iostream>
+#include <set>
+#include <string>
+
+#include <spdlog/fmt/fmt.h>
+
+auto
+main(int argc, char* argv[]) -> int
+{
+  using namespace couchbase::cng::test;
+
+  std::set<std::string> filter;
+  for (int i = 1; i < argc; ++i) {
+    filter.insert(std::string{ argv[i] });
+  }
+
+  // Real-cluster mode iff TEST_CONNECTION_STRING is set and non-empty (the couchbase-cxx-client
+  // integration convention).
+  const bool real_cluster = safe_getenv("TEST_CONNECTION_STRING").has_value();
+
+  const auto suite = tests();
+  const auto result = run(suite, filter, real_cluster, std::cout);
+
+  if (result.failed > 0) {
+    std::cout << fmt::format("Suite \"{}\": {} passed, {} skipped, {} FAILED\n",
+                             suite.name,
+                             result.passed,
+                             result.skipped,
+                             result.failed);
+  } else if (result.passed == 0 && result.skipped > 0) {
+    std::cout << fmt::format("Suite \"{}\": all {} case(s) skipped (not applicable to this mode)\n",
+                             suite.name,
+                             result.skipped);
+  } else if (result.passed == 0) {
+    std::cout << fmt::format("Suite \"{}\": no cases executed\n", suite.name);
+  } else {
+    std::cout << fmt::format(
+      "Suite \"{}\": {} passed, {} skipped\n", suite.name, result.passed, result.skipped);
+  }
+
+  // A timed-out case leaves its worker detached and still running. Returning from main would run
+  // static destructors underneath it -- tearing down spdlog's registry, std::cout and any gRPC
+  // channel the body still holds -- which surfaces as a nondeterministic abort at exit, exactly
+  // what the timeout runner exists to prevent. Leave immediately instead. Conditional on purpose:
+  // an unconditional _Exit would also suppress LeakSanitizer's atexit report.
+  if (result.timed_out > 0) {
+    std::cout.flush();
+    std::_Exit(exit_code(result));
+  }
+
+  return exit_code(result);
+}

--- a/test/cng/framework/test_runner.cxx
+++ b/test/cng/framework/test_runner.cxx
@@ -1,0 +1,195 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "test_runner.hxx"
+
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <future>
+#include <thread>
+
+#include <spdlog/fmt/fmt.h>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+struct case_result {
+  enum class status : std::uint8_t {
+    passed,
+    skipped,
+    failed
+  };
+  status outcome{ status::passed };
+  std::chrono::nanoseconds duration{ 0 };
+  std::string message{};
+  bool timed_out{ false };
+};
+
+// One decimal place: truncating to whole milliseconds reports every timeout::instant-class case as
+// "0ms", which hides a case that got an order of magnitude slower.
+auto
+human(std::chrono::nanoseconds ns) -> std::string
+{
+  return fmt::format("{:.1f}ms", std::chrono::duration<double, std::milli>(ns).count());
+}
+
+// Run one case on a worker thread, enforcing `timeout`. On timeout the worker is detached: the
+// packaged_task moved into it co-owns the future's shared state, so the detached thread writes
+// only to that heap state (never to this stack frame) and the result is simply never read.
+auto
+run_case(void (*func)(), std::chrono::milliseconds timeout) -> case_result
+{
+  std::packaged_task<void()> task(func);
+  auto future = task.get_future();
+  const auto start = std::chrono::steady_clock::now();
+  std::thread worker(std::move(task));
+
+  if (future.wait_for(timeout) == std::future_status::ready) {
+    const auto duration = std::chrono::steady_clock::now() - start;
+    worker.join();
+    try {
+      future.get();
+      return { case_result::status::passed, duration, {} };
+    } catch (const test_skip_exception& e) {
+      return { case_result::status::skipped, duration, e.reason() };
+    } catch (const std::exception& e) {
+      return { case_result::status::failed, duration, e.what() };
+    } catch (...) {
+      return { case_result::status::failed, duration, "threw an unknown exception" };
+    }
+  }
+
+  worker.detach();
+  const auto duration = std::chrono::steady_clock::now() - start;
+  return { case_result::status::failed,
+           duration,
+           fmt::format("timed out after {}", human(timeout)),
+           /*timed_out=*/true };
+}
+} // namespace
+
+auto
+run(const test_suite& suite,
+    const std::set<std::string>& filter,
+    bool real_cluster,
+    std::ostream& out) -> run_result
+{
+  run_result result;
+  // Names the filter asked for that actually exist, so an unmatched name can be reported below.
+  std::set<std::string> matched;
+
+  const auto run_cases = [&](const std::vector<test_case>& cases) {
+    for (const auto& tc : cases) {
+      if (!filter.empty()) {
+        if (filter.find(tc.name) == filter.end()) {
+          continue;
+        }
+        matched.insert(tc.name);
+      }
+      if (!should_run(tc.env, real_cluster)) {
+        out << fmt::format("Skipping \"{}\" (environment not applicable)\n", tc.name);
+        ++result.skipped;
+        continue;
+      }
+      out << fmt::format("Running \"{}\" (budget: {})...\n", tc.name, human(tc.timeout));
+      const auto r = run_case(tc.func, tc.timeout);
+      switch (r.outcome) {
+        case case_result::status::passed:
+          out << fmt::format("\"{}\" passed ({})\n", tc.name, human(r.duration));
+          ++result.passed;
+          break;
+        case case_result::status::skipped:
+          out << fmt::format("\"{}\" skipped ({})\n", tc.name, r.message);
+          ++result.skipped;
+          break;
+        case case_result::status::failed:
+          out << fmt::format("\"{}\" FAILED: {}\n", tc.name, r.message);
+          ++result.failed;
+          if (r.timed_out) {
+            ++result.timed_out;
+          }
+          break;
+      }
+    }
+  };
+
+  run_cases(suite.test_cases);
+  if (!suite.slow_test_cases.empty()) {
+    out << "\nRunning slow tests...\n";
+    run_cases(suite.slow_test_cases);
+  }
+
+  // A filter name that matches nothing is a typo, not a request to run nothing: without this the
+  // binary would exit 0 having tested nothing at all.
+  for (const auto& name : filter) {
+    if (matched.find(name) == matched.end()) {
+      out << fmt::format("No test case named \"{}\" in suite \"{}\"\n", name, suite.name);
+      ++result.failed;
+    }
+  }
+  return result;
+}
+
+auto
+exit_code(const run_result& result) -> int
+{
+  if (result.failed > 0) {
+    return 1;
+  }
+  if (result.passed == 0 && result.skipped > 0) {
+    return 77; // GNU/ctest "skipped" convention
+  }
+  if (result.passed == 0) {
+    // Nothing ran, nothing skipped, nothing failed. An empty tests(), or a suite whose every case
+    // was filtered out, must not report PASS -- otherwise ctest stays green on a binary that
+    // verified nothing, indefinitely and silently.
+    return 1;
+  }
+  return 0;
+}
+
+auto
+safe_getenv(const std::string& name) noexcept -> std::optional<std::string>
+{
+  if (name.empty()) {
+    return std::nullopt;
+  }
+
+#if defined(_WIN32)
+  char* buf = nullptr;
+  std::size_t len = 0;
+  if (_dupenv_s(&buf, &len, name.c_str()) == 0 && buf != nullptr) {
+    std::string value(buf);
+    free(buf); // NOLINT(cppcoreguidelines-no-malloc) — _dupenv_s allocates with malloc
+    if (!value.empty()) {
+      return value;
+    }
+  }
+  return std::nullopt;
+#else
+  if (const char* value = std::getenv(name.c_str()); // NOLINT(concurrency-mt-unsafe)
+      value != nullptr && value[0] != '\0') {
+    return std::string{ value };
+  }
+  return std::nullopt;
+#endif
+}
+
+} // namespace couchbase::cng::test

--- a/test/cng/framework/test_runner.hxx
+++ b/test/cng/framework/test_runner.hxx
@@ -1,0 +1,64 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include "test_framework.hxx"
+
+#include <cstddef>
+#include <optional>
+#include <ostream>
+#include <set>
+#include <string>
+
+namespace couchbase::cng::test
+{
+
+struct run_result {
+  std::size_t passed{ 0 };
+  std::size_t skipped{ 0 };
+  std::size_t failed{ 0 };
+  // Cases that exceeded their budget. Counted in `failed` too; tracked separately because a
+  // timeout leaves a detached worker thread running, which changes how the process must exit
+  // (see main()).
+  std::size_t timed_out{ 0 };
+};
+
+// Run a suite. `filter` empty => run every case; otherwise only cases whose name is in `filter`;
+// a filter name matching no case is itself a failure. `real_cluster` selects env-gated cases (see
+// should_run). Progress lines go to `out`. Every selected case runs even after one fails, so a
+// single CI round-trip reports every regression in the binary. Exposed (rather than buried in
+// main) so a self-test can drive it with in-memory suites.
+auto
+run(const test_suite& suite,
+    const std::set<std::string>& filter,
+    bool real_cluster,
+    std::ostream& out) -> run_result;
+
+// Process exit code for a result: any failure => 1; nothing ran but something skipped => 77
+// (the GNU/ctest "skipped" convention); otherwise 0.
+[[nodiscard]] auto
+exit_code(const run_result& result) -> int;
+
+// Portable std::getenv wrapper returning std::nullopt for unset *or* empty values, matching the
+// wrappers in tools/utils.cxx and examples/external_circuit_breaker. Needed because MSVC treats
+// plain getenv() as deprecated, and the CNG tree builds with /W4 /WX. Lives here so every CNG
+// test executable shares one implementation.
+[[nodiscard]] auto
+safe_getenv(const std::string& name) noexcept -> std::optional<std::string>;
+
+} // namespace couchbase::cng::test


### PR DESCRIPTION
CNG work needs a test harness that is not Catch2, the couchbase-cxx-client
default. Add a small framework under `test/cng/framework/`, ported to the C++17
the library targets (the source design is C++23): a `tests()` entry point
returning a `test_suite` of `test_case{name, func, timeout, env}`; a per-case
timeout runner that reports pass/skip/fail without aborting the process;
environment gating (agnostic/any_server/mock_only/cluster_only) driven by
`TEST_CONNECTION_STRING`; and `assert_*` helpers over a `source_location` shim
built on compiler builtins.

Gated by `COUCHBASE_CXX_CLIENT_BUILD_CNG_TESTS` and registered with ctest via
`add_cng_test()`; the harness does not link the client library and leaves the
Catch2 suite untouched. A self-test exercises the pass, fail, skip, timeout,
gating, and filter paths.

---
Part of the CNG (`couchbase2://`) transport series — stacked PR **01/29**, the base of the stack. Merge bottom-up.
