### PR TITLE
CXXCBC-886: vendor Protostellar schema and build gRPC/protobuf stubs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,12 @@ jobs:
         timeout-minutes: 60
         env:
           CB_NUMBER_OF_JOBS: 8
+          # Compile the generated Protostellar stubs on Apple clang too. These legs already build
+          # gRPC and protobuf from source for fit_performer -- BUILD_FIT_PERFORMER defaults to
+          # BUILD_TOOLS, so ThirdPartyDependencies.cmake pulls in GrpcProtobuf.cmake regardless --
+          # so the only added cost is generating and compiling the schema. Apple clang is otherwise
+          # never exercised against the generated code.
+          CB_COUCHBASE2: 1
         run: ./bin/build-tests
   windows:
     strategy:
@@ -69,4 +75,11 @@ jobs:
           # the runner's processor count via Etc.nprocessors (4 on windows-2022/2025).
           # Combined with /MP added in CMakeLists.txt this enables both axes of
           # parallelism instead of the previous /m:2 + serial-cl.exe cap.
+          #
+          # Compile the generated Protostellar stubs on MSVC. This leg already builds gRPC and
+          # protobuf from source for fit_performer, so the only added cost is generating and
+          # compiling the 14 services -- and MSVC is the only toolchain where the generated
+          # protobuf/gRPC code needs special handling (see the MSVC branch of
+          # cmake/Protostellar.cmake), which nothing else in CI would exercise.
+          CB_COUCHBASE2: 1
         run: ruby ./bin/build-tests.rb

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,11 @@ jobs:
         run: ./bin/build-tests
         env:
           CB_NUMBER_OF_JOBS: 8
+          # Generate and compile the Protostellar gRPC/protobuf stubs, and the CNG tests that use
+          # them. The gRPC/protobuf dev packages this needs are installed above. Without it the
+          # generated stubs are never built by CI, so codegen breakage would only ever surface
+          # locally; later commits add the couchbase2:// transport on top of the same option.
+          CB_COUCHBASE2: 1
       - name: Upload build artifacts
         if: ${{ success() }}
         uses: actions/upload-artifact@v4
@@ -56,7 +61,10 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y libssl-dev cmake gcc g++ curl gdb
+          # libgrpc++-dev/libprotobuf-dev pull in the gRPC runtime needed to *run* the gRPC-linked
+          # binaries in the prebuilt artifact -- currently cng_codegen_smoke_test. (A later commit
+          # links the transport into the client library itself, which extends this to every binary.)
+          sudo apt-get install -y libssl-dev cmake gcc g++ curl gdb libprotobuf-dev libgrpc-dev libgrpc++-dev
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -72,6 +80,45 @@ jobs:
         run: |
           chmod -R +x ./cmake-build-tests
           ./bin/run-unit-tests
+      - name: Run CNG tests
+        # The CNG tests carry LABELS "cng" (test/cng/CMakeLists.txt), which matches none of the
+        # --label-regex filters in bin/run-{unit,integration,transaction,benchmark}-tests. Without
+        # this step they are compiled and linked by the build job but never executed by any job.
+        #
+        # --no-tests=error is load-bearing: a --label-regex that matches nothing makes ctest exit 0
+        # (measured: exit 0 without the flag, 8 with it), so a renamed label or a BUILD_CNG_TESTS
+        # that silently went OFF would leave this step passing vacuously -- the same "green means
+        # nothing ran" failure this step exists to close. Needs ctest >= 3.20; CI has 3.28.3.
+        #
+        # --output-junit resolves relative to --test-dir, so the report lands beside the build tree.
+        # The name deliberately differs from the results.xml that bin/run-unit-tests has already
+        # written into the same directory, and it is uploaded as its own artifact rather than folded
+        # into unit-test-results: a CNG test is not a unit test.
+        #
+        # always(): a unit-test failure must not mask CNG results.
+        if: ${{ always() }}
+        timeout-minutes: 10
+        env:
+          TEST_LOG_LEVEL: trace
+        run: |
+          chmod -R +x ./cmake-build-tests
+          ctest --test-dir ./cmake-build-tests --output-on-failure --label-regex 'cng' \
+                --no-tests=error --output-junit cng-results.xml
+      - name: Upload test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-results
+          # bin/run-unit-tests cds into the build dir before ctest, so --output-junit lands there.
+          path: ./cmake-build-tests/results.xml
+          if-no-files-found: warn
+      - name: Upload CNG test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: cng-test-results
+          path: ./cmake-build-tests/cng-results.xml
+          if-no-files-found: warn
   integration:
     needs: build
     strategy:
@@ -92,7 +139,10 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y libssl-dev cmake gcc g++ curl gdb
+          # libgrpc++-dev/libprotobuf-dev pull in the gRPC runtime needed to *run* the gRPC-linked
+          # binaries in the prebuilt artifact -- currently cng_codegen_smoke_test. (A later commit
+          # links the transport into the client library itself, which extends this to every binary.)
+          sudo apt-get install -y libssl-dev cmake gcc g++ curl gdb libprotobuf-dev libgrpc-dev libgrpc++-dev
       - uses: actions/checkout@v4
         with:
           submodules: recursive

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,20 @@ option(COUCHBASE_CXX_CLIENT_BUILD_FIT_PERFORMER
        "Build the FIT performer integration-test tool (requires gRPC + protobuf >= 3.15)"
        ${COUCHBASE_CXX_CLIENT_BUILD_TOOLS})
 
+# couchbase2:// (Protostellar) support. Like the FIT performer it needs gRPC + protobuf >= 3.15.
+# Default OFF: the transport is experimental and opt-in. When enabled it vendors the Protostellar
+# schema and builds the generated stubs; later commits compile the couchbase2 transport into the
+# client library on top of them.
+option(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2
+       "Build with couchbase2:// (Protostellar/gRPC) support (requires gRPC + protobuf >= 3.15)"
+       OFF)
+
 include(cmake/ThirdPartyDependencies.cmake)
+
+if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2)
+  # Vendors the Protostellar schema (CPM) and builds the generated gRPC/protobuf stubs library.
+  include(cmake/Protostellar.cmake)
+endif()
 
 include(cmake/VersionInfo.cmake)
 
@@ -638,9 +651,8 @@ if(COUCHBASE_CXX_CLIENT_BUILD_TESTS)
 endif()
 
 # CNG (Protostellar) tests use a hand-rolled framework (NOT Catch2), so they can be built
-# independently of the main (Catch2) test suite. Individual cases opt into linking the client
-# library via the LINK_CLIENT argument to add_cng_test() in test/cng/CMakeLists.txt; the framework
-# itself does not require it.
+# independently of the main (Catch2) test suite. The framework itself links no client code; each
+# test links only what it exercises (see test/cng/CMakeLists.txt).
 option(COUCHBASE_CXX_CLIENT_BUILD_CNG_TESTS "Build CNG (Protostellar) tests"
        ${COUCHBASE_CXX_CLIENT_BUILD_TESTS})
 if(COUCHBASE_CXX_CLIENT_BUILD_CNG_TESTS)

--- a/bin/build-tests
+++ b/bin/build-tests
@@ -97,6 +97,13 @@ if [ ! -z "$CB_COLUMNAR" ] ; then
 fi
 echo "CB_COLUMNAR=${CB_COLUMNAR}"
 
+# couchbase2:// (Protostellar/gRPC) support is opt-in because it needs gRPC and protobuf >= 3.15.
+CB_COUCHBASE2=${CB_COUCHBASE2:-""}
+if [ ! -z "$CB_COUCHBASE2" ] ; then
+    CB_CMAKE_EXTRAS="${CB_CMAKE_EXTRAS} -DCOUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2=ON"
+fi
+echo "CB_COUCHBASE2=${CB_COUCHBASE2}"
+
 CB_STDLIB_FLAGS=${CB_STDLIB_FLAGS:-""}
 CB_LINK_FLAGS=${CB_LINK_FLAGS:-""}
 

--- a/bin/build-tests.rb
+++ b/bin/build-tests.rb
@@ -106,6 +106,13 @@ if ENV["CB_OPENSSL_NO_ASM"] == "1"
   CB_CMAKE_EXTRAS << "-DOPENSSL_NO_ASM=1"
 end
 
+# couchbase2:// (Protostellar/gRPC) support is opt-in because it needs gRPC and protobuf >= 3.15.
+# Mirrors the CB_COUCHBASE2 switch in bin/build-tests. On Windows this is what gets the generated
+# gRPC stubs compiled by MSVC at all -- see .github/workflows/build.yml.
+unless ENV.fetch("CB_COUCHBASE2", "").empty?
+  CB_CMAKE_EXTRAS << "-DCOUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2=ON"
+end
+
 BUILD_DIR = if CB_SANITIZER.empty?
               File.join(PROJECT_ROOT, "cmake-build-tests")
             else

--- a/cmake/Protostellar.cmake
+++ b/cmake/Protostellar.cmake
@@ -1,0 +1,197 @@
+# Vendors the Couchbase Protostellar (couchbase2://) protobuf/gRPC schema and builds the generated
+# C++ stubs into the couchbase_cxx_protostellar static library.
+#
+# For VCS builds the schema is fetched via CPM (DOWNLOAD_ONLY, no CMakeLists), mirroring how
+# tools/fit_performer vendors couchbaselabs/fit-protocol.
+#
+# NOTE: offline/tarball builds are NOT yet fully wired for couchbase2. Before this feature ships
+# enabled, the source-tarball step must (a) enable COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 in the
+# inner packaging configure so these CPM packages are fetched into the cache, and (b) add
+# protostellar/api_common_protos glob entries to cmake/tarball_glob.txt so they are embedded in
+# the tarball (mirroring fit_protocol). Until then a FETCHCONTENT_FULLY_DISCONNECTED build with
+# this option ON will fail. To be addressed as part of the ship-enable work.
+#
+# gRPC::grpc++, gRPC::grpc_cpp_plugin, protobuf::libprotobuf and protobuf::protoc are provided by
+# cmake/GrpcProtobuf.cmake, which CMakeLists.txt includes before this module.
+
+if(NOT TARGET gRPC::grpc++)
+  message(FATAL_ERROR "gRPC::grpc++ not found; cmake/GrpcProtobuf.cmake must be included first")
+endif()
+if(NOT TARGET protobuf::libprotobuf)
+  message(FATAL_ERROR "protobuf::libprotobuf not found; cmake/GrpcProtobuf.cmake must be included first")
+endif()
+
+# The Protostellar schema. The .proto files live at the repository root under couchbase/**.
+# WARNING: do NOT add GIT_SHALLOW — a shallow clone cannot reach an arbitrary pinned commit.
+cpmaddpackage(
+  NAME
+  protostellar
+  GITHUB_REPOSITORY
+  "couchbase/protostellar"
+  GIT_TAG
+  36d4d9aba03a388f7edb05290f1093d9497b1005
+  DOWNLOAD_ONLY
+  YES)
+
+# The schema imports google/rpc/status.proto (a googleapis common proto that protobuf itself does
+# not ship). api-common-protos is the small canonical source for it. The google/protobuf/* imports
+# (any, duration, timestamp) are well-known types resolved by protoc from the protobuf install.
+cpmaddpackage(
+  NAME
+  api_common_protos
+  GITHUB_REPOSITORY
+  "googleapis/api-common-protos"
+  GIT_TAG
+  3332dec527759859840a3a2ff108c67a54708130
+  DOWNLOAD_ONLY
+  YES)
+
+set(_ps_out "${CMAKE_CURRENT_BINARY_DIR}/protostellar_generated")
+
+if(TARGET gRPC::grpc_cpp_plugin)
+  set(_ps_grpc_plugin "$<TARGET_FILE:gRPC::grpc_cpp_plugin>")
+  # Depend on the target so it is built before codegen runs.
+  set(_ps_grpc_plugin_dep gRPC::grpc_cpp_plugin)
+else()
+  find_program(_ps_grpc_plugin grpc_cpp_plugin REQUIRED)
+  # No target to depend on; the discovered executable path is the dependency.
+  set(_ps_grpc_plugin_dep "${_ps_grpc_plugin}")
+endif()
+
+set(_ps_import_flags -I "${protostellar_SOURCE_DIR}" -I "${api_common_protos_SOURCE_DIR}")
+# When protobuf is built from source (not a system package) protoc has no built-in path to the
+# well-known .proto files; GrpcProtobuf.cmake sets PROTOBUF_IMPORT_DIRS in that case.
+if(DEFINED PROTOBUF_IMPORT_DIRS)
+  foreach(_dir ${PROTOBUF_IMPORT_DIRS})
+    list(APPEND _ps_import_flags -I "${_dir}")
+  endforeach()
+endif()
+
+# Service protos (generate both message and gRPC stubs), relative to the Protostellar root.
+set(_ps_service_protos
+    couchbase/admin/analytics/v1/analytics.proto
+    couchbase/admin/bucket/v1/bucket.proto
+    couchbase/admin/collection/v1/collection.proto
+    couchbase/admin/query/v1/query.proto
+    couchbase/admin/search/v1/search.proto
+    couchbase/analytics/v1/analytics.proto
+    couchbase/internal/hooks/v1/hooks.proto
+    couchbase/internal/xdcr/v1/xdcr.proto
+    couchbase/kv/v1/kv.proto
+    couchbase/query/v1/query.proto
+    couchbase/routing/v2/routing.proto
+    couchbase/search/v1/search.proto
+    couchbase/transactions/v1/transactions.proto
+    couchbase/view/v1/view.proto)
+
+set(_ps_srcs "")
+set(_ps_hdrs "")
+
+# Emit the protobuf (message) sources for one proto given its import-root base and relative path.
+# Appends the outputs to _ps_srcs / _ps_hdrs in the caller scope.
+function(_ps_generate_cpp base rel out_srcs out_hdrs)
+  get_filename_component(_rel_dir "${rel}" DIRECTORY)
+  get_filename_component(_rel_we "${rel}" NAME_WE)
+  file(MAKE_DIRECTORY "${_ps_out}/${_rel_dir}")
+  set(_cc "${_ps_out}/${_rel_dir}/${_rel_we}.pb.cc")
+  set(_h "${_ps_out}/${_rel_dir}/${_rel_we}.pb.h")
+  add_custom_command(
+    OUTPUT "${_cc}" "${_h}"
+    COMMAND protobuf::protoc
+            --cpp_out "${_ps_out}" ${_ps_import_flags} "${base}/${rel}"
+            --experimental_allow_proto3_optional
+    DEPENDS "${base}/${rel}" protobuf::protoc
+    COMMENT "protoc cpp: ${rel}"
+    VERBATIM)
+  set(${out_srcs} ${${out_srcs}} "${_cc}" PARENT_SCOPE)
+  set(${out_hdrs} ${${out_hdrs}} "${_h}" PARENT_SCOPE)
+endfunction()
+
+# Emit the gRPC service sources for one proto.
+function(_ps_generate_grpc base rel out_srcs out_hdrs)
+  get_filename_component(_rel_dir "${rel}" DIRECTORY)
+  get_filename_component(_rel_we "${rel}" NAME_WE)
+  file(MAKE_DIRECTORY "${_ps_out}/${_rel_dir}")
+  set(_cc "${_ps_out}/${_rel_dir}/${_rel_we}.grpc.pb.cc")
+  set(_h "${_ps_out}/${_rel_dir}/${_rel_we}.grpc.pb.h")
+  add_custom_command(
+    OUTPUT "${_cc}" "${_h}"
+    COMMAND protobuf::protoc
+            --grpc_out "${_ps_out}" ${_ps_import_flags}
+            "--plugin=protoc-gen-grpc=${_ps_grpc_plugin}" "${base}/${rel}"
+            --experimental_allow_proto3_optional
+    DEPENDS "${base}/${rel}" protobuf::protoc ${_ps_grpc_plugin_dep}
+    COMMENT "protoc grpc: ${rel}"
+    VERBATIM)
+  set(${out_srcs} ${${out_srcs}} "${_cc}" PARENT_SCOPE)
+  set(${out_hdrs} ${${out_hdrs}} "${_h}" PARENT_SCOPE)
+endfunction()
+
+# google/rpc/status.proto — message stubs only (no service).
+_ps_generate_cpp("${api_common_protos_SOURCE_DIR}" "google/rpc/status.proto" _ps_srcs _ps_hdrs)
+
+# google/rpc/error_details.proto — the typed detail blocks (ErrorInfo, PreconditionFailure,
+# ResourceInfo, …) that CNG packs into Status.details; RFC 77 error handling needs them decoded.
+_ps_generate_cpp(
+  "${api_common_protos_SOURCE_DIR}" "google/rpc/error_details.proto" _ps_srcs _ps_hdrs)
+
+foreach(_proto ${_ps_service_protos})
+  _ps_generate_cpp("${protostellar_SOURCE_DIR}" "${_proto}" _ps_srcs _ps_hdrs)
+  _ps_generate_grpc("${protostellar_SOURCE_DIR}" "${_proto}" _ps_srcs _ps_hdrs)
+endforeach()
+
+set_source_files_properties(${_ps_srcs} ${_ps_hdrs} PROPERTIES GENERATED TRUE)
+
+add_library(couchbase_cxx_protostellar STATIC ${_ps_srcs} ${_ps_hdrs})
+add_library(couchbase::cxx_protostellar ALIAS couchbase_cxx_protostellar)
+# Consumers include the generated headers by their proto path, e.g.
+# <couchbase/kv/v1/kv.pb.h>. Exposed SYSTEM so the (warning-heavy) generated code does not trip
+# the project's warnings-as-errors in downstream targets.
+target_include_directories(couchbase_cxx_protostellar SYSTEM PUBLIC "${_ps_out}")
+target_link_libraries(couchbase_cxx_protostellar PUBLIC gRPC::grpc++ protobuf::libprotobuf)
+set_target_properties(
+  couchbase_cxx_protostellar
+  PROPERTIES POSITION_INDEPENDENT_CODE ON
+             COMPILE_WARNING_AS_ERROR OFF
+             CXX_CLANG_TIDY ""
+             CXX_INCLUDE_WHAT_YOU_USE "")
+# NOTE (ABI visibility): nothing links this library into couchbase_cxx_client yet -- at this commit
+# it stands alone and only the codegen smoke test links it. Once a later commit embeds the transport
+# in the client, the generated protobuf/gRPC symbols will land in the exported ABI of
+# libcouchbase_cxx_client.so with default visibility, which can clash with an application linking
+# its own protobuf/gRPC. The fix is hidden visibility here + --exclude-libs on the shared client
+# target, BUT that will require reworking how the white-box CNG tests link (they will link this
+# static lib AND the client lib that embeds it; default visibility merges the two protobuf
+# descriptor copies into one, hidden visibility does not -> duplicate descriptor registration
+# abort). Deferred to the ship-enable ticket; the option is OFF by default.
+if(MSVC)
+  # /bigobj: the generated translation units are large -- search.pb.cc is 18k lines and yields a
+  # 7.4 MB object -- and protobuf-generated code this size can exceed the COFF section limit
+  # (fatal error C1128). CI builds RelWithDebInfo, but a Debug MSVC build (the default for
+  # bin/build-tests) produces markedly larger objects. tools/fit_performer gets this flag from
+  # set_project_options() for the same class of file; this target does not call that function.
+  #
+  # Do NOT add the /FI<proto_utils.h> force-include that tools/fit_performer uses. It was tried
+  # here and breaks the build: proto_utils.h reaches grpc/support/port_platform.h, which includes
+  # <windows.h> unconditionally ("Get windows.h included everywhere (we need it)"), so forcing it
+  # ahead of the translation unit's own includes puts winnt.h's STATUS_TIMEOUT macro in scope before
+  # couchbase/query/v1/query.pb.h is parsed. That header declares an enum constant of the same name,
+  # so
+  #   static constexpr Status STATUS_TIMEOUT = ...
+  # expands to ((DWORD)0x00000102L): C2143, plus a member named DWORD (C2789). query.pb.h is the
+  # only generated header carrying such a collision. In normal include order it is parsed before
+  # anything drags in windows.h, so there is no clash.
+  #
+  # That force-include exists to work around MSVC's non-conformant two-phase lookup leaving
+  # grpc::SerializationTraits undefined when call_op_set.h is processed before proto_utils.h. The
+  # ordering does occur here: grpc_cpp_plugin emits the generated .grpc.pb.h includes
+  # alphabetically, so async_stream.h (which pulls call_op_set.h) precedes proto_utils.h. It does
+  # not, however, produce a diagnostic: the windows-2022 and windows-11-arm legs each compile all 30
+  # of this library's translation units and link it without one, so the workaround is not needed
+  # here. Should SerializationTraits ever turn up undefined in a *.grpc.pb.cc, the remedy is
+  # /permissive-, which makes the lookup conformant without inverting include order -- not the
+  # force-include.
+  target_compile_options(couchbase_cxx_protostellar PRIVATE /W0 /FS /bigobj)
+else()
+  target_compile_options(couchbase_cxx_protostellar PRIVATE -w)
+endif()

--- a/cmake/ThirdPartyDependencies.cmake
+++ b/cmake/ThirdPartyDependencies.cmake
@@ -39,8 +39,10 @@ if(NOT TARGET spdlog::spdlog)
     "SPDLOG_FMT_EXTERNAL OFF")
 endif()
 
-if(COUCHBASE_CXX_CLIENT_BUILD_TOOLS AND COUCHBASE_CXX_CLIENT_BUILD_FIT_PERFORMER)
-  # gRPC/Protobuf are pulled in only for gRPC-based components (currently the FIT performer).
+if((COUCHBASE_CXX_CLIENT_BUILD_TOOLS AND COUCHBASE_CXX_CLIENT_BUILD_FIT_PERFORMER)
+   OR COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2)
+  # gRPC/Protobuf are pulled in only for gRPC-based components (the FIT performer and the
+  # couchbase2:// transport). This MUST come before OpenTelemetry so OTel reuses these targets.
   include(cmake/GrpcProtobuf.cmake)
 endif()
 

--- a/test/cng/CMakeLists.txt
+++ b/test/cng/CMakeLists.txt
@@ -46,3 +46,10 @@ function(add_cng_test relpath)
 endfunction()
 
 add_cng_test(framework/framework_selftest)
+
+# Protostellar codegen smoke test — only when couchbase2 support (and thus the generated stubs
+# library) is built. See CXXCBC-886.
+if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 AND TARGET couchbase_cxx_protostellar)
+  add_cng_test(protostellar/codegen_smoke)
+  target_link_libraries(cng_codegen_smoke_test PRIVATE couchbase_cxx_protostellar)
+endif()

--- a/test/cng/protostellar/codegen_smoke.cxx
+++ b/test/cng/protostellar/codegen_smoke.cxx
@@ -1,0 +1,96 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Codegen smoke test for CXXCBC-886. It proves the Protostellar schema was vendored and the
+// generated stubs compile and link: a protobuf message from kv.v1, the vendored google/rpc/status
+// message, and a gRPC service type. It does not talk to any server (env-agnostic).
+
+#include "framework/test_runner.hxx"
+
+#include <string>
+
+#include <couchbase/kv/v1/kv.grpc.pb.h>
+#include <couchbase/kv/v1/kv.pb.h>
+#include <google/rpc/status.pb.h>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+void
+kv_message_roundtrips()
+{
+  ::couchbase::kv::v1::GetRequest req;
+  req.set_bucket_name("travel-sample");
+  req.set_scope_name("inventory");
+  req.set_collection_name("airline");
+  req.set_key("airline_10");
+  assert_eq(req.bucket_name(), std::string{ "travel-sample" }, "bucket_name round-trips");
+  assert_eq(req.key(), std::string{ "airline_10" }, "key round-trips");
+
+  ::couchbase::kv::v1::GetResponse resp;
+  resp.set_cas(0x1234'5678'9abc'def0ULL);
+  resp.set_content_uncompressed("{\"type\":\"airline\"}");
+  assert_eq(resp.cas(), 0x1234'5678'9abc'def0ULL, "cas round-trips");
+  assert_eq(resp.content_uncompressed(),
+            std::string{ "{\"type\":\"airline\"}" },
+            "content_uncompressed round-trips");
+}
+
+void
+googleapis_status_message_is_available()
+{
+  // Proves google/rpc/status.proto (the sole googleapis import) was fetched and compiled.
+  ::google::rpc::Status status;
+  status.set_code(5); // NOT_FOUND
+  status.set_message("document not found");
+  assert_eq(status.code(), 5, "status code round-trips");
+}
+
+void
+grpc_service_stub_is_generated()
+{
+  // Proves the gRPC plugin ran and its output linked: the generated service exposes its full
+  // name, and the Stub type is a complete type.
+  assert_eq(std::string{ ::couchbase::kv::v1::KvService::service_full_name() },
+            std::string{ "couchbase.kv.v1.KvService" },
+            "KvService full name");
+  // Completeness of Stub is a compile-time property, so assert it at compile time: an incomplete
+  // type fails the sizeof here regardless of whether this case is ever executed or filtered out.
+  static_assert(sizeof(::couchbase::kv::v1::KvService::Stub) > 0, "Stub is a complete type");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_codegen_smoke",
+    {
+      // All three are in-memory message/stub checks with no I/O, so they get the tightest preset
+      // rather than the 5 s network default.
+      { "kv_message_roundtrips", kv_message_roundtrips, timeout::instant },
+      { "googleapis_status_message_is_available",
+        googleapis_status_message_is_available,
+        timeout::instant },
+      { "grpc_service_stub_is_generated", grpc_service_stub_is_generated, timeout::instant },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test


### PR DESCRIPTION
The couchbase2:// transport needs generated protobuf/gRPC stubs from the
Protostellar schema. Add cmake/Protostellar.cmake, which for VCS builds fetches
the schema via CPM (couchbase/protostellar, DOWNLOAD_ONLY) — the source-tarball
step captures the CPM cache so offline builds need no network — and generates
C++ stubs for the couchbase.* services plus the sole googleapis import,
google/rpc/status.proto (from googleapis/api-common-protos); google.protobuf
well-known types come from protoc. The output is the couchbase_cxx_protostellar
static library, linking gRPC::grpc++ and protobuf::libprotobuf and exposing the
generated headers by proto path (e.g. <couchbase/kv/v1/kv.pb.h>).

Gated by COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 (default OFF, opt-in until a
transport consumer lands). When enabled, cmake/GrpcProtobuf.cmake is included
before OpenTelemetry, matching the FIT performer path, so protobuf targets are
shared. A codegen smoke test in the CNG harness instantiates a message and a
service type to prove the stubs compile and link.

---
Stacked PR **02/29** in the CNG (`couchbase2://`) transport series. This branch includes every commit from PRs 01–02; the change specific to this PR is its top commit. Depends on #1023 — merge the series bottom-up.
