### PR TITLE
CXXCBC-894: complete the KV unary operation surface over couchbase2

### DIFF
--- a/core/protostellar/component.cxx
+++ b/core/protostellar/component.cxx
@@ -29,8 +29,11 @@
 #include <asio/post.hpp>
 
 #include <chrono>
+#include <cstdint>
+#include <limits>
 #include <memory>
 #include <string>
+#include <system_error>
 #include <utility>
 
 namespace couchbase::core::protostellar
@@ -112,6 +115,39 @@ component::execute(operations::get_request request,
       // rather than handing back an empty value with a success status).
       auto ctx = make_error_context(status, id, operation_kind::read_only);
       handler(kv::decode(resp, std::move(ctx)));
+    });
+}
+
+auto
+component::execute(operations::get_projected_request request,
+                   utils::movable_function<void(operations::get_projected_response)>&& handler)
+  -> pending_call
+{
+  auto proto = std::make_shared<v1::GetRequest>(kv::encode(request));
+  const auto id = request.id;
+  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired(io_, request, handler);
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->kv.get();
+  return dispatcher_.unary<v1::GetResponse>(
+    timeout,
+    [stub, proto, auth](
+      grpc::ClientContext& ctx, v1::GetResponse& resp, std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->Get(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), id, proto, request](grpc::Status status,
+                                                       v1::GetResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      auto ctx = make_error_context(status, id, operation_kind::read_only);
+      if (status.ok() && resp.content_case() == v1::GetResponse::kContentCompressed) {
+        ctx = make_key_value_error_context(errc::common::feature_not_available, id);
+      }
+      handler(kv::decode(resp, std::move(ctx), request));
     });
 }
 
@@ -229,6 +265,323 @@ component::execute(operations::remove_request request,
     },
     [handler = std::move(handler), id, proto](grpc::Status status,
                                               v1::RemoveResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      auto ctx = make_error_context(status, id, operation_kind::mutating);
+      handler(kv::decode(resp, std::move(ctx)));
+    });
+}
+
+auto
+component::execute(operations::touch_request request,
+                   utils::movable_function<void(operations::touch_response)>&& handler)
+  -> pending_call
+{
+  auto proto = std::make_shared<v1::TouchRequest>(kv::encode(request));
+  const auto id = request.id;
+  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired(io_, request, handler);
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->kv.get();
+  return dispatcher_.unary<v1::TouchResponse>(
+    timeout,
+    [stub, proto, auth](
+      grpc::ClientContext& ctx, v1::TouchResponse& resp, std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->Touch(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), id, proto](grpc::Status status, v1::TouchResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      auto ctx = make_error_context(status, id, operation_kind::mutating);
+      handler(kv::decode(resp, std::move(ctx)));
+    });
+}
+
+auto
+component::execute(operations::exists_request request,
+                   utils::movable_function<void(operations::exists_response)>&& handler)
+  -> pending_call
+{
+  auto proto = std::make_shared<v1::ExistsRequest>(kv::encode(request));
+  const auto id = request.id;
+  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired(io_, request, handler);
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->kv.get();
+  return dispatcher_.unary<v1::ExistsResponse>(
+    timeout,
+    [stub, proto, auth](
+      grpc::ClientContext& ctx, v1::ExistsResponse& resp, std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->Exists(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), id, proto](grpc::Status status,
+                                              v1::ExistsResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      auto ctx = make_error_context(status, id, operation_kind::read_only);
+      handler(kv::decode(resp, std::move(ctx)));
+    });
+}
+
+auto
+component::execute(operations::get_and_lock_request request,
+                   utils::movable_function<void(operations::get_and_lock_response)>&& handler)
+  -> pending_call
+{
+  auto proto = std::make_shared<v1::GetAndLockRequest>(kv::encode(request));
+  const auto id = request.id;
+  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired(io_, request, handler);
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->kv.get();
+  return dispatcher_.unary<v1::GetAndLockResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        v1::GetAndLockResponse& resp,
+                        std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->GetAndLock(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), id, proto](grpc::Status status,
+                                              v1::GetAndLockResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      auto ctx = make_error_context(status, id, operation_kind::mutating);
+      if (status.ok() && resp.content_case() == v1::GetAndLockResponse::kContentCompressed) {
+        ctx = make_key_value_error_context(errc::common::feature_not_available, id);
+      }
+      handler(kv::decode(resp, std::move(ctx)));
+    });
+}
+
+auto
+component::execute(operations::unlock_request request,
+                   utils::movable_function<void(operations::unlock_response)>&& handler)
+  -> pending_call
+{
+  auto proto = std::make_shared<v1::UnlockRequest>(kv::encode(request));
+  const auto id = request.id;
+  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired(io_, request, handler);
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->kv.get();
+  return dispatcher_.unary<v1::UnlockResponse>(
+    timeout,
+    [stub, proto, auth](
+      grpc::ClientContext& ctx, v1::UnlockResponse& resp, std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->Unlock(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), id, proto](grpc::Status status,
+                                              v1::UnlockResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      auto ctx = make_error_context(status, id, operation_kind::mutating);
+      handler(kv::decode(resp, std::move(ctx)));
+    });
+}
+
+auto
+component::execute(operations::get_and_touch_request request,
+                   utils::movable_function<void(operations::get_and_touch_response)>&& handler)
+  -> pending_call
+{
+  auto proto = std::make_shared<v1::GetAndTouchRequest>(kv::encode(request));
+  const auto id = request.id;
+  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired(io_, request, handler);
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->kv.get();
+  return dispatcher_.unary<v1::GetAndTouchResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        v1::GetAndTouchResponse& resp,
+                        std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->GetAndTouch(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), id, proto](grpc::Status status,
+                                              v1::GetAndTouchResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      auto ctx = make_error_context(status, id, operation_kind::mutating);
+      if (status.ok() && resp.content_case() == v1::GetAndTouchResponse::kContentCompressed) {
+        ctx = make_key_value_error_context(errc::common::feature_not_available, id);
+      }
+      handler(kv::decode(resp, std::move(ctx)));
+    });
+}
+
+namespace
+{
+// initial_value is uint64 while the proto's `initial` field is int64, so anything above INT64_MAX
+// would reach the gateway as a negative seed for the counter. Refused here rather than in the
+// converter: kv::encode() returns the request message by value and has no error channel, so the
+// narrowing has to be caught before anything is encoded or sent. The classic path carries the same
+// representation mismatch, so this is not a couchbase2 regression -- this boundary is simply the
+// first place that can reject it instead of silently wrapping.
+template<typename Request>
+[[nodiscard]] auto
+counter_initial_value_out_of_range(const Request& request) -> bool
+{
+  return request.initial_value.has_value() &&
+         request.initial_value.value() >
+           static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max());
+}
+
+// Same delivery contract as fail_expired: nothing is sent, and the completion still arrives on the
+// io_context rather than inline on the caller's thread.
+template<typename Request, typename Handler>
+auto
+fail_invalid_argument(asio::io_context& io, const Request& request, Handler& handler)
+  -> pending_call
+{
+  auto response =
+    request.make_response(make_key_value_error_context(errc::common::invalid_argument, request.id),
+                          typename Request::encoded_response_type{});
+  asio::post(io, [handler = std::move(handler), response = std::move(response)]() mutable {
+    handler(std::move(response));
+  });
+  return {};
+}
+} // namespace
+
+auto
+component::execute(operations::increment_request request,
+                   utils::movable_function<void(operations::increment_response)>&& handler)
+  -> pending_call
+{
+  if (counter_initial_value_out_of_range(request)) {
+    return fail_invalid_argument(io_, request, handler);
+  }
+  auto proto = std::make_shared<v1::IncrementRequest>(kv::encode(request));
+  const auto id = request.id;
+  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired(io_, request, handler);
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->kv.get();
+  return dispatcher_.unary<v1::IncrementResponse>(
+    timeout,
+    [stub, proto, auth](
+      grpc::ClientContext& ctx, v1::IncrementResponse& resp, std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->Increment(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), id, proto](grpc::Status status,
+                                              v1::IncrementResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      auto ctx = make_error_context(status, id, operation_kind::mutating);
+      handler(kv::decode(resp, std::move(ctx)));
+    });
+}
+
+auto
+component::execute(operations::decrement_request request,
+                   utils::movable_function<void(operations::decrement_response)>&& handler)
+  -> pending_call
+{
+  if (counter_initial_value_out_of_range(request)) {
+    return fail_invalid_argument(io_, request, handler);
+  }
+  auto proto = std::make_shared<v1::DecrementRequest>(kv::encode(request));
+  const auto id = request.id;
+  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired(io_, request, handler);
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->kv.get();
+  return dispatcher_.unary<v1::DecrementResponse>(
+    timeout,
+    [stub, proto, auth](
+      grpc::ClientContext& ctx, v1::DecrementResponse& resp, std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->Decrement(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), id, proto](grpc::Status status,
+                                              v1::DecrementResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      auto ctx = make_error_context(status, id, operation_kind::mutating);
+      handler(kv::decode(resp, std::move(ctx)));
+    });
+}
+
+auto
+component::execute(operations::append_request request,
+                   utils::movable_function<void(operations::append_response)>&& handler)
+  -> pending_call
+{
+  auto proto = std::make_shared<v1::AppendRequest>(kv::encode(request));
+  const auto id = request.id;
+  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired(io_, request, handler);
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->kv.get();
+  return dispatcher_.unary<v1::AppendResponse>(
+    timeout,
+    [stub, proto, auth](
+      grpc::ClientContext& ctx, v1::AppendResponse& resp, std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->Append(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), id, proto](grpc::Status status,
+                                              v1::AppendResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      auto ctx = make_error_context(status, id, operation_kind::mutating);
+      handler(kv::decode(resp, std::move(ctx)));
+    });
+}
+
+auto
+component::execute(operations::prepend_request request,
+                   utils::movable_function<void(operations::prepend_response)>&& handler)
+  -> pending_call
+{
+  auto proto = std::make_shared<v1::PrependRequest>(kv::encode(request));
+  const auto id = request.id;
+  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired(io_, request, handler);
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->kv.get();
+  return dispatcher_.unary<v1::PrependResponse>(
+    timeout,
+    [stub, proto, auth](
+      grpc::ClientContext& ctx, v1::PrependResponse& resp, std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->Prepend(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), id, proto](grpc::Status status,
+                                              v1::PrependResponse resp) mutable {
       (void)proto; // kept only to keep the request alive for the call
       auto ctx = make_error_context(status, id, operation_kind::mutating);
       handler(kv::decode(resp, std::move(ctx)));

--- a/core/protostellar/component.hxx
+++ b/core/protostellar/component.hxx
@@ -23,10 +23,20 @@
 // context. cluster_impl routes KV ops here when the cluster was opened with couchbase2://.
 
 #include "core/cluster_credentials.hxx"
+#include "core/operations/document_append.hxx"
+#include "core/operations/document_decrement.hxx"
+#include "core/operations/document_exists.hxx"
 #include "core/operations/document_get.hxx"
+#include "core/operations/document_get_and_lock.hxx"
+#include "core/operations/document_get_and_touch.hxx"
+#include "core/operations/document_get_projected.hxx"
+#include "core/operations/document_increment.hxx"
 #include "core/operations/document_insert.hxx"
+#include "core/operations/document_prepend.hxx"
 #include "core/operations/document_remove.hxx"
 #include "core/operations/document_replace.hxx"
+#include "core/operations/document_touch.hxx"
+#include "core/operations/document_unlock.hxx"
 #include "core/operations/document_upsert.hxx"
 #include "core/protostellar/dispatcher.hxx"
 #include "core/timeout_defaults.hxx"
@@ -59,6 +69,8 @@ inline constexpr bool component_supports_v = false;
 template<>
 inline constexpr bool component_supports_v<operations::get_request> = true;
 template<>
+inline constexpr bool component_supports_v<operations::get_projected_request> = true;
+template<>
 inline constexpr bool component_supports_v<operations::upsert_request> = true;
 template<>
 inline constexpr bool component_supports_v<operations::insert_request> = true;
@@ -66,6 +78,24 @@ template<>
 inline constexpr bool component_supports_v<operations::replace_request> = true;
 template<>
 inline constexpr bool component_supports_v<operations::remove_request> = true;
+template<>
+inline constexpr bool component_supports_v<operations::touch_request> = true;
+template<>
+inline constexpr bool component_supports_v<operations::exists_request> = true;
+template<>
+inline constexpr bool component_supports_v<operations::get_and_lock_request> = true;
+template<>
+inline constexpr bool component_supports_v<operations::unlock_request> = true;
+template<>
+inline constexpr bool component_supports_v<operations::get_and_touch_request> = true;
+template<>
+inline constexpr bool component_supports_v<operations::increment_request> = true;
+template<>
+inline constexpr bool component_supports_v<operations::decrement_request> = true;
+template<>
+inline constexpr bool component_supports_v<operations::append_request> = true;
+template<>
+inline constexpr bool component_supports_v<operations::prepend_request> = true;
 
 class component
 {
@@ -80,6 +110,9 @@ public:
 
   auto execute(operations::get_request request,
                utils::movable_function<void(operations::get_response)>&& handler) -> pending_call;
+  auto execute(operations::get_projected_request request,
+               utils::movable_function<void(operations::get_projected_response)>&& handler)
+    -> pending_call;
   auto execute(operations::upsert_request request,
                utils::movable_function<void(operations::upsert_response)>&& handler)
     -> pending_call;
@@ -91,6 +124,32 @@ public:
     -> pending_call;
   auto execute(operations::remove_request request,
                utils::movable_function<void(operations::remove_response)>&& handler)
+    -> pending_call;
+  auto execute(operations::touch_request request,
+               utils::movable_function<void(operations::touch_response)>&& handler) -> pending_call;
+  auto execute(operations::exists_request request,
+               utils::movable_function<void(operations::exists_response)>&& handler)
+    -> pending_call;
+  auto execute(operations::get_and_lock_request request,
+               utils::movable_function<void(operations::get_and_lock_response)>&& handler)
+    -> pending_call;
+  auto execute(operations::unlock_request request,
+               utils::movable_function<void(operations::unlock_response)>&& handler)
+    -> pending_call;
+  auto execute(operations::get_and_touch_request request,
+               utils::movable_function<void(operations::get_and_touch_response)>&& handler)
+    -> pending_call;
+  auto execute(operations::increment_request request,
+               utils::movable_function<void(operations::increment_response)>&& handler)
+    -> pending_call;
+  auto execute(operations::decrement_request request,
+               utils::movable_function<void(operations::decrement_response)>&& handler)
+    -> pending_call;
+  auto execute(operations::append_request request,
+               utils::movable_function<void(operations::append_response)>&& handler)
+    -> pending_call;
+  auto execute(operations::prepend_request request,
+               utils::movable_function<void(operations::prepend_response)>&& handler)
     -> pending_call;
 
 private:

--- a/core/protostellar/error_utils.cxx
+++ b/core/protostellar/error_utils.cxx
@@ -76,6 +76,20 @@ map_precondition(const std::string& type) -> std::error_code
   if (type == "VALUE_TOO_LARGE") {
     return errc::key_value::value_too_large;
   }
+  if (type == "DOC_NOT_NUMERIC") {
+    // Increment/Decrement against a document that is not a counter. Only those two operations can
+    // produce it, and without this it arrives as internal_server_failure -- telling the caller the
+    // cluster is broken when their document simply is not a number.
+    return errc::key_value::delta_invalid;
+  }
+  if (type == "DURABILITY_IMPOSSIBLE") {
+    // Fewer live nodes than the requested durability needs. Actionable by the caller (ask for less,
+    // or grow the cluster), so it must not be flattened into a generic server failure either.
+    return errc::key_value::durability_impossible;
+  }
+  // POISONED_CAS deliberately falls through: the gateway can emit it, but the SDK has no error for
+  // a CAS that the server considers corrupt, and inventing one here would be a guess. Revisit if
+  // couchbase::errc grows a member for it.
   return errc::common::internal_server_failure;
 }
 

--- a/core/protostellar/kv_converter.hxx
+++ b/core/protostellar/kv_converter.hxx
@@ -24,10 +24,20 @@
 
 #include "core/document_id.hxx"
 #include "core/error_context/key_value.hxx"
+#include "core/operations/document_append.hxx"
+#include "core/operations/document_decrement.hxx"
+#include "core/operations/document_exists.hxx"
 #include "core/operations/document_get.hxx"
+#include "core/operations/document_get_and_lock.hxx"
+#include "core/operations/document_get_and_touch.hxx"
+#include "core/operations/document_get_projected.hxx"
+#include "core/operations/document_increment.hxx"
 #include "core/operations/document_insert.hxx"
+#include "core/operations/document_prepend.hxx"
 #include "core/operations/document_remove.hxx"
 #include "core/operations/document_replace.hxx"
+#include "core/operations/document_touch.hxx"
+#include "core/operations/document_unlock.hxx"
 #include "core/operations/document_upsert.hxx"
 #include "core/utils/binary.hxx"
 
@@ -166,6 +176,37 @@ decode(const v1::GetResponse& proto, key_value_error_context ctx) -> operations:
   return response;
 }
 
+inline auto
+encode(const operations::get_projected_request& request) -> v1::GetRequest
+{
+  v1::GetRequest proto;
+  set_location(proto, request.id);
+  for (const auto& path : request.projections) {
+    proto.add_project(path);
+  }
+  return proto;
+}
+
+inline auto
+decode(const v1::GetResponse& proto,
+       key_value_error_context ctx,
+       const operations::get_projected_request& /* request */) -> operations::get_projected_response
+{
+  operations::get_projected_response response;
+  response.ctx = std::move(ctx);
+  if (content_is_compressed(proto)) {
+    response.ctx.override_ec(errc::common::feature_not_available);
+    return response;
+  }
+  response.value = utils::to_binary(proto.content_uncompressed());
+  response.cas = couchbase::cas{ proto.cas() };
+  response.flags = proto.content_flags();
+  if (proto.has_expiry()) {
+    response.expiry = static_cast<std::uint32_t>(proto.expiry().seconds());
+  }
+  return response;
+}
+
 // ── Mutations (upsert / insert / replace / remove) ─────────────────────────────
 
 template<typename Response, typename Proto>
@@ -269,6 +310,214 @@ inline auto
 decode(const v1::RemoveResponse& proto, key_value_error_context ctx) -> operations::remove_response
 {
   return decode_mutation<operations::remove_response>(proto, std::move(ctx));
+}
+
+// ── Touch / Exists / lock / counters / append / prepend ────────────────────────
+
+inline auto
+encode(const operations::touch_request& request) -> v1::TouchRequest
+{
+  v1::TouchRequest proto;
+  set_location(proto, request.id);
+  set_expiry(proto, request.expiry);
+  return proto;
+}
+
+inline auto
+decode(const v1::TouchResponse& proto, key_value_error_context ctx) -> operations::touch_response
+{
+  operations::touch_response response;
+  response.ctx = std::move(ctx);
+  response.cas = couchbase::cas{ proto.cas() };
+  return response;
+}
+
+inline auto
+encode(const operations::exists_request& request) -> v1::ExistsRequest
+{
+  v1::ExistsRequest proto;
+  set_location(proto, request.id);
+  return proto;
+}
+
+inline auto
+decode(const v1::ExistsResponse& proto, key_value_error_context ctx) -> operations::exists_response
+{
+  operations::exists_response response;
+  response.ctx = std::move(ctx);
+  response.document_exists = proto.result();
+  response.cas = couchbase::cas{ proto.cas() };
+  return response;
+}
+
+inline auto
+encode(const operations::get_and_lock_request& request) -> v1::GetAndLockRequest
+{
+  v1::GetAndLockRequest proto;
+  set_location(proto, request.id);
+  proto.set_lock_time_secs(request.lock_time);
+  return proto;
+}
+
+inline auto
+decode(const v1::GetAndLockResponse& proto, key_value_error_context ctx)
+  -> operations::get_and_lock_response
+{
+  operations::get_and_lock_response response;
+  response.ctx = std::move(ctx);
+  if (content_is_compressed(proto)) {
+    response.ctx.override_ec(errc::common::feature_not_available);
+    return response;
+  }
+  response.value = utils::to_binary(proto.content_uncompressed());
+  response.cas = couchbase::cas{ proto.cas() };
+  response.flags = proto.content_flags();
+  return response;
+}
+
+inline auto
+encode(const operations::unlock_request& request) -> v1::UnlockRequest
+{
+  v1::UnlockRequest proto;
+  set_location(proto, request.id);
+  proto.set_cas(request.cas.value());
+  return proto;
+}
+
+inline auto
+decode(const v1::UnlockResponse& /* proto */, key_value_error_context ctx)
+  -> operations::unlock_response
+{
+  operations::unlock_response response;
+  response.ctx = std::move(ctx);
+  return response;
+}
+
+inline auto
+encode(const operations::get_and_touch_request& request) -> v1::GetAndTouchRequest
+{
+  v1::GetAndTouchRequest proto;
+  set_location(proto, request.id);
+  set_expiry(proto, request.expiry);
+  return proto;
+}
+
+inline auto
+decode(const v1::GetAndTouchResponse& proto, key_value_error_context ctx)
+  -> operations::get_and_touch_response
+{
+  operations::get_and_touch_response response;
+  response.ctx = std::move(ctx);
+  if (content_is_compressed(proto)) {
+    response.ctx.override_ec(errc::common::feature_not_available);
+    return response;
+  }
+  response.value = utils::to_binary(proto.content_uncompressed());
+  response.cas = couchbase::cas{ proto.cas() };
+  response.flags = proto.content_flags();
+  return response;
+}
+
+template<typename Request, typename Proto>
+inline void
+set_counter_fields(Proto& proto, const Request& request)
+{
+  set_location(proto, request.id);
+  proto.set_delta(request.delta);
+  set_expiry(proto, request.expiry);
+  if (request.initial_value.has_value()) {
+    proto.set_initial(static_cast<std::int64_t>(request.initial_value.value()));
+  }
+  if (const auto level = to_proto_durability(request.durability_level); level) {
+    proto.set_durability_level(*level);
+  }
+}
+
+template<typename Response, typename Proto>
+inline auto
+decode_counter(const Proto& proto, key_value_error_context ctx) -> Response
+{
+  Response response;
+  response.ctx = std::move(ctx);
+  response.content = static_cast<std::uint64_t>(proto.content());
+  response.cas = couchbase::cas{ proto.cas() };
+  if (proto.has_mutation_token()) {
+    response.token = to_core_token(proto.mutation_token());
+  }
+  return response;
+}
+
+inline auto
+encode(const operations::increment_request& request) -> v1::IncrementRequest
+{
+  v1::IncrementRequest proto;
+  set_counter_fields(proto, request);
+  return proto;
+}
+
+inline auto
+decode(const v1::IncrementResponse& proto, key_value_error_context ctx)
+  -> operations::increment_response
+{
+  return decode_counter<operations::increment_response>(proto, std::move(ctx));
+}
+
+inline auto
+encode(const operations::decrement_request& request) -> v1::DecrementRequest
+{
+  v1::DecrementRequest proto;
+  set_counter_fields(proto, request);
+  return proto;
+}
+
+inline auto
+decode(const v1::DecrementResponse& proto, key_value_error_context ctx)
+  -> operations::decrement_response
+{
+  return decode_counter<operations::decrement_response>(proto, std::move(ctx));
+}
+
+inline auto
+encode(const operations::append_request& request) -> v1::AppendRequest
+{
+  v1::AppendRequest proto;
+  set_location(proto, request.id);
+  proto.set_content(utils::to_string(request.value));
+  if (request.cas.value() != 0) {
+    proto.set_cas(request.cas.value());
+  }
+  if (const auto level = to_proto_durability(request.durability_level); level) {
+    proto.set_durability_level(*level);
+  }
+  return proto;
+}
+
+inline auto
+decode(const v1::AppendResponse& proto, key_value_error_context ctx) -> operations::append_response
+{
+  return decode_mutation<operations::append_response>(proto, std::move(ctx));
+}
+
+inline auto
+encode(const operations::prepend_request& request) -> v1::PrependRequest
+{
+  v1::PrependRequest proto;
+  set_location(proto, request.id);
+  proto.set_content(utils::to_string(request.value));
+  if (request.cas.value() != 0) {
+    proto.set_cas(request.cas.value());
+  }
+  if (const auto level = to_proto_durability(request.durability_level); level) {
+    proto.set_durability_level(*level);
+  }
+  return proto;
+}
+
+inline auto
+decode(const v1::PrependResponse& proto, key_value_error_context ctx)
+  -> operations::prepend_response
+{
+  return decode_mutation<operations::prepend_response>(proto, std::move(ctx));
 }
 
 } // namespace couchbase::core::protostellar::kv

--- a/test/cng/CMakeLists.txt
+++ b/test/cng/CMakeLists.txt
@@ -117,6 +117,8 @@ if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 AND TARGET couchbase_cxx_protostellar)
 
   # Protostellar KV component (CXXCBC-891).
   add_cng_test(protostellar/component LINK_CLIENT LIBS couchbase_cxx_protostellar)
+  add_cng_test(protostellar/component_kv_operations LINK_CLIENT LIBS couchbase_cxx_protostellar)
+  add_cng_test(protostellar/live_kv_operations LINK_CLIENT LIBS couchbase_cxx_protostellar)
 
   # Live KV verification vs a real gateway (CXXCBC-891).
   add_cng_test(protostellar/live_kv LINK_CLIENT LIBS couchbase_cxx_protostellar)

--- a/test/cng/framework/live_fixture.hxx
+++ b/test/cng/framework/live_fixture.hxx
@@ -17,9 +17,23 @@
 
 #pragma once
 
+#include "framework/test_runner.hxx"
+
+#include "core/cluster_credentials.hxx"
+#include "core/cluster_options.hxx"
+#include "core/document_id.hxx"
+#include "core/protostellar/component.hxx"
+#include "core/protostellar/credentials.hxx"
+#include "core/tls_verify_mode.hxx"
+#include "core/utils/connection_string.hxx"
+
 #include <asio/executor_work_guard.hpp>
 #include <asio/io_context.hpp>
 
+#include <chrono>
+#include <future>
+#include <memory>
+#include <string>
 #include <thread>
 
 namespace couchbase::cng::test
@@ -58,6 +72,102 @@ public:
 private:
   asio::executor_work_guard<asio::io_context::executor_type> work_;
   std::thread thread_;
+};
+
+// A component wired to the gateway named by TEST_CONNECTION_STRING, with the io_context already
+// running on its own thread so an operation can be awaited inline.
+//
+// Constructing one skips the case unless the environment actually describes a couchbase2://
+// endpoint, so a case body can assume it has a live gateway. The alternative -- repeating the
+// parse/skip/credentials/channel preamble per case -- is about forty lines each, which buries the
+// one operation the case exists to check and drifts between copies.
+class live_kv_fixture
+{
+public:
+  live_kv_fixture()
+  {
+    const auto connection_string = safe_getenv("TEST_CONNECTION_STRING");
+    if (!connection_string.has_value()) {
+      skip("TEST_CONNECTION_STRING is not set");
+    }
+    const auto parsed = core::utils::parse_connection_string(connection_string.value());
+    if (!parsed.uses_protostellar()) {
+      skip("TEST_CONNECTION_STRING is not a couchbase2:// endpoint");
+    }
+    if (parsed.bootstrap_nodes.empty()) {
+      skip("no nodes in TEST_CONNECTION_STRING");
+    }
+
+    const auto& node = parsed.bootstrap_nodes.front();
+    const auto port = node.port > 0 ? node.port : parsed.default_port;
+
+    core::cluster_options options;
+    options.enable_tls = true;
+    options.tls_verify = core::tls_verify_mode::none; // dev gateway certificate is not chainable
+
+    credentials_.username = env_or("TEST_CB2_USERNAME", "Administrator");
+    credentials_.password = env_or("TEST_CB2_PASSWORD", "password");
+    bucket_ = env_or("TEST_CB2_BUCKET", "default");
+
+    // Only the two fields whose names are stable across the series are set here. The per-operation
+    // deadline is applied in execute() instead of through the config, because the config's timeout
+    // members are reshaped partway up the stack and a fixture that named them would have to be
+    // edited in step with that.
+    core::protostellar::component_config config;
+    config.channel = core::protostellar::make_channel(
+      node.address + ":" + std::to_string(port), options, credentials_);
+    config.credentials = credentials_;
+    component_ = std::make_unique<core::protostellar::component>(io_, config);
+  }
+
+  live_kv_fixture(const live_kv_fixture&) = delete;
+  live_kv_fixture(live_kv_fixture&&) = delete;
+  auto operator=(const live_kv_fixture&) -> live_kv_fixture& = delete;
+  auto operator=(live_kv_fixture&&) -> live_kv_fixture& = delete;
+  ~live_kv_fixture() = default;
+
+  // Dispatches one operation and blocks until its handler runs. The handler runs on the io thread
+  // while this waits, so a case reads as a sequence of operations rather than as nested callbacks.
+  template<typename Request>
+  [[nodiscard]] auto execute(Request request) -> typename Request::response_type
+  {
+    // A real gateway over a real network needs more than the SDK's default KV deadline, and a case
+    // that wants a different one can set it before calling.
+    if (!request.timeout.has_value()) {
+      request.timeout = std::chrono::milliseconds{ 20000 };
+    }
+    std::promise<typename Request::response_type> promise;
+    auto future = promise.get_future();
+    component_->execute(std::move(request),
+                        [&promise](typename Request::response_type response) mutable {
+                          promise.set_value(std::move(response));
+                        });
+    return future.get();
+  }
+
+  [[nodiscard]] auto id(const std::string& key) const -> core::document_id
+  {
+    return core::document_id{ bucket_, "_default", "_default", key };
+  }
+
+  [[nodiscard]] auto bucket() const -> const std::string&
+  {
+    return bucket_;
+  }
+
+private:
+  [[nodiscard]] static auto env_or(const char* name, const char* fallback) -> std::string
+  {
+    return safe_getenv(name).value_or(fallback);
+  }
+
+  asio::io_context io_{};
+  // Declared after io_ and before component_: the component drains its gRPC calls as it is
+  // destroyed, which needs the io thread still running, and the guard joins it afterwards.
+  io_thread_guard runner_{ io_ };
+  core::cluster_credentials credentials_{};
+  std::string bucket_{};
+  std::unique_ptr<core::protostellar::component> component_{};
 };
 
 } // namespace couchbase::cng::test

--- a/test/cng/protostellar/component.cxx
+++ b/test/cng/protostellar/component.cxx
@@ -40,6 +40,8 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstdint>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
@@ -66,6 +68,10 @@ public:
     -> grpc::Status override
   {
     record_auth(context);
+    last_project.clear();
+    for (int i = 0; i < request->project_size(); ++i) {
+      last_project.push_back(request->project(i));
+    }
     if (request->key() == "missing") {
       return { grpc::StatusCode::NOT_FOUND, "no such document" };
     }
@@ -148,6 +154,7 @@ public:
     return grpc::Status::OK;
   }
 
+  std::vector<std::string> last_project{};
   std::string last_auth_header{};
 
   // Test knobs. `reply_delay` makes every handler sleep before answering, so a client-side deadline
@@ -604,6 +611,43 @@ an_exhausted_default_timeout_is_also_rejected()
   assert_eq(server.service().calls_received.load(), 0, "nothing reached the server");
 }
 
+// increment_request::initial_value is uint64 while the proto's `initial` field is int64, so a seed
+// above INT64_MAX has no representation on the wire and would arrive as a negative number -- the
+// gateway would be asked to seed a counter with it. It is refused before anything is encoded.
+//
+// calls_received is the assertion that distinguishes the two stories: "refused locally" and "sent
+// and then rejected by the gateway" would both surface as invalid_argument, and only the counter
+// separates them.
+void
+a_counter_seed_above_int64_max_is_rejected_before_dispatch()
+{
+  in_process_server server;
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, { 5000ms } } };
+
+  ops::increment_request request;
+  request.id = make_id("k1");
+  request.initial_value =
+    static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()) + 1ULL;
+
+  std::optional<ops::increment_response> outcome;
+  int completions = 0;
+  comp.execute(std::move(request), [&](ops::increment_response response) {
+    ++completions;
+    outcome = std::move(response);
+    work.reset();
+  });
+  io.run();
+
+  assert_true(outcome.has_value(), "the handler runs");
+  assert_eq(completions, 1, "the handler runs exactly once");
+  assert_true(
+    outcome->ctx.ec() == couchbase::errc::common::invalid_argument,
+    "a counter seed that cannot be represented is an invalid argument, not a wrapped one");
+  assert_eq(server.service().calls_received.load(), 0, "nothing reached the server");
+}
+
 // Cancelling an in-flight call still completes the handler, exactly once. A cancellation that
 // dropped the completion would hang whatever is waiting on it, which is worse than the error.
 void
@@ -634,6 +678,33 @@ cancellation_completes_the_handler_once()
               "cancellation surfaces as request_canceled");
 }
 
+void
+get_projected_encodes_projections_and_decodes_response()
+{
+  in_process_server server;
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+
+  ops::get_projected_request request;
+  request.id = make_id("k1");
+  request.projections = { "foo", "bar.baz" };
+
+  ops::get_projected_response outcome;
+  comp.execute(std::move(request), [&](ops::get_projected_response response) {
+    outcome = std::move(response);
+    work.reset();
+  });
+  io.run();
+
+  assert_false(static_cast<bool>(outcome.ctx.ec()), "get_projected succeeded");
+  assert_eq(cu::to_string(outcome.value), std::string{ "value:k1" }, "value round-trips");
+  assert_eq(outcome.cas.value(), 0x2222ULL, "cas round-trips");
+  assert_eq(server.service().last_project.size(), 2U, "projection size matches");
+  assert_eq(server.service().last_project[0], "foo", "first projection path matches");
+  assert_eq(server.service().last_project[1], "bar.baz", "second projection path matches");
+}
+
 } // namespace
 
 auto
@@ -643,6 +714,9 @@ tests() -> test_suite
     "protostellar_component",
     {
       { "get_round_trips_on_the_io_thread", get_round_trips_on_the_io_thread, timeout::network },
+      { "get_projected_encodes_projections_and_decodes_response",
+        get_projected_encodes_projections_and_decodes_response,
+        timeout::network },
       { "get_maps_not_found_into_the_error_context",
         get_maps_not_found_into_the_error_context,
         timeout::network },
@@ -673,6 +747,9 @@ tests() -> test_suite
       { "get_honours_the_request_timeout", get_honours_the_request_timeout, timeout::network },
       { "mutation_timeout_is_reported_as_ambiguous",
         mutation_timeout_is_reported_as_ambiguous,
+        timeout::network },
+      { "a_counter_seed_above_int64_max_is_rejected_before_dispatch",
+        a_counter_seed_above_int64_max_is_rejected_before_dispatch,
         timeout::network },
       { "an_exhausted_budget_is_rejected_before_dispatch",
         an_exhausted_budget_is_rejected_before_dispatch,

--- a/test/cng/protostellar/component_kv_operations.cxx
+++ b/test/cng/protostellar/component_kv_operations.cxx
@@ -1,0 +1,1530 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Dispatch-level coverage for the rest of the KV surface (CXXCBC-894).
+//
+// component.cxx drives get/get_projected/upsert/insert/replace/remove through component::execute().
+// The nine operations here -- touch, exists, get_and_lock, unlock, get_and_touch, increment,
+// decrement, append, prepend -- had encode/decode coverage in kv_converter.cxx and nothing that put
+// them through the real gRPC path. Two classes of defect fall in that gap: an operation wired to
+// the wrong stub still encodes correctly, and a response guard keyed on the wrong message type
+// still compiles. Both need a real round trip to show up.
+//
+// The expectations here are taken from the protocol rather than from this implementation, so that a
+// case fails when the client stops honouring the contract instead of merely when the code changes.
+// The reference behaviour is the one the gateway and the other SDKs agree on -- gocbcoreps'
+// impl_kv_test.go is the closest analogue, and its expectations are named in the cases below where
+// they are not obvious. The notable ones:
+//
+//   * `exists` on a missing document is a success carrying result=false, never a NOT_FOUND.
+//   * NOT_FOUND is not by itself "document not found": the resource_type in the google.rpc
+//     ResourceInfo detail selects between bucket/scope/collection/document (RFC 77).
+//   * a locked document surfaces as FAILED_PRECONDITION carrying a PreconditionFailure violation of
+//     type LOCKED, and unlocking one that is not locked as NOT_LOCKED.
+//   * `unlock` with a zero cas is rejected by the server as INVALID_ARGUMENT.
+//
+// Env-agnostic: an in-process gRPC server, no cluster.
+
+#include "framework/test_runner.hxx"
+
+#include "core/cluster_credentials.hxx"
+#include "core/document_id.hxx"
+#include "core/error_context/key_value.hxx"
+#include "core/protostellar/component.hxx"
+#include "core/utils/binary.hxx"
+
+#include <couchbase/error_codes.hxx>
+
+#include <couchbase/kv/v1/kv.grpc.pb.h>
+
+#include <google/rpc/error_details.pb.h>
+#include <google/rpc/status.pb.h>
+
+#include <asio/executor_work_guard.hpp>
+#include <asio/io_context.hpp>
+
+#include <grpcpp/server_builder.h>
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <system_error>
+#include <utility>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace v1 = ::couchbase::kv::v1;
+namespace ops = ::couchbase::core::operations;
+namespace cu = ::couchbase::core::utils;
+using ::couchbase::core::cluster_credentials;
+using ::couchbase::core::document_id;
+using ::couchbase::core::protostellar::component;
+using ::couchbase::core::protostellar::component_config;
+using namespace std::chrono_literals;
+
+// A gateway reports the specific failure in the google.rpc.Status details rather than in the gRPC
+// status code, which alone is too coarse to distinguish "no such bucket" from "no such document".
+// Building the real payload here is what makes these cases exercise the mapping the gateway drives;
+// a status carrying only a code would take a different branch in error_utils entirely.
+template<typename Detail>
+[[nodiscard]] auto
+rich_status(grpc::StatusCode code, const std::string& message, const Detail& detail) -> grpc::Status
+{
+  google::rpc::Status rich;
+  rich.set_code(static_cast<std::int32_t>(code));
+  rich.set_message(message);
+  rich.add_details()->PackFrom(detail);
+  return { code, message, rich.SerializeAsString() };
+}
+
+[[nodiscard]] auto
+resource_not_found(const std::string& resource_type) -> grpc::Status
+{
+  google::rpc::ResourceInfo info;
+  info.set_resource_type(resource_type);
+  info.set_resource_name("test");
+  return rich_status(grpc::StatusCode::NOT_FOUND, resource_type + " not found", info);
+}
+
+[[nodiscard]] auto
+precondition_failed(const std::string& violation_type) -> grpc::Status
+{
+  google::rpc::PreconditionFailure failure;
+  failure.add_violations()->set_type(violation_type);
+  return rich_status(grpc::StatusCode::FAILED_PRECONDITION, violation_type, failure);
+}
+
+// Keys that steer the double into a specific failure. Spelling the trigger into the key keeps each
+// case's intent visible at the call site instead of in server state set up three lines earlier.
+constexpr const char* key_missing = "missing";
+constexpr const char* key_locked = "locked";
+constexpr const char* key_not_locked = "not-locked";
+constexpr const char* key_cas_mismatch = "cas-mismatch";
+constexpr const char* key_compressed = "compressed";
+constexpr const char* key_missing_bucket = "missing-bucket";
+constexpr const char* key_missing_scope = "missing-scope";
+constexpr const char* key_missing_collection = "missing-collection";
+
+// Records what each request carried so a case can assert the encoding directly, rather than infer
+// it from a response this same double produced.
+struct recorded_request {
+  std::string key{};
+  std::string bucket{};
+  std::string scope{};
+  std::string collection{};
+  std::uint64_t cas{ 0 };
+  std::uint32_t lock_time_secs{ 0 };
+  std::optional<std::uint32_t> expiry_secs{};
+  std::optional<std::int64_t> expiry_time_secs{};
+  std::string content{};
+  std::uint64_t delta{ 0 };
+  std::optional<std::int64_t> initial{};
+  bool has_cas{ false };
+};
+
+class kv_surface_service final : public v1::KvService::Service
+{
+public:
+  auto Touch(grpc::ServerContext* /* context */,
+             const v1::TouchRequest* request,
+             v1::TouchResponse* response) -> grpc::Status override
+  {
+    record(request);
+    record_expiry(request);
+    if (auto status = fail_for(request->key()); !status.ok()) {
+      return status;
+    }
+    response->set_cas(0xa001ULL);
+    return grpc::Status::OK;
+  }
+
+  auto Exists(grpc::ServerContext* /* context */,
+              const v1::ExistsRequest* request,
+              v1::ExistsResponse* response) -> grpc::Status override
+  {
+    record(request);
+    // Deliberately container_failure and not fail_for: a missing document is a successful Exists
+    // carrying result=false. That is the contract the gateway implements -- reporting NOT_FOUND
+    // here would make "does it exist" unanswerable -- so the double must not raise for it either.
+    if (auto status = container_failure(request->key()); !status.ok()) {
+      return status;
+    }
+    const bool present = request->key() != std::string{ key_missing };
+    response->set_result(present);
+    response->set_cas(present ? 0xa002ULL : 0ULL);
+    return grpc::Status::OK;
+  }
+
+  auto GetAndLock(grpc::ServerContext* /* context */,
+                  const v1::GetAndLockRequest* request,
+                  v1::GetAndLockResponse* response) -> grpc::Status override
+  {
+    record(request);
+    last.lock_time_secs = request->lock_time_secs();
+    if (auto status = fail_for(request->key()); !status.ok()) {
+      return status;
+    }
+    if (request->key() == std::string{ key_compressed }) {
+      response->set_content_compressed("dummy_compressed_data");
+      response->set_cas(0xa003ULL);
+      return grpc::Status::OK;
+    }
+    response->set_content_uncompressed("locked:" + request->key());
+    response->set_cas(0xa003ULL);
+    response->set_content_flags(0x06U);
+    return grpc::Status::OK;
+  }
+
+  auto Unlock(grpc::ServerContext* /* context */,
+              const v1::UnlockRequest* request,
+              v1::UnlockResponse* /* response */) -> grpc::Status override
+  {
+    record(request);
+    last.cas = request->cas();
+    if (request->cas() == 0) {
+      return { grpc::StatusCode::INVALID_ARGUMENT, "cas cannot be zero" };
+    }
+    return fail_for(request->key());
+  }
+
+  auto GetAndTouch(grpc::ServerContext* /* context */,
+                   const v1::GetAndTouchRequest* request,
+                   v1::GetAndTouchResponse* response) -> grpc::Status override
+  {
+    record(request);
+    record_expiry(request);
+    if (auto status = fail_for(request->key()); !status.ok()) {
+      return status;
+    }
+    if (request->key() == std::string{ key_compressed }) {
+      response->set_content_compressed("dummy_compressed_data");
+      response->set_cas(0xa004ULL);
+      return grpc::Status::OK;
+    }
+    response->set_content_uncompressed("touched:" + request->key());
+    response->set_cas(0xa004ULL);
+    response->set_content_flags(0x06U);
+    return grpc::Status::OK;
+  }
+
+  auto Increment(grpc::ServerContext* /* context */,
+                 const v1::IncrementRequest* request,
+                 v1::IncrementResponse* response) -> grpc::Status override
+  {
+    record(request);
+    record_expiry(request);
+    record_counter(request);
+    if (auto status = fail_for(request->key()); !status.ok()) {
+      return status;
+    }
+    response->set_content(42);
+    response->set_cas(0xa005ULL);
+    set_token(response->mutable_mutation_token(), request->bucket_name(), 11U, 0xb005ULL, 205ULL);
+    return grpc::Status::OK;
+  }
+
+  auto Decrement(grpc::ServerContext* /* context */,
+                 const v1::DecrementRequest* request,
+                 v1::DecrementResponse* response) -> grpc::Status override
+  {
+    record(request);
+    record_expiry(request);
+    record_counter(request);
+    if (auto status = fail_for(request->key()); !status.ok()) {
+      return status;
+    }
+    response->set_content(7);
+    response->set_cas(0xa006ULL);
+    set_token(response->mutable_mutation_token(), request->bucket_name(), 12U, 0xb006ULL, 206ULL);
+    return grpc::Status::OK;
+  }
+
+  auto Append(grpc::ServerContext* /* context */,
+              const v1::AppendRequest* request,
+              v1::AppendResponse* response) -> grpc::Status override
+  {
+    record(request);
+    last.content = request->content();
+    // has_cas(), not cas() != 0: the field tracks presence, and "absent" is what distinguishes an
+    // unconditional append from one requiring cas 0. Deriving it from the value cannot tell the
+    // two apart, which is exactly the bug a mutation to the encoder would slip through.
+    last.has_cas = request->has_cas();
+    last.cas = request->cas();
+    if (auto status = fail_for(request->key()); !status.ok()) {
+      return status;
+    }
+    response->set_cas(0xa007ULL);
+    set_token(response->mutable_mutation_token(), request->bucket_name(), 13U, 0xb007ULL, 207ULL);
+    return grpc::Status::OK;
+  }
+
+  auto Prepend(grpc::ServerContext* /* context */,
+               const v1::PrependRequest* request,
+               v1::PrependResponse* response) -> grpc::Status override
+  {
+    record(request);
+    last.content = request->content();
+    // has_cas(), not cas() != 0: the field tracks presence, and "absent" is what distinguishes an
+    // unconditional append from one requiring cas 0. Deriving it from the value cannot tell the
+    // two apart, which is exactly the bug a mutation to the encoder would slip through.
+    last.has_cas = request->has_cas();
+    last.cas = request->cas();
+    if (auto status = fail_for(request->key()); !status.ok()) {
+      return status;
+    }
+    response->set_cas(0xa008ULL);
+    set_token(response->mutable_mutation_token(), request->bucket_name(), 14U, 0xb008ULL, 208ULL);
+    return grpc::Status::OK;
+  }
+
+  recorded_request last{};
+
+  // The server outlives every case, so each one starts by wiping what the last left behind.
+  // Without this a programmed status would leak into the next case and fail it somewhere
+  // unrelated to its own subject.
+  void reset_state()
+  {
+    last = recorded_request{};
+    programmed = grpc::Status::OK;
+  }
+
+  // When set, every handler returns this instead of consulting the key. Lets a case hand the double
+  // a status transcribed from the gateway without teaching the key-trigger table about it, and
+  // keeps the catalogue (defined below, after this class) out of the double's name lookup.
+  grpc::Status programmed{ grpc::Status::OK };
+
+private:
+  template<typename Request>
+  void record(const Request* request)
+  {
+    last = recorded_request{};
+    last.key = request->key();
+    last.bucket = request->bucket_name();
+    last.scope = request->scope_name();
+    last.collection = request->collection_name();
+  }
+
+  template<typename Request>
+  void record_expiry(const Request* request)
+  {
+    if (request->has_expiry_secs()) {
+      last.expiry_secs = request->expiry_secs();
+    }
+    if (request->has_expiry_time()) {
+      last.expiry_time_secs = request->expiry_time().seconds();
+    }
+  }
+
+  template<typename Request>
+  void record_counter(const Request* request)
+  {
+    last.delta = request->delta();
+    if (request->has_initial()) {
+      last.initial = request->initial();
+    }
+  }
+
+  static void set_token(v1::MutationToken* token,
+                        const std::string& bucket,
+                        std::uint32_t vbucket_id,
+                        std::uint64_t vbucket_uuid,
+                        std::uint64_t seq_no)
+  {
+    token->set_bucket_name(bucket);
+    token->set_vbucket_id(vbucket_id);
+    token->set_vbucket_uuid(vbucket_uuid);
+    token->set_seq_no(seq_no);
+  }
+
+  // Failures that are about the container rather than the document. Split out because Exists
+  // reports a missing *document* as a successful false and must still fail on a missing bucket.
+  [[nodiscard]] auto container_failure(const std::string& key) const -> grpc::Status
+  {
+    if (!programmed.ok()) {
+      return programmed;
+    }
+    if (key == key_missing_bucket) {
+      return resource_not_found("bucket");
+    }
+    if (key == key_missing_scope) {
+      return resource_not_found("scope");
+    }
+    if (key == key_missing_collection) {
+      return resource_not_found("collection");
+    }
+    return grpc::Status::OK;
+  }
+
+  [[nodiscard]] auto fail_for(const std::string& key) const -> grpc::Status
+  {
+    if (auto status = container_failure(key); !status.ok()) {
+      return status;
+    }
+    if (key == key_missing) {
+      return resource_not_found("document");
+    }
+    if (key == key_locked) {
+      return precondition_failed("LOCKED");
+    }
+    if (key == key_not_locked) {
+      return precondition_failed("NOT_LOCKED");
+    }
+    if (key == key_cas_mismatch) {
+      return { grpc::StatusCode::ABORTED, "cas mismatch" };
+    }
+    return grpc::Status::OK;
+  }
+};
+
+// A handle onto ONE process-wide in-process server and channel.
+//
+// Each case still writes `in_process_server server;` and gets a clean slate, but the gRPC server
+// and channel underneath are built once for the whole binary and never torn down.
+//
+// This is not premature tidying, it is a workaround for a defect in gRPC. Every grpc::Channel takes
+// a reference on gRPC's process-global callback completion queue on its first callback-API call and
+// drops it when destroyed; when that count reaches zero gRPC shuts the queue down and joins its
+// polling threads, and driving that repeatedly races those threads and aborts the whole process:
+//
+//     ref_counted.h:183]  assertion failed: prior > 0
+//
+// That is CXXCBC-919. A server-and-channel per case was measured aborting roughly one run in twenty
+// once this suite grew to 38 cases -- and because it aborts the process rather than failing a case,
+// it takes the entire binary down and tells you nothing about which case was running. Building the
+// pair once removes the churn completely instead of making it rarer.
+//
+// The pair is deliberately leaked rather than held in a destructible static: letting it be torn
+// down at exit would run exactly the teardown this avoids, at the least debuggable moment there is.
+class in_process_server
+{
+public:
+  in_process_server()
+  {
+    shared().service.reset_state();
+  }
+  in_process_server(const in_process_server&) = delete;
+  in_process_server(in_process_server&&) = delete;
+  auto operator=(const in_process_server&) -> in_process_server& = delete;
+  auto operator=(in_process_server&&) -> in_process_server& = delete;
+  ~in_process_server()
+  {
+    shared().service.reset_state();
+  }
+  [[nodiscard]] auto channel() -> std::shared_ptr<grpc::Channel>
+  {
+    return shared().channel;
+  }
+  [[nodiscard]] auto service() -> kv_surface_service&
+  {
+    return shared().service;
+  }
+
+private:
+  struct shared_state {
+    kv_surface_service service{};
+    std::unique_ptr<grpc::Server> server{};
+    std::shared_ptr<grpc::Channel> channel{};
+  };
+
+  [[nodiscard]] static auto shared() -> shared_state&
+  {
+    static shared_state* state = [] {
+      auto* fresh = new shared_state{}; // NOLINT(cppcoreguidelines-owning-memory) -- see above
+      grpc::ServerBuilder builder;
+      builder.RegisterService(&fresh->service);
+      fresh->server = builder.BuildAndStart();
+      fresh->channel = fresh->server->InProcessChannel(grpc::ChannelArguments{});
+      return fresh;
+    }();
+    return *state;
+  }
+};
+
+[[nodiscard]] auto
+make_id(std::string key) -> document_id
+{
+  return document_id{ "b", "s", "c", std::move(key) };
+}
+
+// Runs one operation to completion on the io_context and hands back its response. Every case needs
+// the same five lines around execute(); factoring them out keeps each case about the expectation it
+// exists to state.
+template<typename Request>
+[[nodiscard]] auto
+run(in_process_server& server, Request request)
+{
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  // Named fields, and the timeouts left at their defaults: component_config gains members as the
+  // series progresses, and a positional list silently rebinds its tail into a new sub-object when
+  // it does. Nothing here is about timeouts, so the defaults are what these cases want anyway.
+  component_config config;
+  config.channel = server.channel();
+  config.credentials = cluster_credentials{};
+  component comp{ io, config };
+
+  typename Request::response_type outcome;
+  comp.execute(std::move(request), [&](typename Request::response_type response) {
+    outcome = std::move(response);
+    work.reset();
+  });
+  io.run();
+  return outcome;
+}
+
+// --- touch --------------------------------------------------------------------------------------
+
+void
+touch_encodes_a_relative_expiry_and_returns_the_cas()
+{
+  in_process_server server;
+  ops::touch_request request;
+  request.id = make_id("k1");
+  request.expiry = 20;
+
+  const auto outcome = run(server, std::move(request));
+
+  assert_false(static_cast<bool>(outcome.ctx.ec()), "touch succeeded");
+  assert_eq(outcome.cas.value(), 0xa001ULL, "cas round-trips");
+  assert_true(server.service().last.expiry_secs.has_value(),
+              "an expiry inside the relative window is sent as expiry_secs");
+  assert_eq(server.service().last.expiry_secs.value(), 20U, "the expiry reaches the wire intact");
+  assert_eq(server.service().last.key, std::string{ "k1" }, "the key reaches the wire");
+}
+
+void
+touch_encodes_an_expiry_beyond_thirty_days_as_an_absolute_time()
+{
+  in_process_server server;
+  ops::touch_request request;
+  request.id = make_id("k1");
+  // Above the 30-day cutoff the server would read a relative value as a unix timestamp in the past
+  // and delete the document, so the client has to switch representations rather than pass it on.
+  request.expiry = 60U * 60U * 24U * 31U;
+
+  const auto outcome = run(server, std::move(request));
+
+  assert_false(static_cast<bool>(outcome.ctx.ec()), "touch succeeded");
+  assert_false(server.service().last.expiry_secs.has_value(),
+               "a value past the cutoff is not sent as a relative expiry");
+  assert_true(server.service().last.expiry_time_secs.has_value(),
+              "it is sent as an absolute expiry_time instead");
+}
+
+void
+touch_maps_a_missing_document_into_the_error_context()
+{
+  in_process_server server;
+  ops::touch_request request;
+  request.id = make_id(key_missing);
+  request.expiry = 20;
+
+  const auto outcome = run(server, std::move(request));
+
+  assert_true(outcome.ctx.ec() == couchbase::errc::key_value::document_not_found,
+              "NOT_FOUND with resource_type=document surfaces as document_not_found");
+}
+
+// --- exists -------------------------------------------------------------------------------------
+
+void
+exists_reports_a_present_document()
+{
+  in_process_server server;
+  ops::exists_request request;
+  request.id = make_id("k1");
+
+  const auto outcome = run(server, std::move(request));
+
+  assert_false(static_cast<bool>(outcome.ctx.ec()), "exists succeeded");
+  assert_true(outcome.document_exists, "a present document is reported as existing");
+  assert_eq(outcome.cas.value(), 0xa002ULL, "cas round-trips");
+}
+
+void
+exists_reports_a_missing_document_as_a_success()
+{
+  in_process_server server;
+  ops::exists_request request;
+  request.id = make_id(key_missing);
+
+  const auto outcome = run(server, std::move(request));
+
+  // The whole point of exists is to answer the question without raising; a document_not_found here
+  // would force every caller to treat the expected answer as an exceptional one.
+  assert_false(static_cast<bool>(outcome.ctx.ec()),
+               "a missing document is a successful exists, not an error");
+  assert_false(outcome.document_exists, "and it is reported as not existing");
+}
+
+// --- get_and_lock -------------------------------------------------------------------------------
+
+void
+get_and_lock_encodes_the_lock_time_and_returns_the_value()
+{
+  in_process_server server;
+  ops::get_and_lock_request request;
+  request.id = make_id("k1");
+  request.lock_time = 30;
+
+  const auto outcome = run(server, std::move(request));
+
+  assert_false(static_cast<bool>(outcome.ctx.ec()), "get_and_lock succeeded");
+  assert_eq(cu::to_string(outcome.value), std::string{ "locked:k1" }, "value round-trips");
+  assert_eq(outcome.cas.value(), 0xa003ULL, "cas round-trips");
+  assert_eq(server.service().last.lock_time_secs, 30U, "the lock time reaches the wire");
+}
+
+void
+get_and_lock_maps_a_locked_document_into_document_locked()
+{
+  in_process_server server;
+  ops::get_and_lock_request request;
+  request.id = make_id(key_locked);
+  request.lock_time = 30;
+
+  const auto outcome = run(server, std::move(request));
+
+  assert_true(outcome.ctx.ec() == couchbase::errc::key_value::document_locked,
+              "a LOCKED precondition violation surfaces as document_locked");
+}
+
+void
+get_and_lock_refuses_compressed_content()
+{
+  in_process_server server;
+  ops::get_and_lock_request request;
+  request.id = make_id(key_compressed);
+  request.lock_time = 30;
+
+  const auto outcome = run(server, std::move(request));
+
+  // The guard has to be keyed on GetAndLockResponse. Copied from get's and left keyed on
+  // GetResponse it would still compile, and compressed content would be handed back as if it were
+  // the document body -- which is why this is checked through a real round trip.
+  assert_true(outcome.ctx.ec() == couchbase::errc::common::feature_not_available,
+              "compressed content is refused rather than returned as the value");
+  assert_true(outcome.value.empty(), "and no body is handed back");
+}
+
+// --- unlock -------------------------------------------------------------------------------------
+
+void
+unlock_sends_the_cas_and_completes()
+{
+  in_process_server server;
+  ops::unlock_request request;
+  request.id = make_id("k1");
+  request.cas = couchbase::cas{ 0xfeedULL };
+
+  const auto outcome = run(server, std::move(request));
+
+  assert_false(static_cast<bool>(outcome.ctx.ec()), "unlock succeeded");
+  assert_eq(server.service().last.cas, 0xfeedULL, "the cas reaches the wire");
+}
+
+void
+unlock_maps_a_cas_mismatch()
+{
+  in_process_server server;
+  ops::unlock_request request;
+  request.id = make_id(key_cas_mismatch);
+  request.cas = couchbase::cas{ 0xfeedULL };
+
+  const auto outcome = run(server, std::move(request));
+
+  assert_true(outcome.ctx.ec() == couchbase::errc::common::cas_mismatch,
+              "ABORTED surfaces as cas_mismatch");
+}
+
+void
+unlock_maps_a_document_that_is_not_locked()
+{
+  in_process_server server;
+  ops::unlock_request request;
+  request.id = make_id(key_not_locked);
+  request.cas = couchbase::cas{ 0xfeedULL };
+
+  const auto outcome = run(server, std::move(request));
+
+  assert_true(outcome.ctx.ec() == couchbase::errc::key_value::document_not_locked,
+              "a NOT_LOCKED precondition violation surfaces as document_not_locked");
+}
+
+// --- get_and_touch ------------------------------------------------------------------------------
+
+void
+get_and_touch_encodes_the_expiry_and_returns_the_value()
+{
+  in_process_server server;
+  ops::get_and_touch_request request;
+  request.id = make_id("k1");
+  request.expiry = 20;
+
+  const auto outcome = run(server, std::move(request));
+
+  assert_false(static_cast<bool>(outcome.ctx.ec()), "get_and_touch succeeded");
+  assert_eq(cu::to_string(outcome.value), std::string{ "touched:k1" }, "value round-trips");
+  assert_eq(outcome.cas.value(), 0xa004ULL, "cas round-trips");
+  assert_true(server.service().last.expiry_secs.has_value(), "the expiry is sent as expiry_secs");
+  assert_eq(server.service().last.expiry_secs.value(), 20U, "the expiry reaches the wire intact");
+}
+
+void
+get_and_touch_refuses_compressed_content()
+{
+  in_process_server server;
+  ops::get_and_touch_request request;
+  request.id = make_id(key_compressed);
+  request.expiry = 20;
+
+  const auto outcome = run(server, std::move(request));
+
+  assert_true(outcome.ctx.ec() == couchbase::errc::common::feature_not_available,
+              "compressed content is refused rather than returned as the value");
+  assert_true(outcome.value.empty(), "and no body is handed back");
+}
+
+// --- increment / decrement ----------------------------------------------------------------------
+
+void
+increment_encodes_the_delta_and_initial_and_returns_the_counter()
+{
+  in_process_server server;
+  ops::increment_request request;
+  request.id = make_id("k1");
+  request.delta = 5;
+  request.initial_value = 100;
+
+  const auto outcome = run(server, std::move(request));
+
+  assert_false(static_cast<bool>(outcome.ctx.ec()), "increment succeeded");
+  assert_eq(outcome.content, std::uint64_t{ 42 }, "the counter value round-trips");
+  assert_eq(outcome.cas.value(), 0xa005ULL, "cas round-trips");
+  assert_eq(outcome.token.sequence_number(), 205ULL, "the mutation token round-trips");
+  assert_eq(server.service().last.delta, std::uint64_t{ 5 }, "the delta reaches the wire");
+  assert_true(server.service().last.initial.has_value(), "the initial value is sent when set");
+  assert_eq(server.service().last.initial.value(),
+            std::int64_t{ 100 },
+            "the initial value reaches the wire");
+}
+
+void
+increment_omits_the_initial_value_when_it_is_unset()
+{
+  in_process_server server;
+  ops::increment_request request;
+  request.id = make_id("k1");
+  request.delta = 5;
+
+  const auto outcome = run(server, std::move(request));
+
+  assert_false(static_cast<bool>(outcome.ctx.ec()), "increment succeeded");
+  // Sending initial=0 instead of leaving it unset would turn "fail if absent" into "create at
+  // zero", which is a different operation from the caller's point of view.
+  assert_false(server.service().last.initial.has_value(),
+               "no initial value is sent when the caller did not ask for one");
+}
+
+void
+decrement_encodes_the_delta_and_initial_and_returns_the_counter()
+{
+  in_process_server server;
+  ops::decrement_request request;
+  request.id = make_id("k1");
+  request.delta = 3;
+  request.initial_value = 50;
+
+  const auto outcome = run(server, std::move(request));
+
+  assert_false(static_cast<bool>(outcome.ctx.ec()), "decrement succeeded");
+  assert_eq(outcome.content, std::uint64_t{ 7 }, "the counter value round-trips");
+  assert_eq(outcome.cas.value(), 0xa006ULL, "cas round-trips");
+  assert_eq(outcome.token.sequence_number(), 206ULL, "the mutation token round-trips");
+  assert_eq(server.service().last.delta, std::uint64_t{ 3 }, "the delta reaches the wire");
+  assert_true(server.service().last.initial.has_value(), "the initial value is sent when set");
+  assert_eq(server.service().last.initial.value(),
+            std::int64_t{ 50 },
+            "the initial value reaches the wire");
+}
+
+void
+decrement_reaches_the_decrement_stub_and_not_increment()
+{
+  in_process_server server;
+  ops::decrement_request request;
+  request.id = make_id("k1");
+  request.delta = 3;
+
+  const auto outcome = run(server, std::move(request));
+
+  // The two counter operations share their encoder and their decoder, so the only thing that makes
+  // a decrement a decrement is which stub it is dispatched to. The double answers them with
+  // different values precisely so that a mis-wiring is visible here.
+  assert_eq(outcome.content, std::uint64_t{ 7 }, "the response came from the Decrement handler");
+  assert_eq(outcome.cas.value(), 0xa006ULL, "and carries the Decrement handler's cas");
+}
+
+// --- append / prepend ---------------------------------------------------------------------------
+
+void
+append_sends_the_content_and_returns_the_cas_and_token()
+{
+  in_process_server server;
+  ops::append_request request;
+  request.id = make_id("k1");
+  request.value = cu::to_binary("-suffix");
+
+  const auto outcome = run(server, std::move(request));
+
+  assert_false(static_cast<bool>(outcome.ctx.ec()), "append succeeded");
+  assert_eq(outcome.cas.value(), 0xa007ULL, "cas round-trips");
+  assert_eq(outcome.token.sequence_number(), 207ULL, "the mutation token round-trips");
+  assert_eq(
+    server.service().last.content, std::string{ "-suffix" }, "the content reaches the wire");
+}
+
+void
+append_omits_the_cas_when_the_caller_did_not_set_one()
+{
+  in_process_server server;
+  ops::append_request request;
+  request.id = make_id("k1");
+  request.value = cu::to_binary("-suffix");
+
+  const auto outcome = run(server, std::move(request));
+
+  assert_false(static_cast<bool>(outcome.ctx.ec()), "append succeeded");
+  // A zero cas is not "cas zero", it is "no cas requirement". Sending it would turn an
+  // unconditional append into one the server must match against, which no document can satisfy.
+  assert_false(server.service().last.has_cas, "no cas is sent when the caller did not set one");
+}
+
+void
+append_sends_the_cas_when_the_caller_set_one()
+{
+  in_process_server server;
+  ops::append_request request;
+  request.id = make_id("k1");
+  request.value = cu::to_binary("-suffix");
+  request.cas = couchbase::cas{ 0xbeefULL };
+
+  const auto outcome = run(server, std::move(request));
+
+  assert_false(static_cast<bool>(outcome.ctx.ec()), "append succeeded");
+  assert_true(server.service().last.has_cas, "a cas requirement is sent when set");
+  assert_eq(server.service().last.cas, 0xbeefULL, "the cas reaches the wire intact");
+}
+
+void
+append_maps_a_cas_mismatch()
+{
+  in_process_server server;
+  ops::append_request request;
+  request.id = make_id(key_cas_mismatch);
+  request.value = cu::to_binary("-suffix");
+  request.cas = couchbase::cas{ 0xbeefULL };
+
+  const auto outcome = run(server, std::move(request));
+
+  assert_true(outcome.ctx.ec() == couchbase::errc::common::cas_mismatch,
+              "ABORTED surfaces as cas_mismatch");
+}
+
+void
+append_maps_a_missing_document()
+{
+  in_process_server server;
+  ops::append_request request;
+  request.id = make_id(key_missing);
+  request.value = cu::to_binary("-suffix");
+
+  const auto outcome = run(server, std::move(request));
+
+  // Appending to a document that is not there is document_not_found, never document_exists -- the
+  // two are easy to transpose because append and insert are both "create-ish" mutations.
+  assert_true(outcome.ctx.ec() == couchbase::errc::key_value::document_not_found,
+              "appending to a missing document is document_not_found");
+}
+
+void
+prepend_sends_the_content_and_reaches_the_prepend_stub()
+{
+  in_process_server server;
+  ops::prepend_request request;
+  request.id = make_id("k1");
+  request.value = cu::to_binary("prefix-");
+
+  const auto outcome = run(server, std::move(request));
+
+  assert_false(static_cast<bool>(outcome.ctx.ec()), "prepend succeeded");
+  assert_eq(
+    server.service().last.content, std::string{ "prefix-" }, "the content reaches the wire");
+  // append and prepend differ only in the stub they reach; the distinct cas proves which answered.
+  assert_eq(outcome.cas.value(), 0xa008ULL, "the response came from the Prepend handler");
+  assert_eq(outcome.token.sequence_number(), 208ULL, "the mutation token round-trips");
+}
+
+// --- the gateway's own error catalogue --------------------------------------------------------
+//
+// Everything below is transcribed from the server rather than inferred from another SDK's tests.
+// stellar-gateway's docs/ERRORS.md states that "All errors produced by CNG are centrally located
+// within two files", one of which is gateway/dataimpl/server_v1/errorhandler.go; that file is
+// therefore the specification, and gateway/dataimpl/server_v1/kvserver.go says which of those
+// errors each RPC can actually produce.
+//
+// Reproducing the status exactly matters. Our mapping keys on the packed google.rpc detail, and
+// the gateway does not use one detail type uniformly: a CAS mismatch travels as ErrorInfo while a
+// locked document travels as PreconditionFailure. A test that sent a bare status code would take a
+// different branch of map_status() than production ever does.
+
+enum class gateway_error {
+  doc_missing,
+  doc_cas_mismatch,
+  doc_locked,
+  doc_not_locked,
+  doc_not_numeric,
+  value_too_large,
+  durability_impossible,
+  sync_write_ambiguous,
+  scope_missing,
+  collection_missing,
+  collection_no_read_access,
+  collection_no_write_access,
+  generic,
+};
+
+// The document key that steers the double into each status.
+[[nodiscard]] auto
+gateway_key(gateway_error which) -> const char*
+{
+  switch (which) {
+    case gateway_error::doc_missing:
+      return "gw-doc-missing";
+    case gateway_error::doc_cas_mismatch:
+      return "gw-cas-mismatch";
+    case gateway_error::doc_locked:
+      return "gw-locked";
+    case gateway_error::doc_not_locked:
+      return "gw-not-locked";
+    case gateway_error::doc_not_numeric:
+      return "gw-not-numeric";
+    case gateway_error::value_too_large:
+      return "gw-value-too-large";
+    case gateway_error::durability_impossible:
+      return "gw-durability-impossible";
+    case gateway_error::sync_write_ambiguous:
+      return "gw-sync-write-ambiguous";
+    case gateway_error::scope_missing:
+      return "gw-scope-missing";
+    case gateway_error::collection_missing:
+      return "gw-collection-missing";
+    case gateway_error::collection_no_read_access:
+      return "gw-no-read-access";
+    case gateway_error::collection_no_write_access:
+      return "gw-no-write-access";
+    case gateway_error::generic:
+      return "gw-generic";
+  }
+  return "gw-unknown";
+}
+
+// One constructor from errorhandler.go each, reproduced field for field.
+[[nodiscard]] auto
+gateway_status(gateway_error which) -> grpc::Status
+{
+  switch (which) {
+    case gateway_error::doc_missing: // NewDocMissingStatus
+      return resource_not_found("document");
+    case gateway_error::scope_missing: // NewScopeMissingStatus
+      return resource_not_found("scope");
+    case gateway_error::collection_missing: // NewCollectionMissingStatus
+      return resource_not_found("collection");
+    case gateway_error::doc_cas_mismatch: { // NewDocCasMismatchStatus
+      // ErrorInfo, not PreconditionFailure -- the one place the gateway uses that detail type for
+      // a KV error the client has to distinguish.
+      google::rpc::ErrorInfo info;
+      info.set_reason("CAS_MISMATCH");
+      return rich_status(grpc::StatusCode::ABORTED, "cas did not match", info);
+    }
+    case gateway_error::doc_locked: // NewDocLockedStatus
+      return precondition_failed("LOCKED");
+    case gateway_error::doc_not_locked: // NewDocNotLockedStatus
+      return precondition_failed("NOT_LOCKED");
+    case gateway_error::doc_not_numeric: // NewDocNotNumericStatus
+      return precondition_failed("DOC_NOT_NUMERIC");
+    case gateway_error::value_too_large: // NewValueTooLargeStatus
+      return precondition_failed("VALUE_TOO_LARGE");
+    case gateway_error::durability_impossible: // NewDurabilityImpossibleStatus
+      return precondition_failed("DURABILITY_IMPOSSIBLE");
+    case gateway_error::sync_write_ambiguous: // NewSyncWriteAmbiguousStatus
+      // Deliberately detail-free: the constructor attaches nothing, so the client has only the
+      // code to work from.
+      return { grpc::StatusCode::DEADLINE_EXCEEDED, "sync write timed out" };
+    case gateway_error::collection_no_read_access:    // NewCollectionNoReadAccessStatus
+    case gateway_error::collection_no_write_access: { // NewCollectionNoWriteAccessStatus
+      google::rpc::ResourceInfo info;
+      info.set_resource_type("collection");
+      info.set_resource_name("b/s/c");
+      return rich_status(grpc::StatusCode::PERMISSION_DENIED, "no access", info);
+    }
+    case gateway_error::generic: // NewGenericStatus, context.Canceled arm
+      return { grpc::StatusCode::CANCELLED, "The request was cancelled." };
+  }
+  return grpc::Status::OK;
+}
+
+// What the SDK must report for each. `mutating` only matters for the detail-free
+// DEADLINE_EXCEEDED: a read cannot have changed anything, so calling it ambiguous would be wrong.
+[[nodiscard]] auto
+gateway_expectation(gateway_error which, bool mutating) -> std::error_code
+{
+  switch (which) {
+    case gateway_error::doc_missing:
+      return couchbase::errc::key_value::document_not_found;
+    case gateway_error::scope_missing:
+      return couchbase::errc::common::scope_not_found;
+    case gateway_error::collection_missing:
+      return couchbase::errc::common::collection_not_found;
+    case gateway_error::doc_cas_mismatch:
+      return couchbase::errc::common::cas_mismatch;
+    case gateway_error::doc_locked:
+      return couchbase::errc::key_value::document_locked;
+    case gateway_error::doc_not_locked:
+      return couchbase::errc::key_value::document_not_locked;
+    case gateway_error::doc_not_numeric:
+      return couchbase::errc::key_value::delta_invalid;
+    case gateway_error::value_too_large:
+      return couchbase::errc::key_value::value_too_large;
+    case gateway_error::durability_impossible:
+      return couchbase::errc::key_value::durability_impossible;
+    case gateway_error::sync_write_ambiguous:
+      return mutating ? couchbase::errc::common::ambiguous_timeout
+                      : couchbase::errc::common::unambiguous_timeout;
+    case gateway_error::collection_no_read_access:
+    case gateway_error::collection_no_write_access:
+      return couchbase::errc::common::authentication_failure;
+    case gateway_error::generic:
+      return couchbase::errc::common::request_canceled;
+  }
+  return {};
+}
+
+// Drives one operation once per status its RPC can actually return, and checks the mapping. The
+// applicable set per operation is taken from kvserver.go, so a case covers exactly what the server
+// can do to it -- no more (which would test fiction) and no less.
+template<typename MakeRequest>
+void
+check_gateway_errors(std::initializer_list<gateway_error> applicable,
+                     bool mutating,
+                     MakeRequest make_request)
+{
+  // One server and one channel for the whole loop, deliberately.
+  //
+  // Every grpc::Channel takes a reference on gRPC's process-global callback completion queue on its
+  // first callback-API call and drops it when destroyed; when that count reaches zero gRPC shuts
+  // the queue down and joins its polling threads, and driving that repeatedly races those threads
+  // and aborts the process with `ref_counted.h: assertion failed: prior > 0` (CXXCBC-919 -- a
+  // defect in gRPC, not here). A channel per status would multiply this suite's channel count by
+  // the size of each set, ten for append alone, which is enough to hit it regularly; it was hit, at
+  // commit 25, before this loop shared its channel. One channel per case also runs faster.
+  in_process_server server;
+  auto channel = server.channel();
+
+  for (const auto which : applicable) {
+    server.service().programmed = gateway_status(which);
+
+    asio::io_context io;
+    auto work = asio::make_work_guard(io);
+    component_config config;
+    config.channel = channel;
+    config.credentials = cluster_credentials{};
+    component comp{ io, config };
+
+    auto request = make_request(gateway_key(which));
+    using response_type = typename decltype(request)::response_type;
+    response_type outcome;
+    comp.execute(std::move(request), [&](response_type response) {
+      outcome = std::move(response);
+      work.reset();
+    });
+    io.run();
+
+    assert_true(outcome.ctx.ec() == gateway_expectation(which, mutating),
+                std::string{ gateway_key(which) } +
+                  " maps as the gateway intends, got: " + outcome.ctx.ec().message());
+  }
+}
+
+void
+touch_maps_every_status_the_gateway_can_return()
+{
+  // kvserver.go Touch: CollectionMissing, CollectionNoWriteAccess, DocLocked, DocMissing, Generic,
+  // ScopeMissing. Touch takes the *write* access path even though it changes only the expiry.
+  check_gateway_errors({ gateway_error::collection_missing,
+                         gateway_error::collection_no_write_access,
+                         gateway_error::doc_locked,
+                         gateway_error::doc_missing,
+                         gateway_error::generic,
+                         gateway_error::scope_missing },
+                       true,
+                       [](const char* key) {
+                         ops::touch_request request;
+                         request.id = make_id(key);
+                         request.expiry = 20;
+                         return request;
+                       });
+}
+
+void
+exists_maps_every_status_the_gateway_can_return()
+{
+  // kvserver.go Exists: CollectionMissing, CollectionNoReadAccess, Generic, ScopeMissing -- and
+  // notably NOT DocMissing. The server cannot report a missing document as an error here, which is
+  // the contract exists_reports_a_missing_document_as_a_success relies on.
+  check_gateway_errors({ gateway_error::collection_missing,
+                         gateway_error::collection_no_read_access,
+                         gateway_error::generic,
+                         gateway_error::scope_missing },
+                       false,
+                       [](const char* key) {
+                         ops::exists_request request;
+                         request.id = make_id(key);
+                         return request;
+                       });
+}
+
+void
+get_and_lock_maps_every_status_the_gateway_can_return()
+{
+  // kvserver.go GetAndLock: CollectionMissing, CollectionNoReadAccess, DocLocked, DocMissing,
+  // Generic, ScopeMissing. DocLocked here is the double-lock case -- locking an already-locked
+  // document is refused rather than queued.
+  check_gateway_errors({ gateway_error::collection_missing,
+                         gateway_error::collection_no_read_access,
+                         gateway_error::doc_locked,
+                         gateway_error::doc_missing,
+                         gateway_error::generic,
+                         gateway_error::scope_missing },
+                       true,
+                       [](const char* key) {
+                         ops::get_and_lock_request request;
+                         request.id = make_id(key);
+                         request.lock_time = 30;
+                         return request;
+                       });
+}
+
+void
+unlock_maps_every_status_the_gateway_can_return()
+{
+  // kvserver.go Unlock: CollectionMissing, CollectionNoWriteAccess, DocCasMismatch, DocMissing,
+  // DocNotLocked, Generic, ScopeMissing. There is deliberately no DocLocked in that set -- see
+  // unlock_reports_a_bad_cas_as_cas_mismatch_not_locked below.
+  check_gateway_errors({ gateway_error::collection_missing,
+                         gateway_error::collection_no_write_access,
+                         gateway_error::doc_cas_mismatch,
+                         gateway_error::doc_missing,
+                         gateway_error::doc_not_locked,
+                         gateway_error::generic,
+                         gateway_error::scope_missing },
+                       true,
+                       [](const char* key) {
+                         ops::unlock_request request;
+                         request.id = make_id(key);
+                         request.cas = couchbase::cas{ 0xfeedULL };
+                         return request;
+                       });
+}
+
+void
+get_and_touch_maps_every_status_the_gateway_can_return()
+{
+  check_gateway_errors({ gateway_error::collection_missing,
+                         gateway_error::collection_no_read_access,
+                         gateway_error::doc_locked,
+                         gateway_error::doc_missing,
+                         gateway_error::generic,
+                         gateway_error::scope_missing },
+                       true,
+                       [](const char* key) {
+                         ops::get_and_touch_request request;
+                         request.id = make_id(key);
+                         request.expiry = 20;
+                         return request;
+                       });
+}
+
+void
+increment_maps_every_status_the_gateway_can_return()
+{
+  // kvserver.go Increment adds DocNotNumeric, DurabilityImpossible and SyncWriteAmbiguous, and has
+  // no CasMismatch -- IncrementRequest carries no cas field to mismatch against.
+  check_gateway_errors({ gateway_error::collection_missing,
+                         gateway_error::collection_no_write_access,
+                         gateway_error::doc_locked,
+                         gateway_error::doc_missing,
+                         gateway_error::doc_not_numeric,
+                         gateway_error::durability_impossible,
+                         gateway_error::generic,
+                         gateway_error::scope_missing,
+                         gateway_error::sync_write_ambiguous },
+                       true,
+                       [](const char* key) {
+                         ops::increment_request request;
+                         request.id = make_id(key);
+                         request.delta = 1;
+                         return request;
+                       });
+}
+
+void
+decrement_maps_every_status_the_gateway_can_return()
+{
+  check_gateway_errors({ gateway_error::collection_missing,
+                         gateway_error::collection_no_write_access,
+                         gateway_error::doc_locked,
+                         gateway_error::doc_missing,
+                         gateway_error::doc_not_numeric,
+                         gateway_error::durability_impossible,
+                         gateway_error::generic,
+                         gateway_error::scope_missing,
+                         gateway_error::sync_write_ambiguous },
+                       true,
+                       [](const char* key) {
+                         ops::decrement_request request;
+                         request.id = make_id(key);
+                         request.delta = 1;
+                         return request;
+                       });
+}
+
+void
+append_maps_every_status_the_gateway_can_return()
+{
+  // kvserver.go Append/Prepend are the only two of these nine that can return both CasMismatch and
+  // ValueTooLarge, and neither can return DocNotNumeric.
+  check_gateway_errors({ gateway_error::collection_missing,
+                         gateway_error::collection_no_write_access,
+                         gateway_error::doc_cas_mismatch,
+                         gateway_error::doc_locked,
+                         gateway_error::doc_missing,
+                         gateway_error::durability_impossible,
+                         gateway_error::generic,
+                         gateway_error::scope_missing,
+                         gateway_error::sync_write_ambiguous,
+                         gateway_error::value_too_large },
+                       true,
+                       [](const char* key) {
+                         ops::append_request request;
+                         request.id = make_id(key);
+                         request.value = cu::to_binary("-suffix");
+                         return request;
+                       });
+}
+
+void
+prepend_maps_every_status_the_gateway_can_return()
+{
+  check_gateway_errors({ gateway_error::collection_missing,
+                         gateway_error::collection_no_write_access,
+                         gateway_error::doc_cas_mismatch,
+                         gateway_error::doc_locked,
+                         gateway_error::doc_missing,
+                         gateway_error::durability_impossible,
+                         gateway_error::generic,
+                         gateway_error::scope_missing,
+                         gateway_error::sync_write_ambiguous,
+                         gateway_error::value_too_large },
+                       true,
+                       [](const char* key) {
+                         ops::prepend_request request;
+                         request.id = make_id(key);
+                         request.value = cu::to_binary("prefix-");
+                         return request;
+                       });
+}
+
+// --- the contested corners, each pinned with its source ---------------------------------------
+
+void
+unlock_reports_a_bad_cas_as_cas_mismatch_not_locked()
+{
+  // The classic protocol makes this opcode-dependent: core/protocol/status.cxx maps status
+  // `locked` to cas_mismatch when the opcode is `unlock`, and to document_locked otherwise. The
+  // gateway reaches the same answer a different way -- kvserver.go Unlock translates
+  // memdx.ErrCasMismatch into NewDocCasMismatchStatus and never emits DocLocked at all -- so both
+  // transports agree, and a caller unlocking with a stale cas sees cas_mismatch on either.
+  in_process_server server;
+  server.service().programmed = gateway_status(gateway_error::doc_cas_mismatch);
+  ops::unlock_request request;
+  request.id = make_id(gateway_key(gateway_error::doc_cas_mismatch));
+  request.cas = couchbase::cas{ 0xfeedULL };
+
+  const auto outcome = run(server, std::move(request));
+
+  assert_true(outcome.ctx.ec() == couchbase::errc::common::cas_mismatch,
+              "a stale cas on unlock is cas_mismatch, matching the classic transport");
+  assert_true(outcome.ctx.ec() != couchbase::errc::key_value::document_locked,
+              "and specifically not document_locked");
+}
+
+void
+a_cas_mismatch_arrives_as_error_info_not_precondition_failure()
+{
+  // NewDocCasMismatchStatus packs ErrorInfo{Reason: "CAS_MISMATCH"}; every other contested KV
+  // error packs PreconditionFailure. A mapping that only ever looked at PreconditionFailure would
+  // still be correct here by accident, because ABORTED alone is enough -- this case exists so that
+  // the accident is deliberate and stays true if the detail handling is reworked.
+  in_process_server server;
+  server.service().programmed = gateway_status(gateway_error::doc_cas_mismatch);
+  ops::append_request request;
+  request.id = make_id(gateway_key(gateway_error::doc_cas_mismatch));
+  request.value = cu::to_binary("-suffix");
+
+  const auto outcome = run(server, std::move(request));
+
+  assert_true(outcome.ctx.ec() == couchbase::errc::common::cas_mismatch,
+              "an ErrorInfo-bearing ABORTED still maps to cas_mismatch");
+}
+
+void
+a_locked_document_is_reported_so_the_retry_layer_can_see_it()
+{
+  // The contested one. The classic transport does not surface a locked document to the caller at
+  // all: core/bucket.cxx and core/io/mcbp_command.hxx raise retry_reason::key_value_locked, which
+  // core/impl/retry_reason.cxx lists under both always_retry and allows_non_idempotent_retry, so
+  // the operation is retried until the lock clears or the deadline does.
+  //
+  // The component deliberately does NOT retry here: it reports document_locked, and cluster.cxx
+  // turns that into retry_reason::key_value_locked (via protostellar::retry_reason_for) one layer
+  // up, which is where the retry strategy lives for every other retryable couchbase2 error too.
+  // Retrying inside the component would put a second, invisible retry loop underneath that one.
+  //
+  // So this assertion is about the contract between the two layers, not about what a user sees.
+  in_process_server server;
+  server.service().programmed = gateway_status(gateway_error::doc_locked);
+  ops::touch_request request;
+  request.id = make_id(gateway_key(gateway_error::doc_locked));
+  request.expiry = 20;
+
+  const auto outcome = run(server, std::move(request));
+
+  assert_true(outcome.ctx.ec() == couchbase::errc::key_value::document_locked,
+              "the component reports document_locked rather than absorbing it");
+}
+
+void
+a_detail_free_deadline_is_ambiguous_for_a_mutation_and_not_for_a_read()
+{
+  // NewSyncWriteAmbiguousStatus attaches no details at all, so the code is the only signal. A
+  // mutation that timed out may already have been applied; a read cannot have changed anything, so
+  // reporting it as ambiguous would claim it might have mutated state it never touched.
+  in_process_server mutating_server;
+  mutating_server.service().programmed = gateway_status(gateway_error::sync_write_ambiguous);
+  ops::touch_request touch;
+  touch.id = make_id(gateway_key(gateway_error::sync_write_ambiguous));
+  touch.expiry = 20;
+  const auto mutation = run(mutating_server, std::move(touch));
+  assert_true(mutation.ctx.ec() == couchbase::errc::common::ambiguous_timeout,
+              "a timed-out mutation is ambiguous");
+
+  in_process_server reading_server;
+  reading_server.service().programmed = gateway_status(gateway_error::sync_write_ambiguous);
+  ops::exists_request exists;
+  exists.id = make_id(gateway_key(gateway_error::sync_write_ambiguous));
+  const auto read = run(reading_server, std::move(exists));
+  assert_true(read.ctx.ec() == couchbase::errc::common::unambiguous_timeout,
+              "a timed-out read is unambiguous");
+}
+
+void
+an_unrecognised_server_error_is_reported_as_cancelled()
+{
+  // Surprising, and worth pinning precisely because it is surprising. NewGenericStatus is the
+  // gateway's fallback for anything it cannot classify, and its context.Canceled arm returns
+  // codes.Canceled -- so a server-side failure the gateway does not recognise reaches the client
+  // as request_canceled rather than as internal_server_failure.
+  in_process_server server;
+  server.service().programmed = gateway_status(gateway_error::generic);
+  ops::touch_request request;
+  request.id = make_id(gateway_key(gateway_error::generic));
+  request.expiry = 20;
+
+  const auto outcome = run(server, std::move(request));
+
+  assert_true(outcome.ctx.ec() == couchbase::errc::common::request_canceled,
+              "the gateway's generic fallback surfaces as request_canceled");
+}
+
+// --- resource-type routing ------------------------------------------------------------------
+
+void
+a_not_found_resource_type_selects_the_specific_error()
+{
+  // NOT_FOUND alone cannot say what was missing. RFC 77 puts that in the ResourceInfo detail, and
+  // collapsing all four onto document_not_found would tell an operator with a typo in a bucket name
+  // that their document is missing.
+  struct expectation {
+    const char* key;
+    std::error_code expected;
+    const char* what;
+  };
+  const std::array<expectation, 4> cases{ {
+    { key_missing_bucket, couchbase::errc::common::bucket_not_found, "bucket" },
+    { key_missing_scope, couchbase::errc::common::scope_not_found, "scope" },
+    { key_missing_collection, couchbase::errc::common::collection_not_found, "collection" },
+    { key_missing, couchbase::errc::key_value::document_not_found, "document" },
+  } };
+
+  for (const auto& c : cases) {
+    in_process_server server;
+    ops::touch_request request;
+    request.id = make_id(c.key);
+    request.expiry = 20;
+
+    const auto outcome = run(server, std::move(request));
+
+    assert_true(outcome.ctx.ec() == c.expected,
+                std::string{ "resource_type=" } + c.what + " selects its own error");
+  }
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_component_kv_operations",
+    {
+      { "touch_encodes_a_relative_expiry_and_returns_the_cas",
+        touch_encodes_a_relative_expiry_and_returns_the_cas,
+        timeout::network },
+      { "touch_encodes_an_expiry_beyond_thirty_days_as_an_absolute_time",
+        touch_encodes_an_expiry_beyond_thirty_days_as_an_absolute_time,
+        timeout::network },
+      { "touch_maps_a_missing_document_into_the_error_context",
+        touch_maps_a_missing_document_into_the_error_context,
+        timeout::network },
+      { "exists_reports_a_present_document", exists_reports_a_present_document, timeout::network },
+      { "exists_reports_a_missing_document_as_a_success",
+        exists_reports_a_missing_document_as_a_success,
+        timeout::network },
+      { "get_and_lock_encodes_the_lock_time_and_returns_the_value",
+        get_and_lock_encodes_the_lock_time_and_returns_the_value,
+        timeout::network },
+      { "get_and_lock_maps_a_locked_document_into_document_locked",
+        get_and_lock_maps_a_locked_document_into_document_locked,
+        timeout::network },
+      { "get_and_lock_refuses_compressed_content",
+        get_and_lock_refuses_compressed_content,
+        timeout::network },
+      { "unlock_sends_the_cas_and_completes",
+        unlock_sends_the_cas_and_completes,
+        timeout::network },
+      { "unlock_maps_a_cas_mismatch", unlock_maps_a_cas_mismatch, timeout::network },
+      { "unlock_maps_a_document_that_is_not_locked",
+        unlock_maps_a_document_that_is_not_locked,
+        timeout::network },
+      { "get_and_touch_encodes_the_expiry_and_returns_the_value",
+        get_and_touch_encodes_the_expiry_and_returns_the_value,
+        timeout::network },
+      { "get_and_touch_refuses_compressed_content",
+        get_and_touch_refuses_compressed_content,
+        timeout::network },
+      { "increment_encodes_the_delta_and_initial_and_returns_the_counter",
+        increment_encodes_the_delta_and_initial_and_returns_the_counter,
+        timeout::network },
+      { "increment_omits_the_initial_value_when_it_is_unset",
+        increment_omits_the_initial_value_when_it_is_unset,
+        timeout::network },
+      { "decrement_encodes_the_delta_and_initial_and_returns_the_counter",
+        decrement_encodes_the_delta_and_initial_and_returns_the_counter,
+        timeout::network },
+      { "decrement_reaches_the_decrement_stub_and_not_increment",
+        decrement_reaches_the_decrement_stub_and_not_increment,
+        timeout::network },
+      { "append_sends_the_content_and_returns_the_cas_and_token",
+        append_sends_the_content_and_returns_the_cas_and_token,
+        timeout::network },
+      { "append_omits_the_cas_when_the_caller_did_not_set_one",
+        append_omits_the_cas_when_the_caller_did_not_set_one,
+        timeout::network },
+      { "append_sends_the_cas_when_the_caller_set_one",
+        append_sends_the_cas_when_the_caller_set_one,
+        timeout::network },
+      { "append_maps_a_cas_mismatch", append_maps_a_cas_mismatch, timeout::network },
+      { "append_maps_a_missing_document", append_maps_a_missing_document, timeout::network },
+      { "prepend_sends_the_content_and_reaches_the_prepend_stub",
+        prepend_sends_the_content_and_reaches_the_prepend_stub,
+        timeout::network },
+      { "a_not_found_resource_type_selects_the_specific_error",
+        a_not_found_resource_type_selects_the_specific_error,
+        timeout::network },
+      { "touch_maps_every_status_the_gateway_can_return",
+        touch_maps_every_status_the_gateway_can_return,
+        timeout::network },
+      { "exists_maps_every_status_the_gateway_can_return",
+        exists_maps_every_status_the_gateway_can_return,
+        timeout::network },
+      { "get_and_lock_maps_every_status_the_gateway_can_return",
+        get_and_lock_maps_every_status_the_gateway_can_return,
+        timeout::network },
+      { "unlock_maps_every_status_the_gateway_can_return",
+        unlock_maps_every_status_the_gateway_can_return,
+        timeout::network },
+      { "get_and_touch_maps_every_status_the_gateway_can_return",
+        get_and_touch_maps_every_status_the_gateway_can_return,
+        timeout::network },
+      { "increment_maps_every_status_the_gateway_can_return",
+        increment_maps_every_status_the_gateway_can_return,
+        timeout::network },
+      { "decrement_maps_every_status_the_gateway_can_return",
+        decrement_maps_every_status_the_gateway_can_return,
+        timeout::network },
+      { "append_maps_every_status_the_gateway_can_return",
+        append_maps_every_status_the_gateway_can_return,
+        timeout::network },
+      { "prepend_maps_every_status_the_gateway_can_return",
+        prepend_maps_every_status_the_gateway_can_return,
+        timeout::network },
+      { "unlock_reports_a_bad_cas_as_cas_mismatch_not_locked",
+        unlock_reports_a_bad_cas_as_cas_mismatch_not_locked,
+        timeout::network },
+      { "a_cas_mismatch_arrives_as_error_info_not_precondition_failure",
+        a_cas_mismatch_arrives_as_error_info_not_precondition_failure,
+        timeout::network },
+      { "a_locked_document_is_reported_so_the_retry_layer_can_see_it",
+        a_locked_document_is_reported_so_the_retry_layer_can_see_it,
+        timeout::network },
+      { "a_detail_free_deadline_is_ambiguous_for_a_mutation_and_not_for_a_read",
+        a_detail_free_deadline_is_ambiguous_for_a_mutation_and_not_for_a_read,
+        timeout::network },
+      { "an_unrecognised_server_error_is_reported_as_cancelled",
+        an_unrecognised_server_error_is_reported_as_cancelled,
+        timeout::network },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test

--- a/test/cng/protostellar/kv_converter.cxx
+++ b/test/cng/protostellar/kv_converter.cxx
@@ -26,6 +26,7 @@
 
 #include <array>
 #include <cstdint>
+#include <limits>
 #include <string>
 
 namespace couchbase::cng::test
@@ -158,6 +159,73 @@ expiry_encodes_every_branch_explicitly()
   }
 }
 
+// The counter seed is optional in the proto, so "not supplied" and "supplied as zero" are different
+// wire messages -- gocb always sends a seed and is the outlier; jvm and .NET send it only when the
+// caller asked for one, which is what is pinned here. INT64_MAX is the largest representable seed
+// and must still be encoded exactly; anything above it is refused by the component before encoding
+// (see a_counter_seed_above_int64_max_is_rejected_before_dispatch), because this converter returns
+// the request message by value and has no error channel of its own.
+void
+counter_initial_value_is_optional_and_encodes_its_upper_bound()
+{
+  ops::increment_request without_seed;
+  without_seed.id = test_id();
+  const auto encoded_without = pk::encode(without_seed);
+  assert_true(!encoded_without.has_initial(),
+              "no seed was supplied, so the optional initial field stays absent");
+
+  ops::increment_request with_zero;
+  with_zero.id = test_id();
+  with_zero.initial_value = 0U;
+  const auto encoded_zero = pk::encode(with_zero);
+  assert_true(encoded_zero.has_initial(), "a seed of zero is still a seed and must be present");
+  assert_eq(encoded_zero.initial(), std::int64_t{ 0 }, "zero seed value");
+
+  ops::increment_request at_max;
+  at_max.id = test_id();
+  at_max.initial_value = static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max());
+  assert_eq(pk::encode(at_max).initial(),
+            std::numeric_limits<std::int64_t>::max(),
+            "the largest representable seed survives the narrowing unchanged");
+
+  ops::decrement_request decrement_at_max;
+  decrement_at_max.id = test_id();
+  decrement_at_max.initial_value =
+    static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max());
+  assert_eq(pk::encode(decrement_at_max).initial(),
+            std::numeric_limits<std::int64_t>::max(),
+            "decrement shares set_counter_fields, so it shares the bound");
+}
+
+// The remaining expiry-bearing operations added here. `touch` is pinned separately by
+// touch_always_sends_an_expiry_arm; these three shared the same defect and had no expiry assertion
+// at all. Like touch, none of them has a preserve_expiry option -- GetAndTouchRequest,
+// IncrementRequest and DecrementRequest have no such field in the proto -- so the oneof is the only
+// channel for the expiry and it must always be set. An omitted oneof would leave the gateway
+// nothing to act on, so get_and_touch(id, 0) would report success and leave the old TTL in place.
+void
+expiry_encodes_every_branch_for_get_and_touch_and_the_counters()
+{
+  for (const auto& expected : expiry_cases) {
+    const auto label = "expiry=" + std::to_string(expected.expiry);
+
+    ops::get_and_touch_request get_and_touch;
+    get_and_touch.id = test_id();
+    get_and_touch.expiry = expected.expiry;
+    assert_expiry(pk::encode(get_and_touch), expected, "get_and_touch " + label);
+
+    ops::increment_request increment;
+    increment.id = test_id();
+    increment.expiry = expected.expiry;
+    assert_expiry(pk::encode(increment), expected, "increment " + label);
+
+    ops::decrement_request decrement;
+    decrement.id = test_id();
+    decrement.expiry = expected.expiry;
+    assert_expiry(pk::encode(decrement), expected, "decrement " + label);
+  }
+}
+
 // preserve_expiry wins over expiry, which is what upsert_options and replace_options document, and
 // the gateway's encoding for it is an omitted oneof (kvserver.go:484 for upsert, :581 for replace).
 void
@@ -226,6 +294,21 @@ upsert_never_emits_a_gateway_rejected_expiry_shape()
                     label + ": a non-preserving upsert always sets the oneof");
       }
     }
+  }
+}
+
+// Touch and GetAndTouch have no preserve concept and reject an absent oneof outright -- their arm
+// dispatch falls through to "Expiry time specification is unknown." (kvserver.go:297-303 for Touch,
+// :131-137 for GetAndTouch). A zero expiry therefore has to be sent, not omitted; the gateway maps
+// it to never-expires (helpers.go:49-51), which is what touch(0) means on the classic path too.
+void
+touch_always_sends_an_expiry_arm()
+{
+  for (const auto& expected : expiry_cases) {
+    ops::touch_request touch;
+    touch.id = test_id();
+    touch.expiry = expected.expiry;
+    assert_expiry(pk::encode(touch), expected, "touch expiry=" + std::to_string(expected.expiry));
   }
 }
 
@@ -304,6 +387,84 @@ durability_none_is_left_unset()
   assert_false(proto.has_durability_level(), "insert leaves durability unset for none");
 }
 
+void
+lifecycle_ops_encode_expected_fields()
+{
+  ops::touch_request touch;
+  touch.id = document_id{ "b", "s", "c", "k" };
+  touch.expiry = 120U;
+  const auto touch_proto = pk::encode(touch);
+  assert_eq(touch_proto.key(), std::string{ "k" }, "touch key");
+  assert_true(touch_proto.expiry_case() == v1::TouchRequest::kExpirySecs, "touch expiry secs");
+  assert_eq(touch_proto.expiry_secs(), static_cast<std::uint32_t>(120), "touch expiry value");
+
+  ops::get_and_lock_request lock;
+  lock.id = document_id{ "b", "s", "c", "k" };
+  lock.lock_time = 30U;
+  assert_eq(pk::encode(lock).lock_time_secs(), static_cast<std::uint32_t>(30), "lock time");
+
+  ops::unlock_request unlock;
+  unlock.id = document_id{ "b", "s", "c", "k" };
+  unlock.cas = couchbase::cas{ 0x42ULL };
+  assert_eq(pk::encode(unlock).cas(), 0x42ULL, "unlock cas");
+}
+
+void
+exists_and_lock_responses_decode()
+{
+  v1::ExistsResponse exists_proto;
+  exists_proto.set_result(true);
+  exists_proto.set_cas(0x9ULL);
+  const auto exists = pk::decode(exists_proto, key_value_error_context{});
+  assert_true(exists.exists(), "exists result");
+  assert_eq(exists.cas.value(), 0x9ULL, "exists cas");
+
+  v1::GetAndLockResponse lock_proto;
+  lock_proto.set_content_uncompressed("locked-value");
+  lock_proto.set_cas(0xabcULL);
+  lock_proto.set_content_flags(0x06U);
+  const auto locked = pk::decode(lock_proto, key_value_error_context{});
+  assert_eq(cu::to_string(locked.value), std::string{ "locked-value" }, "get_and_lock value");
+  assert_eq(locked.cas.value(), 0xabcULL, "get_and_lock cas");
+}
+
+void
+counter_encodes_and_decodes()
+{
+  ops::increment_request inc;
+  inc.id = document_id{ "b", "s", "c", "counter" };
+  inc.delta = 5ULL;
+  inc.initial_value = 42ULL;
+  inc.expiry = 100U;
+  inc.durability_level = couchbase::durability_level::majority;
+  const auto proto = pk::encode(inc);
+  assert_eq(proto.delta(), 5ULL, "counter delta");
+  assert_true(proto.has_initial(), "counter initial set");
+  assert_eq(proto.initial(), std::int64_t{ 42 }, "counter initial value");
+  assert_true(proto.expiry_case() == v1::IncrementRequest::kExpirySecs, "counter expiry secs");
+  assert_true(proto.has_durability_level(), "counter durability set");
+
+  v1::IncrementResponse resp;
+  resp.set_cas(0x1ULL);
+  resp.set_content(43);
+  const auto result = pk::decode(resp, key_value_error_context{});
+  assert_eq(result.content, static_cast<std::uint64_t>(43), "counter content");
+  assert_eq(result.cas.value(), 0x1ULL, "counter cas");
+}
+
+void
+append_encodes_content_and_cas()
+{
+  ops::append_request append;
+  append.id = document_id{ "b", "s", "c", "k" };
+  append.value = cu::to_binary("-tail");
+  append.cas = couchbase::cas{ 0x55ULL };
+  const auto proto = pk::encode(append);
+  assert_eq(proto.content(), std::string{ "-tail" }, "append content");
+  assert_true(proto.has_cas(), "append cas set");
+  assert_eq(proto.cas(), 0x55ULL, "append cas value");
+}
+
 } // namespace
 
 auto
@@ -316,13 +477,22 @@ tests() -> test_suite
       { "get_response_decodes_value_cas_flags", get_response_decodes_value_cas_flags },
       { "get_response_refuses_compressed_content", get_response_refuses_compressed_content },
       { "expiry_encodes_every_branch_explicitly", expiry_encodes_every_branch_explicitly },
+      { "expiry_encodes_every_branch_for_get_and_touch_and_the_counters",
+        expiry_encodes_every_branch_for_get_and_touch_and_the_counters },
+      { "counter_initial_value_is_optional_and_encodes_its_upper_bound",
+        counter_initial_value_is_optional_and_encodes_its_upper_bound },
       { "preserve_expiry_omits_the_expiry_oneof", preserve_expiry_omits_the_expiry_oneof },
+      { "touch_always_sends_an_expiry_arm", touch_always_sends_an_expiry_arm },
       { "upsert_never_emits_a_gateway_rejected_expiry_shape",
         upsert_never_emits_a_gateway_rejected_expiry_shape },
       { "upsert_request_encodes_all_fields", upsert_request_encodes_all_fields },
       { "mutation_response_decodes_cas_and_token", mutation_response_decodes_cas_and_token },
       { "replace_and_remove_encode_cas", replace_and_remove_encode_cas },
       { "durability_none_is_left_unset", durability_none_is_left_unset },
+      { "lifecycle_ops_encode_expected_fields", lifecycle_ops_encode_expected_fields },
+      { "exists_and_lock_responses_decode", exists_and_lock_responses_decode },
+      { "counter_encodes_and_decodes", counter_encodes_and_decodes },
+      { "append_encodes_content_and_cas", append_encodes_content_and_cas },
     },
   };
 }

--- a/test/cng/protostellar/live_kv_operations.cxx
+++ b/test/cng/protostellar/live_kv_operations.cxx
@@ -1,0 +1,486 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Live coverage of the KV operations beyond the CRUD chain (CXXCBC-894). cluster_only.
+//
+// component_kv_operations.cxx proves the client speaks the protocol correctly to a double that
+// answers the way the protocol says it should. That leaves one thing unproven: whether a real
+// gateway agrees. These cases check the behaviour the operations exist for -- that a lock actually
+// blocks a write, that an expiry actually expires the document, that append actually appends --
+// rather than that a particular field survived a round trip.
+//
+// The expectations mirror the reference suites (gocbcoreps impl_kv_test.go); where a case pins
+// something subtle the reasoning is written next to it.
+//
+// Cases that need an RPC the gateway does not serve skip rather than fail: gateway builds vary in
+// which of the KV surface they implement, and a skip says "not covered here" where a failure would
+// wrongly say "the client is broken".
+
+#include "framework/live_fixture.hxx"
+#include "framework/test_runner.hxx"
+
+#include "core/error_context/key_value.hxx"
+#include "core/utils/binary.hxx"
+
+#include <couchbase/error_codes.hxx>
+
+#include <chrono>
+#include <string>
+#include <thread>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace ops = ::couchbase::core::operations;
+namespace cu = ::couchbase::core::utils;
+
+// A gateway that does not implement an RPC reports feature_not_available; that is a statement about
+// the deployment, not about the client, so the case steps aside instead of going red.
+void
+skip_if_unsupported(const std::error_code& ec, const char* what)
+{
+  if (ec == couchbase::errc::common::feature_not_available) {
+    skip(std::string{ "gateway does not implement " } + what);
+  }
+}
+
+// Puts a known document in place and hands back its cas. Every case needs one and none of them are
+// about upsert, so a failure here is reported as a precondition rather than as the case's subject.
+auto
+seed(live_kv_fixture& fixture, const std::string& key, const std::string& value) -> couchbase::cas
+{
+  ops::upsert_request request;
+  request.id = fixture.id(key);
+  request.value = cu::to_binary(value);
+  request.flags = 0x06U;
+  const auto response = fixture.execute(std::move(request));
+  assert_false(static_cast<bool>(response.ctx.ec()), "precondition: seeding " + key + " succeeded");
+  return response.cas;
+}
+
+void
+discard(live_kv_fixture& fixture, const std::string& key)
+{
+  ops::remove_request request;
+  request.id = fixture.id(key);
+  (void)fixture.execute(std::move(request));
+}
+
+[[nodiscard]] auto
+read(live_kv_fixture& fixture, const std::string& key) -> ops::get_response
+{
+  ops::get_request request;
+  request.id = fixture.id(key);
+  return fixture.execute(std::move(request));
+}
+
+// How long an expiry case will wait for a document to become unreadable. Far longer than the one
+// second of expiry it sets, on purpose: the number is not a prediction of how fast the server is,
+// it is the point past which "the document is still here" stops being slowness and starts being a
+// defect.
+//
+// Deliberately under the case's own timeout budget. If the two were equal the harness would kill
+// the case first and report a bare timeout, hiding the assertion message that says what actually
+// went wrong -- turning a precise failure into a mystery. The static_assert holds that property
+// rather than leaving it to a comment: whichever of the two numbers someone changes later, the
+// build stops instead of the diagnostics quietly degrading.
+constexpr std::chrono::seconds expiry_deadline{ 20 };
+static_assert(expiry_deadline < timeout::integration,
+              "the expiry poll must give up before the harness times the case out, so that a "
+              "failure reports the assertion rather than a bare timeout");
+
+// Polls until the document is gone, or the deadline passes.
+//
+// A fixed sleep would be a bet that the machine is fast enough, and that bet is lost exactly when
+// CI is busiest -- the classic shape of a test that is green locally and flaky in the pipeline.
+// Polling inverts it: a slow host only makes the case take longer, never fail, and the case still
+// fails promptly-ish when expiry genuinely does not work. Nothing here asserts on elapsed time,
+// only on the state transition, so a starved host cannot produce a wrong answer.
+[[nodiscard]] auto
+wait_until_unreadable(live_kv_fixture& fixture, const std::string& key) -> bool
+{
+  const auto give_up = std::chrono::steady_clock::now() + expiry_deadline;
+  for (;;) {
+    if (read(fixture, key).ctx.ec() == couchbase::errc::key_value::document_not_found) {
+      return true;
+    }
+    if (std::chrono::steady_clock::now() >= give_up) {
+      return false;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds{ 100 });
+  }
+}
+
+// Seeds a second document that nothing expires, so a case can tell "the expiry worked" apart from
+// "everything vanished". Without it, a bucket flush, a dropped collection or a broken fixture would
+// make an expiry case pass for entirely the wrong reason.
+struct expiry_control {
+  explicit expiry_control(live_kv_fixture& fixture, std::string key)
+    : fixture_{ fixture }
+    , key_{ std::move(key) }
+  {
+    seed(fixture_, key_, R"({"cng":"control"})");
+  }
+
+  expiry_control(const expiry_control&) = delete;
+  expiry_control(expiry_control&&) = delete;
+  auto operator=(const expiry_control&) -> expiry_control& = delete;
+  auto operator=(expiry_control&&) -> expiry_control& = delete;
+  ~expiry_control() = default;
+
+  void assert_survived() const
+  {
+    const auto control = read(fixture_, key_);
+    assert_false(static_cast<bool>(control.ctx.ec()),
+                 "control document, which was never given an expiry, is still readable -- so the "
+                 "document under test disappeared because of its expiry and not for some other "
+                 "reason");
+  }
+
+  void discard() const
+  {
+    ::couchbase::cng::test::discard(fixture_, key_);
+  }
+
+private:
+  live_kv_fixture& fixture_;
+  std::string key_;
+};
+
+void
+exists_distinguishes_a_present_document_from_a_missing_one()
+{
+  live_kv_fixture fixture;
+  const std::string key{ "cng-live-exists" };
+  seed(fixture, key, R"({"cng":true})");
+
+  ops::exists_request present;
+  present.id = fixture.id(key);
+  const auto present_result = fixture.execute(std::move(present));
+  skip_if_unsupported(present_result.ctx.ec(), "Exists");
+  assert_false(static_cast<bool>(present_result.ctx.ec()),
+               "exists on a present document succeeded");
+  assert_true(present_result.document_exists, "the document is reported as existing");
+
+  discard(fixture, key);
+
+  ops::exists_request absent;
+  absent.id = fixture.id(key);
+  const auto absent_result = fixture.execute(std::move(absent));
+
+  // The contract the whole operation rests on: asking about a document that is not there is a
+  // successful answer of "no", not an error. A gateway that returned NOT_FOUND here would make
+  // every caller wrap exists in a try/catch to learn the ordinary case.
+  assert_false(static_cast<bool>(absent_result.ctx.ec()),
+               "exists on a removed document is still a success");
+  assert_false(absent_result.document_exists, "and reports the document as absent");
+}
+
+void
+touch_expires_a_document()
+{
+  live_kv_fixture fixture;
+  const std::string key{ "cng-live-touch" };
+  seed(fixture, key, R"({"cng":true})");
+
+  const expiry_control control{ fixture, "cng-live-touch-control" };
+
+  // Before the touch the document has no expiry, so it must be readable. This is what makes the
+  // disappearance below attributable to the touch rather than to the seed having silently failed.
+  assert_false(static_cast<bool>(read(fixture, key).ctx.ec()),
+               "the document is readable before any expiry is applied");
+
+  ops::touch_request request;
+  request.id = fixture.id(key);
+  request.expiry = 1;
+  const auto touched = fixture.execute(std::move(request));
+  skip_if_unsupported(touched.ctx.ec(), "Touch");
+  assert_false(static_cast<bool>(touched.ctx.ec()), "touch succeeded");
+
+  // Reading the document back once the expiry has passed is what proves the expiry was applied;
+  // asserting only that touch returned a cas would pass against a client that dropped the field.
+  assert_true(wait_until_unreadable(fixture, key),
+              "the document became unreadable within the deadline after a 1s expiry");
+  control.assert_survived();
+  control.discard();
+}
+
+void
+get_and_lock_blocks_a_write_and_unlock_releases_it()
+{
+  live_kv_fixture fixture;
+  const std::string key{ "cng-live-lock" };
+  seed(fixture, key, R"({"cng":true})");
+
+  ops::get_and_lock_request lock;
+  lock.id = fixture.id(key);
+  lock.lock_time = 15;
+  const auto locked = fixture.execute(std::move(lock));
+  skip_if_unsupported(locked.ctx.ec(), "GetAndLock");
+  assert_false(static_cast<bool>(locked.ctx.ec()), "get_and_lock succeeded");
+  assert_eq(cu::to_string(locked.value),
+            std::string{ R"({"cng":true})" },
+            "get_and_lock returns the document body");
+
+  // A lock that does not block a write is not a lock. This is the property the operation exists
+  // for, and it cannot be observed against a test double that merely echoes a cas back.
+  ops::upsert_request blocked;
+  blocked.id = fixture.id(key);
+  blocked.value = cu::to_binary(R"({"cng":"blocked"})");
+  const auto blocked_result = fixture.execute(std::move(blocked));
+  assert_true(blocked_result.ctx.ec() == couchbase::errc::key_value::document_locked,
+              "a write to a locked document is refused with document_locked");
+
+  ops::unlock_request unlock;
+  unlock.id = fixture.id(key);
+  unlock.cas = locked.cas;
+  const auto unlocked = fixture.execute(std::move(unlock));
+  assert_false(static_cast<bool>(unlocked.ctx.ec()), "unlock with the lock cas succeeded");
+
+  ops::upsert_request allowed;
+  allowed.id = fixture.id(key);
+  allowed.value = cu::to_binary(R"({"cng":"allowed"})");
+  const auto allowed_result = fixture.execute(std::move(allowed));
+  assert_false(static_cast<bool>(allowed_result.ctx.ec()),
+               "the same write succeeds once the lock is released");
+
+  discard(fixture, key);
+}
+
+void
+unlock_with_the_wrong_cas_is_refused()
+{
+  live_kv_fixture fixture;
+  const std::string key{ "cng-live-unlock-cas" };
+  seed(fixture, key, R"({"cng":true})");
+
+  ops::get_and_lock_request lock;
+  lock.id = fixture.id(key);
+  lock.lock_time = 5;
+  const auto locked = fixture.execute(std::move(lock));
+  skip_if_unsupported(locked.ctx.ec(), "GetAndLock");
+  assert_false(static_cast<bool>(locked.ctx.ec()), "get_and_lock succeeded");
+
+  ops::unlock_request wrong;
+  wrong.id = fixture.id(key);
+  wrong.cas = couchbase::cas{ locked.cas.value() ^ 0xffULL };
+  const auto refused = fixture.execute(std::move(wrong));
+
+  // Unlocking with a cas that is not the lock's must not succeed: the cas is what proves the caller
+  // is the lock holder, so accepting any value would let an unrelated caller release someone
+  // else's lock.
+  assert_true(static_cast<bool>(refused.ctx.ec()),
+              "unlock with a cas that is not the lock's is refused");
+
+  ops::unlock_request right;
+  right.id = fixture.id(key);
+  right.cas = locked.cas;
+  (void)fixture.execute(std::move(right));
+  discard(fixture, key);
+}
+
+void
+get_and_touch_returns_the_value_and_applies_the_expiry()
+{
+  live_kv_fixture fixture;
+  const std::string key{ "cng-live-gat" };
+  seed(fixture, key, R"({"cng":true})");
+  const expiry_control control{ fixture, "cng-live-gat-control" };
+
+  ops::get_and_touch_request request;
+  request.id = fixture.id(key);
+  request.expiry = 1;
+  const auto result = fixture.execute(std::move(request));
+  skip_if_unsupported(result.ctx.ec(), "GetAndTouch");
+  assert_false(static_cast<bool>(result.ctx.ec()), "get_and_touch succeeded");
+  assert_eq(cu::to_string(result.value),
+            std::string{ R"({"cng":true})" },
+            "get_and_touch returns the document body");
+
+  assert_true(wait_until_unreadable(fixture, key),
+              "the expiry get_and_touch applied took effect within the deadline");
+  control.assert_survived();
+  control.discard();
+}
+
+void
+counters_increment_and_decrement_a_live_value()
+{
+  live_kv_fixture fixture;
+  const std::string key{ "cng-live-counter" };
+  discard(fixture, key); // a counter from an earlier run would change the arithmetic
+
+  ops::increment_request first;
+  first.id = fixture.id(key);
+  first.delta = 5;
+  first.initial_value = 100;
+  const auto seeded = fixture.execute(std::move(first));
+  skip_if_unsupported(seeded.ctx.ec(), "Increment");
+  assert_false(static_cast<bool>(seeded.ctx.ec()), "increment succeeded");
+  // With initial set and no document present the counter is created at the initial value; the
+  // delta is not applied on top of it. Getting this backwards yields 105 and is the classic
+  // counter-semantics bug.
+  assert_eq(seeded.content,
+            std::uint64_t{ 100 },
+            "a counter that did not exist is created at the initial value");
+
+  ops::increment_request again;
+  again.id = fixture.id(key);
+  again.delta = 5;
+  again.initial_value = 100;
+  const auto incremented = fixture.execute(std::move(again));
+  assert_false(static_cast<bool>(incremented.ctx.ec()), "the second increment succeeded");
+  assert_eq(incremented.content,
+            std::uint64_t{ 105 },
+            "an existing counter is incremented by the delta and ignores the initial value");
+
+  ops::decrement_request down;
+  down.id = fixture.id(key);
+  down.delta = 3;
+  const auto decremented = fixture.execute(std::move(down));
+  skip_if_unsupported(decremented.ctx.ec(), "Decrement");
+  assert_false(static_cast<bool>(decremented.ctx.ec()), "decrement succeeded");
+  assert_eq(decremented.content, std::uint64_t{ 102 }, "decrement subtracts the delta");
+
+  discard(fixture, key);
+}
+
+void
+append_and_prepend_extend_a_live_value()
+{
+  live_kv_fixture fixture;
+  const std::string key{ "cng-live-append" };
+  seed(fixture, key, "base");
+
+  ops::append_request append;
+  append.id = fixture.id(key);
+  append.value = cu::to_binary("-suffix");
+  const auto appended = fixture.execute(std::move(append));
+  skip_if_unsupported(appended.ctx.ec(), "Append");
+  assert_false(static_cast<bool>(appended.ctx.ec()), "append succeeded");
+
+  ops::prepend_request prepend;
+  prepend.id = fixture.id(key);
+  prepend.value = cu::to_binary("prefix-");
+  const auto prepended = fixture.execute(std::move(prepend));
+  skip_if_unsupported(prepended.ctx.ec(), "Prepend");
+  assert_false(static_cast<bool>(prepended.ctx.ec()), "prepend succeeded");
+
+  // Reading the result is what distinguishes append from prepend. Two operations that both
+  // succeeded and both returned a cas would look identical without this.
+  const auto after = read(fixture, key);
+  assert_false(static_cast<bool>(after.ctx.ec()), "the document reads back");
+  assert_eq(cu::to_string(after.value),
+            std::string{ "prefix-base-suffix" },
+            "append went to the end and prepend to the beginning");
+
+  discard(fixture, key);
+}
+
+void
+incrementing_a_non_numeric_document_is_reported_as_delta_invalid()
+{
+  live_kv_fixture fixture;
+  const std::string key{ "cng-live-not-numeric" };
+  seed(fixture, key, R"({"cng":"not a number"})");
+
+  ops::increment_request request;
+  request.id = fixture.id(key);
+  request.delta = 1;
+  const auto result = fixture.execute(std::move(request));
+  skip_if_unsupported(result.ctx.ec(), "Increment");
+
+  // The gateway answers this with FAILED_PRECONDITION carrying a PreconditionFailure violation of
+  // type DOC_NOT_NUMERIC (NewDocNotNumericStatus in gateway/dataimpl/server_v1/errorhandler.go,
+  // reachable only from Increment and Decrement). Reporting it as internal_server_failure would
+  // tell the caller the cluster is broken when in fact their document is not a counter.
+  assert_true(result.ctx.ec() == couchbase::errc::key_value::delta_invalid,
+              "a counter operation on a non-numeric document is delta_invalid, got: " +
+                result.ctx.ec().message());
+
+  discard(fixture, key);
+}
+
+void
+append_to_a_missing_document_is_reported_as_not_found()
+{
+  live_kv_fixture fixture;
+  const std::string key{ "cng-live-append-missing" };
+  discard(fixture, key);
+
+  ops::append_request request;
+  request.id = fixture.id(key);
+  request.value = cu::to_binary("-suffix");
+  const auto result = fixture.execute(std::move(request));
+  skip_if_unsupported(result.ctx.ec(), "Append");
+
+  // Append does not create. A gateway or client that reported this as a success would silently
+  // lose the write.
+  assert_true(result.ctx.ec() == couchbase::errc::key_value::document_not_found,
+              "appending to a document that does not exist is document_not_found");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_live_kv_operations",
+    {
+      { "exists_distinguishes_a_present_document_from_a_missing_one",
+        exists_distinguishes_a_present_document_from_a_missing_one,
+        timeout::integration,
+        test_env::cluster_only },
+      { "touch_expires_a_document",
+        touch_expires_a_document,
+        timeout::integration,
+        test_env::cluster_only },
+      { "get_and_lock_blocks_a_write_and_unlock_releases_it",
+        get_and_lock_blocks_a_write_and_unlock_releases_it,
+        timeout::integration,
+        test_env::cluster_only },
+      { "unlock_with_the_wrong_cas_is_refused",
+        unlock_with_the_wrong_cas_is_refused,
+        timeout::integration,
+        test_env::cluster_only },
+      { "get_and_touch_returns_the_value_and_applies_the_expiry",
+        get_and_touch_returns_the_value_and_applies_the_expiry,
+        timeout::integration,
+        test_env::cluster_only },
+      { "counters_increment_and_decrement_a_live_value",
+        counters_increment_and_decrement_a_live_value,
+        timeout::integration,
+        test_env::cluster_only },
+      { "append_and_prepend_extend_a_live_value",
+        append_and_prepend_extend_a_live_value,
+        timeout::integration,
+        test_env::cluster_only },
+      { "incrementing_a_non_numeric_document_is_reported_as_delta_invalid",
+        incrementing_a_non_numeric_document_is_reported_as_delta_invalid,
+        timeout::integration,
+        test_env::cluster_only },
+      { "append_to_a_missing_document_is_reported_as_not_found",
+        append_to_a_missing_document_is_reported_as_not_found,
+        timeout::integration,
+        test_env::cluster_only },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test


### PR DESCRIPTION
Add the remaining single-document KV operations to the converter and component:
touch, exists, get_and_lock, unlock, get_and_touch, increment, decrement,
append, and prepend, each with its kv.v1 request/response mapping (lock time,
expiry, counter delta/initial, append/prepend content, CAS, durability). Each is
routed by cluster_impl::execute via a component_supports_v specialization; the
five CRUD ops from CXXCBC-891/892 already covered the rest.

Covered by converter unit tests and two live cluster_only round-trips against a
CNG gateway (CRUD, and increment/exists/remove).

---
Stacked PR **12/29** in the CNG (`couchbase2://`) transport series. This branch includes every commit from PRs 01–12; the change specific to this PR is its top commit. Depends on #1044 — merge the series bottom-up.

**Not included: subdoc.** `lookup_in` and `mutate_in` are not routed over `couchbase2://` and return `errc::common::feature_not_available`. "The KV unary operation surface" here means the whole-document operations; the proto does define `LookupInRequest` and `MutateInRequest`, and the reference clients implement them, so this is a gap to be closed by a separate ticket rather than a limitation of the transport. Failing cleanly rather than silently degrading is deliberate.
