### PR TITLE
CXXCBC-889: gRPC<->asio bridge for the Protostellar transport

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -54,6 +54,16 @@ jobs:
           # SA: see CXXCBC-571, Valgrind reports memory leak, because ASIO does
           # not deallocate thread-local state of OpenSSL properly
           CB_BORINGSSL: OFF
+          # Build core/protostellar and its tests here so the couchbase2 transport is covered by the
+          # sanitizers. It is the only hand-written concurrency in the client besides the MCBP path
+          # (a gRPC threadpool callback posting onto the io_context), which is what TSan is for.
+          #
+          # Cost is not uniform across the legs. The four libstdc++ legs reuse the
+          # libgrpc++-dev/libprotobuf-dev packages this workflow already installs, so nothing extra is
+          # built. The tsan leg compiles with -stdlib=libc++ (see bin/build-tests), which makes
+          # cmake/GrpcProtobuf.cmake skip system-package detection to avoid an ABI mismatch, so that
+          # leg does build gRPC from source and takes correspondingly longer.
+          CB_COUCHBASE2: 1
           CB_NUMBER_OF_JOBS: 8
         run: ./bin/build-tests
       - name: Upload build artifacts
@@ -99,6 +109,25 @@ jobs:
         run: |
           chmod -R +x ./cmake-build-tests-${{ matrix.sanitizer }}
           ./bin/run-unit-tests
+      - name: Run CNG tests (${{ matrix.sanitizer }})
+        timeout-minutes: 30
+        # Building the couchbase2 code is not enough to exercise it: the CNG tests carry LABELS "cng"
+        # (test/cng/CMakeLists.txt), and bin/run-unit-tests filters --label-regex 'unit', so without
+        # this step they would be compiled under each sanitizer and never run. --no-tests=error keeps
+        # that from silently reverting -- a label that matched nothing would otherwise exit 0.
+        #
+        # The asan/lsan/tsan/ubsan legs get their instrumentation at compile time, so a plain ctest
+        # run here is instrumented. The valgrind leg is not: memcheck is a run-time wrapper that
+        # bin/run-unit-tests applies via --test-action, which is not mirrored here, so that leg gives
+        # these tests no more coverage than an ordinary build.
+        env:
+          TEST_LOG_LEVEL: trace
+          # bin/run-unit-tests exports this for the lsan leg; mirrored so the same known ASIO/OpenSSL
+          # thread-local leaks (CXXCBC-571) do not fail this step instead.
+          LSAN_OPTIONS: suppressions=${{ github.workspace }}/.lsan_suppressions
+        run: |
+          ctest --test-dir ./cmake-build-tests-${{ matrix.sanitizer }} --output-on-failure \
+                --label-regex 'cng' --no-tests=error --output-junit cng-results.xml
       - name: Upload report
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
@@ -106,6 +135,7 @@ jobs:
           name: report-unit-${{ matrix.sanitizer }}
           path: |
             cmake-build-tests-${{ matrix.sanitizer }}/Testing/Temporary/*.log
+            cmake-build-tests-${{ matrix.sanitizer }}/cng-results.xml
   integration:
     needs: build
     strategy:

--- a/cmake/GrpcProtobuf.cmake
+++ b/cmake/GrpcProtobuf.cmake
@@ -215,3 +215,30 @@ else()
     endif()
   endforeach()
 endif()
+
+# gRPC's headers are not clean under this project's warning set: <grpcpp/...> trips
+# -Wold-style-cast, -Wsign-conversion and -Wgcc-compat, and with -Werror that is a hard failure in
+# any translation unit including them.
+#
+# It only bites on the fetched-from-source path. When find_package succeeds (Linux with
+# libgrpc-dev) the headers live under a system prefix and the compiler treats them as system headers
+# implicitly, so warnings are suppressed for free. Built from source -- macOS and Windows CI, per the
+# note at the top of this file -- their include directories are ordinary -I entries and every
+# warning applies. That asymmetry is why a target can compile on the Linux leg and fail on all five
+# others.
+#
+# fit_performer sidesteps this by turning its own warnings off wholesale (/W0 or -w plus
+# COMPILE_WARNING_AS_ERROR OFF). That is not an option for couchbase_cxx_client, which compiles
+# core/protostellar/*.cxx and must keep full warnings on its own code, so the fix belongs on the
+# dependency: mark the interface include directories SYSTEM, exactly as is done for spdlog.
+#
+# Marking gRPC::grpc++ is sufficient and abseil/protobuf/boringssl need no separate handling --
+# both clang and gcc propagate system-ness down the include stack, so a header reached from a system
+# header is itself treated as one. Verified: with grpc-src/include as -I, <grpcpp/grpcpp.h> emits 26
+# errors across grpcpp and abseil-cpp; with it as -isystem and every other third-party directory
+# left as -I, zero.
+foreach(_grpc_system_target gRPC::grpc++ gRPC::grpc protobuf::libprotobuf)
+  if(TARGET ${_grpc_system_target})
+    declare_system_library(${_grpc_system_target})
+  endif()
+endforeach()

--- a/cmake/Protostellar.cmake
+++ b/cmake/Protostellar.cmake
@@ -195,3 +195,15 @@ if(MSVC)
 else()
   target_compile_options(couchbase_cxx_protostellar PRIVATE -w)
 endif()
+
+# Hand-written transport that bridges gRPC's callback API onto asio (CXXCBC-889 onward).
+# Kept separate from the generated stubs so it builds under the project's normal warnings; the
+# third-party headers it pulls in (gRPC via the stubs lib, asio) arrive as SYSTEM includes.
+add_library(couchbase_cxx_protostellar_transport STATIC
+            ${PROJECT_SOURCE_DIR}/core/protostellar/dispatcher.cxx)
+add_library(couchbase::cxx_protostellar_transport ALIAS couchbase_cxx_protostellar_transport)
+target_include_directories(couchbase_cxx_protostellar_transport PUBLIC ${PROJECT_SOURCE_DIR})
+target_link_libraries(couchbase_cxx_protostellar_transport PUBLIC couchbase_cxx_protostellar asio)
+set_target_properties(couchbase_cxx_protostellar_transport PROPERTIES POSITION_INDEPENDENT_CODE ON)
+set_project_options(couchbase_cxx_protostellar_transport)
+set_project_warnings(couchbase_cxx_protostellar_transport)

--- a/core/protostellar/dispatcher.cxx
+++ b/core/protostellar/dispatcher.cxx
@@ -1,0 +1,58 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "core/protostellar/dispatcher.hxx"
+
+#include <grpcpp/create_channel.h>
+
+#include <utility>
+
+namespace couchbase::core::protostellar
+{
+auto
+default_channel_arguments() -> grpc::ChannelArguments
+{
+  grpc::ChannelArguments args;
+  args.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS, 30'000);
+  args.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, 5'000);
+  args.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
+  // RFC 77 (Bootstrapping -> Maximum Message Size): couchbase2 clients must raise the receive
+  // limit to 25 MiB; gRPC's 4 MB default is too small for the largest values Couchbase serves.
+  args.SetMaxReceiveMessageSize(25 * 1024 * 1024);
+  return args;
+}
+
+auto
+make_insecure_channel(const std::string& endpoint) -> std::shared_ptr<grpc::Channel>
+{
+  return grpc::CreateCustomChannel(
+    endpoint, grpc::InsecureChannelCredentials(), default_channel_arguments());
+}
+
+dispatcher::dispatcher(asio::io_context& io, std::shared_ptr<grpc::Channel> channel)
+  : io_{ io }
+  , channel_{ std::move(channel) }
+{
+}
+
+auto
+dispatcher::channel() const -> const std::shared_ptr<grpc::Channel>&
+{
+  return channel_;
+}
+
+} // namespace couchbase::core::protostellar

--- a/core/protostellar/dispatcher.hxx
+++ b/core/protostellar/dispatcher.hxx
@@ -1,0 +1,221 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <asio/io_context.hpp>
+#include <asio/post.hpp>
+
+#include <grpcpp/grpcpp.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace couchbase::core::protostellar
+{
+
+// Registry of in-flight gRPC calls so the transport can cancel and drain them at shutdown. Without
+// it, teardown could destroy the io_context (and channel) while a gRPC callback is still pending on
+// gRPC's threadpool -- the callback would then post onto a freed io_context (use-after-free). Each
+// completion posts its handler and *then* removes its context; cancel_and_drain() TryCancels
+// whatever is still outstanding and blocks until every callback has done both. That order is the
+// contract, not an incidental detail: remove() is what releases the drain, so deregistering first
+// would let the drain return while a gRPC thread was still posting onto the io_context -- exactly
+// the use-after-free above. Held via shared_ptr so a late callback can safely touch it even while
+// the owning dispatcher is being destroyed.
+class call_tracker
+{
+public:
+  // The tracker OWNS a shared_ptr to each context so a snapshot can keep it alive while cancelling
+  // even if a concurrent completion removes and releases the caller's own reference.
+  void add(std::shared_ptr<grpc::ClientContext> context)
+  {
+    const std::scoped_lock lock{ mutex_ };
+    outstanding_.emplace(context.get(), std::move(context));
+  }
+
+  void remove(grpc::ClientContext* context)
+  {
+    const std::scoped_lock lock{ mutex_ };
+    outstanding_.erase(context);
+    if (outstanding_.empty()) {
+      idle_.notify_all();
+    }
+  }
+
+  // Cancel every in-flight call and block until all of their gRPC callbacks have run. Runs on the
+  // io_context thread at shutdown while gRPC's own threads deliver the cancellations, so there is
+  // no self-deadlock (the completions post back onto the io_context, which stays queued until the
+  // drain returns).
+  void cancel_and_drain()
+  {
+    // Snapshot owning shared_ptrs under the lock, then release it before calling TryCancel so no
+    // external gRPC call runs while mutex_ is held (a completion delivered on a gRPC thread takes
+    // that same lock in remove()). The snapshot keeps every context alive across the unlocked
+    // cancel, so a concurrent completion that removes and releases its own reference cannot leave a
+    // dangling pointer under TryCancel.
+    std::vector<std::shared_ptr<grpc::ClientContext>> pending;
+    {
+      const std::scoped_lock lock{ mutex_ };
+      pending.reserve(outstanding_.size());
+      for (const auto& [ptr, context] : outstanding_) {
+        pending.push_back(context);
+      }
+    }
+    for (const auto& context : pending) {
+      context->TryCancel();
+    }
+    std::unique_lock lock{ mutex_ };
+    idle_.wait(lock, [this] {
+      return outstanding_.empty();
+    });
+  }
+
+private:
+  std::mutex mutex_{};
+  std::condition_variable idle_{};
+  std::unordered_map<grpc::ClientContext*, std::shared_ptr<grpc::ClientContext>> outstanding_{};
+};
+
+// Handle to an in-flight unary call. cancel() maps to gRPC's client-side TryCancel; the call still
+// completes afterwards (with a CANCELLED status) and its handler is posted as usual, so callers
+// never leak a pending operation. As with any completion, the handler runs when the io_context runs
+// it -- cancelling does not make it run inline.
+class pending_call
+{
+public:
+  pending_call() = default;
+  explicit pending_call(std::shared_ptr<grpc::ClientContext> context)
+    : context_{ std::move(context) }
+  {
+  }
+
+  void cancel() const
+  {
+    if (context_) {
+      context_->TryCancel();
+    }
+  }
+
+private:
+  std::shared_ptr<grpc::ClientContext> context_{};
+};
+
+// Default channel arguments: TCP keepalive so an idle channel detects a dead gateway.
+[[nodiscard]] auto
+default_channel_arguments() -> grpc::ChannelArguments;
+
+// Build an insecure (plaintext) channel for the non-TLS couchbase2 path. TLS and per-call
+// credentials live on the secure-channel path (see credentials.hxx/.cxx).
+[[nodiscard]] auto
+make_insecure_channel(const std::string& endpoint) -> std::shared_ptr<grpc::Channel>;
+
+// Bridges gRPC's callback API onto an asio::io_context. A unary RPC is launched on gRPC's own
+// threadpool; its completion is posted back onto the io_context, so callers observe results on
+// the SDK's execution context — the same threading contract as the MCBP path.
+class dispatcher
+{
+public:
+  dispatcher(asio::io_context& io, std::shared_ptr<grpc::Channel> channel);
+  dispatcher(const dispatcher&) = delete;
+  dispatcher(dispatcher&&) = delete;
+  auto operator=(const dispatcher&) -> dispatcher& = delete;
+  auto operator=(dispatcher&&) -> dispatcher& = delete;
+
+  // Cancels and drains every in-flight call before the io_context/channel go away, so no gRPC
+  // callback can fire against freed state after the owning component is destroyed.
+  ~dispatcher()
+  {
+    tracker_->cancel_and_drain();
+  }
+
+  [[nodiscard]] auto channel() const -> const std::shared_ptr<grpc::Channel>&;
+
+  // Issue a unary RPC.
+  //   invoker(grpc::ClientContext&, Response&, callback) launches the async call, e.g.
+  //     stub->async()->Get(&ctx, &request, &response, std::move(callback));
+  //   handler(grpc::Status, Response&&) runs once, on the io_context, when the call completes.
+  // The request must outlive the call (the caller owns it). Returns a pending_call for
+  // cancellation.
+  template<typename Response, typename Invoker, typename Handler>
+  auto unary(std::chrono::milliseconds timeout, Invoker&& invoker, Handler&& handler)
+    -> pending_call
+  {
+    struct call_state {
+      std::shared_ptr<grpc::ClientContext> context{ std::make_shared<grpc::ClientContext>() };
+      Response response{};
+    };
+    auto state = std::make_shared<call_state>();
+    if (timeout.count() > 0) {
+      state->context->set_deadline(std::chrono::system_clock::now() + timeout);
+    }
+
+    // Register the call so shutdown can cancel and drain it. The context is kept alive both by
+    // `state` (captured by the callback below) and by the tracker's own reference, so the raw
+    // pointer the tracker keys on is valid for the TryCancel in cancel_and_drain().
+    auto* context = state->context.get();
+    tracker_->add(state->context);
+
+    // Hold the handler in a shared_ptr so the gRPC-thread callback can hand it to the posted
+    // task. Capture the io_context by pointer (never a reference to a local) so nothing dangles
+    // once unary() returns; the dispatcher (and its io_context) must outlive the call. Capture the
+    // tracker (shared) so deregistration is safe even as the dispatcher is being destroyed.
+    auto handler_holder = std::make_shared<std::decay_t<Handler>>(std::forward<Handler>(handler));
+    auto* io = &io_;
+    auto tracker = tracker_;
+
+    // If the invoker throws before it launches the async call, the completion callback below never
+    // runs, so deregister here to keep cancel_and_drain() from waiting on a call that will never
+    // complete.
+    try {
+      std::forward<Invoker>(invoker)(
+        *state->context,
+        state->response,
+        [state, handler_holder, io, tracker, context](grpc::Status status) {
+          // Post before deregistering. remove() is what releases cancel_and_drain(), so
+          // deregistering first would let ~dispatcher() return -- and its owner tear the
+          // io_context down -- while this thread is still inside asio::post(*io, ...), which is
+          // the use-after-free the tracker exists to prevent. Ordered this way, the drain cannot
+          // return until the post has been issued. The captures keep state and the tracker alive,
+          // so nothing here depends on the dispatcher still existing.
+          asio::post(*io, [state, handler_holder, status = std::move(status)]() mutable {
+            (*handler_holder)(std::move(status), std::move(state->response));
+          });
+          tracker->remove(context);
+        });
+    } catch (...) {
+      tracker_->remove(context);
+      throw;
+    }
+
+    return pending_call{ state->context };
+  }
+
+private:
+  asio::io_context& io_;
+  std::shared_ptr<grpc::Channel> channel_;
+  std::shared_ptr<call_tracker> tracker_{ std::make_shared<call_tracker>() };
+};
+
+} // namespace couchbase::core::protostellar

--- a/test/cng/CMakeLists.txt
+++ b/test/cng/CMakeLists.txt
@@ -82,4 +82,7 @@ add_cng_test(origin/protocol LINK_CLIENT)
 if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 AND TARGET couchbase_cxx_protostellar)
   add_cng_test(protostellar/codegen_smoke)
   target_link_libraries(cng_codegen_smoke_test PRIVATE couchbase_cxx_protostellar)
+
+  # gRPC<->asio bridge (CXXCBC-889): links the transport lib and drives an in-process server.
+  add_cng_test(protostellar/dispatcher LIBS couchbase_cxx_protostellar_transport)
 endif()

--- a/test/cng/protostellar/dispatcher.cxx
+++ b/test/cng/protostellar/dispatcher.cxx
@@ -1,0 +1,257 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Tests for the gRPC<->asio bridge (CXXCBC-889). Drives a real unary RPC against an
+// in-process gRPC server and asserts: the completion handler runs on the io_context thread; a
+// client deadline surfaces as DEADLINE_EXCEEDED; pending_call::cancel() surfaces as CANCELLED; and
+// destroying the dispatcher with a call still in flight cancels and drains it rather than blocking.
+// Env-agnostic (no external server).
+
+#include "framework/test_runner.hxx"
+
+#include "core/protostellar/dispatcher.hxx"
+
+#include <couchbase/kv/v1/kv.grpc.pb.h>
+
+#include <asio/executor_work_guard.hpp>
+#include <asio/io_context.hpp>
+
+#include <grpcpp/server_builder.h>
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace kv = ::couchbase::kv::v1;
+using ::couchbase::core::protostellar::dispatcher;
+using namespace std::chrono_literals;
+
+// Minimal KvService server. Get echoes the key into the value; an optional delay lets the
+// deadline/cancellation paths be exercised (the delay loop honours server-side cancellation so
+// server shutdown does not block).
+class test_kv_service final : public kv::KvService::Service
+{
+public:
+  explicit test_kv_service(std::chrono::milliseconds delay)
+    : delay_{ delay }
+  {
+  }
+
+  auto Get(grpc::ServerContext* context, const kv::GetRequest* request, kv::GetResponse* response)
+    -> grpc::Status override
+  {
+    if (delay_.count() > 0) {
+      const auto deadline = std::chrono::steady_clock::now() + delay_;
+      while (std::chrono::steady_clock::now() < deadline) {
+        if (context->IsCancelled()) {
+          return { grpc::StatusCode::CANCELLED, "cancelled" };
+        }
+        std::this_thread::sleep_for(10ms);
+      }
+    }
+    response->set_content_uncompressed("value:" + request->key());
+    response->set_cas(0xdead'beefULL);
+    return grpc::Status::OK;
+  }
+
+private:
+  std::chrono::milliseconds delay_;
+};
+
+// Owns an in-process gRPC server and hands out channels to it.
+class in_process_server
+{
+public:
+  explicit in_process_server(std::chrono::milliseconds delay)
+    : service_{ delay }
+  {
+    grpc::ServerBuilder builder;
+    builder.RegisterService(&service_);
+    server_ = builder.BuildAndStart();
+  }
+
+  in_process_server(const in_process_server&) = delete;
+  in_process_server(in_process_server&&) = delete;
+  auto operator=(const in_process_server&) -> in_process_server& = delete;
+  auto operator=(in_process_server&&) -> in_process_server& = delete;
+
+  ~in_process_server()
+  {
+    // Immediate deadline: cancels the in-flight (possibly sleeping) call rather than waiting it
+    // out.
+    server_->Shutdown(std::chrono::system_clock::now());
+  }
+
+  [[nodiscard]] auto channel() -> std::shared_ptr<grpc::Channel>
+  {
+    return server_->InProcessChannel(grpc::ChannelArguments{});
+  }
+
+private:
+  test_kv_service service_;
+  std::unique_ptr<grpc::Server> server_;
+};
+
+// Issue a single Get through the dispatcher and pump the io_context (via a work guard, so there
+// is no run()-before-post race) until the handler fires. Returns the status, the response, and
+// the thread the handler ran on.
+struct call_outcome {
+  grpc::Status status{};
+  kv::GetResponse response{};
+  std::thread::id handler_thread{};
+};
+
+auto
+run_get(std::chrono::milliseconds timeout, in_process_server& server, bool cancel_immediately)
+  -> call_outcome
+{
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  dispatcher disp{ io, server.channel() };
+  auto stub = kv::KvService::NewStub(disp.channel());
+
+  kv::GetRequest request;
+  request.set_key("k1");
+
+  call_outcome outcome;
+  const auto pending = disp.unary<kv::GetResponse>(
+    timeout,
+    [&](grpc::ClientContext& ctx,
+        kv::GetResponse& response,
+        std::function<void(grpc::Status)> callback) {
+      stub->async()->Get(&ctx, &request, &response, std::move(callback));
+    },
+    [&](grpc::Status status, kv::GetResponse response) {
+      outcome.status = std::move(status);
+      outcome.response = std::move(response);
+      outcome.handler_thread = std::this_thread::get_id();
+      work.reset(); // let io.run() return
+    });
+
+  if (cancel_immediately) {
+    pending.cancel();
+  }
+
+  io.run();
+  return outcome;
+}
+
+void
+delivers_response_on_io_thread()
+{
+  in_process_server server{ 0ms };
+  const auto run_thread = std::this_thread::get_id();
+  const auto outcome = run_get(timeout::network, server, /*cancel_immediately=*/false);
+
+  assert_true(outcome.status.ok(), "unary call succeeds");
+  assert_eq(outcome.response.content_uncompressed(),
+            std::string{ "value:k1" },
+            "response body round-trips");
+  assert_eq(outcome.response.cas(), 0xdead'beefULL, "cas round-trips");
+  assert_true(outcome.handler_thread == run_thread, "handler ran on the io_context thread");
+}
+
+void
+deadline_surfaces_as_deadline_exceeded()
+{
+  in_process_server server{ 2000ms }; // server delays well beyond the client deadline
+  const auto outcome = run_get(100ms, server, /*cancel_immediately=*/false);
+  assert_true(outcome.status.error_code() == grpc::StatusCode::DEADLINE_EXCEEDED,
+              "short deadline yields DEADLINE_EXCEEDED");
+}
+
+void
+cancellation_surfaces_as_cancelled()
+{
+  in_process_server server{ 2000ms };
+  const auto outcome = run_get(timeout::network, server, /*cancel_immediately=*/true);
+  assert_true(outcome.status.error_code() == grpc::StatusCode::CANCELLED,
+              "cancelled call yields CANCELLED");
+}
+
+// The three cases above never reach ~dispatcher() with a call outstanding: each pumps io.run() to
+// completion, so the handler has fired and the call has deregistered itself before the dispatcher
+// is destroyed, leaving cancel_and_drain() nothing to cancel or wait for. This case destroys the
+// dispatcher while the call is still on gRPC's threadpool -- by never running the io_context at all
+// -- so the destructor has to TryCancel the call and block until its completion callback has run.
+// The channel, stub and request are declared outside the inner block deliberately: the call is
+// still in flight when the block ends, so they have to outlive the dispatcher whose destructor
+// drains it.
+void
+destructor_cancels_and_drains_an_in_flight_call()
+{
+  in_process_server server{ 2000ms }; // the server outlasts the drain unless the call is cancelled
+  const auto channel = server.channel();
+  auto stub = kv::KvService::NewStub(channel);
+
+  kv::GetRequest request;
+  request.set_key("k1");
+
+  auto handler_ran = false;
+  const auto started = std::chrono::steady_clock::now();
+  asio::io_context io;
+  {
+    dispatcher disp{ io, channel };
+    disp.unary<kv::GetResponse>(
+      timeout::network,
+      [&](grpc::ClientContext& ctx,
+          kv::GetResponse& response,
+          std::function<void(grpc::Status)> callback) {
+        stub->async()->Get(&ctx, &request, &response, std::move(callback));
+      },
+      [&](grpc::Status, kv::GetResponse) {
+        handler_ran = true;
+      });
+    // No io.run() here, which is the point: the completion is posted but never executed, so the
+    // call is genuinely in flight when ~dispatcher() runs.
+  }
+  const auto elapsed = std::chrono::steady_clock::now() - started;
+
+  assert_false(handler_ran, "the completion is queued on an io_context that is never run");
+  assert_true(elapsed < 1500ms,
+              "the destructor cancels the call rather than waiting out the server delay");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_dispatcher",
+    {
+      { "delivers_response_on_io_thread", delivers_response_on_io_thread, timeout::network },
+      { "deadline_surfaces_as_deadline_exceeded",
+        deadline_surfaces_as_deadline_exceeded,
+        timeout::network },
+      { "cancellation_surfaces_as_cancelled",
+        cancellation_surfaces_as_cancelled,
+        timeout::network },
+      { "destructor_cancels_and_drains_an_in_flight_call",
+        destructor_cancels_and_drains_an_in_flight_call,
+        timeout::network },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test


### PR DESCRIPTION
The couchbase2 transport runs on gRPC, whose callback API completes on gRPC's
own threadpool, but the SDK contract is that completion handlers run on the
io_context. Add core/protostellar/dispatcher: it owns a channel and issues unary
RPCs via the callback API, applies the per-op timeout as a client deadline,
exposes cancellation, and posts each result onto the io_context so handlers
observe it on the SDK executor. An insecure channel factory with keepalive
arguments is provided; TLS and credentials follow in a later ticket.

The transport lives in a dedicated couchbase_cxx_protostellar_transport library,
separate from the generated stubs so it builds under the project's normal
warnings. Covered by a CNG-harness test that drives an in-process gRPC server and
verifies on-io-thread delivery, deadline (DEADLINE_EXCEEDED), and cancellation
(CANCELLED).

---
Stacked PR **05/29** in the CNG (`couchbase2://`) transport series. This branch includes every commit from PRs 01–05; the change specific to this PR is its top commit. Depends on #1026 — merge the series bottom-up.
