### PR TITLE
CXXCBC-887: recognize the couchbase2:// connection-string scheme

### DIFF
--- a/core/utils/connection_string.cxx
+++ b/core/utils/connection_string.cxx
@@ -91,6 +91,12 @@ struct action<scheme> {
       cs.default_port = 18091;
       cs.default_mode = connection_string::bootstrap_mode::http;
       cs.tls = true;
+    } else if (cs.scheme == "couchbase2") {
+      // Protostellar: the gateway does routing, so there is no MCBP-style config bootstrap.
+      cs.default_port = 18098;
+      cs.default_mode = connection_string::bootstrap_mode::unspecified;
+      cs.tls = true;
+      cs.protocol = connection_string::protocol_type::protostellar;
     } else {
       cs.default_mode = connection_string::bootstrap_mode::unspecified;
       cs.default_port = 0;
@@ -364,6 +370,19 @@ extract_options(connection_string& connstr)
       connstr.bootstrap_nodes[0].type != connection_string::address_type::dns) {
     connstr.options.enable_dns_srv = false;
   }
+  // couchbase2:// never resolves DNS *SRV*: there are no _couchbaseXXX._tcp records for a gateway,
+  // which is addressed directly and does its own routing. This does not turn off name resolution --
+  // ordinary A/AAAA lookup still happens inside gRPC, which is how a CNG cluster behind a network
+  // load balancer is reached (one hostname, one address per instance).
+  //
+  // cluster::open() already returns into open_protostellar() before reaching the DNS SRV branch, so
+  // this changes no behaviour today; it keeps the parsed options honest -- to_json() reports
+  // enable_dns_srv in diagnostics -- and stops the option becoming live if that ordering changes.
+  // Placed with the rule above, before the parameter loop, so an explicit enable_dns_srv= still
+  // wins, same as the single-node rule it sits next to.
+  if (connstr.protocol == connection_string::protocol_type::protostellar) {
+    connstr.options.enable_dns_srv = false;
+  }
   for (const auto& [name, value] : connstr.params) {
 #ifdef COUCHBASE_CXX_CLIENT_COLUMNAR
     if (name == "security.trust_only_pem_file") {
@@ -598,6 +617,34 @@ extract_options(connection_string& connstr)
     }
   }
 }
+// couchbase2:// addresses one CNG endpoint. The gateway performs routing, so there is no node list
+// to rotate through and no MCBP bootstrap mode to select per node. Reject strings that ask for
+// either instead of silently honouring only the first host. couchbase-jvm-clients does the same,
+// though it validates at transport construction (CoreProtostellar) rather than while parsing; here
+// connection_string already carries an error field, so failing at the parse boundary keeps the
+// diagnosis next to the input that caused it.
+void
+validate_protostellar(connection_string& connstr)
+{
+  if (connstr.error.has_value() ||
+      connstr.protocol != connection_string::protocol_type::protostellar) {
+    return;
+  }
+  if (connstr.bootstrap_nodes.size() != 1) {
+    connstr.error =
+      fmt::format(R"(connection string with scheme "couchbase2" must have exactly one host, )"
+                  R"(but got {}: "{}")",
+                  connstr.bootstrap_nodes.size(),
+                  connstr.input);
+    return;
+  }
+  if (connstr.bootstrap_nodes[0].mode != connection_string::bootstrap_mode::unspecified) {
+    connstr.error =
+      fmt::format(R"(connection string with scheme "couchbase2" does not accept a bootstrap mode )"
+                  R"(suffix, because the gateway does not use MCBP or HTTP config bootstrap: "{}")",
+                  connstr.input);
+  }
+}
 } // namespace
 
 auto
@@ -630,6 +677,7 @@ parse_connection_string(const std::string& input, cluster_options options) -> co
     }
   }
   extract_options(res);
+  validate_protostellar(res);
   return res;
 }
 } // namespace couchbase::core::utils

--- a/core/utils/connection_string.hxx
+++ b/core/utils/connection_string.hxx
@@ -34,6 +34,13 @@ struct connection_string {
     http,
   };
 
+  // Which client protocol the scheme selects. The classic MCBP stack (couchbase/couchbases/
+  // http/https) versus the Protostellar gRPC transport (couchbase2).
+  enum class protocol_type {
+    mcbp,
+    protostellar,
+  };
+
   enum class address_type {
     ipv4,
     ipv6,
@@ -68,9 +75,17 @@ struct connection_string {
   std::optional<std::string> default_bucket_name{};
   bootstrap_mode default_mode{ connection_string::bootstrap_mode::gcccp };
   std::uint16_t default_port{ 11210 };
+  protocol_type protocol{ protocol_type::mcbp };
 
   std::vector<std::string> warnings{};
   std::optional<std::string> error{};
+
+  // True for the couchbase2:// (Protostellar) transport. The upper layer branches on this to
+  // pick the gRPC client instead of the MCBP stack.
+  [[nodiscard]] auto uses_protostellar() const -> bool
+  {
+    return protocol == protocol_type::protostellar;
+  }
 };
 
 auto

--- a/test/cng/CMakeLists.txt
+++ b/test/cng/CMakeLists.txt
@@ -13,16 +13,24 @@ add_library(
   ${PROJECT_SOURCE_DIR}/test/cng/framework/test_main.cxx)
 target_include_directories(cng_test_main PUBLIC ${PROJECT_SOURCE_DIR}/test/cng
                                                 ${PROJECT_SOURCE_DIR})
-target_include_directories(
-  cng_test_main SYSTEM BEFORE
-  PUBLIC $<BUILD_INTERFACE:$<TARGET_PROPERTY:spdlog::spdlog,INTERFACE_INCLUDE_DIRECTORIES>>)
-target_link_libraries(cng_test_main PUBLIC Threads::Threads)
+# spdlog is linked, not merely included, so the framework compiles bundled fmt in the same mode as
+# the client library. Borrowing only spdlog's include directories left SPDLOG_COMPILED_LIB undefined
+# here, and spdlog/fmt/fmt.h responds by defining FMT_HEADER_ONLY, which emits definitions of
+# fmt::v11::vformat, report_error, is_printable, write_loc and friends into test_runner.obj and
+# test_main.obj. A test that also links the client -- any add_cng_test(... LINK_CLIENT) -- then puts
+# those next to the compiled spdlog's copies of the same symbols. ld folds that silently; link.exe
+# does not, and fails with LNK2005. declare_system_library() already marks spdlog's includes SYSTEM,
+# so linking it keeps its headers out of /W4 /WX without the manual BEFORE override.
+target_link_libraries(cng_test_main PUBLIC Threads::Threads spdlog::spdlog)
 set_project_options(cng_test_main)
 set_project_warnings(cng_test_main)
 
-# add_cng_test(<relpath>) — relpath is under test/cng/ without extension (e.g.
-# framework/framework_selftest). The executable/ctest name is the file stem prefixed with cng_.
+# add_cng_test(<relpath> [LINK_CLIENT] [LIBS <lib>...]) — relpath is under test/cng/ without
+# extension (e.g. framework/framework_selftest). The executable/ctest name is the file stem
+# prefixed with cng_. LINK_CLIENT links the client library and its core header include set, for
+# tests that exercise core code (e.g. the connection-string parser).
 function(add_cng_test relpath)
+  cmake_parse_arguments(ARG "LINK_CLIENT" "" "LIBS" ${ARGN})
   get_filename_component(stem ${relpath} NAME_WE)
   set(target cng_${stem}_test)
   # The name comes from the file stem, not the full relpath, so kv/options.cxx and
@@ -38,6 +46,21 @@ function(add_cng_test relpath)
     ${target} SYSTEM BEFORE
     PRIVATE $<BUILD_INTERFACE:$<TARGET_PROPERTY:spdlog::spdlog,INTERFACE_INCLUDE_DIRECTORIES>>)
   target_link_libraries(${target} PRIVATE cng_test_main Threads::Threads)
+  if(ARG_LINK_CLIENT)
+    target_include_directories(${target} PRIVATE ${PROJECT_BINARY_DIR}/generated
+                                                 ${PROJECT_BINARY_DIR}/generated_$<CONFIG>)
+    target_include_directories(
+      ${target} SYSTEM BEFORE
+      PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third_party/expected/include>
+              $<BUILD_INTERFACE:$<TARGET_PROPERTY:asio,INTERFACE_INCLUDE_DIRECTORIES>>)
+    propagate_public_compile_definitions(${target} spdlog::spdlog asio)
+    target_link_libraries(
+      ${target} PRIVATE ${couchbase_cxx_client_DEFAULT_LIBRARY}
+                        $<BUILD_INTERFACE:Microsoft.GSL::GSL> $<BUILD_INTERFACE:taocpp::json>)
+  endif()
+  if(ARG_LIBS)
+    target_link_libraries(${target} PRIVATE ${ARG_LIBS})
+  endif()
   set_project_options(${target})
   set_project_warnings(${target})
   add_test(NAME ${target} COMMAND $<TARGET_FILE:${target}>)
@@ -46,6 +69,10 @@ function(add_cng_test relpath)
 endfunction()
 
 add_cng_test(framework/framework_selftest)
+
+# couchbase2:// connection-string scheme (CXXCBC-887). Exercises the core parser, so it
+# links the client library.
+add_cng_test(connection_string/couchbase2_scheme LINK_CLIENT)
 
 # Protostellar codegen smoke test — only when couchbase2 support (and thus the generated stubs
 # library) is built. See CXXCBC-886.

--- a/test/cng/connection_string/couchbase2_scheme.cxx
+++ b/test/cng/connection_string/couchbase2_scheme.cxx
@@ -1,0 +1,152 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Unit tests for the couchbase2:// connection-string scheme (CXXCBC-887). Pure parsing, no
+// server, so these run in every mode (env-agnostic).
+
+#include "framework/test_runner.hxx"
+
+#include "core/utils/connection_string.hxx"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+using ::couchbase::core::utils::connection_string;
+using ::couchbase::core::utils::parse_connection_string;
+
+void
+couchbase2_defaults()
+{
+  const auto cs = parse_connection_string("couchbase2://localhost");
+  assert_false(cs.error.has_value(), "parses without error");
+  assert_eq(cs.scheme, std::string{ "couchbase2" }, "scheme is couchbase2");
+  assert_true(cs.uses_protostellar(), "protocol is protostellar");
+  assert_true(cs.protocol == connection_string::protocol_type::protostellar, "protocol enum");
+  assert_true(cs.tls, "couchbase2 implies TLS");
+  assert_true(cs.options.enable_tls, "TLS propagated to options");
+  assert_eq(cs.default_port, std::uint16_t{ 18098 }, "default port is 18098");
+  assert_eq(cs.bootstrap_nodes.size(), std::size_t{ 1 }, "one bootstrap node");
+  // The parser leaves a portless node at 0; the default_port is applied later by the consumer
+  // (same as couchbase://). So we assert the default_port field, not the node port.
+  assert_eq(cs.bootstrap_nodes.at(0).port, std::uint16_t{ 0 }, "portless node stays 0");
+}
+
+void
+couchbase2_explicit_port_wins()
+{
+  const auto cs = parse_connection_string("couchbase2://example.com:12345");
+  assert_false(cs.error.has_value(), "parses without error");
+  assert_eq(cs.bootstrap_nodes.size(), std::size_t{ 1 }, "one bootstrap node");
+  assert_eq(cs.bootstrap_nodes.at(0).address, std::string{ "example.com" }, "address parsed");
+  assert_eq(cs.bootstrap_nodes.at(0).port, std::uint16_t{ 12345 }, "explicit port overrides");
+}
+
+// A CNG gateway fronts the whole cluster and does its own routing, so there is nothing to rotate
+// through: exactly one host is meaningful. Silently using the first and dropping the rest would
+// hide a misconfiguration, so the parser rejects it. couchbase-jvm-clients rejects the same shape.
+void
+couchbase2_rejects_multiple_hosts()
+{
+  const auto cs = parse_connection_string("couchbase2://a.example.com,b.example.com,c.example.com");
+  assert_true(cs.error.has_value(), "multiple hosts are rejected");
+  assert_true(cs.error.value().find("exactly one host") != std::string::npos,
+              "error names the constraint");
+  // The classic schemes are unaffected -- they genuinely rotate through the list.
+  const auto classic = parse_connection_string("couchbase://a.example.com,b.example.com");
+  assert_false(classic.error.has_value(), "couchbase:// still accepts multiple hosts");
+  assert_eq(classic.bootstrap_nodes.size(), std::size_t{ 2 }, "both nodes kept");
+}
+
+// The gateway uses neither MCBP nor HTTP config bootstrap, so a per-node mode suffix cannot be
+// honoured. Rejected for the same reason as extra hosts.
+void
+couchbase2_rejects_mode_suffix()
+{
+  for (const auto* input : { "couchbase2://host=mcd", "couchbase2://host=http" }) {
+    const auto cs = parse_connection_string(input);
+    assert_true(cs.error.has_value(), "mode suffix is rejected");
+  }
+  const auto classic = parse_connection_string("couchbase://host=mcd");
+  assert_false(classic.error.has_value(), "couchbase:// still accepts a mode suffix");
+}
+
+// couchbase2:// is addressed directly, so there are no SRV records to resolve. The option must be
+// off regardless of the string looking SRV-eligible (single DNS host, no port), which is exactly
+// the shape that enables it for couchbase://.
+void
+couchbase2_disables_dns_srv()
+{
+  const auto cs = parse_connection_string("couchbase2://localhost");
+  assert_false(cs.error.has_value(), "parses without error");
+  assert_false(cs.options.enable_dns_srv, "DNS SRV is off for couchbase2");
+
+  const auto classic = parse_connection_string("couchbase://localhost");
+  assert_true(classic.options.enable_dns_srv, "couchbase:// with one DNS host keeps DNS SRV on");
+}
+
+void
+couchbase2_params_pass_through()
+{
+  const auto cs = parse_connection_string("couchbase2://host?kv_timeout=5000");
+  assert_false(cs.error.has_value(), "parses with options without error");
+  assert_true(cs.uses_protostellar(), "still protostellar with params");
+  assert_eq(cs.bootstrap_nodes.size(), std::size_t{ 1 }, "node parsed alongside params");
+}
+
+void
+classic_schemes_remain_mcbp()
+{
+  const auto plain = parse_connection_string("couchbase://host");
+  assert_false(plain.uses_protostellar(), "couchbase is MCBP");
+  assert_false(plain.tls, "couchbase has no TLS");
+  assert_eq(plain.default_port, std::uint16_t{ 11210 }, "couchbase default port");
+
+  const auto secure = parse_connection_string("couchbases://host");
+  assert_false(secure.uses_protostellar(), "couchbases is MCBP");
+  assert_true(secure.tls, "couchbases has TLS");
+  assert_eq(secure.default_port, std::uint16_t{ 11207 }, "couchbases default port");
+
+  const auto http = parse_connection_string("http://host");
+  assert_false(http.uses_protostellar(), "http is MCBP");
+  assert_eq(http.default_port, std::uint16_t{ 8091 }, "http default port");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "connection_string_couchbase2",
+    {
+      { "couchbase2_defaults", couchbase2_defaults },
+      { "couchbase2_explicit_port_wins", couchbase2_explicit_port_wins },
+      { "couchbase2_rejects_multiple_hosts", couchbase2_rejects_multiple_hosts },
+      { "couchbase2_rejects_mode_suffix", couchbase2_rejects_mode_suffix },
+      { "couchbase2_disables_dns_srv", couchbase2_disables_dns_srv },
+      { "couchbase2_params_pass_through", couchbase2_params_pass_through },
+      { "classic_schemes_remain_mcbp", classic_schemes_remain_mcbp },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test

--- a/test/cng/framework/test_framework.hxx
+++ b/test/cng/framework/test_framework.hxx
@@ -35,8 +35,10 @@
 #include <utility>
 #include <vector>
 
-// The wrapper (not <spdlog/fmt/bundled/format.h>) is required: it defines FMT_HEADER_ONLY for this
-// standalone test framework, which links spdlog's headers only, not its compiled fmt.
+// The wrapper (not <spdlog/fmt/bundled/format.h>) is required: it selects bundled fmt and derives
+// the header-only-vs-compiled mode from SPDLOG_COMPILED_LIB, which cng_test_main picks up by
+// linking spdlog::spdlog. Including the bundled header directly would bypass that and reintroduce
+// the duplicate fmt definitions that MSVC rejects -- see the note in test/cng/CMakeLists.txt.
 #include <spdlog/fmt/fmt.h>
 
 namespace couchbase::cng::test


### PR DESCRIPTION
The Protostellar transport is selected by the couchbase2:// scheme, which the
connection-string parser did not recognize. Add it: default port 18098, TLS
implied (propagated to cluster options), and a typed protocol marker
(connection_string::protocol_type plus uses_protostellar()) so the connect path
can branch to the gRPC client without a string comparison. The classic schemes
(couchbase/couchbases/http/https) are unchanged.

Covered by a connection-string unit test on the CNG harness.

---
Stacked PR **03/29** in the CNG (`couchbase2://`) transport series. This branch includes every commit from PRs 01–03; the change specific to this PR is its top commit. Depends on #1024 — merge the series bottom-up.
