### PR TITLE
CXXCBC-891: Protostellar KV component

### DIFF
--- a/cmake/Protostellar.cmake
+++ b/cmake/Protostellar.cmake
@@ -155,15 +155,18 @@ set_target_properties(
              COMPILE_WARNING_AS_ERROR OFF
              CXX_CLANG_TIDY ""
              CXX_INCLUDE_WHAT_YOU_USE "")
-# NOTE (ABI visibility): nothing links this library into couchbase_cxx_client yet -- at this commit
-# it stands alone and only the codegen smoke test links it. Once a later commit embeds the transport
-# in the client, the generated protobuf/gRPC symbols will land in the exported ABI of
+# NOTE (ABI visibility): couchbase_cxx_client links this library whenever
+# COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 is on (see the target_link_libraries guarded by that option
+# in the top-level CMakeLists.txt, alongside the transport sources appended below). So in a
+# couchbase2-enabled build the generated protobuf/gRPC symbols already land in the exported ABI of
 # libcouchbase_cxx_client.so with default visibility, which can clash with an application linking
-# its own protobuf/gRPC. The fix is hidden visibility here + --exclude-libs on the shared client
+# its own protobuf/gRPC. What keeps that off released artefacts today is only that the option
+# defaults to OFF -- it is not, as this note previously claimed, that nothing links the library.
+# The fix is hidden visibility here + --exclude-libs on the shared client
 # target, BUT that will require reworking how the white-box CNG tests link (they will link this
 # static lib AND the client lib that embeds it; default visibility merges the two protobuf
 # descriptor copies into one, hidden visibility does not -> duplicate descriptor registration
-# abort). Deferred to the ship-enable ticket; the option is OFF by default.
+# abort). Deferred to the ship-enable ticket.
 if(MSVC)
   # /bigobj: the generated translation units are large -- search.pb.cc is 18k lines and yields a
   # 7.4 MB object -- and protobuf-generated code this size can exceed the COFF section limit
@@ -205,4 +208,5 @@ endif()
 set(couchbase_cxx_protostellar_TRANSPORT_FILES
     ${PROJECT_SOURCE_DIR}/core/protostellar/dispatcher.cxx
     ${PROJECT_SOURCE_DIR}/core/protostellar/credentials.cxx
-    ${PROJECT_SOURCE_DIR}/core/protostellar/error_utils.cxx)
+    ${PROJECT_SOURCE_DIR}/core/protostellar/error_utils.cxx
+    ${PROJECT_SOURCE_DIR}/core/protostellar/component.cxx)

--- a/core/protostellar/component.cxx
+++ b/core/protostellar/component.cxx
@@ -1,0 +1,238 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "core/protostellar/component.hxx"
+
+#include "core/error_context/key_value.hxx"
+#include "core/protostellar/credentials.hxx"
+#include "core/protostellar/error_utils.hxx"
+#include "core/protostellar/kv_converter.hxx"
+
+#include <couchbase/error_codes.hxx>
+
+#include <couchbase/kv/v1/kv.grpc.pb.h>
+
+#include <asio/post.hpp>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace couchbase::core::protostellar
+{
+namespace v1 = ::couchbase::kv::v1;
+
+// Defined here rather than in the header so the generated gRPC types stay out of every consumer of
+// component.hxx.
+struct component::stubs {
+  std::unique_ptr<v1::KvService::Stub> kv;
+};
+
+namespace
+{
+// A request whose time budget is already spent must not be dispatched. dispatcher::unary only sets
+// a deadline when the timeout is positive, so handing it a non-positive one produces a call with no
+// deadline at all -- an RPC that runs until the channel breaks, and that cluster::close() then
+// blocks on. Turning "no time left" into "no limit" is the wrong direction for the mistake to go.
+//
+// Nothing is sent, so the operation provably did not reach the server. That makes it an
+// unambiguous timeout for every operation, mutating ones included: the ambiguity that
+// ambiguous_timeout warns about is whether the server applied the write, and here it never saw it.
+template<typename Request, typename Handler>
+auto
+fail_expired(asio::io_context& io, const Request& request, Handler& handler) -> pending_call
+{
+  auto response = request.make_response(
+    make_key_value_error_context(errc::common::unambiguous_timeout, request.id),
+    typename Request::encoded_response_type{});
+  // Delivered through the io_context, not inline on the caller's thread: "completions arrive on the
+  // SDK's execution context" is the contract every other path here honours, and a synchronous
+  // callback out of execute() would also re-enter the caller before it has its pending_call back.
+  asio::post(io, [handler = std::move(handler), response = std::move(response)]() mutable {
+    handler(std::move(response));
+  });
+  return {};
+}
+} // namespace
+
+component::component(asio::io_context& io, component_config config)
+  : io_{ io }
+  , stubs_{ std::make_unique<stubs>(stubs{ v1::KvService::NewStub(config.channel) }) }
+  , authorization_{ authorization_header(config.credentials) }
+  , default_kv_timeout_{ config.default_kv_timeout }
+  // Initialised last (see the declaration order in the header), so the channel can be moved in.
+  , dispatcher_{ io, std::move(config.channel) }
+{
+}
+
+component::~component() = default;
+
+auto
+component::execute(operations::get_request request,
+                   utils::movable_function<void(operations::get_response)>&& handler)
+  -> pending_call
+{
+  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired(io_, request, handler);
+  }
+  auto proto = std::make_shared<v1::GetRequest>(kv::encode(request));
+  const auto id = request.id;
+  const auto auth = authorization_;
+  auto* stub = stubs_->kv.get();
+  return dispatcher_.unary<v1::GetResponse>(
+    timeout,
+    [stub, proto, auth](
+      grpc::ClientContext& ctx, v1::GetResponse& resp, std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->Get(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    // `proto` is captured here too so the request outlives the in-flight call.
+    [handler = std::move(handler), id, proto](grpc::Status status, v1::GetResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      // A get reads and nothing more, so a deadline here is unambiguous: the document cannot have
+      // changed. kv::decode owns the compressed-content rule (it reports feature_not_available
+      // rather than handing back an empty value with a success status).
+      auto ctx = make_error_context(status, id, operation_kind::read_only);
+      handler(kv::decode(resp, std::move(ctx)));
+    });
+}
+
+auto
+component::execute(operations::upsert_request request,
+                   utils::movable_function<void(operations::upsert_response)>&& handler)
+  -> pending_call
+{
+  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired(io_, request, handler);
+  }
+  auto proto = std::make_shared<v1::UpsertRequest>(kv::encode(request));
+  const auto id = request.id;
+  const auto auth = authorization_;
+  auto* stub = stubs_->kv.get();
+  return dispatcher_.unary<v1::UpsertResponse>(
+    timeout,
+    [stub, proto, auth](
+      grpc::ClientContext& ctx, v1::UpsertResponse& resp, std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->Upsert(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), id, proto](grpc::Status status,
+                                              v1::UpsertResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      auto ctx = make_error_context(status, id, operation_kind::mutating);
+      handler(kv::decode(resp, std::move(ctx)));
+    });
+}
+
+auto
+component::execute(operations::insert_request request,
+                   utils::movable_function<void(operations::insert_response)>&& handler)
+  -> pending_call
+{
+  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired(io_, request, handler);
+  }
+  auto proto = std::make_shared<v1::InsertRequest>(kv::encode(request));
+  const auto id = request.id;
+  const auto auth = authorization_;
+  auto* stub = stubs_->kv.get();
+  return dispatcher_.unary<v1::InsertResponse>(
+    timeout,
+    [stub, proto, auth](
+      grpc::ClientContext& ctx, v1::InsertResponse& resp, std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->Insert(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), id, proto](grpc::Status status,
+                                              v1::InsertResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      auto ctx = make_error_context(status, id, operation_kind::mutating);
+      handler(kv::decode(resp, std::move(ctx)));
+    });
+}
+
+auto
+component::execute(operations::replace_request request,
+                   utils::movable_function<void(operations::replace_response)>&& handler)
+  -> pending_call
+{
+  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired(io_, request, handler);
+  }
+  auto proto = std::make_shared<v1::ReplaceRequest>(kv::encode(request));
+  const auto id = request.id;
+  const auto auth = authorization_;
+  auto* stub = stubs_->kv.get();
+  return dispatcher_.unary<v1::ReplaceResponse>(
+    timeout,
+    [stub, proto, auth](
+      grpc::ClientContext& ctx, v1::ReplaceResponse& resp, std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->Replace(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), id, proto](grpc::Status status,
+                                              v1::ReplaceResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      auto ctx = make_error_context(status, id, operation_kind::mutating);
+      handler(kv::decode(resp, std::move(ctx)));
+    });
+}
+
+auto
+component::execute(operations::remove_request request,
+                   utils::movable_function<void(operations::remove_response)>&& handler)
+  -> pending_call
+{
+  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired(io_, request, handler);
+  }
+  auto proto = std::make_shared<v1::RemoveRequest>(kv::encode(request));
+  const auto id = request.id;
+  const auto auth = authorization_;
+  auto* stub = stubs_->kv.get();
+  return dispatcher_.unary<v1::RemoveResponse>(
+    timeout,
+    [stub, proto, auth](
+      grpc::ClientContext& ctx, v1::RemoveResponse& resp, std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->Remove(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), id, proto](grpc::Status status,
+                                              v1::RemoveResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      auto ctx = make_error_context(status, id, operation_kind::mutating);
+      handler(kv::decode(resp, std::move(ctx)));
+    });
+}
+
+} // namespace couchbase::core::protostellar

--- a/core/protostellar/component.hxx
+++ b/core/protostellar/component.hxx
@@ -1,0 +1,96 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+// The Protostellar KV component: the couchbase2 counterpart to the MCBP data-plane. It owns the
+// gRPC stubs over a channel and executes core KV operations by encoding the request (kv_converter),
+// dispatching it through the gRPC<->asio bridge, and decoding the reply plus a mapped error
+// context. cluster_impl routes KV ops here when the cluster was opened with couchbase2://.
+
+#include "core/cluster_credentials.hxx"
+#include "core/operations/document_get.hxx"
+#include "core/operations/document_insert.hxx"
+#include "core/operations/document_remove.hxx"
+#include "core/operations/document_replace.hxx"
+#include "core/operations/document_upsert.hxx"
+#include "core/protostellar/dispatcher.hxx"
+#include "core/timeout_defaults.hxx"
+#include "core/utils/movable_function.hxx"
+
+#include <asio/io_context.hpp>
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+namespace couchbase::core::protostellar
+{
+
+// Construction parameters for `component`, grouped so that adding one is a source-compatible
+// change. Every field a caller can reasonably omit carries a default, so a new trailing field
+// leaves existing initialisers compiling instead of silently shifting a positional argument onto
+// the wrong parameter -- which is the failure this shape exists to prevent, the constructor having
+// gained and lost trailing parameters repeatedly as services were added.
+struct component_config {
+  std::shared_ptr<grpc::Channel> channel{};
+  cluster_credentials credentials{};
+  std::chrono::milliseconds default_kv_timeout{ timeout_defaults::key_value_timeout };
+};
+
+class component
+{
+public:
+  component(asio::io_context& io, component_config config);
+  component(const component&) = delete;
+  component(component&&) = delete;
+  auto operator=(const component&) -> component& = delete;
+  auto operator=(component&&) -> component& = delete;
+  // Out of line: `stubs` is incomplete here, so its deleter cannot be instantiated in this header.
+  ~component();
+
+  auto execute(operations::get_request request,
+               utils::movable_function<void(operations::get_response)>&& handler) -> pending_call;
+  auto execute(operations::upsert_request request,
+               utils::movable_function<void(operations::upsert_response)>&& handler)
+    -> pending_call;
+  auto execute(operations::insert_request request,
+               utils::movable_function<void(operations::insert_response)>&& handler)
+    -> pending_call;
+  auto execute(operations::replace_request request,
+               utils::movable_function<void(operations::replace_response)>&& handler)
+    -> pending_call;
+  auto execute(operations::remove_request request,
+               utils::movable_function<void(operations::remove_response)>&& handler)
+    -> pending_call;
+
+private:
+  // The generated gRPC stubs are held behind an opaque pointer so the generated protobuf and gRPC
+  // surface stays out of every translation unit that includes this header -- none of it appears in
+  // the interface, and the stub count grows with every service the transport learns to speak.
+  struct stubs;
+
+  asio::io_context& io_;
+  std::unique_ptr<stubs> stubs_;
+  std::string authorization_;
+  std::chrono::milliseconds default_kv_timeout_;
+  // Declared last, so it is destroyed first: ~dispatcher() cancels and drains the calls issued
+  // through the stubs above, which must therefore still be alive while it runs.
+  dispatcher dispatcher_;
+};
+
+} // namespace couchbase::core::protostellar

--- a/core/protostellar/error_utils.cxx
+++ b/core/protostellar/error_utils.cxx
@@ -124,7 +124,7 @@ map_already_exists(const std::string& resource_type) -> std::error_code
 } // namespace
 
 auto
-map_status_code(grpc::StatusCode code) -> std::error_code
+map_status_code(grpc::StatusCode code, operation_kind kind) -> std::error_code
 {
   switch (code) {
     case grpc::StatusCode::OK:
@@ -137,10 +137,14 @@ map_status_code(grpc::StatusCode code) -> std::error_code
       // gRPC ABORTED is the canonical concurrency-conflict code; for KV that is a CAS mismatch.
       return errc::common::cas_mismatch;
     case grpc::StatusCode::DEADLINE_EXCEEDED:
-      // A server-side deadline on a mutation is genuinely ambiguous (the write may already have
-      // been applied), so default to the ambiguous timeout rather than telling the retry layer
-      // it is safe to replay a possibly-non-idempotent operation.
-      return errc::common::ambiguous_timeout;
+      // A deadline on a mutation is genuinely ambiguous -- the write may already have been applied
+      // server-side -- so it must not tell the retry layer it is safe to replay a
+      // possibly-non-idempotent operation. A read changed nothing by definition, so reporting it
+      // as ambiguous would be strictly wrong: it claims the operation may have mutated state that
+      // it cannot have touched, and a caller that declines to retry ambiguous operations would
+      // give up on an operation that is perfectly safe to repeat.
+      return kind == operation_kind::read_only ? errc::common::unambiguous_timeout
+                                               : errc::common::ambiguous_timeout;
     case grpc::StatusCode::CANCELLED:
       return errc::common::request_canceled;
     case grpc::StatusCode::UNAUTHENTICATED:
@@ -165,15 +169,13 @@ map_status_code(grpc::StatusCode code) -> std::error_code
 }
 
 auto
-map_status(const grpc::Status& status) -> std::error_code
+map_status(const grpc::Status& status, operation_kind kind) -> std::error_code
 {
   const auto code = status.error_code();
 
   // The typed google.rpc.Status details refine three codes into specific SDK errors (RFC 77 "Other
-  // errors" + errorhandler.go). Everything else is keyed on the bare gRPC code.
-  // NOTE: DEADLINE_EXCEEDED is mapped to the safe ambiguous_timeout default. Distinguishing the
-  // read-only case (unambiguous for reads) would need the request's readonly flag, which is not
-  // available at this layer.
+  // errors" + errorhandler.go). Everything else is keyed on the bare gRPC code, plus `kind` for
+  // DEADLINE_EXCEEDED (see map_status_code).
   google::rpc::Status rich;
   const bool have_rich =
     !status.error_details().empty() && rich.ParseFromString(status.error_details());
@@ -202,7 +204,7 @@ map_status(const grpc::Status& status) -> std::error_code
       }
       return errc::key_value::document_exists;
     default:
-      return map_status_code(code);
+      return map_status_code(code, kind);
   }
 }
 
@@ -219,9 +221,10 @@ error_message(const grpc::Status& status) -> std::string
 }
 
 auto
-make_error_context(const grpc::Status& status, const document_id& id) -> key_value_error_context
+make_error_context(const grpc::Status& status, const document_id& id, operation_kind kind)
+  -> key_value_error_context
 {
-  const auto ec = map_status(status);
+  const auto ec = map_status(status, kind);
   std::optional<key_value_extended_error_info> extended{};
   if (!status.ok()) {
     if (auto message = error_message(status); !message.empty()) {

--- a/core/protostellar/error_utils.hxx
+++ b/core/protostellar/error_utils.hxx
@@ -31,16 +31,34 @@ class key_value_error_context;
 namespace couchbase::core::protostellar
 {
 
+// Whether the operation whose failure is being mapped can have changed server state. This is the
+// bit RFC 77 keys the DEADLINE_EXCEEDED mapping on, in its "Other errors" table:
+//
+//   "Readonly ops: UnambiguousTimeoutException Otherwise: AmbiguousTimeoutException [...] Remember
+//    the 'Ambiguous' refers to whether the operation may have mutated state. This needs to be based
+//    on a readonly status, not an idempotent status. An upsert op is idempotent but mutates state."
+//
+// So it is deliberately not idempotency: the two disagree exactly where it matters, and keying on
+// idempotency would report a timed-out upsert as unambiguous -- telling the caller a write
+// definitely did not happen when it may well have.
+//
+// It is also not "returns a value to the user". get_and_lock and get_and_touch read a document but
+// take a lock / rewrite the expiry as they do, so they are `mutating` here despite reading.
+enum class operation_kind {
+  read_only,
+  mutating,
+};
+
 // Map a bare gRPC status code to a couchbase error_code. OK yields a default-constructed
 // (success) error_code. Exposed separately from map_status so it can be unit-tested directly.
 [[nodiscard]] auto
-map_status_code(grpc::StatusCode code) -> std::error_code;
+map_status_code(grpc::StatusCode code, operation_kind kind) -> std::error_code;
 
 // Map a gRPC status to a couchbase error_code. Keyed on the status code, with the typed
 // google.rpc.Status details (see error_message) refining FAILED_PRECONDITION, NOT_FOUND, and
 // ALREADY_EXISTS into specific KV/management errors.
 [[nodiscard]] auto
-map_status(const grpc::Status& status) -> std::error_code;
+map_status(const grpc::Status& status, operation_kind kind) -> std::error_code;
 
 // Human-readable message for a failed status: the message from the attached google.rpc.Status
 // rich-error details when present, otherwise the plain gRPC status message.
@@ -51,6 +69,7 @@ error_message(const grpc::Status& status) -> std::string;
 // failure, attaches the server-provided message (see error_message) as the context's
 // human-readable explanation so callers see why the gateway rejected the operation.
 [[nodiscard]] auto
-make_error_context(const grpc::Status& status, const document_id& id) -> key_value_error_context;
+make_error_context(const grpc::Status& status, const document_id& id, operation_kind kind)
+  -> key_value_error_context;
 
 } // namespace couchbase::core::protostellar

--- a/test/cng/CMakeLists.txt
+++ b/test/cng/CMakeLists.txt
@@ -110,4 +110,7 @@ if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 AND TARGET couchbase_cxx_protostellar)
 
   # KV converter (CXXCBC-892).
   add_cng_test(protostellar/kv_converter LINK_CLIENT LIBS couchbase_cxx_protostellar)
+
+  # Protostellar KV component (CXXCBC-891).
+  add_cng_test(protostellar/component LINK_CLIENT LIBS couchbase_cxx_protostellar)
 endif()

--- a/test/cng/protostellar/component.cxx
+++ b/test/cng/protostellar/component.cxx
@@ -1,0 +1,693 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Tests for the Protostellar KV component (CXXCBC-891): a real KV op is encoded, dispatched
+// over gRPC to an in-process server, and decoded into a core response delivered on the
+// io_context, with the error context reflecting the gRPC status. Env-agnostic (in-process
+// server, no external cluster). The connect-time wiring into cluster_impl is a separate change.
+
+#include "framework/test_runner.hxx"
+
+#include "core/cluster_credentials.hxx"
+#include "core/document_id.hxx"
+#include "core/error_context/key_value.hxx"
+#include "core/protostellar/component.hxx"
+#include "core/protostellar/kv_converter.hxx"
+#include "core/utils/binary.hxx"
+
+#include <couchbase/error_codes.hxx>
+
+#include <couchbase/kv/v1/kv.grpc.pb.h>
+
+#include <asio/executor_work_guard.hpp>
+#include <asio/io_context.hpp>
+
+#include <grpcpp/server_builder.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <string>
+#include <thread>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace v1 = ::couchbase::kv::v1;
+namespace ops = ::couchbase::core::operations;
+namespace pk = ::couchbase::core::protostellar::kv;
+namespace cu = ::couchbase::core::utils;
+using ::couchbase::core::cluster_credentials;
+using ::couchbase::core::document_id;
+using ::couchbase::core::protostellar::component;
+using ::couchbase::core::protostellar::component_config;
+using namespace std::chrono_literals;
+
+class test_kv_service final : public v1::KvService::Service
+{
+public:
+  auto Get(grpc::ServerContext* context, const v1::GetRequest* request, v1::GetResponse* response)
+    -> grpc::Status override
+  {
+    record_auth(context);
+    if (request->key() == "missing") {
+      return { grpc::StatusCode::NOT_FOUND, "no such document" };
+    }
+    if (request->key() == "compressed") {
+      response->set_content_compressed("dummy_compressed_data");
+      response->set_cas(0x2222ULL);
+      return grpc::Status::OK;
+    }
+    response->set_content_uncompressed("value:" + request->key());
+    response->set_cas(0x2222ULL);
+    response->set_content_flags(0x06U);
+    return grpc::Status::OK;
+  }
+
+  auto Upsert(grpc::ServerContext* context,
+              const v1::UpsertRequest* request,
+              v1::UpsertResponse* response) -> grpc::Status override
+  {
+    record_auth(context);
+    if (request->key() == "fail") {
+      return { grpc::StatusCode::UNAVAILABLE, "node unavailable" };
+    }
+    response->set_cas(0x3333ULL);
+    auto* token = response->mutable_mutation_token();
+    token->set_bucket_name(request->bucket_name());
+    token->set_vbucket_id(7U);
+    token->set_vbucket_uuid(0x1111ULL);
+    token->set_seq_no(99ULL);
+    return grpc::Status::OK;
+  }
+
+  auto Insert(grpc::ServerContext* context,
+              const v1::InsertRequest* request,
+              v1::InsertResponse* response) -> grpc::Status override
+  {
+    record_auth(context);
+    if (request->key() == "exists") {
+      return { grpc::StatusCode::ALREADY_EXISTS, "document exists" };
+    }
+    response->set_cas(0x4444ULL);
+    auto* token = response->mutable_mutation_token();
+    token->set_bucket_name(request->bucket_name());
+    token->set_vbucket_id(1U);
+    token->set_vbucket_uuid(0x5555ULL);
+    token->set_seq_no(101ULL);
+    return grpc::Status::OK;
+  }
+
+  auto Replace(grpc::ServerContext* context,
+               const v1::ReplaceRequest* request,
+               v1::ReplaceResponse* response) -> grpc::Status override
+  {
+    record_auth(context);
+    if (request->key() == "missing") {
+      return { grpc::StatusCode::NOT_FOUND, "no such document" };
+    }
+    response->set_cas(0x5555ULL);
+    auto* token = response->mutable_mutation_token();
+    token->set_bucket_name(request->bucket_name());
+    token->set_vbucket_id(2U);
+    token->set_vbucket_uuid(0x6666ULL);
+    token->set_seq_no(102ULL);
+    return grpc::Status::OK;
+  }
+
+  auto Remove(grpc::ServerContext* context,
+              const v1::RemoveRequest* request,
+              v1::RemoveResponse* response) -> grpc::Status override
+  {
+    record_auth(context);
+    if (request->key() == "missing") {
+      return { grpc::StatusCode::NOT_FOUND, "no such document" };
+    }
+    response->set_cas(0x6666ULL);
+    auto* token = response->mutable_mutation_token();
+    token->set_bucket_name(request->bucket_name());
+    token->set_vbucket_id(3U);
+    token->set_vbucket_uuid(0x7777ULL);
+    token->set_seq_no(103ULL);
+    return grpc::Status::OK;
+  }
+
+  std::string last_auth_header{};
+
+  // Test knobs. `reply_delay` makes every handler sleep before answering, so a client-side deadline
+  // can fire while the call is genuinely in flight. `calls_received` counts the requests that
+  // actually reached the server, which is how a case distinguishes "rejected before dispatch" from
+  // "dispatched and then failed" -- the two are indistinguishable from the response alone.
+  std::atomic<std::chrono::milliseconds> reply_delay{ std::chrono::milliseconds::zero() };
+  std::atomic<int> calls_received{ 0 };
+
+private:
+  void record_auth(grpc::ServerContext* context)
+  {
+    calls_received.fetch_add(1);
+    const auto& meta = context->client_metadata();
+    auto it = meta.find("authorization");
+    if (it != meta.end()) {
+      last_auth_header = std::string(it->second.data(), it->second.length());
+    }
+    if (const auto delay = reply_delay.load(); delay > std::chrono::milliseconds::zero()) {
+      std::this_thread::sleep_for(delay);
+    }
+  }
+};
+
+class in_process_server
+{
+public:
+  in_process_server()
+  {
+    grpc::ServerBuilder builder;
+    builder.RegisterService(&service_);
+    server_ = builder.BuildAndStart();
+  }
+  in_process_server(const in_process_server&) = delete;
+  in_process_server(in_process_server&&) = delete;
+  auto operator=(const in_process_server&) -> in_process_server& = delete;
+  auto operator=(in_process_server&&) -> in_process_server& = delete;
+  ~in_process_server()
+  {
+    server_->Shutdown(std::chrono::system_clock::now());
+  }
+  [[nodiscard]] auto channel() -> std::shared_ptr<grpc::Channel>
+  {
+    return server_->InProcessChannel(grpc::ChannelArguments{});
+  }
+  [[nodiscard]] auto service() -> test_kv_service&
+  {
+    return service_;
+  }
+
+private:
+  test_kv_service service_;
+  std::unique_ptr<grpc::Server> server_;
+};
+
+auto
+make_id(std::string key) -> document_id
+{
+  return document_id{ "b", "s", "c", std::move(key) };
+}
+
+void
+get_round_trips_on_the_io_thread()
+{
+  in_process_server server;
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+
+  ops::get_request request;
+  request.id = make_id("k1");
+
+  ops::get_response outcome;
+  std::thread::id handler_thread;
+  comp.execute(std::move(request), [&](ops::get_response response) {
+    outcome = std::move(response);
+    handler_thread = std::this_thread::get_id();
+    work.reset();
+  });
+  io.run();
+
+  assert_false(static_cast<bool>(outcome.ctx.ec()), "get succeeded");
+  assert_eq(cu::to_string(outcome.value), std::string{ "value:k1" }, "value round-trips");
+  assert_eq(outcome.cas.value(), 0x2222ULL, "cas round-trips");
+  assert_true(handler_thread == std::this_thread::get_id(), "handler ran on io thread");
+}
+
+void
+get_maps_not_found_into_the_error_context()
+{
+  in_process_server server;
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+
+  ops::get_request request;
+  request.id = make_id("missing");
+
+  ops::get_response outcome;
+  comp.execute(std::move(request), [&](ops::get_response response) {
+    outcome = std::move(response);
+    work.reset();
+  });
+  io.run();
+
+  assert_true(outcome.ctx.ec() == couchbase::errc::key_value::document_not_found,
+              "NOT_FOUND surfaces as document_not_found");
+}
+
+void
+upsert_returns_cas_and_mutation_token()
+{
+  in_process_server server;
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+
+  ops::upsert_request request;
+  request.id = make_id("k1");
+  request.value = cu::to_binary("body");
+
+  ops::upsert_response outcome;
+  comp.execute(std::move(request), [&](ops::upsert_response response) {
+    outcome = std::move(response);
+    work.reset();
+  });
+  io.run();
+
+  assert_false(static_cast<bool>(outcome.ctx.ec()), "upsert succeeded");
+  assert_eq(outcome.cas.value(), 0x3333ULL, "cas round-trips");
+  assert_eq(outcome.token.partition_id(), static_cast<std::uint16_t>(7), "token vbucket id");
+  assert_eq(outcome.token.sequence_number(), static_cast<std::uint64_t>(99), "token seqno");
+}
+
+void
+get_handles_compressed_content_with_feature_not_available()
+{
+  in_process_server server;
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+
+  ops::get_request request;
+  request.id = make_id("compressed");
+
+  ops::get_response outcome;
+  comp.execute(std::move(request), [&](ops::get_response response) {
+    outcome = std::move(response);
+    work.reset();
+  });
+  io.run();
+
+  assert_true(outcome.ctx.ec() == couchbase::errc::common::feature_not_available,
+              "compressed content surfaces feature_not_available");
+}
+
+void
+insert_returns_cas_and_mutation_token()
+{
+  in_process_server server;
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+
+  ops::insert_request request;
+  request.id = make_id("k1");
+  request.value = cu::to_binary("body");
+
+  ops::insert_response outcome;
+  comp.execute(std::move(request), [&](ops::insert_response response) {
+    outcome = std::move(response);
+    work.reset();
+  });
+  io.run();
+
+  assert_false(static_cast<bool>(outcome.ctx.ec()), "insert succeeded");
+  assert_eq(outcome.cas.value(), 0x4444ULL, "cas round-trips");
+  assert_eq(outcome.token.partition_id(), static_cast<std::uint16_t>(1), "token vbucket id");
+  assert_eq(outcome.token.sequence_number(), static_cast<std::uint64_t>(101), "token seqno");
+}
+
+void
+insert_maps_already_exists_into_error_context()
+{
+  in_process_server server;
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+
+  ops::insert_request request;
+  request.id = make_id("exists");
+  request.value = cu::to_binary("body");
+
+  ops::insert_response outcome;
+  comp.execute(std::move(request), [&](ops::insert_response response) {
+    outcome = std::move(response);
+    work.reset();
+  });
+  io.run();
+
+  assert_true(outcome.ctx.ec() == couchbase::errc::key_value::document_exists,
+              "ALREADY_EXISTS surfaces as document_exists");
+}
+
+void
+replace_returns_cas_and_mutation_token()
+{
+  in_process_server server;
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+
+  ops::replace_request request;
+  request.id = make_id("k1");
+  request.value = cu::to_binary("body");
+
+  ops::replace_response outcome;
+  comp.execute(std::move(request), [&](ops::replace_response response) {
+    outcome = std::move(response);
+    work.reset();
+  });
+  io.run();
+
+  assert_false(static_cast<bool>(outcome.ctx.ec()), "replace succeeded");
+  assert_eq(outcome.cas.value(), 0x5555ULL, "cas round-trips");
+  assert_eq(outcome.token.partition_id(), static_cast<std::uint16_t>(2), "token vbucket id");
+  assert_eq(outcome.token.sequence_number(), static_cast<std::uint64_t>(102), "token seqno");
+}
+
+void
+replace_maps_not_found_into_error_context()
+{
+  in_process_server server;
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+
+  ops::replace_request request;
+  request.id = make_id("missing");
+  request.value = cu::to_binary("body");
+
+  ops::replace_response outcome;
+  comp.execute(std::move(request), [&](ops::replace_response response) {
+    outcome = std::move(response);
+    work.reset();
+  });
+  io.run();
+
+  assert_true(outcome.ctx.ec() == couchbase::errc::key_value::document_not_found,
+              "NOT_FOUND surfaces as document_not_found");
+}
+
+void
+remove_returns_cas_and_mutation_token()
+{
+  in_process_server server;
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+
+  ops::remove_request request;
+  request.id = make_id("k1");
+
+  ops::remove_response outcome;
+  comp.execute(std::move(request), [&](ops::remove_response response) {
+    outcome = std::move(response);
+    work.reset();
+  });
+  io.run();
+
+  assert_false(static_cast<bool>(outcome.ctx.ec()), "remove succeeded");
+  assert_eq(outcome.cas.value(), 0x6666ULL, "cas round-trips");
+  assert_eq(outcome.token.partition_id(), static_cast<std::uint16_t>(3), "token vbucket id");
+  assert_eq(outcome.token.sequence_number(), static_cast<std::uint64_t>(103), "token seqno");
+}
+
+void
+remove_maps_not_found_into_error_context()
+{
+  in_process_server server;
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+
+  ops::remove_request request;
+  request.id = make_id("missing");
+
+  ops::remove_response outcome;
+  comp.execute(std::move(request), [&](ops::remove_response response) {
+    outcome = std::move(response);
+    work.reset();
+  });
+  io.run();
+
+  assert_true(outcome.ctx.ec() == couchbase::errc::key_value::document_not_found,
+              "NOT_FOUND surfaces as document_not_found");
+}
+
+void
+authorization_header_passed_to_grpc_context()
+{
+  in_process_server server;
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  cluster_credentials creds;
+  creds.username = "Administrator";
+  creds.password = "password";
+
+  component comp{ io, component_config{ server.channel(), creds, 5000ms } };
+
+  ops::get_request request;
+  request.id = make_id("k1");
+
+  ops::get_response outcome;
+  comp.execute(std::move(request), [&](ops::get_response response) {
+    outcome = std::move(response);
+    work.reset();
+  });
+  io.run();
+
+  assert_false(static_cast<bool>(outcome.ctx.ec()), "get succeeded");
+  assert_false(server.service().last_auth_header.empty(), "authorization header received");
+  assert_eq(server.service().last_auth_header,
+            "Basic QWRtaW5pc3RyYXRvcjpwYXNzd29yZA==",
+            "auth header matches expected basic auth");
+}
+
+// The deadline actually fires. Nothing else in this file exercises the timeout the component
+// resolves: every other case leaves request.timeout unset against a server that answers at once, so
+// an execute() that ignored the value entirely would still pass them all.
+//
+// Two properties are asserted together because they are only observable on this path: that
+// request.timeout wins over the component default (50ms against a 5000ms default and a server that
+// takes 400ms -- if the default were used the call would succeed instead), and that a timed-out
+// read reports unambiguous_timeout, since a get cannot have changed the document.
+void
+get_honours_the_request_timeout()
+{
+  in_process_server server;
+  server.service().reply_delay.store(400ms);
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+
+  ops::get_request request;
+  request.id = make_id("k1");
+  request.timeout = 50ms;
+
+  std::optional<ops::get_response> outcome;
+  int completions = 0;
+  comp.execute(std::move(request), [&](ops::get_response response) {
+    ++completions;
+    outcome = std::move(response);
+    work.reset();
+  });
+  io.run();
+
+  assert_true(outcome.has_value(), "the handler runs");
+  assert_eq(completions, 1, "the handler runs exactly once");
+  assert_true(outcome->ctx.ec() == couchbase::errc::common::unambiguous_timeout,
+              "a timed-out read is unambiguous: a get cannot have mutated the document");
+}
+
+// The mutating arm of the same mapping. Kept as a separate case because a single shared
+// classification would satisfy the read-only assertion above by accident.
+void
+mutation_timeout_is_reported_as_ambiguous()
+{
+  in_process_server server;
+  server.service().reply_delay.store(400ms);
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+
+  ops::upsert_request request;
+  request.id = make_id("k1");
+  request.value = cu::to_binary("v");
+  request.timeout = 50ms;
+
+  std::optional<ops::upsert_response> outcome;
+  comp.execute(std::move(request), [&](ops::upsert_response response) {
+    outcome = std::move(response);
+    work.reset();
+  });
+  io.run();
+
+  assert_true(outcome.has_value(), "the handler runs");
+  assert_true(outcome->ctx.ec() == couchbase::errc::common::ambiguous_timeout,
+              "a timed-out mutation is ambiguous: the write may already have been applied");
+}
+
+// An already-exhausted budget must not be dispatched. dispatcher::unary only sets a deadline when
+// the timeout is positive, so forwarding a non-positive one would produce a call with no deadline
+// at all -- the opposite of what "no time left" should mean.
+//
+// calls_received is what makes this a real assertion rather than a restatement of the error code:
+// it proves the request was rejected before reaching the wire, not dispatched and then failed.
+void
+an_exhausted_budget_is_rejected_before_dispatch()
+{
+  in_process_server server;
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+
+  ops::get_request request;
+  request.id = make_id("k1");
+  request.timeout = 0ms;
+
+  std::optional<ops::get_response> outcome;
+  std::thread::id handler_thread;
+  int completions = 0;
+  comp.execute(std::move(request), [&](ops::get_response response) {
+    ++completions;
+    outcome = std::move(response);
+    handler_thread = std::this_thread::get_id();
+    work.reset();
+  });
+  io.run();
+
+  assert_true(outcome.has_value(), "the handler runs");
+  assert_eq(completions, 1, "the handler runs exactly once");
+  assert_true(outcome->ctx.ec() == couchbase::errc::common::unambiguous_timeout,
+              "an operation that was never sent definitively did not happen");
+  assert_eq(server.service().calls_received.load(), 0, "nothing reached the server");
+  assert_true(handler_thread == std::this_thread::get_id(),
+              "the rejection is delivered on the io thread like every other completion");
+}
+
+// A non-positive default is rejected on the same path, which is the case that does not depend on
+// the caller: request.timeout is unset here, so the component's own default is what resolves to
+// zero.
+void
+an_exhausted_default_timeout_is_also_rejected()
+{
+  in_process_server server;
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 0ms } };
+
+  ops::remove_request request;
+  request.id = make_id("k1");
+
+  std::optional<ops::remove_response> outcome;
+  comp.execute(std::move(request), [&](ops::remove_response response) {
+    outcome = std::move(response);
+    work.reset();
+  });
+  io.run();
+
+  assert_true(outcome.has_value(), "the handler runs");
+  assert_true(outcome->ctx.ec() == couchbase::errc::common::unambiguous_timeout,
+              "a non-positive default is rejected exactly like a non-positive request timeout");
+  assert_eq(server.service().calls_received.load(), 0, "nothing reached the server");
+}
+
+// Cancelling an in-flight call still completes the handler, exactly once. A cancellation that
+// dropped the completion would hang whatever is waiting on it, which is worse than the error.
+void
+cancellation_completes_the_handler_once()
+{
+  in_process_server server;
+  server.service().reply_delay.store(400ms);
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+
+  ops::get_request request;
+  request.id = make_id("k1");
+
+  std::optional<ops::get_response> outcome;
+  int completions = 0;
+  auto call = comp.execute(std::move(request), [&](ops::get_response response) {
+    ++completions;
+    outcome = std::move(response);
+    work.reset();
+  });
+  call.cancel();
+  io.run();
+
+  assert_true(outcome.has_value(), "a cancelled call still completes its handler");
+  assert_eq(completions, 1, "the handler runs exactly once");
+  assert_true(outcome->ctx.ec() == couchbase::errc::common::request_canceled,
+              "cancellation surfaces as request_canceled");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_component",
+    {
+      { "get_round_trips_on_the_io_thread", get_round_trips_on_the_io_thread, timeout::network },
+      { "get_maps_not_found_into_the_error_context",
+        get_maps_not_found_into_the_error_context,
+        timeout::network },
+      { "get_handles_compressed_content_with_feature_not_available",
+        get_handles_compressed_content_with_feature_not_available,
+        timeout::network },
+      { "upsert_returns_cas_and_mutation_token",
+        upsert_returns_cas_and_mutation_token,
+        timeout::network },
+      { "insert_returns_cas_and_mutation_token",
+        insert_returns_cas_and_mutation_token,
+        timeout::network },
+      { "insert_maps_already_exists_into_error_context",
+        insert_maps_already_exists_into_error_context,
+        timeout::network },
+      { "replace_returns_cas_and_mutation_token",
+        replace_returns_cas_and_mutation_token,
+        timeout::network },
+      { "replace_maps_not_found_into_error_context",
+        replace_maps_not_found_into_error_context,
+        timeout::network },
+      { "remove_returns_cas_and_mutation_token",
+        remove_returns_cas_and_mutation_token,
+        timeout::network },
+      { "remove_maps_not_found_into_error_context",
+        remove_maps_not_found_into_error_context,
+        timeout::network },
+      { "get_honours_the_request_timeout", get_honours_the_request_timeout, timeout::network },
+      { "mutation_timeout_is_reported_as_ambiguous",
+        mutation_timeout_is_reported_as_ambiguous,
+        timeout::network },
+      { "an_exhausted_budget_is_rejected_before_dispatch",
+        an_exhausted_budget_is_rejected_before_dispatch,
+        timeout::network },
+      { "an_exhausted_default_timeout_is_also_rejected",
+        an_exhausted_default_timeout_is_also_rejected,
+        timeout::network },
+      { "cancellation_completes_the_handler_once",
+        cancellation_completes_the_handler_once,
+        timeout::network },
+      { "authorization_header_passed_to_grpc_context",
+        authorization_header_passed_to_grpc_context,
+        timeout::network },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test

--- a/test/cng/protostellar/error_utils.cxx
+++ b/test/cng/protostellar/error_utils.cxx
@@ -70,105 +70,154 @@ resource(const std::string& resource_type) -> google::rpc::ResourceInfo
 void
 ok_maps_to_success()
 {
-  assert_false(static_cast<bool>(ps::map_status_code(grpc::StatusCode::OK)), "OK is not an error");
+  assert_false(
+    static_cast<bool>(ps::map_status_code(grpc::StatusCode::OK, ps::operation_kind::mutating)),
+    "OK is not an error");
 }
 
 void
 status_codes_map_to_expected_errc()
 {
-  assert_true(ps::map_status_code(grpc::StatusCode::NOT_FOUND) ==
+  assert_true(ps::map_status_code(grpc::StatusCode::NOT_FOUND, ps::operation_kind::mutating) ==
                 couchbase::errc::key_value::document_not_found,
               "NOT_FOUND -> document_not_found");
-  assert_true(ps::map_status_code(grpc::StatusCode::ALREADY_EXISTS) ==
+  assert_true(ps::map_status_code(grpc::StatusCode::ALREADY_EXISTS, ps::operation_kind::mutating) ==
                 couchbase::errc::key_value::document_exists,
               "ALREADY_EXISTS -> document_exists");
-  assert_true(ps::map_status_code(grpc::StatusCode::ABORTED) ==
+  assert_true(ps::map_status_code(grpc::StatusCode::ABORTED, ps::operation_kind::mutating) ==
                 couchbase::errc::common::cas_mismatch,
               "ABORTED -> cas_mismatch");
-  assert_true(ps::map_status_code(grpc::StatusCode::DEADLINE_EXCEEDED) ==
-                couchbase::errc::common::ambiguous_timeout,
-              "DEADLINE_EXCEEDED -> ambiguous_timeout (a mutation may have applied)");
-  assert_true(ps::map_status_code(grpc::StatusCode::CANCELLED) ==
+  assert_true(
+    ps::map_status_code(grpc::StatusCode::DEADLINE_EXCEEDED, ps::operation_kind::mutating) ==
+      couchbase::errc::common::ambiguous_timeout,
+    "DEADLINE_EXCEEDED -> ambiguous_timeout (a mutation may have applied)");
+  assert_true(ps::map_status_code(grpc::StatusCode::CANCELLED, ps::operation_kind::mutating) ==
                 couchbase::errc::common::request_canceled,
               "CANCELLED -> request_canceled");
-  assert_true(ps::map_status_code(grpc::StatusCode::UNAUTHENTICATED) ==
-                couchbase::errc::common::authentication_failure,
-              "UNAUTHENTICATED -> authentication_failure");
-  assert_true(ps::map_status_code(grpc::StatusCode::UNIMPLEMENTED) ==
+  assert_true(
+    ps::map_status_code(grpc::StatusCode::UNAUTHENTICATED, ps::operation_kind::mutating) ==
+      couchbase::errc::common::authentication_failure,
+    "UNAUTHENTICATED -> authentication_failure");
+  assert_true(ps::map_status_code(grpc::StatusCode::UNIMPLEMENTED, ps::operation_kind::mutating) ==
                 couchbase::errc::common::feature_not_available,
               "UNIMPLEMENTED -> feature_not_available");
-  assert_true(ps::map_status_code(grpc::StatusCode::UNAVAILABLE) ==
+  assert_true(ps::map_status_code(grpc::StatusCode::UNAVAILABLE, ps::operation_kind::mutating) ==
                 couchbase::errc::common::temporary_failure,
               "UNAVAILABLE -> temporary_failure");
-  assert_true(ps::map_status_code(grpc::StatusCode::INTERNAL) ==
+  assert_true(ps::map_status_code(grpc::StatusCode::INTERNAL, ps::operation_kind::mutating) ==
                 couchbase::errc::common::internal_server_failure,
               "INTERNAL -> internal_server_failure");
+}
+
+// DEADLINE_EXCEEDED is the one code whose mapping depends on what the operation does. Reporting a
+// timed-out read as ambiguous claims the operation may have changed state it cannot have touched,
+// and a caller that refuses to replay ambiguous operations would then give up on one that is
+// perfectly safe to repeat.
+//
+// The distinction is read-only-ness, not idempotency: the two disagree precisely where it matters,
+// since an upsert is idempotent and still mutates. Asserted through every layer that carries the
+// bit, so none of them can quietly drop it.
+void
+deadline_exceeded_depends_on_the_operation_kind()
+{
+  assert_true(
+    ps::map_status_code(grpc::StatusCode::DEADLINE_EXCEEDED, ps::operation_kind::read_only) ==
+      couchbase::errc::common::unambiguous_timeout,
+    "a timed-out read changed nothing, so it is unambiguous");
+  assert_true(
+    ps::map_status_code(grpc::StatusCode::DEADLINE_EXCEEDED, ps::operation_kind::mutating) ==
+      couchbase::errc::common::ambiguous_timeout,
+    "a timed-out mutation may have applied, so it stays ambiguous");
+
+  const grpc::Status expired{ grpc::StatusCode::DEADLINE_EXCEEDED, "deadline exceeded" };
+  assert_true(ps::map_status(expired, ps::operation_kind::read_only) ==
+                couchbase::errc::common::unambiguous_timeout,
+              "map_status carries the kind through to the code");
+  assert_true(ps::map_status(expired, ps::operation_kind::mutating) ==
+                couchbase::errc::common::ambiguous_timeout,
+              "map_status carries the kind through to the code");
+
+  const couchbase::core::document_id id{ "b", "s", "c", "k" };
+  assert_true(ps::make_error_context(expired, id, ps::operation_kind::read_only).ec() ==
+                couchbase::errc::common::unambiguous_timeout,
+              "make_error_context carries the kind through to the context");
+  assert_true(ps::make_error_context(expired, id, ps::operation_kind::mutating).ec() ==
+                couchbase::errc::common::ambiguous_timeout,
+              "make_error_context carries the kind through to the context");
 }
 
 void
 map_status_uses_the_status_code()
 {
   const grpc::Status status{ grpc::StatusCode::NOT_FOUND, "missing" };
-  assert_true(ps::map_status(status) == couchbase::errc::key_value::document_not_found,
+  assert_true(ps::map_status(status, ps::operation_kind::mutating) ==
+                couchbase::errc::key_value::document_not_found,
               "map_status keys on the code");
 }
 
 void
 precondition_details_map_to_specific_kv_errors()
 {
-  assert_true(ps::map_status(status_with_detail(grpc::StatusCode::FAILED_PRECONDITION,
-                                                precondition("LOCKED"))) ==
-                couchbase::errc::key_value::document_locked,
+  assert_true(ps::map_status(
+                status_with_detail(grpc::StatusCode::FAILED_PRECONDITION, precondition("LOCKED")),
+                ps::operation_kind::mutating) == couchbase::errc::key_value::document_locked,
               "PreconditionFailure LOCKED -> document_locked");
   assert_true(ps::map_status(status_with_detail(grpc::StatusCode::FAILED_PRECONDITION,
-                                                precondition("NOT_LOCKED"))) ==
+                                                precondition("NOT_LOCKED")),
+                             ps::operation_kind::mutating) ==
                 couchbase::errc::key_value::document_not_locked,
               "NOT_LOCKED -> document_not_locked");
   assert_true(ps::map_status(status_with_detail(grpc::StatusCode::FAILED_PRECONDITION,
-                                                precondition("DOC_NOT_JSON"))) ==
+                                                precondition("DOC_NOT_JSON")),
+                             ps::operation_kind::mutating) ==
                 couchbase::errc::key_value::document_not_json,
               "DOC_NOT_JSON -> document_not_json");
   assert_true(ps::map_status(status_with_detail(grpc::StatusCode::FAILED_PRECONDITION,
-                                                precondition("PATH_VALUE_OUT_OF_RANGE"))) ==
+                                                precondition("PATH_VALUE_OUT_OF_RANGE")),
+                             ps::operation_kind::mutating) ==
                 couchbase::errc::key_value::number_too_big,
               "PATH_VALUE_OUT_OF_RANGE -> number_too_big");
   assert_true(ps::map_status(status_with_detail(grpc::StatusCode::FAILED_PRECONDITION,
-                                                precondition("VALUE_TOO_LARGE"))) ==
+                                                precondition("VALUE_TOO_LARGE")),
+                             ps::operation_kind::mutating) ==
                 couchbase::errc::key_value::value_too_large,
               "VALUE_TOO_LARGE -> value_too_large");
 
   // FAILED_PRECONDITION with no (recognized) detail falls back to internal_server_failure.
   const grpc::Status bare{ grpc::StatusCode::FAILED_PRECONDITION, "no details" };
-  assert_true(ps::map_status(bare) == couchbase::errc::common::internal_server_failure,
+  assert_true(ps::map_status(bare, ps::operation_kind::mutating) ==
+                couchbase::errc::common::internal_server_failure,
               "bare FAILED_PRECONDITION -> internal_server_failure");
 }
 
 void
 resource_info_selects_typed_not_found_and_exists()
 {
-  assert_true(ps::map_status(status_with_detail(grpc::StatusCode::NOT_FOUND, resource("bucket"))) ==
+  assert_true(ps::map_status(status_with_detail(grpc::StatusCode::NOT_FOUND, resource("bucket")),
+                             ps::operation_kind::mutating) ==
                 couchbase::errc::common::bucket_not_found,
               "NOT_FOUND + bucket -> bucket_not_found");
   assert_true(
-    ps::map_status(status_with_detail(grpc::StatusCode::NOT_FOUND, resource("collection"))) ==
-      couchbase::errc::common::collection_not_found,
+    ps::map_status(status_with_detail(grpc::StatusCode::NOT_FOUND, resource("collection")),
+                   ps::operation_kind::mutating) == couchbase::errc::common::collection_not_found,
     "NOT_FOUND + collection -> collection_not_found");
   assert_true(
-    ps::map_status(status_with_detail(grpc::StatusCode::NOT_FOUND, resource("queryindex"))) ==
-      couchbase::errc::common::index_not_found,
+    ps::map_status(status_with_detail(grpc::StatusCode::NOT_FOUND, resource("queryindex")),
+                   ps::operation_kind::mutating) == couchbase::errc::common::index_not_found,
     "NOT_FOUND + queryindex -> index_not_found");
   assert_true(
-    ps::map_status(status_with_detail(grpc::StatusCode::ALREADY_EXISTS, resource("bucket"))) ==
-      couchbase::errc::management::bucket_exists,
+    ps::map_status(status_with_detail(grpc::StatusCode::ALREADY_EXISTS, resource("bucket")),
+                   ps::operation_kind::mutating) == couchbase::errc::management::bucket_exists,
     "ALREADY_EXISTS + bucket -> bucket_exists");
   assert_true(
-    ps::map_status(status_with_detail(grpc::StatusCode::ALREADY_EXISTS, resource("scope"))) ==
-      couchbase::errc::management::scope_exists,
+    ps::map_status(status_with_detail(grpc::StatusCode::ALREADY_EXISTS, resource("scope")),
+                   ps::operation_kind::mutating) == couchbase::errc::management::scope_exists,
     "ALREADY_EXISTS + scope -> scope_exists");
 
   // Without a ResourceInfo, NOT_FOUND/ALREADY_EXISTS stay document-scoped (backward compatible).
   const grpc::Status bare{ grpc::StatusCode::NOT_FOUND, "no details" };
-  assert_true(ps::map_status(bare) == couchbase::errc::key_value::document_not_found,
+  assert_true(ps::map_status(bare, ps::operation_kind::mutating) ==
+                couchbase::errc::key_value::document_not_found,
               "bare NOT_FOUND -> document_not_found");
 }
 
@@ -197,7 +246,7 @@ make_error_context_maps_code_and_attaches_message()
   const couchbase::core::document_id id{ "bucket", "scope", "collection", "key" };
 
   const grpc::Status failure{ grpc::StatusCode::NOT_FOUND, "document 'key' not found" };
-  const auto ctx = ps::make_error_context(failure, id);
+  const auto ctx = ps::make_error_context(failure, id, ps::operation_kind::mutating);
   assert_true(ctx.ec() == couchbase::errc::key_value::document_not_found,
               "make_error_context maps the status code");
   assert_eq(ctx.id(), std::string{ "key" }, "carries the document key");
@@ -208,7 +257,7 @@ make_error_context_maps_code_and_attaches_message()
             "server message lands in the error context");
 
   const grpc::Status ok{};
-  const auto ok_ctx = ps::make_error_context(ok, id);
+  const auto ok_ctx = ps::make_error_context(ok, id, ps::operation_kind::mutating);
   assert_false(static_cast<bool>(ok_ctx.ec()), "OK yields a success context");
   assert_false(ok_ctx.extended_error_info().has_value(), "success carries no extended error info");
 }
@@ -224,6 +273,8 @@ tests() -> test_suite
       { "ok_maps_to_success", ok_maps_to_success },
       { "status_codes_map_to_expected_errc", status_codes_map_to_expected_errc },
       { "map_status_uses_the_status_code", map_status_uses_the_status_code },
+      { "deadline_exceeded_depends_on_the_operation_kind",
+        deadline_exceeded_depends_on_the_operation_kind },
       { "precondition_details_map_to_specific_kv_errors",
         precondition_details_map_to_specific_kv_errors },
       { "resource_info_selects_typed_not_found_and_exists",


### PR DESCRIPTION
Add core/protostellar/component: the couchbase2 KV data-plane. It owns the
KvService stub over a channel and executes the core get/upsert/insert/replace/
remove operations by encoding the request (kv_converter), dispatching it through
the gRPC<->asio bridge with the credentials' authorization attached as call
metadata, and delivering a decoded response whose key_value_error_context
carries the mapped gRPC status. The request message is kept alive for the
duration of the in-flight call.

Covered by a CNG-harness test that runs real KV round-trips against an
in-process gRPC server: success delivered on the io_context thread, NOT_FOUND
mapped to document_not_found, and upsert returning CAS plus a mutation token.
Wiring the component into cluster_impl::open/execute for couchbase2:// connect
is a separate follow-up.

---
Stacked PR **09/29** in the CNG (`couchbase2://`) transport series. This branch includes every commit from PRs 01–09; the change specific to this PR is its top commit. Depends on #1030 — merge the series bottom-up.
