### PR TITLE
CXXCBC-891: tls_verify=none and live KV verification vs a CNG gateway

### DIFF
--- a/.github/actions/create-cng-cluster/action.yml
+++ b/.github/actions/create-cng-cluster/action.yml
@@ -1,0 +1,107 @@
+name: create-cng-cluster
+description: >
+  Creates a Couchbase cluster fronted by Cloud Native Gateway (the couchbase2:// gRPC endpoint)
+  using cbdinocluster's Couchbase Autonomous Operator deployer on a local k3d Kubernetes cluster.
+  Separate from create-cluster because CNG is only deployable by the operator: the docker deployer
+  has no gateway, so there is no couchbase2:// endpoint to connect to.
+inputs:
+  version:
+    description: 'Couchbase Server version to use'
+    required: true
+  operator-version:
+    # Release versions only. cbdinocluster maps a version with a build number (e.g. 2.8.0-123) to
+    # ghcr.io/cb-vanilla/*, which needs a Couchbase-org token; a plain release maps to the public
+    # couchbase/* image on Docker Hub and needs no credentials at all. Keep it that way.
+    # 2.8.0 also matches the cao-tools version cbdinocluster's `init` downloads by default.
+    description: 'Couchbase Autonomous Operator release version'
+    required: false
+    default: '2.8.0'
+  gateway-version:
+    description: 'Cloud Native Gateway release version'
+    required: false
+    default: '1.2.1'
+  bucket:
+    description: 'Bucket to create for the tests'
+    required: false
+    default: 'default'
+outputs:
+  connstr:
+    description: 'couchbase2:// connection string for the gateway'
+    value: ${{ steps.start-cluster.outputs.connstr }}
+  id:
+    description: 'The cbdinocluster ID of the created cluster'
+    value: ${{ steps.start-cluster.outputs.id }}
+runs:
+  using: composite
+  steps:
+    - name: Install k3d and cbdinocluster
+      shell: bash
+      run: |
+        mkdir -p "$HOME/bin"
+        wget -nv -O $HOME/bin/k3d https://github.com/k3d-io/k3d/releases/download/v5.9.0/k3d-linux-amd64
+        # Newer than the v0.0.86 that create-cluster (docker deployer) pins: the cao deployer only
+        # learned to create buckets in v0.0.104 ("Implemented gocbcorex based helper for caodeploy"),
+        # and before that `buckets add` fails outright with "caodeploy does not support creating
+        # buckets". v0.0.104 is the floor; this pins the newest release at time of writing.
+        wget -nv -O $HOME/bin/cbdinocluster https://github.com/couchbaselabs/cbdinocluster/releases/download/v0.0.119/cbdinocluster-linux-amd64
+        chmod +x $HOME/bin/k3d $HOME/bin/cbdinocluster
+        echo "$HOME/bin" >> $GITHUB_PATH
+    - name: Create Kubernetes cluster
+      shell: bash
+      run: |
+        k3d cluster create cbdino --wait
+        kubectl wait --for=condition=Ready nodes --all --timeout=180s
+        kubectl get nodes -o wide
+    - name: Initialize cbdinocluster
+      shell: bash
+      run: |
+        # No context flag on purpose. cbdinocluster registers --k8s-context but its handler reads an
+        # unregistered "kube-context", so the value is discarded either way and it always falls back
+        # to the kubeconfig's current-context -- which is exactly what `k3d cluster create` sets.
+        cbdinocluster -v init --auto --kube-config "$HOME/.kube/config"
+        cbdinocluster ps
+    - name: Start Couchbase cluster with Cloud Native Gateway
+      id: start-cluster
+      shell: bash
+      env:
+        # Single node: a GitHub-hosted runner has 4 vCPU / 16 GB, and the operator, the gateway and
+        # a server pod all have to fit. The `docker:` memory block that create-cluster uses is
+        # ignored by the cao deployer, so quotas stay at the server defaults (256 MB).
+        CLUSTER_CONFIG: |
+          nodes:
+            - count: 1
+              version: ${{ inputs.version }}
+              services: [kv, n1ql, index]
+          cao:
+            operator-version: "${{ inputs.operator-version }}"
+            gateway-version: "${{ inputs.gateway-version }}"
+          expiry: 1h
+      run: |
+        CBDC_ID=$(cbdinocluster -v alloc --deployer cao --def="${CLUSTER_CONFIG}")
+        echo "CBDC_ID=$CBDC_ID" >> "$GITHUB_ENV"
+        echo "id=$CBDC_ID" >> "$GITHUB_OUTPUT"
+        # The tests set tls_verify_mode::none themselves, so the bare connstr is what they want:
+        # couchbase2 is always TLS and the gateway's dev certificate is not chainable.
+        echo "connstr=$(cbdinocluster -v connstr --couchbase2 $CBDC_ID)" >> "$GITHUB_OUTPUT"
+    - name: Add bucket
+      shell: bash
+      env:
+        # Map input to an environment variable to prevent shell injection
+        BUCKET: ${{ inputs.bucket }}
+      run: |
+        # num-replicas 0: a single-node cluster cannot satisfy replicas, and the bucket would
+        # never come healthy.
+        cbdinocluster buckets add $CBDC_ID "$BUCKET" --ram-quota-mb 100 --num-replicas 0
+    - name: Dump cluster state on failure
+      if: ${{ failure() }}
+      shell: bash
+      run: |
+        kubectl get pods,svc -A || true
+        # The CouchbaseCluster CRD only exists once the operator is installed, so tolerate its
+        # absence rather than letting it mask the output above.
+        kubectl get couchbaseclusters -A || true
+        kubectl describe pods -A || true
+        # `kubectl logs` has no -A/--all-namespaces, so walk the namespaces explicitly.
+        for ns in $(kubectl get ns -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+          kubectl logs -n "$ns" -l app=couchbase-operator --tail=200 || true
+        done

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -176,3 +176,55 @@ jobs:
         uses: ./.github/actions/remove-cluster
         with:
           id: ${{ steps.cbdino.outputs.id }}
+  cng:
+    # CNG (couchbase2://) tests against a real Cloud Native Gateway. The gateway is only deployable
+    # by the Couchbase Autonomous Operator, so unlike the `integration` job this one needs a
+    # Kubernetes cluster (k3d) rather than the docker deployer.
+    needs: build
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libssl-dev cmake gcc g++ curl gdb libprotobuf-dev libgrpc-dev libgrpc++-dev
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+          path: ./cmake-build-tests
+      - name: Create Couchbase cluster with Cloud Native Gateway
+        id: cbdino
+        uses: ./.github/actions/create-cng-cluster
+        with:
+          version: 8.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run CNG tests
+        timeout-minutes: 40
+        env:
+          # The cng suite reads this to pick real-cluster mode; cases gated cluster_only skip
+          # without it. Credentials default to cbdinocluster's Administrator/password.
+          TEST_CONNECTION_STRING: ${{ steps.cbdino.outputs.connstr }}
+          TEST_LOG_LEVEL: trace
+        run: |
+          chmod -R +x ./cmake-build-tests
+          ctest --test-dir ./cmake-build-tests --output-on-failure --label-regex 'cng' \
+                --no-tests=error --output-junit cng-live-results.xml
+      - name: Upload CNG live test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          # Distinct from the unit job's cng-test-results: artifact names must be unique per run.
+          name: cng-live-test-results
+          path: ./cmake-build-tests/cng-live-results.xml
+          if-no-files-found: warn
+      - name: Remove Couchbase cluster
+        if: ${{ always() }}
+        uses: ./.github/actions/remove-cluster
+        with:
+          id: ${{ steps.cbdino.outputs.id }}

--- a/cmake/Protostellar.cmake
+++ b/cmake/Protostellar.cmake
@@ -155,6 +155,24 @@ set_target_properties(
              COMPILE_WARNING_AS_ERROR OFF
              CXX_CLANG_TIDY ""
              CXX_INCLUDE_WHAT_YOU_USE "")
+# The generated stubs MUST be compiled with the same sanitizer flags as everything that includes the
+# generated headers, because protobuf changes the LAYOUT of every message under ThreadSanitizer:
+# port_def.inc defines PROTOBUF_TSAN from the compiler's thread_sanitizer feature test, and
+# PROTOBUF_TSAN_DECLARE_MEMBER -- which appears in every generated message's Impl_ -- then adds a
+# `::uint32_t _tsan_detect_race` member. So sizeof(UpsertResponse) is 40 without -fsanitize=thread
+# and 48 with it, and every setter additionally stores a race-detection byte past the smaller size.
+#
+# enable_sanitizers() attaches the flags PUBLIC to the client target, which propagates UP to the
+# tests but never DOWN into this library (the client links it PRIVATE). That left RpcMethodHandler
+# -- instantiated in the uninstrumented kv.grpc.pb.cc -- reserving a 40-byte `ResponseType rsp` on
+# its stack directly below the saved `param` reference, while the instrumented handler's set_cas()
+# wrote the race byte at offset 40, zeroing that pointer's low byte. RunHandler then read
+# param.request from an address 32 bytes off, got a null, and destroyed a null request: the
+# `unit (tsan)` SEGV in cng_component_test at method_handler.h:119 (CXXCBC-917).
+#
+# PROTOBUF_TSAN cannot be forced to a fixed value instead -- port_def.inc #errors if it is already
+# defined -- so matching the flags is the only supported remedy.
+enable_sanitizers(couchbase_cxx_protostellar)
 # NOTE (ABI visibility): couchbase_cxx_client links this library whenever
 # COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 is on (see the target_link_libraries guarded by that option
 # in the top-level CMakeLists.txt, alongside the transport sources appended below). So in a

--- a/core/protostellar/credentials.cxx
+++ b/core/protostellar/credentials.cxx
@@ -20,17 +20,22 @@
 #include "core/capella_ca.hxx"
 #include "core/cluster_credentials.hxx"
 #include "core/cluster_options.hxx"
+#include "core/logger/logger.hxx"
 #include "core/mozilla_ca_bundle.hxx"
 #include "core/platform/base64.h"
 #include "core/protostellar/dispatcher.hxx"
+#include "core/tls_verify_mode.hxx"
 
 #include <grpcpp/create_channel.h>
+#include <grpcpp/security/tls_certificate_provider.h>
+#include <grpcpp/security/tls_credentials_options.h>
 
 #include <fstream>
 #include <optional>
 #include <sstream>
 #include <stdexcept>
 #include <utility>
+#include <vector>
 
 namespace couchbase::core::protostellar
 {
@@ -166,16 +171,52 @@ authorization_header(const cluster_credentials& credentials) -> std::string
 }
 
 auto
+tls_peer_verification_disabled(const cluster_options& options) -> bool
+{
+  return options.enable_tls && options.tls_verify == tls_verify_mode::none;
+}
+
+auto
 make_channel_credentials(const cluster_options& options, const cluster_credentials& credentials)
   -> std::shared_ptr<grpc::ChannelCredentials>
 {
   if (!options.enable_tls) {
+    // Fail closed: never let username/password or a JWT ride a plaintext channel (base64 is not
+    // encryption). couchbase2:// implies TLS; a programmatic config that disables it while
+    // carrying credentials is a misconfiguration, not a downgrade we perform silently.
     if (credentials.uses_password() || credentials.uses_jwt() ||
         !credentials.certificate_path.empty() || !credentials.key_path.empty()) {
       throw std::invalid_argument(
         "couchbase2: refusing to send credentials over a plaintext channel; enable TLS");
     }
     return grpc::InsecureChannelCredentials();
+  }
+  if (tls_peer_verification_disabled(options)) {
+    // Encrypt the channel but skip server-certificate and hostname verification. Used against
+    // dev/test gateways whose certificate cannot be chained to a trusted CA (e.g. the CNG cert
+    // served by the Couchbase operator on a k8s NodePort).
+    //
+    // Warn here rather than only at the call site: this is the one point every couchbase2 channel
+    // passes through, including callers that build a component directly without going through
+    // cluster::open. A deployment that enabled this by accident has to be able to see it.
+    CB_LOG_WARNING("couchbase2: TLS certificate verification is DISABLED (tls_verify=none); the "
+                   "connection is encrypted but unauthenticated and can be intercepted. Do not use "
+                   "this outside development.");
+    grpc::experimental::TlsChannelCredentialsOptions tls;
+    tls.set_verify_server_certs(false);
+    tls.set_check_call_host(false);
+    tls.set_certificate_verifier(std::make_shared<grpc::experimental::NoOpCertificateVerifier>());
+    // Still present the configured client identity (mTLS) so certificate auth works even when the
+    // gateway's server certificate cannot be verified. Skipping server verification does not imply
+    // skipping our own authentication.
+    if (auto identity = read_client_identity(credentials)) {
+      tls.set_certificate_provider(
+        std::make_shared<grpc::experimental::StaticDataCertificateProvider>(
+          std::vector<grpc::experimental::IdentityKeyCertPair>{
+            { identity->first, identity->second } }));
+      tls.watch_identity_key_cert_pairs();
+    }
+    return grpc::experimental::TlsCredentials(tls);
   }
   return grpc::SslCredentials(build_ssl_options(options, credentials));
 }

--- a/core/protostellar/credentials.hxx
+++ b/core/protostellar/credentials.hxx
@@ -60,8 +60,20 @@ bearer_auth_value(const std::string& jwt_token) -> std::string;
 [[nodiscard]] auto
 authorization_header(const cluster_credentials& credentials) -> std::string;
 
+// Whether these options select a channel that encrypts but does NOT verify the server certificate
+// or hostname. make_channel_credentials() branches on exactly this predicate, so pinning it in a
+// test pins the real decision: grpc::ChannelCredentials is opaque, and nothing about the object it
+// returns reveals which branch produced it.
+//
+// Only tls_verify=none on a TLS-enabled channel reaches that branch. A plaintext channel is a
+// different thing, not a weaker one -- it presents no certificate at all, and
+// make_channel_credentials refuses to put credentials on it.
+[[nodiscard]] auto
+tls_peer_verification_disabled(const cluster_options& options) -> bool;
+
 // Channel credentials for a couchbase2 endpoint: TLS (from build_ssl_options) when TLS is
-// enabled, otherwise insecure.
+// enabled, otherwise insecure. When tls_peer_verification_disabled() holds, the channel is
+// encrypted but unverified, and taking that branch is logged at warning level.
 [[nodiscard]] auto
 make_channel_credentials(const cluster_options& options, const cluster_credentials& credentials)
   -> std::shared_ptr<grpc::ChannelCredentials>;

--- a/test/cng/CMakeLists.txt
+++ b/test/cng/CMakeLists.txt
@@ -113,4 +113,7 @@ if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 AND TARGET couchbase_cxx_protostellar)
 
   # Protostellar KV component (CXXCBC-891).
   add_cng_test(protostellar/component LINK_CLIENT LIBS couchbase_cxx_protostellar)
+
+  # Live KV verification vs a real gateway (CXXCBC-891).
+  add_cng_test(protostellar/live_kv LINK_CLIENT LIBS couchbase_cxx_protostellar)
 endif()

--- a/test/cng/protostellar/credentials.cxx
+++ b/test/cng/protostellar/credentials.cxx
@@ -26,6 +26,7 @@
 #include "core/cluster_options.hxx"
 #include "core/platform/base64.h"
 #include "core/protostellar/credentials.hxx"
+#include "core/tls_verify_mode.hxx"
 
 #include <filesystem>
 #include <fstream>
@@ -39,6 +40,7 @@ namespace
 namespace ps = ::couchbase::core::protostellar;
 using ::couchbase::core::cluster_credentials;
 using ::couchbase::core::cluster_options;
+using ::couchbase::core::tls_verify_mode;
 
 void
 basic_and_bearer_header_values()
@@ -161,6 +163,73 @@ channel_credentials_switch_on_tls()
               "insecure channel credentials");
 }
 
+// The security-critical property of make_channel_credentials(): exactly one combination of options
+// selects the branch that skips server-certificate and hostname verification. Asserting that
+// make_channel_credentials() returns non-null cannot express this -- every branch returns non-null,
+// including one that returned unverified credentials unconditionally -- and the returned
+// grpc::ChannelCredentials is opaque, so the branch is not recoverable from it afterwards. The
+// function therefore branches on tls_peer_verification_disabled(), and this pins that predicate.
+void
+peer_verification_is_disabled_only_by_tls_verify_none()
+{
+  cluster_options defaults;
+  assert_false(ps::tls_peer_verification_disabled(defaults),
+               "default options must verify the peer certificate");
+
+  cluster_options verifying;
+  verifying.enable_tls = true;
+  verifying.tls_verify = tls_verify_mode::peer;
+  assert_false(ps::tls_peer_verification_disabled(verifying),
+               "tls_verify=peer over TLS must verify the peer certificate");
+
+  cluster_options unverified;
+  unverified.enable_tls = true;
+  unverified.tls_verify = tls_verify_mode::none;
+  assert_true(ps::tls_peer_verification_disabled(unverified),
+              "tls_verify=none over TLS reaches the unverified branch");
+
+  // A plaintext channel is not "unverified" in this sense: it carries no server certificate to
+  // verify, and make_channel_credentials() refuses to put credentials on it at all. Reporting it as
+  // unverified would conflate two different failures and make the predicate useless as a signal.
+  cluster_options plaintext;
+  plaintext.enable_tls = false;
+  plaintext.tls_verify = tls_verify_mode::none;
+  assert_false(ps::tls_peer_verification_disabled(plaintext),
+               "tls_verify=none without TLS is a plaintext channel, not an unverified one");
+}
+
+// The predicate would be worthless if the credential shape could steer the decision -- e.g. if a
+// configured client identity or a JWT quietly relaxed verification. Sweep every credential shape
+// against both verify modes and assert the answer tracks tls_verify alone.
+void
+peer_verification_does_not_depend_on_the_credential_shape()
+{
+  cluster_credentials password;
+  password.username = "Administrator";
+  password.password = "secret";
+
+  cluster_credentials jwt;
+  jwt.jwt_token = "jwt-token";
+
+  cluster_credentials certificate;
+  certificate.certificate_path = "/nonexistent/cert.pem";
+  certificate.key_path = "/nonexistent/key.pem";
+
+  for (const auto& creds : { cluster_credentials{}, password, jwt, certificate }) {
+    cluster_options verifying;
+    verifying.enable_tls = true;
+    assert_false(ps::tls_peer_verification_disabled(verifying),
+                 "no credential shape may reach the unverified branch on its own");
+
+    cluster_options unverified;
+    unverified.enable_tls = true;
+    unverified.tls_verify = tls_verify_mode::none;
+    assert_true(ps::tls_peer_verification_disabled(unverified),
+                "tls_verify=none stays decisive for every credential shape");
+    (void)creds;
+  }
+}
+
 } // namespace
 
 auto
@@ -175,6 +244,10 @@ tests() -> test_suite
         ssl_root_certs_prefer_explicit_then_capella_and_mozilla },
       { "ssl_client_certificate_is_read_from_files", ssl_client_certificate_is_read_from_files },
       { "channel_credentials_switch_on_tls", channel_credentials_switch_on_tls },
+      { "peer_verification_is_disabled_only_by_tls_verify_none",
+        peer_verification_is_disabled_only_by_tls_verify_none },
+      { "peer_verification_does_not_depend_on_the_credential_shape",
+        peer_verification_does_not_depend_on_the_credential_shape },
     },
   };
 }

--- a/test/cng/protostellar/live_kv.cxx
+++ b/test/cng/protostellar/live_kv.cxx
@@ -1,0 +1,330 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Live KV round-trip against a real couchbase2:// (Cloud Native Gateway) endpoint. cluster_only:
+// runs only when TEST_CONNECTION_STRING is set (the harness skips it otherwise). It drives the
+// full transport -- channel/credentials, dispatcher, converter, component, error mapping --
+// through an upsert -> get -> remove chain, so it fails loudly if any layer regresses against a
+// real gateway. Extra env: TEST_CB2_USERNAME/TEST_CB2_PASSWORD (default Administrator/password),
+// TEST_CB2_BUCKET (default "default"). TLS verification is disabled (dev gateway cert).
+
+#include "framework/test_runner.hxx"
+
+#include "core/cluster_credentials.hxx"
+#include "core/cluster_options.hxx"
+#include "core/document_id.hxx"
+#include "core/error_context/key_value.hxx"
+#include "core/protostellar/component.hxx"
+#include "core/protostellar/credentials.hxx"
+#include "core/protostellar/kv_converter.hxx"
+#include "core/tls_verify_mode.hxx"
+#include "core/utils/binary.hxx"
+#include "core/utils/connection_string.hxx"
+
+#include <couchbase/error_codes.hxx>
+
+#include <asio/executor_work_guard.hpp>
+#include <asio/io_context.hpp>
+
+#include <cstdlib>
+#include <string>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace ops = ::couchbase::core::operations;
+namespace ps = ::couchbase::core::protostellar;
+namespace pk = ::couchbase::core::protostellar::kv;
+namespace cu = ::couchbase::core::utils;
+using ::couchbase::core::cluster_credentials;
+using ::couchbase::core::cluster_options;
+using ::couchbase::core::document_id;
+using ::couchbase::core::tls_verify_mode;
+using ::couchbase::core::protostellar::component;
+using ::couchbase::core::protostellar::component_config;
+using ::couchbase::core::utils::parse_connection_string;
+using namespace std::chrono_literals;
+
+auto
+env_or(const char* name, const char* fallback) -> std::string
+{
+  return safe_getenv(name).value_or(fallback);
+}
+
+void
+kv_crud_round_trip_against_live_gateway()
+{
+  const auto connstr_opt = safe_getenv("TEST_CONNECTION_STRING");
+  if (!connstr_opt.has_value()) {
+    skip("TEST_CONNECTION_STRING is not set");
+  }
+  const auto parsed = parse_connection_string(connstr_opt.value());
+  if (!parsed.uses_protostellar()) {
+    skip("TEST_CONNECTION_STRING is not a couchbase2:// endpoint");
+  }
+  if (parsed.bootstrap_nodes.empty()) {
+    skip("no nodes in TEST_CONNECTION_STRING");
+  }
+
+  const auto& node = parsed.bootstrap_nodes.front();
+  const auto port = node.port > 0 ? node.port : parsed.default_port;
+  const std::string endpoint = node.address + ":" + std::to_string(port);
+
+  cluster_options options;
+  options.enable_tls = true;
+  options.tls_verify = tls_verify_mode::none; // dev gateway certificate is not chainable
+
+  cluster_credentials credentials;
+  credentials.username = env_or("TEST_CB2_USERNAME", "Administrator");
+  credentials.password = env_or("TEST_CB2_PASSWORD", "password");
+
+  const auto bucket = env_or("TEST_CB2_BUCKET", "default");
+  const auto id = document_id{ bucket, "_default", "_default", "cng-live-kv-key" };
+  const std::string document = "{\"cng\":true}";
+
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  auto channel = ps::make_channel(endpoint, options, credentials);
+  // Named-field assignment rather than positional aggregate initialisation: component_config
+  // gains fields as the series progresses, and a positional list silently rebinds when it does.
+  component_config config;
+  config.channel = channel;
+  config.credentials = credentials;
+  config.default_kv_timeout = 20000ms;
+  component comp{ io, config };
+
+  std::string failure;    // non-empty => the round-trip failed at some stage
+  bool completed = false; // the whole chain ran
+  couchbase::cas upsert_cas;
+
+  ops::upsert_request upsert;
+  upsert.id = id;
+  upsert.value = cu::to_binary(document);
+  upsert.flags = 0x06U;
+
+  comp.execute(std::move(upsert), [&](ops::upsert_response upsert_result) {
+    if (upsert_result.ctx.ec()) {
+      failure = "upsert: " + upsert_result.ctx.ec().message();
+      work.reset();
+      return;
+    }
+    upsert_cas = upsert_result.cas;
+
+    ops::get_request get;
+    get.id = id;
+    comp.execute(std::move(get), [&](ops::get_response get_result) {
+      if (get_result.ctx.ec()) {
+        failure = "get: " + get_result.ctx.ec().message();
+        work.reset();
+        return;
+      }
+      if (cu::to_string(get_result.value) != document) {
+        failure = "get: value mismatch, got '" + cu::to_string(get_result.value) + "'";
+        work.reset();
+        return;
+      }
+      // The upsert set these deliberately so the document is written as JSON. Checking only the
+      // value bytes would pass against a converter that dropped content_flags entirely.
+      if (get_result.flags != 0x06U) {
+        failure = "get: flags mismatch, got " + std::to_string(get_result.flags);
+        work.reset();
+        return;
+      }
+
+      ops::remove_request remove;
+      remove.id = id;
+      comp.execute(std::move(remove), [&](ops::remove_response remove_result) {
+        if (remove_result.ctx.ec()) {
+          failure = "remove: " + remove_result.ctx.ec().message();
+        } else {
+          completed = true;
+        }
+        work.reset();
+      });
+    });
+  });
+
+  io.run();
+
+  assert_true(failure.empty(), failure);
+  assert_true(completed, "upsert -> get -> remove chain completed");
+  assert_true(upsert_cas.value() != 0, "upsert returned a non-zero CAS");
+}
+
+void
+insert_and_replace_round_trip_against_live_gateway()
+{
+  const auto connstr_opt = safe_getenv("TEST_CONNECTION_STRING");
+  if (!connstr_opt.has_value()) {
+    skip("TEST_CONNECTION_STRING is not set");
+  }
+  const auto parsed = parse_connection_string(connstr_opt.value());
+  if (!parsed.uses_protostellar() || parsed.bootstrap_nodes.empty()) {
+    skip("TEST_CONNECTION_STRING is not a couchbase2:// endpoint");
+  }
+  const auto& node = parsed.bootstrap_nodes.front();
+  const auto port = node.port > 0 ? node.port : parsed.default_port;
+  const std::string endpoint = node.address + ":" + std::to_string(port);
+
+  cluster_options options;
+  options.enable_tls = true;
+  options.tls_verify = tls_verify_mode::none;
+
+  cluster_credentials credentials;
+  credentials.username = env_or("TEST_CB2_USERNAME", "Administrator");
+  credentials.password = env_or("TEST_CB2_PASSWORD", "password");
+
+  const auto bucket = env_or("TEST_CB2_BUCKET", "default");
+  const auto id = document_id{ bucket, "_default", "_default", "cng-live-insert-replace-key" };
+  const auto missing_id = document_id{ bucket, "_default", "_default", "cng-live-missing-key" };
+
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  auto channel = ps::make_channel(endpoint, options, credentials);
+  // Named-field assignment rather than positional aggregate initialisation: component_config
+  // gains fields as the series progresses, and a positional list silently rebinds when it does.
+  component_config config;
+  config.channel = channel;
+  config.credentials = credentials;
+  config.default_kv_timeout = 20000ms;
+  component comp{ io, config };
+
+  std::string failure;
+  bool completed = false;
+  bool duplicate_insert_failed_correctly = false;
+  bool replace_missing_failed_correctly = false;
+  bool remove_missing_failed_correctly = false;
+
+  // 1. Clean slate
+  ops::remove_request pre_remove;
+  pre_remove.id = id;
+  comp.execute(std::move(pre_remove), [&](ops::remove_response) {
+    // 2. Insert new document
+    ops::insert_request insert;
+    insert.id = id;
+    insert.value = cu::to_binary("doc1");
+    comp.execute(std::move(insert), [&](ops::insert_response insert_result) {
+      if (insert_result.ctx.ec()) {
+        failure = "insert: " + insert_result.ctx.ec().message();
+        work.reset();
+        return;
+      }
+
+      // 3. Insert existing document should fail with document_exists
+      ops::insert_request dup_insert;
+      dup_insert.id = id;
+      dup_insert.value = cu::to_binary("doc1_dup");
+      comp.execute(std::move(dup_insert), [&](ops::insert_response dup_result) {
+        if (dup_result.ctx.ec() == couchbase::errc::key_value::document_exists) {
+          duplicate_insert_failed_correctly = true;
+        } else {
+          failure = "duplicate insert did not fail with document_exists, got: " +
+                    dup_result.ctx.ec().message();
+          work.reset();
+          return;
+        }
+
+        // 4. Replace existing document
+        ops::replace_request replace;
+        replace.id = id;
+        replace.value = cu::to_binary("doc2");
+        comp.execute(std::move(replace), [&](ops::replace_response replace_result) {
+          if (replace_result.ctx.ec()) {
+            failure = "replace: " + replace_result.ctx.ec().message();
+            work.reset();
+            return;
+          }
+
+          // 5. Replace missing document should fail with document_not_found
+          ops::replace_request missing_replace;
+          missing_replace.id = missing_id;
+          missing_replace.value = cu::to_binary("doc_missing");
+          comp.execute(std::move(missing_replace), [&](ops::replace_response missing_result) {
+            if (missing_result.ctx.ec() == couchbase::errc::key_value::document_not_found) {
+              replace_missing_failed_correctly = true;
+            } else {
+              failure = "replace missing did not fail with document_not_found, got: " +
+                        missing_result.ctx.ec().message();
+              work.reset();
+              return;
+            }
+
+            // 6. Remove existing document
+            ops::remove_request remove;
+            remove.id = id;
+            comp.execute(std::move(remove), [&](ops::remove_response remove_result) {
+              if (remove_result.ctx.ec()) {
+                failure = "remove: " + remove_result.ctx.ec().message();
+                work.reset();
+                return;
+              }
+
+              // 7. Remove missing document should fail with document_not_found
+              ops::remove_request missing_remove;
+              missing_remove.id = missing_id;
+              comp.execute(
+                std::move(missing_remove), [&](ops::remove_response missing_remove_result) {
+                  if (missing_remove_result.ctx.ec() ==
+                      couchbase::errc::key_value::document_not_found) {
+                    remove_missing_failed_correctly = true;
+                    completed = true;
+                  } else {
+                    failure = "remove missing did not fail with document_not_found, got: " +
+                              missing_remove_result.ctx.ec().message();
+                  }
+                  work.reset();
+                });
+            });
+          });
+        });
+      });
+    });
+  });
+
+  io.run();
+
+  assert_true(failure.empty(), failure);
+  assert_true(duplicate_insert_failed_correctly, "duplicate insert failed with document_exists");
+  assert_true(replace_missing_failed_correctly, "replace missing failed with document_not_found");
+  assert_true(remove_missing_failed_correctly, "remove missing failed with document_not_found");
+  assert_true(
+    completed,
+    "insert -> dup_insert -> replace -> missing_replace -> remove -> missing_remove completed");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_live_kv",
+    {
+      { "kv_crud_round_trip_against_live_gateway",
+        kv_crud_round_trip_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "insert_and_replace_round_trip_against_live_gateway",
+        insert_and_replace_round_trip_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test


### PR DESCRIPTION
To reach a real couchbase2 gateway whose certificate cannot be chained to a
trusted CA (the operator-served CNG cert on a k8s NodePort), honor
tls_verify=none: make_channel_credentials then builds an encrypted channel that
skips server-certificate and hostname verification (gRPC TlsCredentials with a
NoOpCertificateVerifier), instead of the CA-verifying SslCredentials.

Add a cluster_only live KV test that drives upsert -> get -> remove against the
endpoint in TEST_CONNECTION_STRING, exercising the whole transport (credentials,
dispatcher, converter, component, error mapping, Basic-auth metadata) against a
real gateway. It skips when TEST_CONNECTION_STRING is unset.

---
Stacked PR **10/29** in the CNG (`couchbase2://`) transport series. This branch includes every commit from PRs 01–10; the change specific to this PR is its top commit. Everything below it has merged except #1059, which is now the bottom of the open series and should merge first — this branch carries its commit as an ancestor and depends on it for a green `unit (tsan)` leg.

This commit previously also contained the `couchbase2://` open path and execute-time routing (now #1033) and a global MSVC link option (dropped from the series; see CXXCBC-916). #1033 no longer shares a head commit with this one.


