### PR TITLE
CXXCBC-895: gRPC server-streaming primitive for the couchbase2 transport

### DIFF
--- a/bin/check-proto-macro-collisions
+++ b/bin/check-proto-macro-collisions
@@ -1,0 +1,167 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+#  Copyright 2026. Couchbase, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Reports generated-protobuf identifiers that a Windows SDK macro would mangle, and sources that
+# reach a hazardous generated header without going through its shielding wrapper.
+#
+# protobuf emits a class-scoped alias per enum value ("static constexpr Status STATUS_TIMEOUT =
+# ..."). Where the Windows SDK defines an object-like macro of the same name -- <winnt.h> has
+# STATUS_TIMEOUT as ((DWORD)0x00000102L), and asio and gRPC reach <winnt.h> transitively -- the
+# alias expands into a parenthesised constant and the generated header stops parsing. Only MSVC is
+# affected, so the Linux and macOS legs stay green and the failure surfaces an hour into CI.
+#
+# Run this after moving the schema pin in cmake/Protostellar.cmake:
+#
+#   ./bin/check-proto-macro-collisions [build-dir]
+#
+# Exits non-zero when a collision is unshielded. A newly colliding family needs the same treatment
+# as core/protostellar/query_proto.hxx: push_macro/#undef around the include, pop_macro after it.
+
+require 'set'
+
+BUILD = ARGV[0] || 'build'
+GENERATED = File.join(BUILD, 'protostellar_generated')
+# Anchored to this script rather than to the caller's cwd. The source scan below walks fixed
+# relative roots and skips any that does not exist, so running from elsewhere would report "(none)"
+# having looked at nothing -- a clean result that means only that the search missed.
+REPO = File.expand_path('..', __dir__)
+
+unless Dir.exist?(GENERATED)
+  warn "#{GENERATED} not found -- configure with -DCOUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2=ON first"
+  exit 2
+end
+
+# Object-like macros the Windows SDK defines for names an enum value plausibly reuses. <winnt.h> is
+# always live once anything reaches <windows.h>; the <ntstatus.h> entries only bite when a
+# dependency pulls that header in, which is why the wrapper suppresses whole families rather than
+# individual names. This list is a tripwire, not the SDK's full ~5000-entry STATUS_* namespace: a
+# clean run means "no known collision", not "provably none".
+WINDOWS_MACROS = %w[
+  STATUS_ABANDONED_WAIT_0 STATUS_ACCESS_VIOLATION STATUS_ARRAY_BOUNDS_EXCEEDED
+  STATUS_ASSERTION_FAILURE STATUS_BREAKPOINT STATUS_CONTROL_C_EXIT STATUS_DATATYPE_MISALIGNMENT
+  STATUS_DLL_INIT_FAILED STATUS_DLL_NOT_FOUND STATUS_ENCLAVE_VIOLATION STATUS_ENTRYPOINT_NOT_FOUND
+  STATUS_FATAL_APP_EXIT STATUS_FLOAT_DENORMAL_OPERAND STATUS_FLOAT_DIVIDE_BY_ZERO
+  STATUS_FLOAT_INEXACT_RESULT STATUS_FLOAT_INVALID_OPERATION STATUS_FLOAT_MULTIPLE_FAULTS
+  STATUS_FLOAT_MULTIPLE_TRAPS STATUS_FLOAT_OVERFLOW STATUS_FLOAT_STACK_CHECK
+  STATUS_FLOAT_UNDERFLOW STATUS_GUARD_PAGE_VIOLATION STATUS_HEAP_CORRUPTION
+  STATUS_ILLEGAL_INSTRUCTION STATUS_INTEGER_DIVIDE_BY_ZERO STATUS_INTEGER_OVERFLOW
+  STATUS_INTERRUPTED STATUS_INVALID_CRUNTIME_PARAMETER STATUS_INVALID_DISPOSITION
+  STATUS_INVALID_HANDLE STATUS_INVALID_PARAMETER STATUS_IN_PAGE_ERROR STATUS_LONGJUMP
+  STATUS_NONCONTINUABLE_EXCEPTION STATUS_NO_MEMORY STATUS_ORDINAL_NOT_FOUND STATUS_PENDING
+  STATUS_PRIVILEGED_INSTRUCTION STATUS_REG_NAT_CONSUMPTION STATUS_SEGMENT_NOTIFICATION
+  STATUS_SINGLE_STEP STATUS_STACK_BUFFER_OVERRUN STATUS_STACK_OVERFLOW
+  STATUS_SXS_EARLY_DEACTIVATION STATUS_SXS_INVALID_DEACTIVATION STATUS_THREAD_NOT_RUNNING
+  STATUS_TIMEOUT STATUS_UNWIND_CONSOLIDATE STATUS_USER_APC STATUS_WAIT_0
+  STATUS_SUCCESS STATUS_ALREADY_REGISTERED
+  DELETE ERROR
+].to_set.freeze
+
+# Generated header (relative to the generated root) => the wrapper that shields it. Sources must
+# include the wrapper; a direct include of the generated header bypasses the macro suppression.
+WRAPPERS = {
+  'couchbase/query/v1/query.pb.h' => 'core/protostellar/query_proto.hxx',
+  'couchbase/query/v1/query.grpc.pb.h' => 'core/protostellar/query_proto.hxx'
+}.freeze
+
+ALIAS_DECL = /^\s*static\s+constexpr\s+\w+\s+(\w+)\s*=/.freeze
+
+# --- 1. which generated headers declare a name a Windows macro would eat ------------------------
+
+collisions = {} # generated header (relative) => { alias => [line, ...] }
+Dir.glob(File.join(GENERATED, '**', '*.pb.h')).sort.each do |path|
+  rel = path.sub("#{GENERATED}/", '')
+  File.foreach(path).with_index(1) do |line, no|
+    m = ALIAS_DECL.match(line) or next
+    next unless WINDOWS_MACROS.include?(m[1])
+
+    ((collisions[rel] ||= {})[m[1]] ||= []) << no
+  end
+end
+
+# A .grpc.pb.h includes its .pb.h, so a hazard in the latter is reachable through the former too.
+collisions.keys.each do |rel|
+  grpc = rel.sub(/\.pb\.h\z/, '.grpc.pb.h')
+  collisions[grpc] ||= {} if File.exist?(File.join(GENERATED, grpc))
+end
+
+puts '--- generated aliases that a Windows SDK macro would mangle ---'
+if collisions.empty?
+  puts '(none)'
+else
+  collisions.sort.each do |rel, aliases|
+    shield = WRAPPERS[rel] || '** UNSHIELDED: no wrapper registered **'
+    detail = aliases.map { |name, lines| "#{name}:#{lines.join(',')}" }.join(' ')
+    puts format('%-46s %s', rel, detail.empty? ? "(via its .pb.h)  -> #{shield}" : "#{detail}  -> #{shield}")
+  end
+end
+
+unshielded_headers = collisions.keys.reject { |rel| WRAPPERS.key?(rel) }.sort
+
+# --- 2. sources that reach a hazardous header without the wrapper -------------------------------
+
+bypasses = []
+scanned = 0
+%w[core couchbase test tools].each do |root|
+  absolute = File.join(REPO, root)
+  unless Dir.exist?(absolute)
+    warn "expected source root #{absolute} is missing; the bypass scan is incomplete"
+    next
+  end
+
+  Dir.glob("#{absolute}/**/*.{cxx,hxx,cpp,hpp}").sort.each do |path|
+    src = path.sub("#{REPO}/", '')
+    scanned += 1
+    File.foreach(path).with_index(1) do |line, no|
+      m = /^\s*#\s*include\s*[<"]([^>"]+)[>"]/.match(line) or next
+      header = m[1]
+      next unless collisions.key?(header)
+
+      wrapper = WRAPPERS[header]
+      next if wrapper.nil?      # unregistered: already reported above
+      next if src == wrapper    # the wrapper is allowed to include it
+
+      bypasses << [src, no, header, wrapper]
+    end
+  end
+end
+
+puts
+puts '--- sources bypassing a wrapper ---'
+if bypasses.empty?
+  puts '(none)'
+else
+  bypasses.each do |src, no, header, wrapper|
+    puts "#{src}:#{no}: includes <#{header}> directly; include \"#{wrapper}\" instead"
+  end
+end
+
+puts
+problems = unshielded_headers.size + bypasses.size
+if problems.zero?
+  # The source count is part of the result: "no bypasses" is only meaningful alongside evidence that
+  # something was actually read.
+  puts "ok: #{collisions.size} hazardous generated header(s), all reached through a wrapper " \
+       "(#{scanned} source file(s) scanned)"
+  exit 0
+end
+unless unshielded_headers.empty?
+  puts "#{unshielded_headers.size} generated header(s) collide with no wrapper registered:"
+  unshielded_headers.each { |rel| puts "  #{rel}" }
+  puts 'Add a wrapper modelled on core/protostellar/query_proto.hxx and register it in WRAPPERS.'
+end
+puts "#{bypasses.size} source(s) bypass a wrapper." unless bypasses.empty?
+exit 1

--- a/cmake/Protostellar.cmake
+++ b/cmake/Protostellar.cmake
@@ -23,6 +23,21 @@ endif()
 
 # The Protostellar schema. The .proto files live at the repository root under couchbase/**.
 # WARNING: do NOT add GIT_SHALLOW — a shallow clone cannot reach an arbitrary pinned commit.
+#
+# CAVEAT when bumping GIT_TAG: protobuf emits a class-scoped alias per enum value ("static
+# constexpr Status STATUS_TIMEOUT = ..."), so an enum value whose name is also an object-like macro
+# in the Windows SDK mangles the generated header. This breaks MSVC only — <winnt.h> is reached
+# transitively through asio and gRPC, so the Linux and macOS legs stay green and the failure shows
+# up an hour later in CI. One name collides today: QueryResponse.MetaData.Status.STATUS_TIMEOUT vs
+# winnt.h's ((DWORD)0x00000102L). couchbase/query/v1/query{,.grpc}.pb.h is therefore included only
+# through core/protostellar/query_proto.hxx, which suppresses the whole STATUS_* family around the
+# include with push_macro/pop_macro. A renamed or added enum value, or the same pattern in another
+# proto, introduces a new collision — after bumping, run
+#
+#   ./bin/check-proto-macro-collisions <build-dir>
+#
+# which lists the hazardous aliases and any source that includes a hazardous header directly
+# instead of through its wrapper.
 cpmaddpackage(
   NAME
   protostellar

--- a/core/protostellar/dispatcher.hxx
+++ b/core/protostellar/dispatcher.hxx
@@ -17,11 +17,15 @@
 
 #pragma once
 
+#include "core/utils/movable_function.hxx"
+
 #include <asio/io_context.hpp>
 #include <asio/post.hpp>
 
 #include <grpcpp/grpcpp.h>
+#include <grpcpp/support/client_callback.h>
 
+#include <algorithm>
 #include <chrono>
 #include <condition_variable>
 #include <memory>
@@ -122,6 +126,25 @@ private:
   std::shared_ptr<grpc::ClientContext> context_{};
 };
 
+// Every call gets a deadline, including one whose budget is already spent.
+//
+// gRPC has no "expire immediately" input: leaving the deadline unset means the call runs until the
+// channel breaks, so guarding the set_deadline with `timeout > 0` turns "no time left" into "no
+// limit" -- the wrong direction for the mistake to go, and one that leaves cluster::close() waiting
+// on a call with no reason to finish. Clamping to the smallest positive deadline expires the call
+// instead, which is what an exhausted budget should do.
+//
+// This is the second line of defence, not the only one: every caller in component.cxx rejects a
+// non-positive timeout up front (see fail_expired there), because failing before anything is sent
+// carries information this layer cannot reconstruct -- that the operation provably never reached
+// the server, hence unambiguous_timeout even for a mutation. The clamp exists so a caller that
+// forgets, or a retry loop passing on what is left of a budget, cannot produce an unbounded call.
+[[nodiscard]] inline auto
+call_deadline(std::chrono::milliseconds timeout) -> std::chrono::system_clock::time_point
+{
+  return std::chrono::system_clock::now() + std::max(timeout, std::chrono::milliseconds{ 1 });
+}
+
 // Default channel arguments: TCP keepalive so an idle channel detects a dead gateway.
 [[nodiscard]] auto
 default_channel_arguments() -> grpc::ChannelArguments;
@@ -130,6 +153,82 @@ default_channel_arguments() -> grpc::ChannelArguments;
 // credentials live on the secure-channel path (see credentials.hxx/.cxx).
 [[nodiscard]] auto
 make_insecure_channel(const std::string& endpoint) -> std::shared_ptr<grpc::Channel>;
+
+// Reads a gRPC server stream via the callback API and hands each message, plus the terminal
+// status, to the io_context. Self-owning: ownership passes to the completion posted from OnDone, so
+// the reactor is destroyed whether that task runs or is discarded with the io_context.
+// Assumes a single-threaded io_context (the SDK contract), so the FIFO post order guarantees
+// every row is delivered before the completion runs.
+template<typename Response>
+class streaming_reactor final : public grpc::ClientReadReactor<Response>
+{
+public:
+  streaming_reactor(asio::io_context& io,
+                    std::shared_ptr<call_tracker> tracker,
+                    std::shared_ptr<grpc::ClientContext> context,
+                    utils::movable_function<void(Response)> on_row,
+                    utils::movable_function<void(grpc::Status)> on_done)
+    : io_{ io }
+    , tracker_{ std::move(tracker) }
+    , context_{ std::move(context) }
+    , on_row_{ std::move(on_row) }
+    , on_done_{ std::move(on_done) }
+  {
+  }
+
+  void begin()
+  {
+    this->StartRead(&current_);
+    this->StartCall();
+  }
+
+  void OnReadDone(bool ok) override
+  {
+    if (!ok) {
+      return; // stream finished; OnDone follows
+    }
+    auto message = std::make_shared<Response>(std::move(current_));
+    asio::post(io_, [this, message]() {
+      on_row_(std::move(*message));
+    });
+    this->StartRead(&current_);
+  }
+
+  void OnDone(const grpc::Status& status) override
+  {
+    // Post before deregistering, for the same reason as unary(): remove() releases
+    // cancel_and_drain(), so deregistering first would let ~dispatcher() return while this thread
+    // is still inside asio::post(). The handle and the context pointer are cached in locals first
+    // because the posted task owns this reactor and may destroy it on the io thread as soon as it
+    // is enqueued -- reading tracker_ or context_ after the post could touch freed storage. The
+    // tracker owns a shared_ptr to the context, so the cached pointer stays valid as a key until
+    // remove() erases it, and remove() never dereferences it.
+    auto tracker = tracker_;
+    auto* context = context_.get();
+    // Copy the status into the closure -- it is a reference parameter, so the posted task must own
+    // its own copy rather than capture a reference that dangles once OnDone returns.
+    //
+    // Ownership of the reactor moves into the task rather than being released by its body: a task
+    // that ran `delete this` would never delete anything when the task is destroyed without being
+    // run, which is exactly what happens when the io_context is torn down with this completion
+    // still queued. Holding it in a unique_ptr covers both endings -- run, or destroyed unrun.
+    asio::post(io_,
+               [self = std::unique_ptr<streaming_reactor>(this), status_copy = status]() mutable {
+                 // Moved rather than copied: the task owns this status and does not touch it again,
+                 // and grpc::Status carries two std::strings.
+                 self->on_done_(std::move(status_copy));
+               });
+    tracker->remove(context);
+  }
+
+private:
+  asio::io_context& io_;
+  std::shared_ptr<call_tracker> tracker_;
+  Response current_{};
+  std::shared_ptr<grpc::ClientContext> context_;
+  utils::movable_function<void(Response)> on_row_;
+  utils::movable_function<void(grpc::Status)> on_done_;
+};
 
 // Bridges gRPC's callback API onto an asio::io_context. A unary RPC is launched on gRPC's own
 // threadpool; its completion is posted back onto the io_context, so callers observe results on
@@ -167,9 +266,7 @@ public:
       Response response{};
     };
     auto state = std::make_shared<call_state>();
-    if (timeout.count() > 0) {
-      state->context->set_deadline(std::chrono::system_clock::now() + timeout);
-    }
+    state->context->set_deadline(call_deadline(timeout));
 
     // Register the call so shutdown can cancel and drain it. The context is kept alive both by
     // `state` (captured by the callback below) and by the tracker's own reference, so the raw
@@ -210,6 +307,47 @@ public:
     }
 
     return pending_call{ state->context };
+  }
+
+  // Issue a server-streaming RPC.
+  //   invoker(grpc::ClientContext&, grpc::ClientReadReactor<Response>*) binds the reactor to the
+  //     call, e.g. stub->async()->Query(&ctx, &request, reactor).
+  //   on_row(Response) runs on the io_context for each streamed message; on_done(grpc::Status)
+  //     runs once when the stream ends. The request must outlive the call (capture it in on_done).
+  template<typename Response, typename Invoker>
+  auto server_stream(std::chrono::milliseconds timeout,
+                     Invoker&& invoker,
+                     utils::movable_function<void(Response)> on_row,
+                     utils::movable_function<void(grpc::Status)> on_done) -> pending_call
+  {
+    auto context = std::make_shared<grpc::ClientContext>();
+    context->set_deadline(call_deadline(timeout));
+    // Register before launch so shutdown can cancel it; the reactor deregisters in OnDone.
+    tracker_->add(context);
+    // Owned by gRPC for the duration of the call; deletes itself in OnDone.
+    auto* reactor = new streaming_reactor<Response>(
+      io_, tracker_, context, std::move(on_row), std::move(on_done));
+    // If the invoker fails to bind the reactor to a call, OnDone never fires, so deregister and
+    // delete the reactor here rather than leak it and block cancel_and_drain() forever at shutdown.
+    //
+    // Only when the invoker itself threw, though. Once it returns, gRPC holds this pointer and will
+    // call OnDone on it, so deleting it because the later begin() threw -- StartRead and StartCall
+    // allocate, so bad_alloc is the realistic path -- would hand gRPC freed storage. Leaving it for
+    // OnDone to release instead risks leaking a reactor whose call never started, which is the
+    // better of the two failures.
+    auto bound = false;
+    try {
+      std::forward<Invoker>(invoker)(*context, reactor);
+      bound = true;
+      reactor->begin();
+    } catch (...) {
+      tracker_->remove(context.get());
+      if (!bound) {
+        delete reactor;
+      }
+      throw;
+    }
+    return pending_call{ context };
   }
 
 private:

--- a/core/protostellar/query_proto.hxx
+++ b/core/protostellar/query_proto.hxx
@@ -1,0 +1,73 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+// The one place the generated couchbase.query.v1 headers are included. Include this instead of
+// <couchbase/query/v1/query.pb.h> or <couchbase/query/v1/query.grpc.pb.h>.
+//
+// protobuf emits a class-scoped alias for every enum value ("static constexpr Status STATUS_TIMEOUT
+// = ..."), and the Windows SDK spells much of that same STATUS_* namespace as object-like macros:
+// <winnt.h> defines STATUS_TIMEOUT as ((DWORD)0x00000102L), and asio and gRPC reach <winnt.h>
+// transitively. On MSVC the alias then expands into a parenthesised constant and the generated
+// header does not parse. No other compiler is affected, so the Linux and macOS legs cannot catch
+// it.
+//
+// The whole QueryResponse.MetaData.Status family is suppressed, not just the one name that collides
+// today: <ntstatus.h> covers far more of the STATUS_* namespace than <winnt.h> does (STATUS_SUCCESS
+// among it) and any dependency may start pulling it in. push_macro/pop_macro keeps the suppression
+// scoped to the includes below, so a translation unit that includes this header does not silently
+// lose a macro it uses elsewhere -- which a bare #undef in a header would do. Pushing and popping a
+// macro that is not defined is a no-op, so this needs no _MSC_VER guard.
+//
+// When the schema pin in cmake/Protostellar.cmake moves, bin/check-proto-macro-collisions reports
+// generated aliases that collide with a Windows macro, including families other than this one.
+
+#pragma push_macro("STATUS_ABORTED")
+#pragma push_macro("STATUS_CLOSED")
+#pragma push_macro("STATUS_COMPLETED")
+#pragma push_macro("STATUS_ERRORS")
+#pragma push_macro("STATUS_FATAL")
+#pragma push_macro("STATUS_RUNNING")
+#pragma push_macro("STATUS_STOPPED")
+#pragma push_macro("STATUS_SUCCESS")
+#pragma push_macro("STATUS_TIMEOUT")
+#pragma push_macro("STATUS_UNKNOWN")
+#undef STATUS_ABORTED
+#undef STATUS_CLOSED
+#undef STATUS_COMPLETED
+#undef STATUS_ERRORS
+#undef STATUS_FATAL
+#undef STATUS_RUNNING
+#undef STATUS_STOPPED
+#undef STATUS_SUCCESS
+#undef STATUS_TIMEOUT
+#undef STATUS_UNKNOWN
+
+#include <couchbase/query/v1/query.grpc.pb.h>
+#include <couchbase/query/v1/query.pb.h>
+
+#pragma pop_macro("STATUS_UNKNOWN")
+#pragma pop_macro("STATUS_TIMEOUT")
+#pragma pop_macro("STATUS_SUCCESS")
+#pragma pop_macro("STATUS_STOPPED")
+#pragma pop_macro("STATUS_RUNNING")
+#pragma pop_macro("STATUS_FATAL")
+#pragma pop_macro("STATUS_ERRORS")
+#pragma pop_macro("STATUS_COMPLETED")
+#pragma pop_macro("STATUS_CLOSED")
+#pragma pop_macro("STATUS_ABORTED")

--- a/test/cng/CMakeLists.txt
+++ b/test/cng/CMakeLists.txt
@@ -131,4 +131,7 @@ if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 AND TARGET couchbase_cxx_protostellar)
 
   # Observability transport-agnostic recording (CXXCBC-902).
   add_cng_test(protostellar/live_observability LINK_CLIENT LIBS couchbase_cxx_protostellar)
+
+  # gRPC server-streaming primitive (CXXCBC-895), verified against an in-process stream.
+  add_cng_test(protostellar/streaming LINK_CLIENT LIBS couchbase_cxx_protostellar)
 endif()

--- a/test/cng/protostellar/dispatcher.cxx
+++ b/test/cng/protostellar/dispatcher.cxx
@@ -188,6 +188,28 @@ deadline_surfaces_as_deadline_exceeded()
               "short deadline yields DEADLINE_EXCEEDED");
 }
 
+// Regression test for the review finding on this PR: unary() used to set a deadline only when the
+// timeout was positive, so a caller whose budget was already spent got a call with *no* deadline --
+// one that runs until the channel breaks, and that cluster::close() then blocks on. The server here
+// delays well past any deadline, so without the clamp the call would wait the delay out and come
+// back OK; the elapsed check is what separates "the deadline fired" from "something else failed".
+//
+// Every caller in component.cxx already rejects a non-positive timeout before dispatch, so this
+// covers the primitive's own guarantee rather than a reachable production path.
+void
+a_non_positive_timeout_expires_the_call_rather_than_removing_the_deadline()
+{
+  in_process_server server{ 2000ms };
+  for (const auto timeout : { 0ms, -1ms, -30'000ms }) {
+    const auto started = std::chrono::steady_clock::now();
+    const auto outcome = run_get(timeout, server, /*cancel_immediately=*/false);
+    const auto elapsed = std::chrono::steady_clock::now() - started;
+    assert_true(outcome.status.error_code() == grpc::StatusCode::DEADLINE_EXCEEDED,
+                "a non-positive timeout expires the call instead of leaving it unbounded");
+    assert_true(elapsed < 1500ms, "it expires at once rather than waiting the server out");
+  }
+}
+
 void
 cancellation_surfaces_as_cancelled()
 {
@@ -251,6 +273,9 @@ tests() -> test_suite
       { "delivers_response_on_io_thread", delivers_response_on_io_thread, timeout::network },
       { "deadline_surfaces_as_deadline_exceeded",
         deadline_surfaces_as_deadline_exceeded,
+        timeout::network },
+      { "a_non_positive_timeout_expires_the_call_rather_than_removing_the_deadline",
+        a_non_positive_timeout_expires_the_call_rather_than_removing_the_deadline,
         timeout::network },
       { "cancellation_surfaces_as_cancelled",
         cancellation_surfaces_as_cancelled,

--- a/test/cng/protostellar/streaming.cxx
+++ b/test/cng/protostellar/streaming.cxx
@@ -1,0 +1,742 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Tests for the gRPC server-streaming primitive (CXXCBC-895). Drives server-streaming RPCs against
+// an in-process QueryService whose behaviour each case configures: how many rows, how slowly, what
+// terminal status, and whether to park until cancelled. Env-agnostic (in-process server).
+//
+// The cases fall into four groups: delivery (rows arrive in order, on the io thread), termination
+// (server error, empty stream, deadline, cancellation), lifetime (teardown with work still queued,
+// an invoker that throws), and concurrency (many streams sharing one dispatcher, which is what
+// makes the call tracker's mutex worth having and gives the TSan leg something to observe).
+
+#include "framework/test_runner.hxx"
+
+#include "callback_queue_keepalive.hxx"
+
+#include "core/protostellar/dispatcher.hxx"
+#include "core/protostellar/query_proto.hxx"
+
+#include <asio/executor_work_guard.hpp>
+#include <asio/io_context.hpp>
+
+#include <grpcpp/server_builder.h>
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace v1 = ::couchbase::query::v1;
+using ::couchbase::core::protostellar::dispatcher;
+using namespace std::chrono_literals;
+
+// A handler that parks must still come back if the client never cancels, or a bug here becomes a
+// hung CI job rather than a failed assertion. Well above any deadline a case sets, well below the
+// runner's own budget.
+constexpr auto park_giveup = 10s;
+
+// What the in-process service should do for the next call. Constructed per case, so nothing is
+// shared between them.
+struct service_plan {
+  int rows{ 0 };                        // one row per message, numbered from 1
+  std::chrono::milliseconds delay{ 0 }; // pause before each message
+  bool send_metadata{ false };          // trailing metadata-only message, as N1QL sends
+  bool park_until_cancelled{ false };   // hold the stream open so the client's deadline/cancel wins
+  grpc::Status terminal{ grpc::Status::OK };
+};
+
+// This tree is C++17, so designated initialisers are out. Named factories rather than positional
+// aggregate init, which is the shape that let fields be set unnoticed elsewhere in this codebase.
+[[nodiscard]] auto
+streams_rows(int rows) -> service_plan
+{
+  service_plan plan;
+  plan.rows = rows;
+  return plan;
+}
+
+// Rows followed by the trailing metadata-only message, which is the shape N1QL actually streams.
+[[nodiscard]] auto
+metadata_plan() -> service_plan
+{
+  auto plan = streams_rows(3);
+  plan.send_metadata = true;
+  return plan;
+}
+
+// Holds the stream open so the client's deadline or cancellation is what ends the call.
+[[nodiscard]] auto
+parks() -> service_plan
+{
+  service_plan plan;
+  plan.park_until_cancelled = true;
+  return plan;
+}
+
+[[nodiscard]] auto
+fails_with(grpc::Status status, int rows = 0) -> service_plan
+{
+  service_plan plan;
+  plan.rows = rows;
+  plan.terminal = std::move(status);
+  return plan;
+}
+
+class test_query_service final : public v1::QueryService::Service
+{
+public:
+  explicit test_query_service(service_plan plan)
+    : plan_{ std::move(plan) }
+  {
+  }
+
+  auto Query(grpc::ServerContext* context,
+             const v1::QueryRequest* /* request */,
+             grpc::ServerWriter<v1::QueryResponse>* writer) -> grpc::Status override
+  {
+    for (int i = 1; i <= plan_.rows; ++i) {
+      if (plan_.delay.count() > 0) {
+        std::this_thread::sleep_for(plan_.delay);
+      }
+      if (context->IsCancelled()) {
+        return { grpc::StatusCode::CANCELLED, "cancelled by client" };
+      }
+      v1::QueryResponse batch;
+      batch.add_rows("{\"row\":" + std::to_string(i) + "}");
+      if (!writer->Write(batch)) {
+        return { grpc::StatusCode::CANCELLED, "client went away" };
+      }
+    }
+    if (plan_.send_metadata) {
+      v1::QueryResponse tail;
+      auto* meta = tail.mutable_meta_data();
+      meta->set_request_id("req-1");
+      meta->set_status(v1::QueryResponse_MetaData_Status_STATUS_SUCCESS);
+      writer->Write(tail);
+    }
+    if (plan_.park_until_cancelled) {
+      const auto giveup = std::chrono::steady_clock::now() + park_giveup;
+      while (!context->IsCancelled() && std::chrono::steady_clock::now() < giveup) {
+        std::this_thread::sleep_for(5ms);
+      }
+      return { grpc::StatusCode::CANCELLED, "cancelled by client" };
+    }
+    return plan_.terminal;
+  }
+
+private:
+  service_plan plan_;
+};
+
+class in_process_query_server
+{
+public:
+  explicit in_process_query_server(service_plan plan = {})
+    : service_{ std::move(plan) }
+  {
+    // Pin gRPC's process-global callback completion queue for the lifetime of this binary.
+    // Without it, destroying the last channel between cases drives a teardown that races gRPC's
+    // own polling threads and aborts the process (CXXCBC-919). This binary cycles a channel per
+    // case, so it is exactly the shape that trips it.
+    pin_callback_queue();
+
+    grpc::ServerBuilder builder;
+    builder.RegisterService(&service_);
+    server_ = builder.BuildAndStart();
+  }
+  in_process_query_server(const in_process_query_server&) = delete;
+  in_process_query_server(in_process_query_server&&) = delete;
+  auto operator=(const in_process_query_server&) -> in_process_query_server& = delete;
+  auto operator=(in_process_query_server&&) -> in_process_query_server& = delete;
+  ~in_process_query_server()
+  {
+    // Shutdown is asynchronous, so Wait() before the members go: a parked handler is still inside
+    // Query() holding a reference to service_ until the cancellation reaches it, and destroying the
+    // service under it is a use-after-free rather than a slow teardown. The immediate deadline is
+    // what wakes those handlers -- it cancels in-flight calls instead of waiting them out.
+    server_->Shutdown(std::chrono::system_clock::now());
+    server_->Wait();
+  }
+  [[nodiscard]] auto channel() -> std::shared_ptr<grpc::Channel>
+  {
+    return server_->InProcessChannel(grpc::ChannelArguments{});
+  }
+
+private:
+  test_query_service service_;
+  std::unique_ptr<grpc::Server> server_;
+};
+
+// Everything a case needs to keep alive for the duration of a stream. The primitive documents that
+// the caller owns the request, and the invoker below hands gRPC a raw pointer into it, so a fixture
+// must outlive every call launched from it -- declare it in the case's own scope, never inside a
+// launcher thread or a loop body that ends while a call is still in flight.
+struct stream_fixture {
+  std::unique_ptr<v1::QueryService::Stub> stub;
+  std::shared_ptr<v1::QueryRequest> request{ std::make_shared<v1::QueryRequest>() };
+
+  explicit stream_fixture(const std::shared_ptr<grpc::Channel>& channel)
+    : stub{ v1::QueryService::NewStub(channel) }
+  {
+    request->set_statement("SELECT 1");
+  }
+
+  // The invoker every case passes to server_stream(): binds the reactor to a Query call.
+  [[nodiscard]] auto invoker() const
+  {
+    return [stub = stub.get(), request = request](
+             grpc::ClientContext& ctx, grpc::ClientReadReactor<v1::QueryResponse>* reactor) {
+      stub->async()->Query(&ctx, request.get(), reactor);
+    };
+  }
+};
+
+// ── Delivery ──────────────────────────────────────────────────────────────────
+
+void
+server_stream_delivers_all_rows_on_the_io_thread()
+{
+  in_process_query_server server{ metadata_plan() };
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  dispatcher disp{ io, server.channel() };
+  stream_fixture fixture{ disp.channel() };
+
+  std::vector<std::string> rows;
+  auto saw_metadata = false;
+  auto rows_on_io_thread = true;
+  grpc::Status final_status;
+  const auto run_thread = std::this_thread::get_id();
+
+  disp.server_stream<v1::QueryResponse>(
+    timeout::network,
+    fixture.invoker(),
+    [&](v1::QueryResponse message) {
+      if (std::this_thread::get_id() != run_thread) {
+        rows_on_io_thread = false;
+      }
+      for (const auto& row : message.rows()) {
+        rows.push_back(row);
+      }
+      if (message.has_meta_data()) {
+        saw_metadata = true;
+      }
+    },
+    [&](grpc::Status status) {
+      final_status = std::move(status);
+      work.reset();
+    });
+
+  io.run();
+
+  assert_true(final_status.ok(), "stream completes OK");
+  assert_eq(rows.size(), std::size_t{ 3 }, "all rows delivered");
+  assert_eq(rows.at(0), std::string{ "{\"row\":1}" }, "row order preserved");
+  assert_eq(rows.at(2), std::string{ "{\"row\":3}" }, "last row delivered");
+  assert_true(saw_metadata, "terminal metadata message delivered");
+  assert_true(rows_on_io_thread, "every message delivered on the io_context thread");
+}
+
+// A short stream can be delivered by a single read, which would hide an ordering bug behind a
+// sample size of three. Enough messages here that the reactor has to re-issue StartRead many times,
+// and every row is checked rather than the first and last.
+void
+a_long_stream_preserves_order()
+{
+  constexpr auto expected_rows = 500;
+  in_process_query_server server{ streams_rows(expected_rows) };
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  dispatcher disp{ io, server.channel() };
+  stream_fixture fixture{ disp.channel() };
+
+  std::vector<std::string> rows;
+  grpc::Status final_status;
+
+  disp.server_stream<v1::QueryResponse>(
+    timeout::network,
+    fixture.invoker(),
+    [&](v1::QueryResponse message) {
+      for (const auto& row : message.rows()) {
+        rows.push_back(row);
+      }
+    },
+    [&](grpc::Status status) {
+      final_status = std::move(status);
+      work.reset();
+    });
+
+  io.run();
+
+  assert_true(final_status.ok(), "stream completes OK");
+  assert_eq(rows.size(), std::size_t{ expected_rows }, "every row delivered");
+  auto in_order = true;
+  for (int i = 1; i <= expected_rows; ++i) {
+    if (rows.at(static_cast<std::size_t>(i - 1)) != "{\"row\":" + std::to_string(i) + "}") {
+      in_order = false;
+      break;
+    }
+  }
+  assert_true(in_order, "rows arrive in the order the server wrote them");
+}
+
+// ── Termination ───────────────────────────────────────────────────────────────
+
+// A stream that yields nothing is not an error, and the completion still has to fire. Without a
+// row to force a read cycle this is the shortest path through the reactor, so it is the one most
+// likely to be broken by a change to the OnReadDone/OnDone handshake.
+void
+an_empty_stream_completes_without_rows()
+{
+  in_process_query_server server{ streams_rows(0) };
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  dispatcher disp{ io, server.channel() };
+  stream_fixture fixture{ disp.channel() };
+
+  auto row_count = 0;
+  auto completions = 0;
+  grpc::Status final_status;
+
+  disp.server_stream<v1::QueryResponse>(
+    timeout::network,
+    fixture.invoker(),
+    [&](v1::QueryResponse) {
+      ++row_count;
+    },
+    [&](grpc::Status status) {
+      ++completions;
+      final_status = std::move(status);
+      work.reset();
+    });
+
+  io.run();
+
+  assert_true(final_status.ok(), "an empty stream is still a successful one");
+  assert_eq(row_count, 0, "no rows delivered");
+  assert_eq(completions, 1, "the completion fires exactly once");
+}
+
+void
+a_server_error_reaches_on_done()
+{
+  in_process_query_server server{ fails_with(
+    grpc::Status{ grpc::StatusCode::INVALID_ARGUMENT, "syntax error" }) };
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  dispatcher disp{ io, server.channel() };
+  stream_fixture fixture{ disp.channel() };
+
+  auto row_count = 0;
+  grpc::Status final_status;
+
+  disp.server_stream<v1::QueryResponse>(
+    timeout::network,
+    fixture.invoker(),
+    [&](v1::QueryResponse) {
+      ++row_count;
+    },
+    [&](grpc::Status status) {
+      final_status = std::move(status);
+      work.reset();
+    });
+
+  io.run();
+
+  assert_true(final_status.error_code() == grpc::StatusCode::INVALID_ARGUMENT,
+              "the server's status code reaches the completion");
+  assert_eq(final_status.error_message(),
+            std::string{ "syntax error" },
+            "the server's message reaches the completion");
+  assert_eq(row_count, 0, "a failed stream delivers no rows");
+}
+
+// A stream that fails partway is the case the consumers above this primitive have to get right:
+// rows already handed over stay handed over, and the failure arrives after them, not instead of
+// them.
+void
+rows_delivered_before_a_mid_stream_error_are_kept()
+{
+  in_process_query_server server{ fails_with(
+    grpc::Status{ grpc::StatusCode::INTERNAL, "gateway gave up" }, 3) };
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  dispatcher disp{ io, server.channel() };
+  stream_fixture fixture{ disp.channel() };
+
+  std::vector<std::string> rows;
+  auto rows_at_completion = std::size_t{ 0 };
+  grpc::Status final_status;
+
+  disp.server_stream<v1::QueryResponse>(
+    timeout::network,
+    fixture.invoker(),
+    [&](v1::QueryResponse message) {
+      for (const auto& row : message.rows()) {
+        rows.push_back(row);
+      }
+    },
+    [&](grpc::Status status) {
+      rows_at_completion = rows.size();
+      final_status = std::move(status);
+      work.reset();
+    });
+
+  io.run();
+
+  assert_true(final_status.error_code() == grpc::StatusCode::INTERNAL,
+              "the terminal error reaches the completion");
+  assert_eq(rows.size(), std::size_t{ 3 }, "rows written before the error are delivered");
+  assert_eq(rows_at_completion,
+            std::size_t{ 3 },
+            "every row is delivered before the completion runs, not after it");
+}
+
+void
+a_deadline_expires_a_parked_stream()
+{
+  in_process_query_server server{ parks() };
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  dispatcher disp{ io, server.channel() };
+  stream_fixture fixture{ disp.channel() };
+
+  grpc::Status final_status;
+  disp.server_stream<v1::QueryResponse>(
+    200ms,
+    fixture.invoker(),
+    [](v1::QueryResponse) {
+    },
+    [&](grpc::Status status) {
+      final_status = std::move(status);
+      work.reset();
+    });
+
+  io.run();
+
+  assert_true(final_status.error_code() == grpc::StatusCode::DEADLINE_EXCEEDED,
+              "a stream that outlives its deadline fails with DEADLINE_EXCEEDED");
+}
+
+// Regression test for the review finding on this PR: the primitive used to set a deadline only when
+// the timeout was positive, so a caller whose budget was already spent got a call with *no*
+// deadline -- one that runs until the channel breaks and that cluster::close() then blocks on. Both
+// of these park on the server, so if the deadline were absent the case would hang until the
+// runner's own timeout rather than fail cleanly.
+void
+a_non_positive_timeout_expires_the_call_rather_than_removing_the_deadline()
+{
+  in_process_query_server server{ parks() };
+  const auto channel = server.channel();
+  stream_fixture fixture{ channel };
+
+  for (const auto timeout : { 0ms, -1ms, -30'000ms }) {
+    asio::io_context io;
+    auto work = asio::make_work_guard(io);
+    dispatcher disp{ io, channel };
+
+    grpc::Status final_status;
+    disp.server_stream<v1::QueryResponse>(
+      timeout,
+      fixture.invoker(),
+      [](v1::QueryResponse) {
+      },
+      [&](grpc::Status status) {
+        final_status = std::move(status);
+        work.reset();
+      });
+
+    io.run();
+
+    assert_true(final_status.error_code() == grpc::StatusCode::DEADLINE_EXCEEDED,
+                "a non-positive timeout expires the call instead of leaving it unbounded");
+  }
+}
+
+void
+cancelling_the_pending_call_ends_the_stream()
+{
+  in_process_query_server server{ parks() };
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  dispatcher disp{ io, server.channel() };
+  stream_fixture fixture{ disp.channel() };
+
+  grpc::Status final_status;
+  auto completions = 0;
+  const auto call = disp.server_stream<v1::QueryResponse>(
+    timeout::network,
+    fixture.invoker(),
+    [](v1::QueryResponse) {
+    },
+    [&](grpc::Status status) {
+      ++completions;
+      final_status = std::move(status);
+      work.reset();
+    });
+
+  call.cancel();
+  io.run();
+
+  assert_true(final_status.error_code() == grpc::StatusCode::CANCELLED,
+              "a cancelled stream completes as CANCELLED");
+  assert_eq(completions, 1, "cancellation still delivers exactly one completion");
+}
+
+// ── Lifetime ──────────────────────────────────────────────────────────────────
+
+// Tears the dispatcher down while a stream is still in flight, which is what cancel_and_drain()
+// exists for and what the delivery cases never reach -- they run io.run() to completion, so their
+// streams have already finished and there is nothing left to cancel. Here the completion posted
+// from OnDone never runs at all, because the io_context is destroyed first, so a reactor that
+// released itself from inside that task body would never be released.
+//
+// `probe` is captured by value in on_done, so a copy of it lives inside the reactor; once the
+// reactor is destroyed that copy goes with it and use_count() falls back to this scope's single
+// reference. A count of 2 means the reactor outlived everything that could have freed it. The count
+// is read only after the io_context has been destroyed, because until then the queued completion
+// legitimately owns the reactor -- reading it earlier reports 2 whether or not the reactor leaks.
+void
+tearing_down_with_an_unrun_completion_releases_the_reactor()
+{
+  in_process_query_server server{ parks() };
+  const auto channel = server.channel();
+  stream_fixture fixture{ channel };
+  const auto probe = std::make_shared<int>(0);
+
+  {
+    asio::io_context io;
+    dispatcher disp{ io, channel };
+    disp.server_stream<v1::QueryResponse>(
+      timeout::network,
+      fixture.invoker(),
+      [](v1::QueryResponse) {
+      },
+      [probe](grpc::Status) {
+      });
+    // io.run() is deliberately never called: ~dispatcher() cancels and drains the call, and then
+    // the io_context is destroyed with the completion still sitting in its queue.
+  }
+
+  assert_eq(
+    probe.use_count(), long{ 1 }, "the reactor is released even though its completion never ran");
+}
+
+// An invoker that throws must leave nothing registered. If the tracker kept the entry, the
+// dispatcher's destructor would wait for a completion that can never arrive and the case would hang
+// rather than fail -- so reaching the assertion at all is most of what is being checked here.
+void
+an_invoker_that_throws_leaves_nothing_registered()
+{
+  in_process_query_server server;
+  asio::io_context io;
+  const auto probe = std::make_shared<int>(0);
+  auto threw = false;
+
+  {
+    dispatcher disp{ io, server.channel() };
+    try {
+      disp.server_stream<v1::QueryResponse>(
+        timeout::network,
+        [](grpc::ClientContext&, grpc::ClientReadReactor<v1::QueryResponse>*) {
+          throw std::runtime_error{ "cannot bind the call" };
+        },
+        [](v1::QueryResponse) {
+        },
+        [probe](grpc::Status) {
+        });
+    } catch (const std::runtime_error&) {
+      threw = true;
+    }
+    // ~dispatcher() runs here. It must not block: nothing should still be registered.
+  }
+
+  assert_true(threw, "the invoker's exception propagates to the caller");
+  assert_eq(probe.use_count(), long{ 1 }, "the reactor is destroyed rather than leaked");
+}
+
+// ── Concurrency ───────────────────────────────────────────────────────────────
+
+// The call tracker's registry is mutex-protected because concurrent dispatch and shutdown are the
+// hazard it exists for, but nothing in this tree drove more than one call at a time, so the mutex
+// was never contended and the TSan leg CI pays for on every pull request had nothing to observe.
+//
+// This starts a batch of streams that will not finish on their own, then destroys the dispatcher
+// while they are all in flight. That puts registration (this thread), completion (gRPC's threads
+// calling remove()) and cancel_and_drain() (this thread again) on the same mutex at the same time.
+// Every completion must still be delivered exactly once: the drain returns only once every call has
+// posted its completion and deregistered, so all of them are queued by the time the io_context is
+// allowed to finish.
+void
+concurrent_streams_are_all_drained_by_the_destructor()
+{
+  constexpr auto concurrency = std::size_t{ 16 };
+  in_process_query_server server{ parks() };
+  const auto channel = server.channel();
+  stream_fixture fixture{ channel };
+
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  std::thread io_thread{ [&io]() {
+    io.run();
+  } };
+
+  std::array<std::atomic<int>, concurrency> completions{};
+  {
+    dispatcher disp{ io, channel };
+    for (std::size_t i = 0; i < concurrency; ++i) {
+      disp.server_stream<v1::QueryResponse>(
+        timeout::network,
+        fixture.invoker(),
+        [](v1::QueryResponse) {
+        },
+        [&completions, i](grpc::Status) {
+          ++completions.at(i);
+        });
+    }
+    // ~dispatcher() cancels every call and blocks until each has posted its completion.
+  }
+  work.reset();
+  io_thread.join();
+
+  auto delivered_once = true;
+  for (const auto& count : completions) {
+    if (count.load() != 1) {
+      delivered_once = false;
+    }
+  }
+  assert_true(delivered_once, "every concurrent stream completes exactly once");
+}
+
+// The case above registers every call from one thread. This one registers from several at once, so
+// call_tracker::add() contends with itself as well as with the remove() calls arriving on gRPC's
+// threads -- the interleaving a single-threaded launcher cannot produce.
+void
+streams_launched_from_many_threads_all_complete()
+{
+  constexpr auto launchers = std::size_t{ 4 };
+  constexpr auto per_launcher = std::size_t{ 4 };
+  in_process_query_server server{ streams_rows(2) };
+  const auto channel = server.channel();
+
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  std::thread io_thread{ [&io]() {
+    io.run();
+  } };
+
+  std::atomic<int> completions{ 0 };
+
+  // One fixture per launcher, owned here rather than by the thread: a fixture destroyed at the end
+  // of its thread would free the QueryRequest that calls still in flight are reading from. These
+  // outlive the dispatcher, so every call's request is alive until the drain has finished with it.
+  std::vector<std::unique_ptr<stream_fixture>> fixtures;
+  fixtures.reserve(launchers);
+  for (std::size_t t = 0; t < launchers; ++t) {
+    // A stub per launcher: gRPC stubs are not documented as safe to share across threads, and
+    // sharing one would put that under test rather than the tracker.
+    fixtures.push_back(std::make_unique<stream_fixture>(channel));
+  }
+
+  {
+    dispatcher disp{ io, channel };
+    std::vector<std::thread> threads;
+    threads.reserve(launchers);
+    for (std::size_t t = 0; t < launchers; ++t) {
+      threads.emplace_back([&, t]() {
+        for (std::size_t i = 0; i < per_launcher; ++i) {
+          disp.server_stream<v1::QueryResponse>(
+            timeout::network,
+            fixtures.at(t)->invoker(),
+            [](v1::QueryResponse) {
+            },
+            [&completions](grpc::Status) {
+              ++completions;
+            });
+        }
+      });
+    }
+    for (auto& thread : threads) {
+      thread.join();
+    }
+    // ~dispatcher() drains whatever is still in flight, so every call has posted its completion by
+    // the time this scope ends.
+  }
+  work.reset();
+  io_thread.join();
+
+  assert_eq(completions.load(),
+            static_cast<int>(launchers * per_launcher),
+            "every stream launched concurrently completes exactly once");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_streaming",
+    {
+      { "server_stream_delivers_all_rows_on_the_io_thread",
+        server_stream_delivers_all_rows_on_the_io_thread,
+        timeout::network },
+      { "a_long_stream_preserves_order", a_long_stream_preserves_order, timeout::network },
+      { "an_empty_stream_completes_without_rows",
+        an_empty_stream_completes_without_rows,
+        timeout::network },
+      { "a_server_error_reaches_on_done", a_server_error_reaches_on_done, timeout::network },
+      { "rows_delivered_before_a_mid_stream_error_are_kept",
+        rows_delivered_before_a_mid_stream_error_are_kept,
+        timeout::network },
+      { "a_deadline_expires_a_parked_stream",
+        a_deadline_expires_a_parked_stream,
+        timeout::network },
+      { "a_non_positive_timeout_expires_the_call_rather_than_removing_the_deadline",
+        a_non_positive_timeout_expires_the_call_rather_than_removing_the_deadline,
+        timeout::network },
+      { "cancelling_the_pending_call_ends_the_stream",
+        cancelling_the_pending_call_ends_the_stream,
+        timeout::network },
+      { "tearing_down_with_an_unrun_completion_releases_the_reactor",
+        tearing_down_with_an_unrun_completion_releases_the_reactor,
+        timeout::network },
+      { "an_invoker_that_throws_leaves_nothing_registered",
+        an_invoker_that_throws_leaves_nothing_registered,
+        timeout::network },
+      { "concurrent_streams_are_all_drained_by_the_destructor",
+        concurrent_streams_are_all_drained_by_the_destructor,
+        timeout::network },
+      { "streams_launched_from_many_threads_all_complete",
+        streams_launched_from_many_threads_all_complete,
+        timeout::network },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test


### PR DESCRIPTION
Query/Analytics/Search/Views over couchbase2 are gRPC server streams. Add
dispatcher::server_stream: a self-owning ClientReadReactor reads each streamed
message and posts it, plus the terminal status, onto the io_context, so callers
observe rows on the SDK executor -- the same contract as the unary path. It
assumes a single-threaded io_context, whose FIFO post order guarantees every row
is delivered before the completion (and the reactor's self-delete) runs.

Covered by a harness test that streams rows from an in-process QueryService and
asserts in-order, on-io-thread delivery of all rows plus terminal metadata.
Wiring this into the public query() path (row aggregation, metadata, prepared
statements) is a follow-up.

---
Stacked PR **13/29** in the CNG (`couchbase2://`) transport series. This branch includes every commit from PRs 01–13; the change specific to this PR is its top commit. Depends on #1034 — merge the series bottom-up.
