### PR TITLE
CXXCBC-888: carry the protostellar protocol marker on origin

### DIFF
--- a/core/origin.cxx
+++ b/core/origin.cxx
@@ -319,9 +319,15 @@ origin::to_json() const -> std::string
 couchbase::core::origin::origin(origin&& other) noexcept
   : options_(std::move(other.options_))
   , nodes_(std::move(other.nodes_))
-  , next_node_(other.next_node_)
+  // next_node_ is an iterator into nodes_. Container move construction transfers the buffer, so
+  // iterators into the source stay valid and now denote elements of nodes_ -- other.next_node_ can
+  // be adopted as-is, preserving the round-robin position. The empty case is guarded separately
+  // because that guarantee does not extend to a past-the-end iterator. nodes_ is declared before
+  // next_node_, so it is already initialized here.
+  , next_node_(nodes_.empty() ? nodes_.begin() : other.next_node_)
   , exhausted_(other.exhausted_)
   , connection_string_(std::move(other.connection_string_))
+  , uses_protostellar_(other.uses_protostellar_)
   , credentials_(std::move(other.credentials_))
 {
 }
@@ -330,20 +336,38 @@ auto
 couchbase::core::origin::operator=(origin&& other) noexcept -> origin&
 {
   if (this != &other) {
+    const auto offset = other.nodes_.empty() ? 0 : other.next_node_ - other.nodes_.begin();
     options_ = std::move(other.options_);
     nodes_ = std::move(other.nodes_);
-    next_node_ = other.next_node_;
+    next_node_ = nodes_.begin() + offset;
     exhausted_ = other.exhausted_;
     connection_string_ = std::move(other.connection_string_);
+    uses_protostellar_ = other.uses_protostellar_;
     credentials_ = std::move(other.credentials_);
   }
   return *this;
 }
 
+// A copy is a fresh origin that has not attempted anything, so the rotation cursor is deliberately
+// reset rather than carried. This matters: next_address() marks an origin exhausted as it hands out
+// the *last* node, which on a single-node cluster is the very first call, so a cluster origin is
+// normally exhausted immediately after bootstrap. open_bucket() copies that origin into every
+// bucket and on into every session, and mcbp_session::initiate_bootstrap() tests exhausted()
+// before it ever calls next_address() -- so carrying the flag would send a session that has tried
+// nothing down the "reached the end of the list of bootstrap nodes" path: an unconditional 500 ms
+// backoff, plus a spurious no_endpoints_left notification under COUCHBASE_CXX_CLIENT_COLUMNAR.
+//
+// Moving, by contrast, does carry it: a move transfers identity rather than producing an
+// independent origin.
+//
+// connection_string_ and uses_protostellar_ *are* copied. They were being dropped entirely, which
+// left connection_string() returning "" on any copied origin.
 couchbase::core::origin::origin(const couchbase::core::origin& other)
   : options_(other.options_)
   , nodes_(other.nodes_)
   , next_node_(nodes_.begin())
+  , connection_string_(other.connection_string_)
+  , uses_protostellar_(other.uses_protostellar_)
 {
   update_credentials(other.credentials());
 }
@@ -378,6 +402,7 @@ couchbase::core::origin::origin(couchbase::core::cluster_credentials auth,
                                 const couchbase::core::utils::connection_string& connstr)
   : options_(connstr.options)
   , connection_string_(connstr.input)
+  , uses_protostellar_(connstr.uses_protostellar())
   , credentials_(std::move(auth))
 {
   nodes_.reserve(connstr.bootstrap_nodes.size());
@@ -396,10 +421,13 @@ couchbase::core::origin::operator=(const couchbase::core::origin& other) -> couc
 {
   if (this != &other) {
     options_ = other.options_;
+    connection_string_ = other.connection_string_;
     update_credentials(other.credentials());
     nodes_ = other.nodes_;
+    // Rotation state is reset, not carried -- see the copy constructor for why.
     next_node_ = nodes_.begin();
     exhausted_ = false;
+    uses_protostellar_ = other.uses_protostellar_;
   }
   return *this;
 }
@@ -407,6 +435,11 @@ auto
 couchbase::core::origin::connection_string() const -> const std::string&
 {
   return connection_string_;
+}
+auto
+couchbase::core::origin::uses_protostellar() const -> bool
+{
+  return uses_protostellar_;
 }
 auto
 couchbase::core::origin::username() const -> std::string
@@ -502,6 +535,11 @@ couchbase::core::origin::set_nodes_from_config(const topology::configuration& co
     shuffle_nodes();
   }
   next_node_ = nodes_.begin();
+  // Matches set_nodes(): the node list has just been replaced, so any exhaustion recorded against
+  // the previous list is meaningless. Without this an origin that was exhausted stays exhausted
+  // across every config update -- cluster.cxx and io/config_tracker.cxx both call this on
+  // long-lived origins that next_address() will have marked exhausted.
+  exhausted_ = false;
 }
 void
 couchbase::core::origin::update_credentials(cluster_credentials auth)

--- a/core/origin.hxx
+++ b/core/origin.hxx
@@ -60,6 +60,9 @@ struct origin {
   auto operator=(const origin& other) -> origin&;
 
   [[nodiscard]] auto connection_string() const -> const std::string&;
+  // True when built from a couchbase2:// connection string (Protostellar transport). Lets the
+  // connect path branch to the gRPC client without re-parsing the connection string.
+  [[nodiscard]] auto uses_protostellar() const -> bool;
   [[nodiscard]] auto username() const -> std::string;
   [[nodiscard]] auto password() const -> std::string;
   [[nodiscard]] auto certificate_path() const -> std::string;
@@ -92,6 +95,7 @@ private:
   node_list::iterator next_node_{};
   bool exhausted_{ false };
   std::string connection_string_{};
+  bool uses_protostellar_{ false };
   cluster_credentials credentials_{};
   mutable std::shared_mutex credentials_mutex_{};
 };

--- a/test/cng/CMakeLists.txt
+++ b/test/cng/CMakeLists.txt
@@ -74,6 +74,9 @@ add_cng_test(framework/framework_selftest)
 # links the client library.
 add_cng_test(connection_string/couchbase2_scheme LINK_CLIENT)
 
+# origin protocol marker (CXXCBC-888).
+add_cng_test(origin/protocol LINK_CLIENT)
+
 # Protostellar codegen smoke test — only when couchbase2 support (and thus the generated stubs
 # library) is built. See CXXCBC-886.
 if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 AND TARGET couchbase_cxx_protostellar)

--- a/test/cng/origin/protocol.cxx
+++ b/test/cng/origin/protocol.cxx
@@ -1,0 +1,157 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Unit tests for origin::uses_protostellar() (CXXCBC-888): the protocol marker parsed from
+// the connection string must reach the origin and survive copy/move. Pure construction, no
+// server (env-agnostic).
+
+#include "framework/test_runner.hxx"
+
+#include "core/cluster_credentials.hxx"
+#include "core/origin.hxx"
+#include "core/utils/connection_string.hxx"
+
+#include <string>
+#include <utility>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+using ::couchbase::core::cluster_credentials;
+using ::couchbase::core::origin;
+using ::couchbase::core::utils::parse_connection_string;
+
+void
+couchbase2_origin_is_protostellar()
+{
+  const auto cs = parse_connection_string("couchbase2://localhost");
+  assert_false(cs.error.has_value(), "connection string parses");
+  const origin o{ cluster_credentials{}, cs };
+  assert_true(o.uses_protostellar(), "couchbase2 origin reports protostellar");
+}
+
+void
+classic_origin_is_not_protostellar()
+{
+  const auto cs = parse_connection_string("couchbase://localhost");
+  assert_false(cs.error.has_value(), "connection string parses");
+  const origin o{ cluster_credentials{}, cs };
+  assert_false(o.uses_protostellar(), "couchbase origin does not report protostellar");
+}
+
+void
+protocol_survives_copy_and_move()
+{
+  const auto cs = parse_connection_string("couchbase2://localhost");
+  assert_false(cs.error.has_value(), "connection string parses");
+  origin o{ cluster_credentials{}, cs };
+
+  const origin copied{ o };
+  assert_true(copied.uses_protostellar(), "copy retains the protocol marker");
+
+  const origin moved{ std::move(o) };
+  assert_true(moved.uses_protostellar(), "move retains the protocol marker");
+
+  // Copy-assignment must carry every observable field: a reassigned origin cannot report one
+  // protocol while still holding another origin's connection string.
+  origin assigned{ cluster_credentials{}, parse_connection_string("couchbase://elsewhere") };
+  assigned = moved;
+  assert_true(assigned.uses_protostellar(), "copy-assignment retains the protocol marker");
+  assert_eq(assigned.connection_string(),
+            std::string{ "couchbase2://localhost" },
+            "copy-assignment copies the connection string");
+
+  // Move-assignment is exercised too: it is the one special member the marker assertions above
+  // would otherwise miss.
+  origin move_target{ cluster_credentials{}, parse_connection_string("couchbase://elsewhere") };
+  move_target = origin{ cluster_credentials{}, parse_connection_string("couchbase2://localhost") };
+  assert_true(move_target.uses_protostellar(), "move-assignment retains the protocol marker");
+  assert_eq(move_target.connection_string(),
+            std::string{ "couchbase2://localhost" },
+            "move-assignment carries the connection string");
+}
+
+// Rotation state (next_node_ / exhausted_) is deliberately NOT inherited by a copy, while a move
+// does carry it. The asymmetry is load-bearing rather than incidental: next_address() marks an
+// origin exhausted as it hands out the last node, so a single-node cluster origin is exhausted
+// straight after bootstrap; open_bucket() copies it into every session, and
+// mcbp_session::initiate_bootstrap() tests exhausted() before its first next_address(). Carrying
+// the flag therefore costs an unconditional 500 ms backoff per session. Pinned here so the
+// semantics cannot regress silently.
+void
+rotation_state_resets_on_copy_and_travels_on_move()
+{
+  auto cs = parse_connection_string("couchbase://a.example.com,b.example.com");
+  assert_false(cs.error.has_value(), "connection string parses");
+  // The constructor shuffles the node list unless told not to; fixing the order lets the cursor be
+  // asserted positionally rather than only through exhausted().
+  cs.options.preserve_bootstrap_nodes_order = true;
+  const auto first = std::string{ "a.example.com" };
+  const auto second = std::string{ "b.example.com" };
+
+  origin o{ cluster_credentials{}, cs };
+  assert_false(o.exhausted(), "a fresh origin is not exhausted");
+  assert_eq(o.next_address().first, first, "the first node is handed out first");
+  assert_false(o.exhausted(), "not exhausted after the first of two nodes");
+  assert_eq(o.next_address().first, second, "the second node is handed out next");
+  assert_true(o.exhausted(), "exhausted once the last node has been handed out");
+
+  origin copied{ o };
+  assert_false(copied.exhausted(), "a copy has attempted nothing, so it starts fresh");
+  assert_eq(copied.next_address().first, first, "and its cursor restarts at the first node");
+
+  origin copy_assigned{ cluster_credentials{}, cs };
+  assert_eq(
+    copy_assigned.next_address().first, first, "cursor advanced before being assigned over");
+  copy_assigned = o;
+  assert_false(copy_assigned.exhausted(), "copy-assignment starts fresh");
+  assert_eq(copy_assigned.next_address().first, first, "and restarts at the first node");
+
+  origin move_source{ cluster_credentials{}, cs };
+  assert_eq(move_source.next_address().first, first, "source consumes the first node");
+  assert_eq(move_source.next_address().first, second, "source consumes the last node");
+  assert_true(move_source.exhausted(), "source is exhausted before being moved");
+  const origin moved{ std::move(move_source) };
+  assert_true(moved.exhausted(), "a move carries the exhausted flag");
+
+  origin move_assign_source{ cluster_credentials{}, cs };
+  assert_eq(move_assign_source.next_address().first, first, "source consumes the first node");
+  assert_eq(move_assign_source.next_address().first, second, "source consumes the last node");
+  origin move_assign_target{ cluster_credentials{}, cs };
+  move_assign_target = std::move(move_assign_source);
+  assert_true(move_assign_target.exhausted(), "move-assignment carries the exhausted flag");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "origin_protocol",
+    {
+      { "couchbase2_origin_is_protostellar", couchbase2_origin_is_protostellar },
+      { "classic_origin_is_not_protostellar", classic_origin_is_not_protostellar },
+      { "protocol_survives_copy_and_move", protocol_survives_copy_and_move },
+      { "rotation_state_resets_on_copy_and_travels_on_move",
+        rotation_state_resets_on_copy_and_travels_on_move },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test


### PR DESCRIPTION
The connect path needs to know a cluster is couchbase2:// without re-parsing the
connection string. Thread the marker from the parsed connection string onto
origin as uses_protostellar(), set in the connection-string constructor and
preserved across copy and move. No behaviour change on the MCBP path.

Covered by an origin unit test on the CNG harness.

---
Stacked PR **04/29** in the CNG (`couchbase2://`) transport series. This branch includes every commit from PRs 01–04; the change specific to this PR is its top commit. Depends on #1025 — merge the series bottom-up.
