### PR TITLE
CXXCBC-897: route N1QL query over the couchbase2 streaming transport

### DIFF
--- a/core/cluster.cxx
+++ b/core/cluster.cxx
@@ -772,12 +772,17 @@ public:
       return handler(request.make_response({ errc::network::cluster_closed }, response_type{}));
     }
 #ifdef COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2
-    if (is_protostellar()) {
-      // Query/analytics/search/views/management over couchbase2 are not wired yet. Reject cleanly
-      // rather than falling through to the MCBP session manager, which is never bootstrapped on
-      // this path.
-      return handler(
-        request.make_response({ errc::common::feature_not_available }, response_type{}));
+    if (auto component = protostellar_component(); component) {
+      if constexpr (std::is_same_v<Request, operations::query_request>) {
+        component->execute(std::move(request), std::forward<Handler>(handler));
+        return;
+      } else {
+        // Analytics/search/views/management over couchbase2 are not wired yet. Reject cleanly
+        // rather than falling through to the MCBP session manager, which is never bootstrapped on
+        // this path.
+        return handler(
+          request.make_response({ errc::common::feature_not_available }, response_type{}));
+      }
     }
 #endif
     // cppcheck-suppress knownConditionTrueFalse
@@ -931,8 +936,10 @@ public:
       const std::scoped_lock lock(protostellar_mutex_);
       protostellar_ = std::make_shared<protostellar::component>(
         ctx_,
-        protostellar::component_config{
-          std::move(channel), origin_.credentials(), options.key_value_timeout });
+        protostellar::component_config{ std::move(channel),
+                                        origin_.credentials(),
+                                        options.key_value_timeout,
+                                        options.query_timeout });
     }
     CB_LOG_INFO(R"(open couchbase2 cluster, id: "{}", endpoint: "{}")", id_, endpoint);
     return handler({});

--- a/core/protostellar/component.cxx
+++ b/core/protostellar/component.cxx
@@ -18,11 +18,16 @@
 #include "core/protostellar/component.hxx"
 
 #include "core/error_context/key_value.hxx"
+#include "core/error_context/query.hxx"
+#include "core/operations/query_response_parsing.hxx"
 #include "core/protostellar/credentials.hxx"
 #include "core/protostellar/error_utils.hxx"
 #include "core/protostellar/kv_converter.hxx"
+#include "core/protostellar/query_converter.hxx"
 
 #include <couchbase/error_codes.hxx>
+
+#include "core/protostellar/query_proto.hxx"
 
 #include <couchbase/kv/v1/kv.grpc.pb.h>
 
@@ -35,15 +40,18 @@
 #include <string>
 #include <system_error>
 #include <utility>
+#include <vector>
 
 namespace couchbase::core::protostellar
 {
 namespace v1 = ::couchbase::kv::v1;
+namespace query_v1 = ::couchbase::query::v1;
 
 // Defined here rather than in the header so the generated gRPC types stay out of every consumer of
 // component.hxx.
 struct component::stubs {
   std::unique_ptr<v1::KvService::Stub> kv;
+  std::unique_ptr<query_v1::QueryService::Stub> query;
 };
 
 namespace
@@ -71,13 +79,30 @@ fail_expired(asio::io_context& io, const Request& request, Handler& handler) -> 
   });
   return {};
 }
+
+// The same rule for the services whose responses carry their own error context rather than a
+// key_value one: they resolve a timeout exactly as the KV overloads do, so a non-positive one
+// would reach the dispatcher and produce a call with no deadline there too. The response the
+// overload would have built is stamped and delivered without anything being sent.
+template<typename Response, typename Handler>
+auto
+fail_expired_ctx(asio::io_context& io, Handler& handler, Response response) -> pending_call
+{
+  response.ctx.ec = errc::common::unambiguous_timeout;
+  asio::post(io, [handler = std::move(handler), response = std::move(response)]() mutable {
+    handler(std::move(response));
+  });
+  return {};
+}
 } // namespace
 
 component::component(asio::io_context& io, component_config config)
   : io_{ io }
-  , stubs_{ std::make_unique<stubs>(stubs{ v1::KvService::NewStub(config.channel) }) }
+  , stubs_{ std::make_unique<stubs>(stubs{ v1::KvService::NewStub(config.channel),
+                                           query_v1::QueryService::NewStub(config.channel) }) }
   , authorization_{ authorization_header(config.credentials) }
   , default_kv_timeout_{ config.default_kv_timeout }
+  , default_query_timeout_{ config.default_query_timeout }
   // Initialised last (see the declaration order in the header), so the channel can be moved in.
   , dispatcher_{ io, std::move(config.channel) }
 {
@@ -585,6 +610,110 @@ component::execute(operations::prepend_request request,
       (void)proto; // kept only to keep the request alive for the call
       auto ctx = make_error_context(status, id, operation_kind::mutating);
       handler(kv::decode(resp, std::move(ctx)));
+    });
+}
+
+auto
+component::execute(operations::query_request request,
+                   utils::movable_function<void(operations::query_response)>&& handler)
+  -> pending_call
+{
+  auto statement = request.statement;
+  auto client_context_id = request.client_context_id.value_or(std::string{});
+  // Stamped even on the paths that send nothing: the error context identifies which query failed,
+  // and a caller correlating by statement or client_context_id has no other handle on it.
+  const auto stamped = [&statement, &client_context_id]() {
+    operations::query_response response;
+    response.ctx.statement = statement;
+    response.ctx.client_context_id = client_context_id;
+    return response;
+  };
+
+  const auto timeout = request.timeout.value_or(default_query_timeout_);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped());
+  }
+
+  // Features with no couchbase2 equivalent (raw passthrough, use_replica, streaming row_callback,
+  // node targeting, out-of-range tuning values): fail cleanly rather than silently dropping the
+  // caller's intent.
+  if (!query::can_encode(request)) {
+    auto response = stamped();
+    response.ctx.ec = errc::common::feature_not_available;
+    // Posted rather than invoked here, for the reason fail_expired above gives: completions arrive
+    // on the SDK's execution context, and calling back inline would re-enter the caller before it
+    // has its pending_call.
+    asio::post(io_, [handler = std::move(handler), response = std::move(response)]() mutable {
+      handler(std::move(response));
+    });
+    return {};
+  }
+
+  auto proto = std::make_shared<query_v1::QueryRequest>(query::encode(request));
+  const auto auth = authorization_;
+  // N1QL is the one service where read-only-ness is a property of the statement rather than of
+  // the operation, and the request already carries the flag, so a timed-out read-only query is
+  // reported as unambiguous exactly like a KV read.
+  const auto kind = request.readonly ? operation_kind::read_only : operation_kind::mutating;
+  auto* stub = stubs_->query.get();
+
+  // Accumulated across streamed messages; shared between the row and completion callbacks.
+  auto rows = std::make_shared<std::vector<std::string>>();
+  auto meta = std::make_shared<operations::query_response::query_meta_data>();
+  // Whether a MetaData message arrived at all, which is not the same as what it said. The gateway
+  // leaves MetaData nil when its own result.MetaData() fails and still ends the stream OK, and an
+  // absent status must not be classified as a failed one.
+  auto meta_received = std::make_shared<bool>(false);
+
+  return dispatcher_.server_stream<query_v1::QueryResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        grpc::ClientReadReactor<query_v1::QueryResponse>* reactor) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->Query(&ctx, proto.get(), reactor);
+    },
+    [rows, meta, meta_received](query_v1::QueryResponse message) {
+      for (const auto& row : message.rows()) {
+        rows->push_back(row);
+      }
+      if (message.has_meta_data()) {
+        *meta_received = true;
+        query::decode_meta_data(message.meta_data(), *meta);
+      }
+    },
+    // `proto` is captured so the request outlives the in-flight stream.
+    [handler = std::move(handler),
+     rows,
+     meta,
+     meta_received,
+     proto,
+     statement,
+     client_context_id,
+     kind](grpc::Status status) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      operations::query_response response;
+      response.ctx.ec = map_status(status, kind);
+      response.ctx.statement = std::move(statement);
+      response.ctx.client_context_id =
+        meta->client_context_id.empty() ? std::move(client_context_id) : meta->client_context_id;
+      if (!status.ok()) {
+        response.ctx.first_error_message = error_message(status);
+      }
+      response.meta = std::move(*meta);
+      response.rows = std::move(*rows);
+      // A terminal status other than "success" arriving with an OK trailer would otherwise be
+      // reported as a successful query whose own metadata says it failed. map_query_error is the
+      // classifier the classic path uses, so the two transports agree on the mapping; the proto
+      // carries no errors list, and for that case it yields internal_server_failure -- the same
+      // fallback document_query.cxx applies when the payload has no error code to classify.
+      //
+      // A transport-level error already in ctx.ec is more specific, so it wins.
+      if (!response.ctx.ec && *meta_received) {
+        response.ctx.ec = operations::map_query_error(response.meta);
+      }
+      handler(std::move(response));
     });
 }
 

--- a/core/protostellar/component.hxx
+++ b/core/protostellar/component.hxx
@@ -33,6 +33,7 @@
 #include "core/operations/document_increment.hxx"
 #include "core/operations/document_insert.hxx"
 #include "core/operations/document_prepend.hxx"
+#include "core/operations/document_query.hxx"
 #include "core/operations/document_remove.hxx"
 #include "core/operations/document_replace.hxx"
 #include "core/operations/document_touch.hxx"
@@ -60,6 +61,7 @@ struct component_config {
   std::shared_ptr<grpc::Channel> channel{};
   cluster_credentials credentials{};
   std::chrono::milliseconds default_kv_timeout{ timeout_defaults::key_value_timeout };
+  std::chrono::milliseconds default_query_timeout{ timeout_defaults::query_timeout };
 };
 
 // The core KV request types the component can execute over couchbase2. cluster_impl routes only
@@ -152,6 +154,11 @@ public:
                utils::movable_function<void(operations::prepend_response)>&& handler)
     -> pending_call;
 
+  // N1QL query over the couchbase2 server-streaming transport. Rows are buffered into the response;
+  // the terminal message carries the metadata.
+  auto execute(operations::query_request request,
+               utils::movable_function<void(operations::query_response)>&& handler) -> pending_call;
+
 private:
   // The generated gRPC stubs are held behind an opaque pointer so the generated protobuf and gRPC
   // surface stays out of every translation unit that includes this header -- none of it appears in
@@ -162,6 +169,7 @@ private:
   std::unique_ptr<stubs> stubs_;
   std::string authorization_;
   std::chrono::milliseconds default_kv_timeout_;
+  std::chrono::milliseconds default_query_timeout_;
   // Declared last, so it is destroyed first: ~dispatcher() cancels and drains the calls issued
   // through the stubs above, which must therefore still be alive while it runs.
   dispatcher dispatcher_;

--- a/core/protostellar/json_payload.hxx
+++ b/core/protostellar/json_payload.hxx
@@ -1,0 +1,49 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include "core/json_string.hxx"
+
+#include <string>
+
+namespace couchbase::core::protostellar
+{
+// The JSON a json_string carries, whichever variant arm holds it.
+//
+// json_string is a variant over nullptr/std::string/std::vector<std::byte>, and str() returns a
+// reference to a static empty string unless the std::string arm is active. Statement parameters
+// never use that arm: the public options types declare them as std::vector<codec::binary> (see
+// couchbase/query_options.hxx) and core/impl/query.cxx moves each one in, which selects the binary
+// arm -- so reading them with str() alone sends every parameter as "".
+//
+// Returning the bytes as they came in also avoids a parse-and-regenerate round trip, since the
+// proto fields these feed are `bytes` rather than structured messages.
+//
+// Lives here rather than in one converter because every service whose request carries
+// caller-supplied JSON needs it, and a per-converter copy is how the query defect reached the
+// analytics converter in the first place.
+[[nodiscard]] inline auto
+json_payload(const core::json_string& value) -> std::string
+{
+  if (value.is_binary()) {
+    const auto& bytes = value.bytes();
+    return { reinterpret_cast<const char*>(bytes.data()), bytes.size() };
+  }
+  return value.str();
+}
+} // namespace couchbase::core::protostellar

--- a/core/protostellar/query_converter.hxx
+++ b/core/protostellar/query_converter.hxx
@@ -1,0 +1,264 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+// Translates the core N1QL query request/response to and from the couchbase.query.v1 protobuf
+// messages. Rows arrive across streamed QueryResponse messages and are buffered into
+// query_response::rows; the terminal message carries the metadata. Deliberately does not reuse the
+// MCBP-bound encode_to/make_response (those build an HTTP body + parse a JSON reply).
+//
+// Query features with no couchbase2 equivalent are reported by can_encode() so the component can
+// surface feature_not_available rather than silently dropping them: the `raw` passthrough map,
+// use_replica, the streaming row_callback (only the buffered result path is wired), node targeting
+// via send_to_node, and tuning values too large for the proto's uint32 fields.
+
+#include "core/json_string.hxx"
+#include "core/operations/document_query.hxx"
+#include "core/protostellar/json_payload.hxx"
+#include "core/protostellar/query_proto.hxx"
+
+#include <couchbase/query_profile.hxx>
+#include <couchbase/query_scan_consistency.hxx>
+
+#include <chrono>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <string>
+
+namespace couchbase::core::protostellar::query
+{
+namespace v1 = ::couchbase::query::v1;
+
+// The proto's tuning fields are uint32 while the core request holds them as uint64, so a value
+// that does not fit is not encodable: casting it would ask the gateway to use the wrapped number.
+[[nodiscard]] inline auto
+fits_uint32(const std::optional<std::uint64_t>& value) -> bool
+{
+  return !value.has_value() || *value <= std::numeric_limits<std::uint32_t>::max();
+}
+
+// Query request features the couchbase2 gateway schema cannot express yet. The component maps this
+// to feature_not_available instead of silently ignoring the caller's intent.
+[[nodiscard]] inline auto
+can_encode(const operations::query_request& request) -> bool
+{
+  return request.raw.empty() && !request.use_replica.value_or(false) &&
+         !request.row_callback.has_value() && !request.send_to_node.has_value() &&
+         fits_uint32(request.max_parallelism) && fits_uint32(request.pipeline_batch) &&
+         fits_uint32(request.pipeline_cap) && fits_uint32(request.scan_cap);
+}
+
+// Split the SDK query_context ("default:`bucket`.`scope`") into the proto's bucket_name/scope_name.
+// Any pair of backtick-delimited identifiers is accepted; a value that does not parse leaves both
+// unset (the statement is then expected to be fully qualified).
+inline void
+apply_query_context(const std::string& query_context, v1::QueryRequest& proto)
+{
+  std::string bucket;
+  std::string scope;
+  std::string* current = &bucket;
+  bool inside = false;
+  int identifiers = 0;
+  for (const char c : query_context) {
+    if (c == '`') {
+      if (inside) { // closing backtick ends an identifier
+        ++identifiers;
+        if (identifiers == 1) {
+          current = &scope;
+        }
+      }
+      inside = !inside;
+      continue;
+    }
+    if (inside) {
+      current->push_back(c);
+    }
+  }
+  // A well-formed context is exactly two balanced backtick-delimited identifiers
+  // (`bucket`.`scope`). Anything else -- unbalanced, too few, or too many -- leaves both unset
+  // rather than routing on a half- or mis-parsed context.
+  if (!inside && identifiers == 2 && !bucket.empty() && !scope.empty()) {
+    proto.set_bucket_name(bucket);
+    proto.set_scope_name(scope);
+  }
+}
+
+inline auto
+encode(const operations::query_request& request) -> v1::QueryRequest
+{
+  v1::QueryRequest proto;
+  proto.set_statement(request.statement);
+  if (request.client_context_id.has_value()) {
+    proto.set_client_context_id(*request.client_context_id);
+  }
+  if (request.query_context.has_value()) {
+    apply_query_context(*request.query_context, proto);
+  }
+  proto.set_read_only(request.readonly);
+  proto.set_flex_index(request.flex_index);
+  proto.set_preserve_expiry(request.preserve_expiry);
+  // adhoc=false means "use a prepared statement" on the MCBP path; the gateway prepares/caches on
+  // its side, so we only signal intent.
+  if (!request.adhoc) {
+    proto.set_prepared(true);
+  }
+
+  if (request.scan_consistency.has_value()) {
+    switch (*request.scan_consistency) {
+      case query_scan_consistency::not_bounded:
+        proto.set_scan_consistency(v1::QueryRequest_ScanConsistency_SCAN_CONSISTENCY_NOT_BOUNDED);
+        break;
+      case query_scan_consistency::request_plus:
+        proto.set_scan_consistency(v1::QueryRequest_ScanConsistency_SCAN_CONSISTENCY_REQUEST_PLUS);
+        break;
+    }
+  }
+  // A non-empty mutation_state carries at_plus scan vectors; the gateway takes them as
+  // consistent_with mutation tokens.
+  for (const auto& token : request.mutation_state) {
+    auto* proto_token = proto.add_consistent_with();
+    proto_token->set_bucket_name(token.bucket_name());
+    proto_token->set_vbucket_id(token.partition_id());
+    proto_token->set_vbucket_uuid(token.partition_uuid());
+    proto_token->set_seq_no(token.sequence_number());
+  }
+
+  if (request.profile.has_value()) {
+    switch (*request.profile) {
+      case query_profile::off:
+        proto.set_profile_mode(v1::QueryRequest_ProfileMode_PROFILE_MODE_OFF);
+        break;
+      case query_profile::phases:
+        proto.set_profile_mode(v1::QueryRequest_ProfileMode_PROFILE_MODE_PHASES);
+        break;
+      case query_profile::timings:
+        proto.set_profile_mode(v1::QueryRequest_ProfileMode_PROFILE_MODE_TIMINGS);
+        break;
+    }
+  }
+
+  for (const auto& parameter : request.positional_parameters) {
+    proto.add_positional_parameters(json_payload(parameter));
+  }
+  for (const auto& [name, value] : request.named_parameters) {
+    (*proto.mutable_named_parameters())[name] = json_payload(value);
+  }
+
+  // Tuning options: the SDK's `metrics` flag defaults to off, so disable_metrics is its inverse.
+  auto* tuning = proto.mutable_tuning_options();
+  tuning->set_disable_metrics(!request.metrics);
+  if (request.max_parallelism.has_value()) {
+    tuning->set_max_parallelism(static_cast<std::uint32_t>(*request.max_parallelism));
+  }
+  if (request.pipeline_batch.has_value()) {
+    tuning->set_pipeline_batch(static_cast<std::uint32_t>(*request.pipeline_batch));
+  }
+  if (request.pipeline_cap.has_value()) {
+    tuning->set_pipeline_cap(static_cast<std::uint32_t>(*request.pipeline_cap));
+  }
+  if (request.scan_cap.has_value()) {
+    tuning->set_scan_cap(static_cast<std::uint32_t>(*request.scan_cap));
+  }
+  if (request.scan_wait.has_value()) {
+    const auto secs = std::chrono::duration_cast<std::chrono::seconds>(*request.scan_wait);
+    const auto nanos =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(*request.scan_wait - secs);
+    auto* scan_wait = tuning->mutable_scan_wait();
+    scan_wait->set_seconds(secs.count());
+    scan_wait->set_nanos(static_cast<std::int32_t>(nanos.count()));
+  }
+
+  return proto;
+}
+
+// google.protobuf.Duration -> nanoseconds.
+[[nodiscard]] inline auto
+to_nanoseconds(const google::protobuf::Duration& duration) -> std::chrono::nanoseconds
+{
+  return std::chrono::seconds{ duration.seconds() } + std::chrono::nanoseconds{ duration.nanos() };
+}
+
+[[nodiscard]] inline auto
+status_to_string(v1::QueryResponse_MetaData_Status status) -> std::string
+{
+  switch (status) {
+    case v1::QueryResponse_MetaData_Status_STATUS_RUNNING:
+      return "running";
+    case v1::QueryResponse_MetaData_Status_STATUS_SUCCESS:
+      return "success";
+    case v1::QueryResponse_MetaData_Status_STATUS_ERRORS:
+      return "errors";
+    case v1::QueryResponse_MetaData_Status_STATUS_COMPLETED:
+      return "completed";
+    case v1::QueryResponse_MetaData_Status_STATUS_STOPPED:
+      return "stopped";
+    case v1::QueryResponse_MetaData_Status_STATUS_TIMEOUT:
+      return "timeout";
+    case v1::QueryResponse_MetaData_Status_STATUS_CLOSED:
+      return "closed";
+    case v1::QueryResponse_MetaData_Status_STATUS_FATAL:
+      return "fatal";
+    case v1::QueryResponse_MetaData_Status_STATUS_ABORTED:
+      return "aborted";
+    default:
+      return "unknown";
+  }
+}
+
+// Fill a query_meta_data from the terminal QueryResponse.MetaData message.
+inline void
+decode_meta_data(const v1::QueryResponse_MetaData& proto,
+                 operations::query_response::query_meta_data& meta)
+{
+  meta.request_id = proto.request_id();
+  meta.client_context_id = proto.client_context_id();
+  meta.status = status_to_string(proto.status());
+  if (!proto.signature().empty()) {
+    meta.signature = proto.signature();
+  }
+  if (!proto.profile().empty()) {
+    meta.profile = proto.profile();
+  }
+  if (proto.has_metrics()) {
+    const auto& m = proto.metrics();
+    operations::query_response::query_metrics metrics;
+    metrics.elapsed_time = to_nanoseconds(m.elapsed_time());
+    metrics.execution_time = to_nanoseconds(m.execution_time());
+    metrics.result_count = m.result_count();
+    metrics.result_size = m.result_size();
+    metrics.sort_count = m.sort_count();
+    metrics.mutation_count = m.mutation_count();
+    metrics.error_count = m.error_count();
+    metrics.warning_count = m.warning_count();
+    meta.metrics = metrics;
+  }
+  if (proto.warnings_size() > 0) {
+    std::vector<operations::query_response::query_problem> warnings;
+    warnings.reserve(static_cast<std::size_t>(proto.warnings_size()));
+    for (const auto& w : proto.warnings()) {
+      operations::query_response::query_problem problem;
+      problem.code = w.code();
+      problem.message = w.message();
+      warnings.push_back(std::move(problem));
+    }
+    meta.warnings = std::move(warnings);
+  }
+}
+
+} // namespace couchbase::core::protostellar::query

--- a/test/cng/CMakeLists.txt
+++ b/test/cng/CMakeLists.txt
@@ -126,12 +126,18 @@ if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 AND TARGET couchbase_cxx_protostellar)
   # Live KV verification vs a real gateway (CXXCBC-891).
   add_cng_test(protostellar/live_kv LINK_CLIENT LIBS couchbase_cxx_protostellar)
 
-  # Live connect-branch round-trip via core::cluster::open/execute (CXXCBC-891; cluster_only).
+  # Live connect verification (CXXCBC-891).
   add_cng_test(protostellar/live_connect LINK_CLIENT LIBS couchbase_cxx_protostellar)
 
   # Observability transport-agnostic recording (CXXCBC-902).
   add_cng_test(protostellar/live_observability LINK_CLIENT LIBS couchbase_cxx_protostellar)
 
-  # gRPC server-streaming primitive (CXXCBC-895), verified against an in-process stream.
+  # Streaming responses primitive (CXXCBC-895).
   add_cng_test(protostellar/streaming LINK_CLIENT LIBS couchbase_cxx_protostellar)
+
+  # N1QL query converter (CXXCBC-897).
+  add_cng_test(protostellar/query_converter LINK_CLIENT LIBS couchbase_cxx_protostellar)
+
+  # Live N1QL query verification (CXXCBC-897).
+  add_cng_test(protostellar/live_query LINK_CLIENT LIBS couchbase_cxx_protostellar)
 endif()

--- a/test/cng/framework/live_fixture.hxx
+++ b/test/cng/framework/live_fixture.hxx
@@ -19,13 +19,33 @@
 
 #include "framework/test_runner.hxx"
 
+// Views are deprecated in the public API but still part of the core surface these fixtures reach,
+// so the core includes below are parsed with the deprecation suppressed -- the same convention
+// component.hxx and cluster.cxx use. push/pop so a translation unit that already defined the macro
+// keeps its own state.
+//
+// The order matters and is not cosmetic: an include-guarded header is parsed once, by whoever
+// reaches it first. core/operations.hxx pulls in core/operations/document_view.hxx, and if that
+// happens before this #define, document_view_request is declared [[deprecated]] -- after which
+// component.hxx's own declaration of the view overload is an error under -Werror, in every
+// translation unit that includes this file without the macro of its own.
+#pragma push_macro("COUCHBASE_CXX_CLIENT_IGNORE_CORE_DEPRECATIONS")
+#define COUCHBASE_CXX_CLIENT_IGNORE_CORE_DEPRECATIONS
+
+// core/operations.hxx (complete operation types) must precede core/cluster.hxx.
+#include "core/operations.hxx"
+
+#include "core/cluster.hxx"
 #include "core/cluster_credentials.hxx"
 #include "core/cluster_options.hxx"
 #include "core/document_id.hxx"
+#include "core/origin.hxx"
 #include "core/protostellar/component.hxx"
 #include "core/protostellar/credentials.hxx"
 #include "core/tls_verify_mode.hxx"
 #include "core/utils/connection_string.hxx"
+
+#include <couchbase/error_codes.hxx>
 
 #include <asio/executor_work_guard.hpp>
 #include <asio/io_context.hpp>
@@ -34,7 +54,10 @@
 #include <future>
 #include <memory>
 #include <string>
+#include <string_view>
+#include <system_error>
 #include <thread>
+#include <utility>
 
 namespace couchbase::cng::test
 {
@@ -73,6 +96,39 @@ private:
   asio::executor_work_guard<asio::io_context::executor_type> work_;
   std::thread thread_;
 };
+
+// Skip the case when -- and only when -- the gateway is what does not implement the service.
+//
+// feature_not_available is ambiguous, and skipping on the bare error code makes a case
+// unfalsifiable. The client produces exactly that code for its own refusals: cluster.cxx answers a
+// request type it does not route over couchbase2 with a plain error context, and a converter's
+// can_encode() rejects an option the schema cannot express the same way. A case that skips on the
+// code alone therefore also skips when the routing it exists to cover is deleted -- it reports
+// "Skipped" instead of failing, so it cannot detect the absence of the thing it tests.
+//
+// The gateway's own answer is distinguishable. An UNIMPLEMENTED reply arrives as a gRPC status and
+// the component copies its message into first_error_message; the client-side refusals leave that
+// field empty because no status was ever received. Requiring the message is what makes the skip
+// evidence that the request reached a gateway and was declined there, rather than a belief about
+// what the gateway supports.
+//
+// loc is forwarded so a failure points at the case rather than at this line.
+template<typename Context>
+void
+skip_unless_service_implemented(const Context& ctx,
+                                std::string_view service,
+                                source_location loc = source_location::current())
+{
+  if (ctx.ec != errc::common::feature_not_available) {
+    return;
+  }
+  assert_false(ctx.first_error_message.empty(),
+               fmt::format("{} reported feature_not_available with no gateway message, so the "
+                           "request was refused by the client and never reached the gateway",
+                           service),
+               loc);
+  skip(fmt::format("gateway does not implement {} ({})", service, ctx.first_error_message));
+}
 
 // A component wired to the gateway named by TEST_CONNECTION_STRING, with the io_context already
 // running on its own thread so an operation can be awaited inline.
@@ -170,4 +226,119 @@ private:
   std::unique_ptr<core::protostellar::component> component_{};
 };
 
+// The same idea one layer up: an opened core::cluster rather than a bare component.
+//
+// A case built on this exercises the routing in cluster.cxx as well as the transport, which is
+// where a request type reaches (or fails to reach) the couchbase2 component at all. Services
+// other than KV have no component-level entry point in the tests, so this is the fixture they
+// use.
+//
+// The preamble it replaces -- parse, skip, credentials, origin, io thread, open, close -- is
+// about thirty lines, and hand-rolling it is what let a raw std::getenv into live_query.cxx while
+// live_connect.cxx used the framework wrapper.
+class live_cluster_fixture
+{
+public:
+  live_cluster_fixture()
+  {
+    const auto connection_string = safe_getenv("TEST_CONNECTION_STRING");
+    if (!connection_string.has_value()) {
+      skip("TEST_CONNECTION_STRING is not set");
+    }
+    auto parsed = core::utils::parse_connection_string(connection_string.value());
+    if (!parsed.uses_protostellar()) {
+      skip("TEST_CONNECTION_STRING is not a couchbase2:// endpoint");
+    }
+
+    core::cluster_credentials credentials;
+    credentials.username = env_or("TEST_CB2_USERNAME", "Administrator");
+    credentials.password = env_or("TEST_CB2_PASSWORD", "password");
+    bucket_ = env_or("TEST_CB2_BUCKET", "default");
+
+    core::origin cluster_origin{ credentials, parsed };
+    cluster_origin.options().tls_verify =
+      core::tls_verify_mode::none; // dev gateway certificate is not chainable
+
+    std::promise<std::error_code> opened;
+    cluster_.open(cluster_origin, [&opened](std::error_code ec) {
+      opened.set_value(ec);
+    });
+    // Recorded rather than asserted: a throw here would skip the destructor, leaving an opened
+    // cluster to be torn down without close(). The case checks it as its first assertion.
+    open_ec_ = opened.get_future().get();
+    opened_ = !open_ec_;
+  }
+
+  live_cluster_fixture(const live_cluster_fixture&) = delete;
+  live_cluster_fixture(live_cluster_fixture&&) = delete;
+  auto operator=(const live_cluster_fixture&) -> live_cluster_fixture& = delete;
+  auto operator=(live_cluster_fixture&&) -> live_cluster_fixture& = delete;
+
+  ~live_cluster_fixture()
+  {
+    if (!opened_) {
+      return;
+    }
+    std::promise<void> closed;
+    cluster_.close([&closed]() {
+      closed.set_value();
+    });
+    closed.get_future().get();
+  }
+
+  // Fails the case unless open() succeeded. Call it first; every other method assumes it passed.
+  void require_open() const
+  {
+    assert_false(static_cast<bool>(open_ec_), "connect(couchbase2://) succeeds");
+  }
+
+  template<typename Request>
+  [[nodiscard]] auto execute(Request request) -> typename Request::response_type
+  {
+    return execute_on(std::move(request)).first;
+  }
+
+  // The response plus the thread the handler ran on. Every completion is supposed to arrive on the
+  // SDK's execution context, so a handler that runs on the calling thread means some path called
+  // back inline out of execute() -- which re-enters the caller before it has its pending_call, and
+  // is invisible to a case that only looks at the response.
+  template<typename Request>
+  [[nodiscard]] auto execute_on(Request request)
+    -> std::pair<typename Request::response_type, std::thread::id>
+  {
+    if (!request.timeout.has_value()) {
+      request.timeout = std::chrono::milliseconds{ 20000 };
+    }
+    std::promise<std::pair<typename Request::response_type, std::thread::id>> promise;
+    auto future = promise.get_future();
+    cluster_.execute(std::move(request),
+                     [&promise](typename Request::response_type response) mutable {
+                       promise.set_value({ std::move(response), std::this_thread::get_id() });
+                     });
+    return future.get();
+  }
+
+  [[nodiscard]] auto bucket() const -> const std::string&
+  {
+    return bucket_;
+  }
+
+private:
+  [[nodiscard]] static auto env_or(const char* name, const char* fallback) -> std::string
+  {
+    return safe_getenv(name).value_or(fallback);
+  }
+
+  asio::io_context io_{};
+  // io_ -> runner_ -> cluster_, so the cluster tears down while the io thread is still running
+  // and the thread is joined afterwards.
+  io_thread_guard runner_{ io_ };
+  core::cluster cluster_{ io_ };
+  std::string bucket_{};
+  std::error_code open_ec_{};
+  bool opened_{ false };
+};
+
 } // namespace couchbase::cng::test
+
+#pragma pop_macro("COUCHBASE_CXX_CLIENT_IGNORE_CORE_DEPRECATIONS")

--- a/test/cng/protostellar/live_kv.cxx
+++ b/test/cng/protostellar/live_kv.cxx
@@ -106,6 +106,7 @@ kv_crud_round_trip_against_live_gateway()
   config.channel = channel;
   config.credentials = credentials;
   config.default_kv_timeout = 20000ms;
+  config.default_query_timeout = 20000ms;
   component comp{ io, config };
 
   std::string failure;    // non-empty => the round-trip failed at some stage
@@ -202,6 +203,7 @@ insert_and_replace_round_trip_against_live_gateway()
   config.channel = channel;
   config.credentials = credentials;
   config.default_kv_timeout = 20000ms;
+  config.default_query_timeout = 20000ms;
   component comp{ io, config };
 
   std::string failure;

--- a/test/cng/protostellar/live_query.cxx
+++ b/test/cng/protostellar/live_query.cxx
@@ -1,0 +1,454 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Live end-to-end tests of N1QL query over the couchbase2:// streaming transport (CXXCBC-897).
+//
+// Each case drives the core::cluster public path -- open() builds the gRPC component,
+// execute(query_request) routes to the component's server-streaming query path -- against a real
+// CNG gateway. cluster_only: the whole suite skips unless TEST_CONNECTION_STRING points at a
+// couchbase2:// endpoint.
+//
+// Every expectation is taken from the gateway's own sources rather than from this client, so a case
+// asserts the answer the gateway defines rather than the behaviour this client happens to have. The
+// error-condition cases in particular are the gateway's acceptance suite
+// (stellar-gateway/gateway/test/query_test.go) re-expressed at this SDK's surface.
+
+#define COUCHBASE_CXX_CLIENT_IGNORE_CORE_DEPRECATIONS
+
+#include "framework/live_fixture.hxx"
+#include "framework/test_runner.hxx"
+
+#include "core/json_string.hxx"
+
+#include <couchbase/error_codes.hxx>
+
+#include <chrono>
+#include <cstddef>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace ops = ::couchbase::core::operations;
+using namespace std::chrono_literals;
+
+// Query parameters reach the core request as codec::binary, which selects json_string's binary
+// arm. Building the string arm here instead would exercise a path core/impl/query.cxx never
+// produces -- and would have hidden the empty-parameter defect this suite exists to catch.
+[[nodiscard]] auto
+binary_json(const std::string& json) -> couchbase::core::json_string
+{
+  std::vector<std::byte> bytes;
+  bytes.reserve(json.size());
+  for (const char c : json) {
+    bytes.push_back(static_cast<std::byte>(c));
+  }
+  return couchbase::core::json_string{ std::move(bytes) };
+}
+
+[[nodiscard]] auto
+select(const std::string& statement) -> ops::query_request
+{
+  ops::query_request request;
+  request.statement = statement;
+  return request;
+}
+
+void
+a_constant_projection_round_trips()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  // Needs no bucket or dataset and still exercises the whole stream: one row plus the terminal
+  // metadata message.
+  const auto result = fixture.execute(select(R"(SELECT "cng" AS greeting)"));
+
+  assert_false(static_cast<bool>(result.ctx.ec), "query over couchbase2 succeeds");
+  assert_eq(result.rows.size(), std::size_t{ 1 }, "single projected row buffered");
+  assert_true(result.rows.at(0).find("cng") != std::string::npos, "row carries the projection");
+  assert_eq(result.meta.status, std::string{ "success" }, "terminal status decoded");
+  assert_true(!result.meta.request_id.empty(), "request_id decoded from metadata");
+}
+
+// The regression test for the #1036 blocker, at the level where it bites. json_string::str()
+// returns a static empty string for the binary arm, so before the fix the gateway received
+// `positional_parameters: [""]` and echoed an empty value here -- a wrong answer, not an error.
+void
+a_positional_parameter_reaches_the_query_engine()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  auto request = select("SELECT $1 AS echo, $2 AS count");
+  request.positional_parameters.emplace_back(binary_json(R"("parameterised")"));
+  request.positional_parameters.emplace_back(binary_json("7"));
+  const auto result = fixture.execute(std::move(request));
+
+  assert_false(static_cast<bool>(result.ctx.ec), "parameterised query succeeds");
+  assert_eq(result.rows.size(), std::size_t{ 1 }, "one row");
+  assert_true(result.rows.at(0).find(R"("parameterised")") != std::string::npos,
+              "the string parameter reached the query engine");
+  assert_true(result.rows.at(0).find('7') != std::string::npos,
+              "the numeric parameter reached the query engine");
+}
+
+void
+a_named_parameter_reaches_the_query_engine()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  auto request = select("SELECT $word AS echo");
+  request.named_parameters.emplace("word", binary_json(R"("named-value")"));
+  const auto result = fixture.execute(std::move(request));
+
+  assert_false(static_cast<bool>(result.ctx.ec), "named-parameter query succeeds");
+  assert_eq(result.rows.size(), std::size_t{ 1 }, "one row");
+  assert_true(result.rows.at(0).find(R"("named-value")") != std::string::npos,
+              "the named parameter reached the query engine");
+}
+
+// queryserver.go flushes its row cache once it exceeds 1024 bytes, so a result this size arrives
+// across several QueryResponse messages and the last one carries rows AND metadata together. A
+// reader that stops at the first message with metadata, or that treats one message as one row,
+// loses part of the result.
+void
+a_result_larger_than_one_batch_arrives_complete_and_in_order()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  constexpr int row_count = 500;
+  const auto result = fixture.execute(
+    select("SELECT RAW v FROM ARRAY_RANGE(0, " + std::to_string(row_count) + ") AS v ORDER BY v"));
+
+  assert_false(static_cast<bool>(result.ctx.ec), "multi-batch query succeeds");
+  assert_eq(result.rows.size(), static_cast<std::size_t>(row_count), "every row is buffered");
+  for (int i = 0; i < row_count; ++i) {
+    assert_eq(result.rows.at(static_cast<std::size_t>(i)),
+              std::to_string(i),
+              "row " + std::to_string(i) + " is in position " + std::to_string(i));
+  }
+  assert_eq(result.meta.status, std::string{ "success" }, "metadata survives the last batch");
+}
+
+void
+an_empty_result_still_carries_metadata()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  // An empty source rather than a false predicate: a FROM-less SELECT still emits its single
+  // projected row, `WHERE false` and all, so that spelling would not produce an empty result.
+  const auto result = fixture.execute(select("SELECT RAW v FROM ARRAY_RANGE(0, 0) AS v"));
+
+  assert_false(static_cast<bool>(result.ctx.ec), "an empty query succeeds");
+  assert_eq(result.rows.size(), std::size_t{ 0 }, "no rows");
+  assert_eq(result.meta.status, std::string{ "success" }, "status still decoded");
+  assert_true(!result.meta.request_id.empty(), "request_id still decoded");
+}
+
+// The core request defaults metrics off, and the gateway defaults them on -- so the converter has
+// to send disable_metrics for the default to hold. Without that line the SDK would return metrics
+// nobody asked for.
+void
+metrics_are_absent_unless_requested()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  const auto result = fixture.execute(select(R"(SELECT "cng" AS greeting)"));
+  assert_false(static_cast<bool>(result.ctx.ec), "query succeeds");
+  assert_false(result.meta.metrics.has_value(), "metrics are off by default");
+}
+
+void
+metrics_are_returned_when_requested()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  auto request = select("SELECT RAW v FROM ARRAY_RANGE(0, 3) AS v");
+  request.metrics = true;
+  const auto result = fixture.execute(std::move(request));
+
+  assert_false(static_cast<bool>(result.ctx.ec), "query succeeds");
+  assert_true(result.meta.metrics.has_value(), "metrics returned when requested");
+  assert_eq(result.meta.metrics->result_count, std::uint64_t{ 3 }, "result_count matches the rows");
+  assert_true(result.meta.metrics->elapsed_time > std::chrono::nanoseconds::zero(),
+              "elapsed_time is populated");
+}
+
+void
+a_profile_is_returned_when_requested()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  auto request = select(R"(SELECT "cng" AS greeting)");
+  request.profile = couchbase::query_profile::timings;
+  const auto result = fixture.execute(std::move(request));
+
+  assert_false(static_cast<bool>(result.ctx.ec), "query succeeds");
+  assert_true(result.meta.profile.has_value(), "profile returned when requested");
+}
+
+// The gateway collapses a parsing failure into InvalidArgument (errorhandler.go
+// NewInvalidQueryStatus), so this is `invalid_argument` over couchbase2 where the classic path
+// reports `parsing_failure`. couchbase-jvm-clients asserts the same divergence.
+void
+a_syntax_error_is_reported_as_invalid_argument()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  const auto result = fixture.execute(select("FINAGLE * FROM default"));
+
+  assert_true(result.ctx.ec == errc::common::invalid_argument,
+              "a syntax error is invalid_argument over couchbase2");
+  assert_true(!result.ctx.first_error_message.empty(), "the server message is carried through");
+  assert_eq(result.ctx.statement,
+            std::string{ "FINAGLE * FROM default" },
+            "the statement is in the error context");
+}
+
+void
+a_write_in_a_read_only_query_is_rejected()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  auto request = select(R"(UPSERT INTO default(KEY, VALUE) VALUES ("cng-never-written", {"x":1}))");
+  request.readonly = true;
+  const auto result = fixture.execute(std::move(request));
+
+  assert_true(result.ctx.ec == errc::common::invalid_argument,
+              "a write under read_only is rejected");
+}
+
+// NOT_FOUND carries a ResourceInfo whose type is "queryindex", which is what separates this from
+// the KV-flavoured document_not_found the bare code would map to.
+void
+dropping_a_missing_index_reports_index_not_found()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  const auto result = fixture.execute(
+    select("DROP INDEX `cng-index-that-does-not-exist` ON `" + fixture.bucket() + "`"));
+
+  assert_true(result.ctx.ec == errc::common::index_not_found,
+              "a missing query index is index_not_found, not document_not_found");
+}
+
+// queryserver.go:144 refuses a request that carries both, and the converter sends both whenever
+// the caller sets both -- so this pins what the caller sees rather than leaving it to chance.
+void
+conflicting_consistency_is_rejected()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  auto request = select("SELECT RAW 1");
+  request.scan_consistency = couchbase::query_scan_consistency::request_plus;
+  request.mutation_state.emplace_back(1ULL, 1ULL, std::uint16_t{ 0 }, fixture.bucket());
+  const auto result = fixture.execute(std::move(request));
+
+  assert_true(result.ctx.ec == errc::common::invalid_argument,
+              "scan consistency and mutation tokens together are rejected");
+}
+
+// queryserver.go:178. Same shape as above: the converter forwards both, the gateway decides.
+void
+named_and_positional_parameters_together_are_rejected()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  auto request = select("SELECT $1 AS a, $b AS b");
+  request.positional_parameters.emplace_back(binary_json("1"));
+  request.named_parameters.emplace("b", binary_json("2"));
+  const auto result = fixture.execute(std::move(request));
+
+  assert_true(result.ctx.ec == errc::common::invalid_argument,
+              "named and positional parameters must be used exclusively");
+}
+
+// can_encode refuses this before anything is sent, so the caller is told the feature is missing
+// rather than getting a result computed without the option they asked for.
+//
+// The refusal still has to arrive like every other completion: on the SDK's execution context,
+// after execute() has returned. Checking the thread is what separates "rejected" from "rejected by
+// calling back inline", which no assertion on the response can see.
+void
+an_unsupported_option_is_refused_without_a_round_trip()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  auto request = select(R"(SELECT "cng" AS greeting)");
+  request.raw.emplace("some_future_option", couchbase::core::json_string{ std::string{ "true" } });
+  const auto [result, handler_thread] = fixture.execute_on(std::move(request));
+
+  assert_true(result.ctx.ec == errc::common::feature_not_available,
+              "the raw passthrough is refused rather than dropped");
+  assert_true(result.rows.empty(), "nothing was executed");
+  assert_eq(result.ctx.statement,
+            std::string{ R"(SELECT "cng" AS greeting)" },
+            "the refusal still identifies the query");
+  assert_true(handler_thread != std::this_thread::get_id(),
+              "the refusal is delivered on the io context, not inline out of execute()");
+}
+
+// The same contract on the other path that answers without sending anything.
+void
+an_expired_budget_is_refused_on_the_io_context()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  auto request = select(R"(SELECT "cng" AS greeting)");
+  request.timeout = 0ms;
+  const auto [result, handler_thread] = fixture.execute_on(std::move(request));
+
+  assert_true(result.ctx.ec == errc::common::unambiguous_timeout,
+              "a spent budget is an unambiguous timeout: nothing reached the server");
+  assert_eq(result.ctx.statement,
+            std::string{ R"(SELECT "cng" AS greeting)" },
+            "the expired response still identifies the query");
+  assert_true(handler_thread != std::this_thread::get_id(),
+              "the expired response is delivered on the io context");
+}
+
+// RFC 77 keys the timeout distinction on read-only status, not on idempotency. A read that ran out
+// of time provably changed nothing, so reporting it as ambiguous would tell a caller that declines
+// to retry ambiguous operations to give up on one that is safe to repeat.
+void
+an_expired_deadline_is_unambiguous_for_a_read_only_query()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  auto request = select("SELECT RAW v FROM ARRAY_RANGE(0, 10000) AS v");
+  request.readonly = true;
+  request.timeout = 1ms;
+  const auto result = fixture.execute(std::move(request));
+
+  assert_true(result.ctx.ec == errc::common::unambiguous_timeout,
+              "a timed-out read-only query is unambiguous");
+}
+
+void
+an_expired_deadline_is_ambiguous_for_a_mutating_query()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  auto request = select(R"(UPSERT INTO default(KEY, VALUE) VALUES ("cng-timeout", {"x":1}))");
+  request.readonly = false;
+  request.timeout = 1ms;
+  const auto result = fixture.execute(std::move(request));
+
+  assert_true(result.ctx.ec == errc::common::ambiguous_timeout,
+              "a timed-out mutating query is ambiguous");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_live_query",
+    {
+      { "a_constant_projection_round_trips",
+        a_constant_projection_round_trips,
+        timeout::integration,
+        test_env::cluster_only },
+      { "a_positional_parameter_reaches_the_query_engine",
+        a_positional_parameter_reaches_the_query_engine,
+        timeout::integration,
+        test_env::cluster_only },
+      { "a_named_parameter_reaches_the_query_engine",
+        a_named_parameter_reaches_the_query_engine,
+        timeout::integration,
+        test_env::cluster_only },
+      { "a_result_larger_than_one_batch_arrives_complete_and_in_order",
+        a_result_larger_than_one_batch_arrives_complete_and_in_order,
+        timeout::integration,
+        test_env::cluster_only },
+      { "an_empty_result_still_carries_metadata",
+        an_empty_result_still_carries_metadata,
+        timeout::integration,
+        test_env::cluster_only },
+      { "metrics_are_absent_unless_requested",
+        metrics_are_absent_unless_requested,
+        timeout::integration,
+        test_env::cluster_only },
+      { "metrics_are_returned_when_requested",
+        metrics_are_returned_when_requested,
+        timeout::integration,
+        test_env::cluster_only },
+      { "a_profile_is_returned_when_requested",
+        a_profile_is_returned_when_requested,
+        timeout::integration,
+        test_env::cluster_only },
+      { "a_syntax_error_is_reported_as_invalid_argument",
+        a_syntax_error_is_reported_as_invalid_argument,
+        timeout::integration,
+        test_env::cluster_only },
+      { "a_write_in_a_read_only_query_is_rejected",
+        a_write_in_a_read_only_query_is_rejected,
+        timeout::integration,
+        test_env::cluster_only },
+      { "dropping_a_missing_index_reports_index_not_found",
+        dropping_a_missing_index_reports_index_not_found,
+        timeout::integration,
+        test_env::cluster_only },
+      { "conflicting_consistency_is_rejected",
+        conflicting_consistency_is_rejected,
+        timeout::integration,
+        test_env::cluster_only },
+      { "named_and_positional_parameters_together_are_rejected",
+        named_and_positional_parameters_together_are_rejected,
+        timeout::integration,
+        test_env::cluster_only },
+      { "an_unsupported_option_is_refused_without_a_round_trip",
+        an_unsupported_option_is_refused_without_a_round_trip,
+        timeout::integration,
+        test_env::cluster_only },
+      { "an_expired_budget_is_refused_on_the_io_context",
+        an_expired_budget_is_refused_on_the_io_context,
+        timeout::integration,
+        test_env::cluster_only },
+      { "an_expired_deadline_is_unambiguous_for_a_read_only_query",
+        an_expired_deadline_is_unambiguous_for_a_read_only_query,
+        timeout::integration,
+        test_env::cluster_only },
+      { "an_expired_deadline_is_ambiguous_for_a_mutating_query",
+        an_expired_deadline_is_ambiguous_for_a_mutating_query,
+        timeout::integration,
+        test_env::cluster_only },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test

--- a/test/cng/protostellar/query_converter.cxx
+++ b/test/cng/protostellar/query_converter.cxx
@@ -1,0 +1,489 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Unit tests for the N1QL query <-> couchbase.query.v1 converter (CXXCBC-897). Pure, no server.
+//
+// The expectations here are read off couchbase/query/v1/query.proto and the gateway's
+// queryserver.go, not off the converter -- an assertion derived from the code it tests only
+// notices that the code changed.
+
+#include "framework/test_runner.hxx"
+
+#include "core/protostellar/query_converter.hxx"
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <initializer_list>
+#include <limits>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace pq = ::couchbase::core::protostellar::query;
+namespace ops = ::couchbase::core::operations;
+namespace v1 = ::couchbase::query::v1;
+
+// A json_string holding the *binary* arm, which is the arm the public API produces:
+// couchbase/query_options.hxx declares parameters as std::vector<codec::binary> and
+// core/impl/query.cxx moves each one into the request. Building the string arm here instead --
+// json_string{std::string} -- would exercise a path no caller reaches.
+[[nodiscard]] auto
+binary_json(const std::string& json) -> couchbase::core::json_string
+{
+  std::vector<std::byte> bytes;
+  bytes.reserve(json.size());
+  for (const char c : json) {
+    bytes.push_back(static_cast<std::byte>(c));
+  }
+  return couchbase::core::json_string{ std::move(bytes) };
+}
+
+void
+encode_maps_core_fields()
+{
+  ops::query_request request;
+  request.statement = "SELECT 1";
+  request.client_context_id = "ctx-42";
+  request.readonly = true;
+  request.adhoc = false;
+  request.flex_index = true;
+  request.preserve_expiry = true;
+  request.scan_consistency = couchbase::query_scan_consistency::request_plus;
+  request.profile = couchbase::query_profile::timings;
+  request.max_parallelism = 4;
+  request.metrics = true;
+
+  const auto proto = pq::encode(request);
+  assert_eq(proto.statement(), std::string{ "SELECT 1" }, "statement mapped");
+  assert_eq(proto.client_context_id(), std::string{ "ctx-42" }, "client_context_id mapped");
+  assert_true(proto.read_only(), "readonly mapped");
+  assert_true(proto.flex_index(), "flex_index mapped");
+  assert_true(proto.preserve_expiry(), "preserve_expiry mapped");
+  assert_true(proto.prepared(), "adhoc=false requests a prepared statement");
+  assert_true(proto.scan_consistency() ==
+                v1::QueryRequest_ScanConsistency_SCAN_CONSISTENCY_REQUEST_PLUS,
+              "scan_consistency mapped");
+  assert_true(proto.profile_mode() == v1::QueryRequest_ProfileMode_PROFILE_MODE_TIMINGS,
+              "profile mapped");
+  assert_true(proto.has_tuning_options(), "tuning options present");
+  assert_eq(proto.tuning_options().max_parallelism(), std::uint32_t{ 4 }, "max_parallelism mapped");
+  assert_false(proto.tuning_options().disable_metrics(),
+               "metrics=true disables the disable_metrics flag");
+}
+
+// The blocker from the #1036 review. json_string::str() returns a reference to a static empty
+// string for the binary arm, so reading parameters through it sends "" for every one of them --
+// and the binary arm is the only arm the public API produces. Asserting on the payload rather
+// than on "a parameter is present" is what separates the two.
+void
+positional_parameters_carry_their_json_payload()
+{
+  ops::query_request request;
+  request.statement = "SELECT * FROM b WHERE id = $1 AND n = $2";
+  request.positional_parameters.emplace_back(binary_json(R"("abc")"));
+  request.positional_parameters.emplace_back(binary_json("42"));
+
+  const auto proto = pq::encode(request);
+  assert_eq(proto.positional_parameters_size(), 2, "both positional parameters encoded");
+  assert_eq(proto.positional_parameters(0), std::string{ R"("abc")" }, "first payload preserved");
+  assert_eq(proto.positional_parameters(1), std::string{ "42" }, "second payload preserved");
+}
+
+void
+named_parameters_carry_their_json_payload()
+{
+  ops::query_request request;
+  request.statement = "SELECT * FROM b WHERE id = $id";
+  request.named_parameters.emplace("id", binary_json(R"("abc")"));
+  request.named_parameters.emplace("limit", binary_json("10"));
+
+  const auto proto = pq::encode(request);
+  const auto& named = proto.named_parameters();
+  assert_eq(named.size(), std::size_t{ 2 }, "both named parameters encoded");
+  assert_true(named.count("id") == 1, "named parameter present");
+  assert_eq(named.at("id"), std::string{ R"("abc")" }, "named payload preserved");
+  assert_eq(named.at("limit"), std::string{ "10" }, "numeric named payload preserved");
+}
+
+// The proto field is `repeated bytes`, so a payload is copied verbatim rather than re-encoded.
+// A parameter whose JSON contains a NUL or a non-ASCII byte must survive intact and keep its
+// length -- treating the payload as a C string would truncate at the NUL.
+void
+a_parameter_payload_is_copied_byte_for_byte()
+{
+  // "a<NUL>b<U+00E9>" as JSON: an embedded NUL and a multi-byte UTF-8 sequence. Built with an
+  // explicit length because a NUL would otherwise end the literal.
+  const std::string payload{ "\"a\0b\xc3\xa9\"", 7 };
+  ops::query_request request;
+  request.statement = "SELECT $1";
+  request.positional_parameters.emplace_back(binary_json(payload));
+
+  const auto proto = pq::encode(request);
+  assert_eq(proto.positional_parameters(0).size(), std::size_t{ 7 }, "payload length preserved");
+  assert_true(proto.positional_parameters(0) == payload, "payload bytes preserved");
+}
+
+// The string arm is unreachable from the public API but is what a direct core caller would build,
+// and json_payload() has to handle both.
+void
+a_string_arm_parameter_is_encoded_too()
+{
+  ops::query_request request;
+  request.statement = "SELECT $1";
+  request.positional_parameters.emplace_back(std::string{ "7" });
+
+  const auto proto = pq::encode(request);
+  assert_eq(proto.positional_parameters(0), std::string{ "7" }, "string-arm payload encoded");
+}
+
+// A default-constructed json_string holds neither arm. It must encode as empty rather than trip
+// over the variant.
+void
+an_empty_parameter_encodes_as_empty()
+{
+  ops::query_request request;
+  request.statement = "SELECT $1";
+  request.positional_parameters.emplace_back();
+
+  const auto proto = pq::encode(request);
+  assert_eq(proto.positional_parameters_size(), 1, "the parameter is still sent");
+  assert_true(proto.positional_parameters(0).empty(), "an unset parameter encodes as empty");
+}
+
+// queryserver.go:93 sets the query context only when bucket AND scope are both present, and
+// rejects a scope without a bucket outright (:89). A context that is not exactly two
+// backtick-delimited identifiers therefore has to leave both fields unset rather than send half
+// of one.
+void
+query_context_sets_both_fields_or_neither()
+{
+  ops::query_request base;
+  base.statement = "SELECT 1";
+
+  auto scoped = base;
+  scoped.query_context = "default:`travel-sample`.`inventory`";
+  const auto proto = pq::encode(scoped);
+  assert_eq(proto.bucket_name(), std::string{ "travel-sample" }, "query_context bucket parsed");
+  assert_eq(proto.scope_name(), std::string{ "inventory" }, "query_context scope parsed");
+
+  for (const auto* malformed : {
+         "default:`travel-sample`",         // one identifier
+         "default:`a`.`b`.`c`",             // three
+         "default:`unbalanced",             // unterminated
+         "default:travel-sample.inventory", // no backticks
+         "",                                // empty
+       }) {
+    auto request = base;
+    request.query_context = malformed;
+    const auto encoded = pq::encode(request);
+    assert_true(encoded.bucket_name().empty() && encoded.scope_name().empty(),
+                std::string{ "a context that is not two identifiers sets neither field: " } +
+                  malformed);
+  }
+}
+
+void
+encode_maps_mutation_state_to_consistent_with()
+{
+  ops::query_request request;
+  request.statement = "SELECT 1";
+  request.mutation_state.emplace_back(0x1234ULL, 42ULL, std::uint16_t{ 7 }, "default");
+
+  const auto proto = pq::encode(request);
+  assert_eq(proto.consistent_with_size(), 1, "one scan-vector token");
+  const auto& token = proto.consistent_with(0);
+  assert_eq(token.bucket_name(), std::string{ "default" }, "token bucket mapped");
+  assert_eq(token.vbucket_id(), std::uint32_t{ 7 }, "token vbucket id mapped");
+  assert_eq(token.vbucket_uuid(), std::uint64_t{ 0x1234 }, "token uuid mapped");
+  assert_eq(token.seq_no(), std::uint64_t{ 42 }, "token seq no mapped");
+}
+
+// Every value of both enums has to map: a value added to the SDK enum without a case here would
+// otherwise fall through and send the proto default (NOT_BOUNDED / OFF), silently downgrading the
+// caller's consistency or profiling request.
+void
+every_scan_consistency_and_profile_value_maps()
+{
+  ops::query_request request;
+  request.statement = "SELECT 1";
+
+  request.scan_consistency = couchbase::query_scan_consistency::not_bounded;
+  assert_true(pq::encode(request).scan_consistency() ==
+                v1::QueryRequest_ScanConsistency_SCAN_CONSISTENCY_NOT_BOUNDED,
+              "not_bounded maps");
+  request.scan_consistency = couchbase::query_scan_consistency::request_plus;
+  assert_true(pq::encode(request).scan_consistency() ==
+                v1::QueryRequest_ScanConsistency_SCAN_CONSISTENCY_REQUEST_PLUS,
+              "request_plus maps");
+
+  request.scan_consistency.reset();
+  request.profile = couchbase::query_profile::off;
+  assert_true(pq::encode(request).profile_mode() == v1::QueryRequest_ProfileMode_PROFILE_MODE_OFF,
+              "profile off maps");
+  request.profile = couchbase::query_profile::phases;
+  assert_true(pq::encode(request).profile_mode() ==
+                v1::QueryRequest_ProfileMode_PROFILE_MODE_PHASES,
+              "profile phases maps");
+  request.profile = couchbase::query_profile::timings;
+  assert_true(pq::encode(request).profile_mode() ==
+                v1::QueryRequest_ProfileMode_PROFILE_MODE_TIMINGS,
+              "profile timings maps");
+}
+
+// scan_wait is a google.protobuf.Duration, whose seconds and nanos are separate fields. A value
+// with a sub-second remainder is where a lossy cast shows up.
+void
+scan_wait_splits_into_seconds_and_nanos()
+{
+  ops::query_request request;
+  request.statement = "SELECT 1";
+  request.scan_wait = std::chrono::milliseconds{ 2500 };
+
+  const auto proto = pq::encode(request);
+  assert_true(proto.tuning_options().has_scan_wait(), "scan_wait present");
+  assert_eq(proto.tuning_options().scan_wait().seconds(), std::int64_t{ 2 }, "seconds split out");
+  assert_eq(proto.tuning_options().scan_wait().nanos(),
+            std::int32_t{ 500'000'000 },
+            "sub-second remainder kept as nanos");
+}
+
+void
+tuning_fields_map_to_their_proto_counterparts()
+{
+  ops::query_request request;
+  request.statement = "SELECT 1";
+  request.max_parallelism = 3;
+  request.pipeline_batch = 5;
+  request.pipeline_cap = 7;
+  request.scan_cap = 9;
+
+  const auto proto = pq::encode(request);
+  const auto& tuning = proto.tuning_options();
+  assert_eq(tuning.max_parallelism(), std::uint32_t{ 3 }, "max_parallelism mapped");
+  assert_eq(tuning.pipeline_batch(), std::uint32_t{ 5 }, "pipeline_batch mapped");
+  assert_eq(tuning.pipeline_cap(), std::uint32_t{ 7 }, "pipeline_cap mapped");
+  assert_eq(tuning.scan_cap(), std::uint32_t{ 9 }, "scan_cap mapped");
+  assert_true(tuning.disable_metrics(), "metrics defaults off, so disable_metrics is set");
+}
+
+// The tuning fields are uint64 in the core request and uint32 in the proto. Encoding a value that
+// does not fit would wrap and ask the gateway to use a different number than the caller asked
+// for, so can_encode rejects it -- the same convention the converter uses for every other
+// "cannot express this" case.
+void
+can_encode_rejects_tuning_values_that_do_not_fit_uint32()
+{
+  constexpr auto max32 = std::uint64_t{ std::numeric_limits<std::uint32_t>::max() };
+
+  ops::query_request base;
+  base.statement = "SELECT 1";
+
+  auto at_limit = base;
+  at_limit.max_parallelism = max32;
+  at_limit.pipeline_batch = max32;
+  at_limit.pipeline_cap = max32;
+  at_limit.scan_cap = max32;
+  assert_true(pq::can_encode(at_limit), "UINT32_MAX itself still encodes");
+  assert_eq(pq::encode(at_limit).tuning_options().max_parallelism(),
+            std::numeric_limits<std::uint32_t>::max(),
+            "the boundary value survives encoding");
+
+  for (auto field : std::initializer_list<std::optional<std::uint64_t> ops::query_request::*>{
+         &ops::query_request::max_parallelism,
+         &ops::query_request::pipeline_batch,
+         &ops::query_request::pipeline_cap,
+         &ops::query_request::scan_cap,
+       }) {
+    auto request = base;
+    request.*field = max32 + 1;
+    assert_false(pq::can_encode(request), "a tuning value above UINT32_MAX is not encodable");
+  }
+}
+
+void
+can_encode_rejects_unsupported_features()
+{
+  ops::query_request base;
+  base.statement = "SELECT 1";
+  assert_true(pq::can_encode(base), "plain query encodes");
+
+  ops::query_request with_raw = base;
+  with_raw.raw.emplace("timeout", couchbase::core::json_string{ std::string{ "\"1s\"" } });
+  assert_false(pq::can_encode(with_raw), "raw passthrough is not supported");
+
+  ops::query_request with_replica = base;
+  with_replica.use_replica = true;
+  assert_false(pq::can_encode(with_replica), "use_replica is not supported");
+
+  // An explicit `false` is a request for the default, not for a feature the gateway lacks.
+  ops::query_request without_replica = base;
+  without_replica.use_replica = false;
+  assert_true(pq::can_encode(without_replica), "use_replica=false is not a rejection");
+
+  ops::query_request with_row_callback = base;
+  with_row_callback.row_callback = [](std::string) {
+    return couchbase::core::utils::json::stream_control::next_row;
+  };
+  assert_false(pq::can_encode(with_row_callback), "the streaming row callback is not wired");
+
+  // There is no proto field for node targeting and the gateway routes on its own, so honouring
+  // the request is impossible; couchbase-jvm-clients raises the same refusal.
+  ops::query_request with_target = base;
+  with_target.send_to_node = "node1:8093";
+  assert_false(pq::can_encode(with_target), "targeting a specific query node is not supported");
+}
+
+void
+decode_meta_data_maps_status_metrics_warnings()
+{
+  v1::QueryResponse_MetaData proto;
+  proto.set_request_id("req-7");
+  proto.set_client_context_id("ctx-7");
+  proto.set_status(v1::QueryResponse_MetaData_Status_STATUS_SUCCESS);
+  proto.set_signature(R"({"greeting":"string"})");
+  proto.set_profile(R"({"phaseTimes":{}})");
+  auto* metrics = proto.mutable_metrics();
+  metrics->set_result_count(3);
+  metrics->set_result_size(128);
+  metrics->set_sort_count(1);
+  metrics->set_mutation_count(2);
+  metrics->set_error_count(0);
+  metrics->set_warning_count(1);
+  metrics->mutable_elapsed_time()->set_seconds(1);
+  metrics->mutable_elapsed_time()->set_nanos(500'000'000);
+  metrics->mutable_execution_time()->set_nanos(250'000'000);
+  auto* warning = proto.add_warnings();
+  warning->set_code(4321);
+  warning->set_message("deprecated");
+
+  ops::query_response::query_meta_data meta;
+  pq::decode_meta_data(proto, meta);
+
+  assert_eq(meta.request_id, std::string{ "req-7" }, "request_id decoded");
+  assert_eq(meta.client_context_id, std::string{ "ctx-7" }, "client_context_id decoded");
+  assert_eq(meta.status, std::string{ "success" }, "status enum -> string");
+  assert_true(meta.signature.has_value(), "signature decoded");
+  assert_true(meta.profile.has_value(), "profile decoded");
+  assert_true(meta.metrics.has_value(), "metrics present");
+  assert_eq(meta.metrics->result_count, std::uint64_t{ 3 }, "result_count decoded");
+  assert_eq(meta.metrics->result_size, std::uint64_t{ 128 }, "result_size decoded");
+  assert_eq(meta.metrics->sort_count, std::uint64_t{ 1 }, "sort_count decoded");
+  assert_eq(meta.metrics->mutation_count, std::uint64_t{ 2 }, "mutation_count decoded");
+  assert_eq(meta.metrics->warning_count, std::uint64_t{ 1 }, "warning_count decoded");
+  assert_true(meta.metrics->elapsed_time == std::chrono::nanoseconds{ 1'500'000'000 },
+              "elapsed_time duration decoded");
+  assert_true(meta.metrics->execution_time == std::chrono::nanoseconds{ 250'000'000 },
+              "execution_time duration decoded");
+  assert_true(meta.warnings.has_value(), "warnings present");
+  assert_eq(meta.warnings->at(0).code, std::uint64_t{ 4321 }, "warning code decoded");
+  assert_eq(meta.warnings->at(0).message, std::string{ "deprecated" }, "warning message decoded");
+}
+
+// metrics, signature, profile and warnings are all optional in the schema. A response without
+// them must leave the corresponding optionals unset rather than fabricate empty values, because
+// the SDK surface distinguishes "not requested" from "requested and empty".
+void
+decode_meta_data_leaves_absent_optionals_unset()
+{
+  v1::QueryResponse_MetaData proto;
+  proto.set_request_id("req-8");
+  proto.set_status(v1::QueryResponse_MetaData_Status_STATUS_SUCCESS);
+
+  ops::query_response::query_meta_data meta;
+  pq::decode_meta_data(proto, meta);
+
+  assert_false(meta.metrics.has_value(), "absent metrics stay unset");
+  assert_false(meta.signature.has_value(), "absent signature stays unset");
+  assert_false(meta.profile.has_value(), "absent profile stays unset");
+  assert_false(meta.warnings.has_value(), "absent warnings stay unset");
+}
+
+// Every Status the schema defines has a string. A value with no case would decode as "unknown",
+// which the SDK surface cannot distinguish from the schema's own STATUS_UNKNOWN.
+void
+every_metadata_status_decodes_to_its_own_string()
+{
+  const std::vector<std::pair<v1::QueryResponse_MetaData_Status, std::string>> expected{
+    { v1::QueryResponse_MetaData_Status_STATUS_RUNNING, "running" },
+    { v1::QueryResponse_MetaData_Status_STATUS_SUCCESS, "success" },
+    { v1::QueryResponse_MetaData_Status_STATUS_ERRORS, "errors" },
+    { v1::QueryResponse_MetaData_Status_STATUS_COMPLETED, "completed" },
+    { v1::QueryResponse_MetaData_Status_STATUS_STOPPED, "stopped" },
+    { v1::QueryResponse_MetaData_Status_STATUS_TIMEOUT, "timeout" },
+    { v1::QueryResponse_MetaData_Status_STATUS_CLOSED, "closed" },
+    { v1::QueryResponse_MetaData_Status_STATUS_FATAL, "fatal" },
+    { v1::QueryResponse_MetaData_Status_STATUS_ABORTED, "aborted" },
+    { v1::QueryResponse_MetaData_Status_STATUS_UNKNOWN, "unknown" },
+  };
+  // Guards against the schema gaining a value that nothing here covers.
+  assert_eq(expected.size(),
+            static_cast<std::size_t>(v1::QueryResponse_MetaData_Status_Status_ARRAYSIZE),
+            "every status the schema defines is covered");
+
+  for (const auto& [status, text] : expected) {
+    v1::QueryResponse_MetaData proto;
+    proto.set_status(status);
+    ops::query_response::query_meta_data meta;
+    pq::decode_meta_data(proto, meta);
+    assert_eq(meta.status, text, "status " + text + " decoded");
+  }
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_query_converter",
+    {
+      { "encode_maps_core_fields", encode_maps_core_fields },
+      { "positional_parameters_carry_their_json_payload",
+        positional_parameters_carry_their_json_payload },
+      { "named_parameters_carry_their_json_payload", named_parameters_carry_their_json_payload },
+      { "a_parameter_payload_is_copied_byte_for_byte",
+        a_parameter_payload_is_copied_byte_for_byte },
+      { "a_string_arm_parameter_is_encoded_too", a_string_arm_parameter_is_encoded_too },
+      { "an_empty_parameter_encodes_as_empty", an_empty_parameter_encodes_as_empty },
+      { "query_context_sets_both_fields_or_neither", query_context_sets_both_fields_or_neither },
+      { "encode_maps_mutation_state_to_consistent_with",
+        encode_maps_mutation_state_to_consistent_with },
+      { "every_scan_consistency_and_profile_value_maps",
+        every_scan_consistency_and_profile_value_maps },
+      { "scan_wait_splits_into_seconds_and_nanos", scan_wait_splits_into_seconds_and_nanos },
+      { "tuning_fields_map_to_their_proto_counterparts",
+        tuning_fields_map_to_their_proto_counterparts },
+      { "can_encode_rejects_tuning_values_that_do_not_fit_uint32",
+        can_encode_rejects_tuning_values_that_do_not_fit_uint32 },
+      { "can_encode_rejects_unsupported_features", can_encode_rejects_unsupported_features },
+      { "decode_meta_data_maps_status_metrics_warnings",
+        decode_meta_data_maps_status_metrics_warnings },
+      { "decode_meta_data_leaves_absent_optionals_unset",
+        decode_meta_data_leaves_absent_optionals_unset },
+      { "every_metadata_status_decodes_to_its_own_string",
+        every_metadata_status_decodes_to_its_own_string },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test


### PR DESCRIPTION
Query was rejected with feature_not_available on couchbase2: the HTTP execute
front-door gate covered every HTTP-shaped request, and nothing bridged the core
query_request onto the gRPC path. Wire it onto the server-streaming primitive.

Add a query converter (core operations <-> couchbase.query.v1): encode statement,
parameters, query_context (parsed into bucket/scope), scan consistency,
mutation-token scan vectors (consistent_with), profile, and tuning options;
decode the terminal metadata message (status, request_id, metrics, warnings).
Rows arrive across streamed messages and are buffered into query_response.rows.
The component gains a QueryService stub and a query execute() that drives
dispatcher::server_stream, mapping the terminal gRPC status to the error
context. cluster_impl routes query_request to the component; other HTTP services
keep returning feature_not_available.

Query features with no couchbase2 equivalent (raw passthrough, use_replica, the
streaming row_callback) are reported up front as feature_not_available rather
than silently dropped. Covered by a converter unit test and a live N1QL
round-trip against a CNG gateway.

---
Stacked PR **14/29** in the CNG (`couchbase2://`) transport series. This branch includes every commit from PRs 01–14; the change specific to this PR is its top commit. Depends on #1035 — merge the series bottom-up.
