### PR TITLE
CXXCBC-893: map gRPC status to couchbase error codes

### DIFF
--- a/cmake/Protostellar.cmake
+++ b/cmake/Protostellar.cmake
@@ -204,4 +204,5 @@ endif()
 # bundle). The source list is exported for CMakeLists.txt to append to couchbase_cxx_client_FILES.
 set(couchbase_cxx_protostellar_TRANSPORT_FILES
     ${PROJECT_SOURCE_DIR}/core/protostellar/dispatcher.cxx
-    ${PROJECT_SOURCE_DIR}/core/protostellar/credentials.cxx)
+    ${PROJECT_SOURCE_DIR}/core/protostellar/credentials.cxx
+    ${PROJECT_SOURCE_DIR}/core/protostellar/error_utils.cxx)

--- a/core/protostellar/error_utils.cxx
+++ b/core/protostellar/error_utils.cxx
@@ -1,0 +1,250 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "core/protostellar/error_utils.hxx"
+
+#include "core/document_id.hxx"
+#include "core/error_context/key_value_error_context.hxx"
+
+#include <couchbase/error_codes.hxx>
+
+#include <google/rpc/error_details.pb.h>
+#include <google/rpc/status.pb.h>
+
+#include <optional>
+#include <string>
+
+namespace couchbase::core::protostellar
+{
+namespace
+{
+// Returns the first detail block of type T packed into the rich status, if any. Per RFC 77 ("Other
+// errors") only the first applicable block is considered.
+template<typename T>
+auto
+find_detail(const google::rpc::Status& rich) -> std::optional<T>
+{
+  for (const auto& any : rich.details()) {
+    T message;
+    if (any.UnpackTo(&message)) {
+      return message;
+    }
+  }
+  return std::nullopt;
+}
+
+// FAILED_PRECONDITION -> the specific KV error carried by PreconditionFailure.type
+// (errorhandler.go).
+auto
+map_precondition(const std::string& type) -> std::error_code
+{
+  if (type == "LOCKED") {
+    return errc::key_value::document_locked;
+  }
+  if (type == "NOT_LOCKED") {
+    return errc::key_value::document_not_locked;
+  }
+  if (type == "DOC_TOO_DEEP") {
+    return errc::key_value::value_too_deep;
+  }
+  if (type == "DOC_NOT_JSON") {
+    return errc::key_value::document_not_json;
+  }
+  if (type == "PATH_MISMATCH") {
+    return errc::key_value::path_mismatch;
+  }
+  if (type == "VALUE_OUT_OF_RANGE") {
+    return errc::key_value::value_invalid;
+  }
+  if (type == "PATH_VALUE_OUT_OF_RANGE") {
+    return errc::key_value::number_too_big;
+  }
+  if (type == "VALUE_TOO_LARGE") {
+    return errc::key_value::value_too_large;
+  }
+  return errc::common::internal_server_failure;
+}
+
+// NOT_FOUND/ALREADY_EXISTS carry a ResourceInfo whose type selects the specific SDK error.
+auto
+map_not_found(const std::string& resource_type) -> std::error_code
+{
+  if (resource_type == "bucket") {
+    return errc::common::bucket_not_found;
+  }
+  if (resource_type == "scope") {
+    return errc::common::scope_not_found;
+  }
+  if (resource_type == "collection") {
+    return errc::common::collection_not_found;
+  }
+  if (resource_type == "queryindex" || resource_type == "searchindex") {
+    return errc::common::index_not_found;
+  }
+  if (resource_type == "path") {
+    return errc::key_value::path_not_found;
+  }
+  return errc::key_value::document_not_found;
+}
+
+auto
+map_already_exists(const std::string& resource_type) -> std::error_code
+{
+  if (resource_type == "bucket") {
+    return errc::management::bucket_exists;
+  }
+  if (resource_type == "scope") {
+    return errc::management::scope_exists;
+  }
+  if (resource_type == "collection") {
+    return errc::management::collection_exists;
+  }
+  if (resource_type == "queryindex" || resource_type == "searchindex") {
+    return errc::common::index_exists;
+  }
+  if (resource_type == "path") {
+    return errc::key_value::path_exists;
+  }
+  return errc::key_value::document_exists;
+}
+} // namespace
+
+auto
+map_status_code(grpc::StatusCode code) -> std::error_code
+{
+  switch (code) {
+    case grpc::StatusCode::OK:
+      return {};
+    case grpc::StatusCode::NOT_FOUND:
+      return errc::key_value::document_not_found;
+    case grpc::StatusCode::ALREADY_EXISTS:
+      return errc::key_value::document_exists;
+    case grpc::StatusCode::ABORTED:
+      // gRPC ABORTED is the canonical concurrency-conflict code; for KV that is a CAS mismatch.
+      return errc::common::cas_mismatch;
+    case grpc::StatusCode::DEADLINE_EXCEEDED:
+      // A server-side deadline on a mutation is genuinely ambiguous (the write may already have
+      // been applied), so default to the ambiguous timeout rather than telling the retry layer
+      // it is safe to replay a possibly-non-idempotent operation.
+      return errc::common::ambiguous_timeout;
+    case grpc::StatusCode::CANCELLED:
+      return errc::common::request_canceled;
+    case grpc::StatusCode::UNAUTHENTICATED:
+    case grpc::StatusCode::PERMISSION_DENIED:
+      return errc::common::authentication_failure;
+    case grpc::StatusCode::INVALID_ARGUMENT:
+    case grpc::StatusCode::OUT_OF_RANGE:
+      return errc::common::invalid_argument;
+    case grpc::StatusCode::UNIMPLEMENTED:
+      return errc::common::feature_not_available;
+    case grpc::StatusCode::UNAVAILABLE:
+      return errc::common::temporary_failure;
+    case grpc::StatusCode::RESOURCE_EXHAUSTED:
+      return errc::common::rate_limited;
+    case grpc::StatusCode::INTERNAL:
+    case grpc::StatusCode::UNKNOWN:
+    case grpc::StatusCode::DATA_LOSS:
+    case grpc::StatusCode::FAILED_PRECONDITION:
+    default:
+      return errc::common::internal_server_failure;
+  }
+}
+
+auto
+map_status(const grpc::Status& status) -> std::error_code
+{
+  const auto code = status.error_code();
+
+  // The typed google.rpc.Status details refine three codes into specific SDK errors (RFC 77 "Other
+  // errors" + errorhandler.go). Everything else is keyed on the bare gRPC code.
+  // NOTE: DEADLINE_EXCEEDED is mapped to the safe ambiguous_timeout default. Distinguishing the
+  // read-only case (unambiguous for reads) would need the request's readonly flag, which is not
+  // available at this layer.
+  google::rpc::Status rich;
+  const bool have_rich =
+    !status.error_details().empty() && rich.ParseFromString(status.error_details());
+
+  switch (code) {
+    case grpc::StatusCode::FAILED_PRECONDITION:
+      if (have_rich) {
+        if (auto failure = find_detail<google::rpc::PreconditionFailure>(rich);
+            failure && failure->violations_size() > 0) {
+          return map_precondition(failure->violations(0).type());
+        }
+      }
+      return errc::common::internal_server_failure;
+    case grpc::StatusCode::NOT_FOUND:
+      if (have_rich) {
+        if (auto info = find_detail<google::rpc::ResourceInfo>(rich)) {
+          return map_not_found(info->resource_type());
+        }
+      }
+      return errc::key_value::document_not_found;
+    case grpc::StatusCode::ALREADY_EXISTS:
+      if (have_rich) {
+        if (auto info = find_detail<google::rpc::ResourceInfo>(rich)) {
+          return map_already_exists(info->resource_type());
+        }
+      }
+      return errc::key_value::document_exists;
+    default:
+      return map_status_code(code);
+  }
+}
+
+auto
+error_message(const grpc::Status& status) -> std::string
+{
+  if (const auto& details = status.error_details(); !details.empty()) {
+    google::rpc::Status rich;
+    if (rich.ParseFromString(details) && !rich.message().empty()) {
+      return rich.message();
+    }
+  }
+  return status.error_message();
+}
+
+auto
+make_error_context(const grpc::Status& status, const document_id& id) -> key_value_error_context
+{
+  const auto ec = map_status(status);
+  std::optional<key_value_extended_error_info> extended{};
+  if (!status.ok()) {
+    if (auto message = error_message(status); !message.empty()) {
+      extended.emplace(std::string{}, std::move(message));
+    }
+  }
+  return key_value_error_context{
+    {},
+    ec,
+    {},
+    {},
+    0,
+    {},
+    id.key(),
+    id.bucket(),
+    id.scope(),
+    id.collection(),
+    0,
+    {},
+    couchbase::cas{},
+    {},
+    std::move(extended),
+  };
+}
+
+} // namespace couchbase::core::protostellar

--- a/core/protostellar/error_utils.hxx
+++ b/core/protostellar/error_utils.hxx
@@ -1,0 +1,56 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <grpcpp/grpcpp.h>
+
+#include <string>
+#include <system_error>
+
+namespace couchbase::core
+{
+struct document_id;
+class key_value_error_context;
+} // namespace couchbase::core
+
+namespace couchbase::core::protostellar
+{
+
+// Map a bare gRPC status code to a couchbase error_code. OK yields a default-constructed
+// (success) error_code. Exposed separately from map_status so it can be unit-tested directly.
+[[nodiscard]] auto
+map_status_code(grpc::StatusCode code) -> std::error_code;
+
+// Map a gRPC status to a couchbase error_code. Keyed on the status code, with the typed
+// google.rpc.Status details (see error_message) refining FAILED_PRECONDITION, NOT_FOUND, and
+// ALREADY_EXISTS into specific KV/management errors.
+[[nodiscard]] auto
+map_status(const grpc::Status& status) -> std::error_code;
+
+// Human-readable message for a failed status: the message from the attached google.rpc.Status
+// rich-error details when present, otherwise the plain gRPC status message.
+[[nodiscard]] auto
+error_message(const grpc::Status& status) -> std::string;
+
+// Build a KV error context from a gRPC status: maps the status code to an error_code and, on
+// failure, attaches the server-provided message (see error_message) as the context's
+// human-readable explanation so callers see why the gateway rejected the operation.
+[[nodiscard]] auto
+make_error_context(const grpc::Status& status, const document_id& id) -> key_value_error_context;
+
+} // namespace couchbase::core::protostellar

--- a/test/cng/CMakeLists.txt
+++ b/test/cng/CMakeLists.txt
@@ -104,4 +104,7 @@ if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 AND TARGET couchbase_cxx_protostellar)
 
   # TLS/auth credentials (CXXCBC-890).
   add_cng_test(protostellar/credentials LINK_CLIENT LIBS couchbase_cxx_protostellar)
+
+  # Error mapping (CXXCBC-893).
+  add_cng_test(protostellar/error_utils LINK_CLIENT LIBS couchbase_cxx_protostellar)
 endif()

--- a/test/cng/protostellar/error_utils.cxx
+++ b/test/cng/protostellar/error_utils.cxx
@@ -1,0 +1,238 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Unit tests for Protostellar error mapping (CXXCBC-893). Pure, no server (env-agnostic).
+
+#include "framework/test_runner.hxx"
+
+#include "core/protostellar/error_utils.hxx"
+
+#include "core/document_id.hxx"
+#include "core/error_context/key_value_error_context.hxx"
+
+#include <couchbase/error_codes.hxx>
+
+#include <google/rpc/error_details.pb.h>
+#include <google/rpc/status.pb.h>
+
+#include <string>
+#include <system_error>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace ps = ::couchbase::core::protostellar;
+
+// Builds a grpc::Status whose serialized google.rpc.Status carries one packed detail block.
+template<typename Detail>
+auto
+status_with_detail(grpc::StatusCode code, const Detail& detail) -> grpc::Status
+{
+  google::rpc::Status rich;
+  rich.set_code(static_cast<std::int32_t>(code));
+  if (!rich.add_details()->PackFrom(detail)) {
+    throw std::runtime_error("status_with_detail: PackFrom failed");
+  }
+  return grpc::Status{ code, "generic grpc message", rich.SerializeAsString() };
+}
+
+auto
+precondition(const std::string& type) -> google::rpc::PreconditionFailure
+{
+  google::rpc::PreconditionFailure failure;
+  failure.add_violations()->set_type(type);
+  return failure;
+}
+
+auto
+resource(const std::string& resource_type) -> google::rpc::ResourceInfo
+{
+  google::rpc::ResourceInfo info;
+  info.set_resource_type(resource_type);
+  return info;
+}
+
+void
+ok_maps_to_success()
+{
+  assert_false(static_cast<bool>(ps::map_status_code(grpc::StatusCode::OK)), "OK is not an error");
+}
+
+void
+status_codes_map_to_expected_errc()
+{
+  assert_true(ps::map_status_code(grpc::StatusCode::NOT_FOUND) ==
+                couchbase::errc::key_value::document_not_found,
+              "NOT_FOUND -> document_not_found");
+  assert_true(ps::map_status_code(grpc::StatusCode::ALREADY_EXISTS) ==
+                couchbase::errc::key_value::document_exists,
+              "ALREADY_EXISTS -> document_exists");
+  assert_true(ps::map_status_code(grpc::StatusCode::ABORTED) ==
+                couchbase::errc::common::cas_mismatch,
+              "ABORTED -> cas_mismatch");
+  assert_true(ps::map_status_code(grpc::StatusCode::DEADLINE_EXCEEDED) ==
+                couchbase::errc::common::ambiguous_timeout,
+              "DEADLINE_EXCEEDED -> ambiguous_timeout (a mutation may have applied)");
+  assert_true(ps::map_status_code(grpc::StatusCode::CANCELLED) ==
+                couchbase::errc::common::request_canceled,
+              "CANCELLED -> request_canceled");
+  assert_true(ps::map_status_code(grpc::StatusCode::UNAUTHENTICATED) ==
+                couchbase::errc::common::authentication_failure,
+              "UNAUTHENTICATED -> authentication_failure");
+  assert_true(ps::map_status_code(grpc::StatusCode::UNIMPLEMENTED) ==
+                couchbase::errc::common::feature_not_available,
+              "UNIMPLEMENTED -> feature_not_available");
+  assert_true(ps::map_status_code(grpc::StatusCode::UNAVAILABLE) ==
+                couchbase::errc::common::temporary_failure,
+              "UNAVAILABLE -> temporary_failure");
+  assert_true(ps::map_status_code(grpc::StatusCode::INTERNAL) ==
+                couchbase::errc::common::internal_server_failure,
+              "INTERNAL -> internal_server_failure");
+}
+
+void
+map_status_uses_the_status_code()
+{
+  const grpc::Status status{ grpc::StatusCode::NOT_FOUND, "missing" };
+  assert_true(ps::map_status(status) == couchbase::errc::key_value::document_not_found,
+              "map_status keys on the code");
+}
+
+void
+precondition_details_map_to_specific_kv_errors()
+{
+  assert_true(ps::map_status(status_with_detail(grpc::StatusCode::FAILED_PRECONDITION,
+                                                precondition("LOCKED"))) ==
+                couchbase::errc::key_value::document_locked,
+              "PreconditionFailure LOCKED -> document_locked");
+  assert_true(ps::map_status(status_with_detail(grpc::StatusCode::FAILED_PRECONDITION,
+                                                precondition("NOT_LOCKED"))) ==
+                couchbase::errc::key_value::document_not_locked,
+              "NOT_LOCKED -> document_not_locked");
+  assert_true(ps::map_status(status_with_detail(grpc::StatusCode::FAILED_PRECONDITION,
+                                                precondition("DOC_NOT_JSON"))) ==
+                couchbase::errc::key_value::document_not_json,
+              "DOC_NOT_JSON -> document_not_json");
+  assert_true(ps::map_status(status_with_detail(grpc::StatusCode::FAILED_PRECONDITION,
+                                                precondition("PATH_VALUE_OUT_OF_RANGE"))) ==
+                couchbase::errc::key_value::number_too_big,
+              "PATH_VALUE_OUT_OF_RANGE -> number_too_big");
+  assert_true(ps::map_status(status_with_detail(grpc::StatusCode::FAILED_PRECONDITION,
+                                                precondition("VALUE_TOO_LARGE"))) ==
+                couchbase::errc::key_value::value_too_large,
+              "VALUE_TOO_LARGE -> value_too_large");
+
+  // FAILED_PRECONDITION with no (recognized) detail falls back to internal_server_failure.
+  const grpc::Status bare{ grpc::StatusCode::FAILED_PRECONDITION, "no details" };
+  assert_true(ps::map_status(bare) == couchbase::errc::common::internal_server_failure,
+              "bare FAILED_PRECONDITION -> internal_server_failure");
+}
+
+void
+resource_info_selects_typed_not_found_and_exists()
+{
+  assert_true(ps::map_status(status_with_detail(grpc::StatusCode::NOT_FOUND, resource("bucket"))) ==
+                couchbase::errc::common::bucket_not_found,
+              "NOT_FOUND + bucket -> bucket_not_found");
+  assert_true(
+    ps::map_status(status_with_detail(grpc::StatusCode::NOT_FOUND, resource("collection"))) ==
+      couchbase::errc::common::collection_not_found,
+    "NOT_FOUND + collection -> collection_not_found");
+  assert_true(
+    ps::map_status(status_with_detail(grpc::StatusCode::NOT_FOUND, resource("queryindex"))) ==
+      couchbase::errc::common::index_not_found,
+    "NOT_FOUND + queryindex -> index_not_found");
+  assert_true(
+    ps::map_status(status_with_detail(grpc::StatusCode::ALREADY_EXISTS, resource("bucket"))) ==
+      couchbase::errc::management::bucket_exists,
+    "ALREADY_EXISTS + bucket -> bucket_exists");
+  assert_true(
+    ps::map_status(status_with_detail(grpc::StatusCode::ALREADY_EXISTS, resource("scope"))) ==
+      couchbase::errc::management::scope_exists,
+    "ALREADY_EXISTS + scope -> scope_exists");
+
+  // Without a ResourceInfo, NOT_FOUND/ALREADY_EXISTS stay document-scoped (backward compatible).
+  const grpc::Status bare{ grpc::StatusCode::NOT_FOUND, "no details" };
+  assert_true(ps::map_status(bare) == couchbase::errc::key_value::document_not_found,
+              "bare NOT_FOUND -> document_not_found");
+}
+
+void
+error_message_prefers_rich_details()
+{
+  google::rpc::Status rich;
+  rich.set_code(static_cast<std::int32_t>(grpc::StatusCode::NOT_FOUND));
+  rich.set_message("document 'foo' not found in collection");
+  const grpc::Status with_details{ grpc::StatusCode::NOT_FOUND,
+                                   "generic grpc message",
+                                   rich.SerializeAsString() };
+  assert_eq(ps::error_message(with_details),
+            std::string{ "document 'foo' not found in collection" },
+            "rich google.rpc.Status message wins");
+
+  const grpc::Status without_details{ grpc::StatusCode::NOT_FOUND, "generic grpc message" };
+  assert_eq(ps::error_message(without_details),
+            std::string{ "generic grpc message" },
+            "falls back to the gRPC message");
+}
+
+void
+make_error_context_maps_code_and_attaches_message()
+{
+  const couchbase::core::document_id id{ "bucket", "scope", "collection", "key" };
+
+  const grpc::Status failure{ grpc::StatusCode::NOT_FOUND, "document 'key' not found" };
+  const auto ctx = ps::make_error_context(failure, id);
+  assert_true(ctx.ec() == couchbase::errc::key_value::document_not_found,
+              "make_error_context maps the status code");
+  assert_eq(ctx.id(), std::string{ "key" }, "carries the document key");
+  assert_eq(ctx.bucket(), std::string{ "bucket" }, "carries the bucket");
+  assert_true(ctx.extended_error_info().has_value(), "failure attaches extended error info");
+  assert_eq(ctx.extended_error_info()->context(),
+            std::string{ "document 'key' not found" },
+            "server message lands in the error context");
+
+  const grpc::Status ok{};
+  const auto ok_ctx = ps::make_error_context(ok, id);
+  assert_false(static_cast<bool>(ok_ctx.ec()), "OK yields a success context");
+  assert_false(ok_ctx.extended_error_info().has_value(), "success carries no extended error info");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_error_utils",
+    {
+      { "ok_maps_to_success", ok_maps_to_success },
+      { "status_codes_map_to_expected_errc", status_codes_map_to_expected_errc },
+      { "map_status_uses_the_status_code", map_status_uses_the_status_code },
+      { "precondition_details_map_to_specific_kv_errors",
+        precondition_details_map_to_specific_kv_errors },
+      { "resource_info_selects_typed_not_found_and_exists",
+        resource_info_selects_typed_not_found_and_exists },
+      { "error_message_prefers_rich_details", error_message_prefers_rich_details },
+      { "make_error_context_maps_code_and_attaches_message",
+        make_error_context_maps_code_and_attaches_message },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test


### PR DESCRIPTION
Add core/protostellar/error_utils: map_status_code translates grpc::StatusCode
to a couchbase error_code (NOT_FOUND -> document_not_found, ALREADY_EXISTS ->
document_exists, ABORTED -> cas_mismatch, DEADLINE_EXCEEDED ->
ambiguous_timeout (the safe default: a timed-out mutation may already have been
applied), UNAUTHENTICATED/PERMISSION_DENIED -> authentication_failure,
UNIMPLEMENTED -> feature_not_available, UNAVAILABLE -> temporary_failure, and so
on); error_message extracts the message from the attached google.rpc.Status rich
details when present, else the plain gRPC message. map_status additionally refines
FAILED_PRECONDITION, NOT_FOUND, and ALREADY_EXISTS into specific KV/management
errors using the typed google.rpc.Status details.

Covered by unit tests on the CNG harness.

---
Stacked PR **07/29** in the CNG (`couchbase2://`) transport series. This branch includes every commit from PRs 01–07; the change specific to this PR is its top commit. Depends on #1028 — merge the series bottom-up.

