### PR TITLE
CXXCBC-890: TLS and authentication for the couchbase2 transport

### DIFF
--- a/.tsan_suppressions
+++ b/.tsan_suppressions
@@ -22,3 +22,12 @@ signal:operator delete
 # Catch2 RunContext is not thread-safe. Some integration tests call REQUIRE
 # macros from IO-thread callbacks, racing with Catch2's internal state.
 race:Catch::RunContext
+
+# gRPC and Abseil internal synchronization (uninstrumented gRPC calls)
+race:grpc_core::*
+race:grpc::*
+race:grpc_*
+race:gpr_*
+race:absl::*
+called_from_lib:libgrpc.so*
+called_from_lib:libgpr.so*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -510,6 +510,11 @@ set(couchbase_cxx_client_FILES
     core/cluster_label_listener.cxx
 )
 
+if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2)
+  # The Protostellar transport is compiled into the client library (see cmake/Protostellar.cmake).
+  list(APPEND couchbase_cxx_client_FILES ${couchbase_cxx_protostellar_TRANSPORT_FILES})
+endif()
+
 set(couchbase_cxx_client_LIBRARIES)
 set(couchbase_cxx_client_DEFAULT_LIBRARY)
 
@@ -594,6 +599,10 @@ foreach(TARGET ${couchbase_cxx_client_LIBRARIES})
             $<BUILD_INTERFACE:jsonsl>)
   if(COUCHBASE_CXX_CLIENT_BUILD_OPENTELEMETRY)
     target_link_libraries(${TARGET} PRIVATE $<BUILD_INTERFACE:opentelemetry_api>)
+  endif()
+  if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2)
+    # Generated Protostellar stubs + gRPC/protobuf, consumed by core/protostellar/*.
+    target_link_libraries(${TARGET} PRIVATE $<BUILD_INTERFACE:couchbase_cxx_protostellar>)
   endif()
 
   if(HAVE_BACKTRACE)

--- a/cmake/GrpcProtobuf.cmake
+++ b/cmake/GrpcProtobuf.cmake
@@ -70,10 +70,15 @@ else()
       set(_gRPC_SSL_INCLUDE_DIR "" CACHE INTERNAL "")
     endif()
     set(gRPC_SSL_PROVIDER "" CACHE STRING "" FORCE)
+  elseif(TARGET PkgConfig::PKG_CONFIG_OPENSSL)
+    # OpenSSL was found via pkg-config (when CMake's find_package(OpenSSL) returned an unusable setup).
+    # Reuse PkgConfig::PKG_CONFIG_OPENSSL directly so gRPC links the exact same OpenSSL library.
+    set(_gRPC_SSL_LIBRARIES PkgConfig::PKG_CONFIG_OPENSSL CACHE INTERNAL "")
+    set(gRPC_SSL_PROVIDER "" CACHE STRING "" FORCE)
   else()
-    # No existing BoringSSL; let gRPC build its own from submodule
-    list(APPEND _GRPC_SUBMODULES "third_party/boringssl-with-bazel")
-    set(gRPC_SSL_PROVIDER "module" CACHE STRING "" FORCE)
+    # No project-provided BoringSSL or pkg-config OpenSSL; point gRPC at the OpenSSL package.
+    find_package(OpenSSL REQUIRED)
+    set(gRPC_SSL_PROVIDER "package" CACHE STRING "" FORCE)
   endif()
 
   # Fetch gRPC from source with selected submodules.

--- a/cmake/Protostellar.cmake
+++ b/cmake/Protostellar.cmake
@@ -196,14 +196,12 @@ else()
   target_compile_options(couchbase_cxx_protostellar PRIVATE -w)
 endif()
 
-# Hand-written transport that bridges gRPC's callback API onto asio (CXXCBC-889 onward).
-# Kept separate from the generated stubs so it builds under the project's normal warnings; the
-# third-party headers it pulls in (gRPC via the stubs lib, asio) arrive as SYSTEM includes.
-add_library(couchbase_cxx_protostellar_transport STATIC
-            ${PROJECT_SOURCE_DIR}/core/protostellar/dispatcher.cxx)
-add_library(couchbase::cxx_protostellar_transport ALIAS couchbase_cxx_protostellar_transport)
-target_include_directories(couchbase_cxx_protostellar_transport PUBLIC ${PROJECT_SOURCE_DIR})
-target_link_libraries(couchbase_cxx_protostellar_transport PUBLIC couchbase_cxx_protostellar asio)
-set_target_properties(couchbase_cxx_protostellar_transport PROPERTIES POSITION_INDEPENDENT_CODE ON)
-set_project_options(couchbase_cxx_protostellar_transport)
-set_project_warnings(couchbase_cxx_protostellar_transport)
+# The hand-written transport (core/protostellar/*.cxx: the gRPC<->asio bridge, credentials, and
+# later the cluster component) is compiled into couchbase_cxx_client itself, guarded by
+# COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 -- the client library links this stubs library. Keeping
+# the transport in the client library (rather than a standalone lib) avoids a dependency cycle
+# once cluster_impl calls into it, and lets it reuse core utilities (base64, the Mozilla CA
+# bundle). The source list is exported for CMakeLists.txt to append to couchbase_cxx_client_FILES.
+set(couchbase_cxx_protostellar_TRANSPORT_FILES
+    ${PROJECT_SOURCE_DIR}/core/protostellar/dispatcher.cxx
+    ${PROJECT_SOURCE_DIR}/core/protostellar/credentials.cxx)

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -63,6 +63,12 @@ function(enable_sanitizers project_name)
        STREQUAL
        "")
       target_compile_options(${project_name} PUBLIC -fsanitize=${LIST_OF_SANITIZERS})
+      if("thread" IN_LIST SANITIZERS AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "14.0.0")
+        # GCC 14+ emits -Wtsan compile-time warnings for std::atomic_thread_fence (e.g. in Asio headers).
+        # Under -Werror, this breaks compilation. -Wno-error=tsan prevents compile errors while keeping
+        # runtime TSan instrumentation (-fsanitize=thread) fully active to catch actual data races.
+        target_compile_options(${project_name} PUBLIC -Wno-error=tsan)
+      endif()
       target_link_libraries(${project_name} PUBLIC -fsanitize=${LIST_OF_SANITIZERS})
       target_compile_definitions(${project_name} PUBLIC COUCHBASE_CXX_CLIENT_BUILD_SANITIZED=1)
       message(STATUS "Enabled sanitizers: ${LIST_OF_SANITIZERS}")

--- a/core/protostellar/credentials.cxx
+++ b/core/protostellar/credentials.cxx
@@ -1,0 +1,192 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "core/protostellar/credentials.hxx"
+
+#include "core/capella_ca.hxx"
+#include "core/cluster_credentials.hxx"
+#include "core/cluster_options.hxx"
+#include "core/mozilla_ca_bundle.hxx"
+#include "core/platform/base64.h"
+#include "core/protostellar/dispatcher.hxx"
+
+#include <grpcpp/create_channel.h>
+
+#include <fstream>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <utility>
+
+namespace couchbase::core::protostellar
+{
+namespace
+{
+// Read a PEM file that the caller has explicitly configured. Fails closed: a configured but
+// unreadable/empty trust or certificate file is an error, never a silent fall-back to the system
+// trust store (which would broaden the accepted-issuer set beyond the operator's intent).
+auto
+read_required_file(const std::string& path) -> std::string
+{
+  const std::ifstream stream{ path, std::ios::binary };
+  if (!stream) {
+    throw std::runtime_error("couchbase2: cannot read configured TLS file: " + path);
+  }
+  std::ostringstream buffer;
+  buffer << stream.rdbuf();
+  auto contents = buffer.str();
+  if (contents.empty()) {
+    throw std::runtime_error("couchbase2: configured TLS file is empty: " + path);
+  }
+  return contents;
+}
+
+// The default trust material, concatenated into a single PEM as gRPC's pem_root_certs expects: the
+// Couchbase Capella root, plus the bundled Mozilla roots unless the operator disabled them. RFC 77
+// (Bootstrapping -> Security) requires that "the set of Root CAs that SDKs trust by default for
+// couchbase2 must be identical to the one used for Classic", and the Capella root is what this path
+// was missing -- MCBP's configure_tls_context() adds it unconditionally whenever no explicit trust
+// material is configured.
+//
+// Why the platform trust store is not also folded in, unlike MCBP's set_default_verify_paths():
+// gRPC accepts trust material only as one PEM blob and treats a non-empty pem_root_certs as the
+// entire store -- "If this parameter is empty, the default roots will be used" -- so there is
+// nothing to layer onto and no incremental API to layer with. Snapshotting the platform store into
+// that blob would not reproduce MCBP anyway: under OpenSSL/BoringSSL "system roots" is not a
+// defined set the way the JVM's trust store or .NET's X509Chain is, but whatever the host happens
+// to ship, relocatable at run time through SSL_CERT_FILE/SSL_CERT_DIR, and BoringSSL compiles in
+// different default paths again. The two sets this SDK ships and can therefore guarantee are the
+// Capella root and the Mozilla bundle, so those are what the default trusts. A private or corporate
+// CA is configured explicitly, which replaces this set outright -- exactly as it does for MCBP.
+//
+// For reference, the other SDKs land in the same place by different routes: Java trusts its Capella
+// root plus the JVM trust store (SecurityConfig::defaultCaCertificates), .NET accepts whatever the
+// platform validated and adds its Capella root to the chain's ExtraStore, and Go trusts only
+// x509.SystemCertPool() and ships no Capella root at all.
+auto
+default_root_certs(bool include_mozilla_bundle) -> std::string
+{
+  std::string pem{ default_ca::capellaCaCert };
+  if (!pem.empty() && pem.back() != '\n') {
+    pem.push_back('\n');
+  }
+  if (include_mozilla_bundle) {
+    for (const auto& cert : default_ca::mozilla_ca_certs()) {
+      pem.append(cert.body);
+      if (pem.back() != '\n') {
+        pem.push_back('\n');
+      }
+    }
+  }
+  return pem;
+}
+
+// The configured client certificate/key pair for mTLS, as {private_key, certificate_chain}.
+// Returns nullopt when neither is set; throws when only one is set, since a half-configured
+// identity produces an opaque connect-time failure rather than a clear misconfiguration error.
+auto
+read_client_identity(const cluster_credentials& credentials)
+  -> std::optional<std::pair<std::string, std::string>>
+{
+  const bool have_cert = !credentials.certificate_path.empty();
+  const bool have_key = !credentials.key_path.empty();
+  if (!have_cert && !have_key) {
+    return std::nullopt;
+  }
+  if (have_cert != have_key) {
+    throw std::invalid_argument("couchbase2: client certificate authentication requires both a "
+                                "certificate and a private key; only one was configured");
+  }
+  return std::pair{ read_required_file(credentials.key_path),
+                    read_required_file(credentials.certificate_path) };
+}
+} // namespace
+
+auto
+build_ssl_options(const cluster_options& options, const cluster_credentials& credentials)
+  -> grpc::SslCredentialsOptions
+{
+  grpc::SslCredentialsOptions ssl;
+  if (!options.trust_certificate_value.empty()) {
+    ssl.pem_root_certs = options.trust_certificate_value;
+  } else if (!options.trust_certificate.empty()) {
+    ssl.pem_root_certs = read_required_file(options.trust_certificate);
+  } else {
+    // Never left empty: gRPC's own fallback is the GRPC_DEFAULT_SSL_ROOTS_FILE_PATH environment
+    // variable, else a process-wide override hook, else roots bundled in the gRPC installation --
+    // none of which is the platform trust store, and all of which are outside this SDK's control.
+    // Disabling the Mozilla bundle drops that layer only; the Capella root stays, matching MCBP,
+    // where disable_mozilla_ca_certificates likewise gates just the bundle loop.
+    ssl.pem_root_certs = default_root_certs(!options.disable_mozilla_ca_certificates);
+  }
+
+  if (auto identity = read_client_identity(credentials)) {
+    ssl.pem_private_key = identity->first;
+    ssl.pem_cert_chain = identity->second;
+  }
+  return ssl;
+}
+
+auto
+basic_auth_value(const std::string& username, const std::string& password) -> std::string
+{
+  return "Basic " + base64::encode(username + ":" + password);
+}
+
+auto
+bearer_auth_value(const std::string& jwt_token) -> std::string
+{
+  return "Bearer " + jwt_token;
+}
+
+auto
+authorization_header(const cluster_credentials& credentials) -> std::string
+{
+  if (credentials.uses_jwt()) {
+    return bearer_auth_value(credentials.jwt_token);
+  }
+  if (credentials.uses_password()) {
+    return basic_auth_value(credentials.username, credentials.password);
+  }
+  return {};
+}
+
+auto
+make_channel_credentials(const cluster_options& options, const cluster_credentials& credentials)
+  -> std::shared_ptr<grpc::ChannelCredentials>
+{
+  if (!options.enable_tls) {
+    if (credentials.uses_password() || credentials.uses_jwt() ||
+        !credentials.certificate_path.empty() || !credentials.key_path.empty()) {
+      throw std::invalid_argument(
+        "couchbase2: refusing to send credentials over a plaintext channel; enable TLS");
+    }
+    return grpc::InsecureChannelCredentials();
+  }
+  return grpc::SslCredentials(build_ssl_options(options, credentials));
+}
+
+auto
+make_channel(const std::string& endpoint,
+             const cluster_options& options,
+             const cluster_credentials& credentials) -> std::shared_ptr<grpc::Channel>
+{
+  return grpc::CreateCustomChannel(
+    endpoint, make_channel_credentials(options, credentials), default_channel_arguments());
+}
+
+} // namespace couchbase::core::protostellar

--- a/core/protostellar/credentials.hxx
+++ b/core/protostellar/credentials.hxx
@@ -1,0 +1,76 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <grpcpp/grpcpp.h>
+
+#include <memory>
+#include <string>
+
+namespace couchbase::core
+{
+struct cluster_options;
+struct cluster_credentials;
+} // namespace couchbase::core
+
+namespace couchbase::core::protostellar
+{
+
+// Translate the SDK's TLS options and credentials into gRPC's SSL material: root certs come from an
+// inline PEM value, else a CA file, else the SDK's own default set -- the Capella root plus the
+// bundled Mozilla roots unless those are disabled. The client chain/key are set together for
+// certificate (mTLS) authentication.
+//
+// The default set matches what MCBP's configure_tls_context() contributes from material this SDK
+// ships, as RFC 77 (Bootstrapping -> Security) requires. It does not additionally fold in the
+// platform trust store that MCBP reaches through set_default_verify_paths(): gRPC takes roots only
+// as a single PEM that replaces its store outright, and under OpenSSL/BoringSSL the platform set is
+// not a defined collection but whatever the host ships, re-pointable at run time via
+// SSL_CERT_FILE/SSL_CERT_DIR. See credentials.cxx for the full reasoning and how the other SDKs
+// handle it.
+[[nodiscard]] auto
+build_ssl_options(const cluster_options& options, const cluster_credentials& credentials)
+  -> grpc::SslCredentialsOptions;
+
+// "Authorization" header values: Basic base64(user:password) and Bearer <jwt>.
+[[nodiscard]] auto
+basic_auth_value(const std::string& username, const std::string& password) -> std::string;
+[[nodiscard]] auto
+bearer_auth_value(const std::string& jwt_token) -> std::string;
+
+// The per-RPC authorization header the credentials imply: Bearer for a JWT, Basic for
+// username/password, empty when neither applies (e.g. certificate auth, where identity is the
+// client cert). couchbase2 attaches this as call metadata rather than as gRPC CallCredentials,
+// so it works on both secure and insecure channels.
+[[nodiscard]] auto
+authorization_header(const cluster_credentials& credentials) -> std::string;
+
+// Channel credentials for a couchbase2 endpoint: TLS (from build_ssl_options) when TLS is
+// enabled, otherwise insecure.
+[[nodiscard]] auto
+make_channel_credentials(const cluster_options& options, const cluster_credentials& credentials)
+  -> std::shared_ptr<grpc::ChannelCredentials>;
+
+// Build a channel to a couchbase2 endpoint honouring the TLS options, with the default channel
+// arguments (keepalive).
+[[nodiscard]] auto
+make_channel(const std::string& endpoint,
+             const cluster_options& options,
+             const cluster_credentials& credentials) -> std::shared_ptr<grpc::Channel>;
+
+} // namespace couchbase::core::protostellar

--- a/test/cng/CMakeLists.txt
+++ b/test/cng/CMakeLists.txt
@@ -66,6 +66,20 @@ function(add_cng_test relpath)
   add_test(NAME ${target} COMMAND $<TARGET_FILE:${target}>)
   # The harness returns 77 when every case was skipped; map that to ctest's "Skipped".
   set_tests_properties(${target} PROPERTIES SKIP_RETURN_CODE 77 LABELS "cng")
+  # Same TSan configuration cmake/Testing.cmake attaches to the Catch2 suites. Sanitizers are applied
+  # per target (cmake/Sanitizers.cmake), so gRPC and abseil -- fetched and built as ordinary
+  # dependencies -- carry no instrumentation, and TSan cannot see the happens-before edges inside
+  # their event-engine and futex code. Without ignore_noninstrumented_modules it reports those as
+  # races: dispatcher tests drive real gRPC threads and produced 54 such reports. Set on the test
+  # rather than in CI so a local `ctest` under TSan behaves the same way.
+  if(DEFINED COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS AND EXISTS "${COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS}")
+    set_tests_properties(
+      ${target}
+      PROPERTIES
+        ENVIRONMENT
+        "TSAN_OPTIONS=halt_on_error=0,second_deadlock_stack=1,ignore_noninstrumented_modules=1,suppressions=${COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS}"
+    )
+  endif()
 endfunction()
 
 add_cng_test(framework/framework_selftest)
@@ -83,6 +97,11 @@ if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 AND TARGET couchbase_cxx_protostellar)
   add_cng_test(protostellar/codegen_smoke)
   target_link_libraries(cng_codegen_smoke_test PRIVATE couchbase_cxx_protostellar)
 
-  # gRPC<->asio bridge (CXXCBC-889): links the transport lib and drives an in-process server.
-  add_cng_test(protostellar/dispatcher LIBS couchbase_cxx_protostellar_transport)
+  # gRPC<->asio bridge (CXXCBC-889). The transport now lives in the client library, so link
+  # that (LINK_CLIENT) plus the stubs library for the generated KvService the in-process test
+  # server implements.
+  add_cng_test(protostellar/dispatcher LINK_CLIENT LIBS couchbase_cxx_protostellar)
+
+  # TLS/auth credentials (CXXCBC-890).
+  add_cng_test(protostellar/credentials LINK_CLIENT LIBS couchbase_cxx_protostellar)
 endif()

--- a/test/cng/protostellar/credentials.cxx
+++ b/test/cng/protostellar/credentials.cxx
@@ -1,0 +1,175 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Unit tests for the couchbase2 credential translation (CXXCBC-890): building gRPC SSL
+// material from the SDK's TLS options, and the authorization header from credentials. Pure
+// construction, no server (env-agnostic).
+
+#include "framework/test_runner.hxx"
+
+#include "core/capella_ca.hxx"
+#include "core/cluster_credentials.hxx"
+#include "core/cluster_options.hxx"
+#include "core/platform/base64.h"
+#include "core/protostellar/credentials.hxx"
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace ps = ::couchbase::core::protostellar;
+using ::couchbase::core::cluster_credentials;
+using ::couchbase::core::cluster_options;
+
+void
+basic_and_bearer_header_values()
+{
+  const auto expected_basic = "Basic " + ::couchbase::core::base64::encode("Administrator:secret");
+  assert_eq(ps::basic_auth_value("Administrator", "secret"), expected_basic, "basic header value");
+  assert_eq(ps::bearer_auth_value("jwt-token"), std::string{ "Bearer jwt-token" }, "bearer value");
+}
+
+void
+authorization_header_selects_scheme()
+{
+  cluster_credentials password;
+  password.username = "Administrator";
+  password.password = "secret";
+  assert_eq(ps::authorization_header(password),
+            ps::basic_auth_value("Administrator", "secret"),
+            "username/password -> Basic");
+
+  cluster_credentials jwt;
+  jwt.jwt_token = "jwt-token";
+  assert_eq(ps::authorization_header(jwt), std::string{ "Bearer jwt-token" }, "JWT -> Bearer");
+
+  cluster_credentials certificate;
+  certificate.certificate_path = "/path/to/cert.pem";
+  certificate.key_path = "/path/to/key.pem";
+  assert_true(ps::authorization_header(certificate).empty(),
+              "certificate auth carries no authorization header");
+}
+
+// RFC 77 (Bootstrapping -> Security): "the set of Root CAs that SDKs trust by default for
+// couchbase2 must be identical to the one used for Classic". Of the material this SDK ships, that
+// means the Capella root and the Mozilla bundle -- the Capella root is what this path originally
+// omitted, so a default-options couchbase2 connection could not verify a certificate chaining to it
+// while the equivalent MCBP connection could. The set is compared against default_ca::capellaCaCert
+// itself rather than a copied fingerprint, so rotating that constant cannot leave this passing
+// vacuously.
+void
+ssl_root_certs_prefer_explicit_then_capella_and_mozilla()
+{
+  const cluster_credentials no_creds;
+  const std::string capella{ ::couchbase::core::default_ca::capellaCaCert };
+
+  cluster_options inline_ca;
+  inline_ca.trust_certificate_value =
+    "-----BEGIN CERTIFICATE-----\ninline\n-----END CERTIFICATE-----\n";
+  const auto explicit_roots = ps::build_ssl_options(inline_ca, no_creds).pem_root_certs;
+  assert_eq(explicit_roots, inline_ca.trust_certificate_value, "inline CA value is used verbatim");
+  // Explicit material replaces the default set rather than extending it, which is also what MCBP
+  // does: "load only the explicit certificate / system and default capella certificates are not
+  // loaded".
+  assert_true(explicit_roots.find(capella) == std::string::npos,
+              "an explicit CA replaces the default set instead of extending it");
+
+  cluster_options defaults; // no explicit CA, bundle enabled by default
+  const auto default_roots = ps::build_ssl_options(defaults, no_creds).pem_root_certs;
+  assert_eq(default_roots.find(capella),
+            std::string::size_type{ 0 },
+            "the Capella root leads the default trust set");
+  assert_true(default_roots.size() > capella.size(), "the Mozilla bundle follows the Capella root");
+  assert_true(default_roots.find("BEGIN CERTIFICATE") != std::string::npos,
+              "the default trust set is PEM");
+
+  cluster_options no_bundle;
+  no_bundle.disable_mozilla_ca_certificates = true;
+  const auto without_bundle = ps::build_ssl_options(no_bundle, no_creds).pem_root_certs;
+  // Disabling the bundle drops that layer only. Leaving the set empty would hand trust to gRPC's
+  // own fallback -- an environment variable, a process-wide hook, or roots bundled in the gRPC
+  // install -- none of which is the platform store and none of which this SDK controls.
+  assert_eq(without_bundle,
+            capella,
+            "disabling the Mozilla bundle keeps the Capella root and nothing else");
+  assert_true(without_bundle.size() < default_roots.size(), "and does drop the bundle");
+}
+
+void
+ssl_client_certificate_is_read_from_files()
+{
+  const auto dir = std::filesystem::temp_directory_path();
+  const auto cert_path = dir / "cng_test_cert.pem";
+  const auto key_path = dir / "cng_test_key.pem";
+  {
+    std::ofstream{ cert_path } << "CERT-CHAIN-CONTENTS";
+    std::ofstream{ key_path } << "PRIVATE-KEY-CONTENTS";
+  }
+
+  cluster_credentials certificate;
+  certificate.certificate_path = cert_path.string();
+  certificate.key_path = key_path.string();
+  const cluster_options options;
+
+  const auto ssl = ps::build_ssl_options(options, certificate);
+  assert_eq(ssl.pem_cert_chain, std::string{ "CERT-CHAIN-CONTENTS" }, "client cert chain is read");
+  assert_eq(ssl.pem_private_key, std::string{ "PRIVATE-KEY-CONTENTS" }, "client key is read");
+
+  std::error_code ec;
+  std::filesystem::remove(cert_path, ec);
+  std::filesystem::remove(key_path, ec);
+}
+
+void
+channel_credentials_switch_on_tls()
+{
+  const cluster_credentials creds;
+
+  cluster_options secure;
+  secure.enable_tls = true;
+  secure.disable_mozilla_ca_certificates = true; // keep it cheap; no bundle needed here
+  assert_true(ps::make_channel_credentials(secure, creds) != nullptr, "TLS channel credentials");
+
+  cluster_options insecure;
+  insecure.enable_tls = false;
+  assert_true(ps::make_channel_credentials(insecure, creds) != nullptr,
+              "insecure channel credentials");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_credentials",
+    {
+      { "basic_and_bearer_header_values", basic_and_bearer_header_values },
+      { "authorization_header_selects_scheme", authorization_header_selects_scheme },
+      { "ssl_root_certs_prefer_explicit_then_capella_and_mozilla",
+        ssl_root_certs_prefer_explicit_then_capella_and_mozilla },
+      { "ssl_client_certificate_is_read_from_files", ssl_client_certificate_is_read_from_files },
+      { "channel_credentials_switch_on_tls", channel_credentials_switch_on_tls },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test

--- a/test/cng/protostellar/dispatcher.cxx
+++ b/test/cng/protostellar/dispatcher.cxx
@@ -100,6 +100,7 @@ public:
     // Immediate deadline: cancels the in-flight (possibly sleeping) call rather than waiting it
     // out.
     server_->Shutdown(std::chrono::system_clock::now());
+    server_->Wait();
   }
 
   [[nodiscard]] auto channel() -> std::shared_ptr<grpc::Channel>


### PR DESCRIPTION
couchbase2 needs gRPC credentials derived from the SDK's TLS options and
authenticators. Add core/protostellar/credentials: build_ssl_options maps the
trust material (inline PEM, else CA file, else the bundled Mozilla roots unless
disabled) and the client cert/key into grpc::SslCredentialsOptions, mirroring
the MCBP configure_tls_context; authorization_header renders Basic (username/
password) or Bearer (JWT) for attachment as call metadata, which works on both
secure and insecure channels; make_channel builds a TLS-or-insecure channel with
keepalive arguments.

The Protostellar transport (the bridge and credentials) is now compiled into
couchbase_cxx_client, guarded by COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2, linking
the generated stubs library. This lets the transport reuse core utilities and
lets cluster_impl call it without a dependency cycle; with the option off the
client library is unchanged. The standalone transport library is retired.

Covered by credential unit tests on the CNG harness.

---
Stacked PR **06/29** in the CNG (`couchbase2://`) transport series. This branch includes every commit from PRs 01–06; the change specific to this PR is its top commit. Depends on #1027 — merge the series bottom-up.
