### PR TITLE
CXXCBC-898: route analytics over the couchbase2 streaming transport

### DIFF
--- a/core/cluster.cxx
+++ b/core/cluster.cxx
@@ -773,13 +773,13 @@ public:
     }
 #ifdef COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2
     if (auto component = protostellar_component(); component) {
-      if constexpr (std::is_same_v<Request, operations::query_request>) {
+      if constexpr (std::is_same_v<Request, operations::query_request> ||
+                    std::is_same_v<Request, operations::analytics_request>) {
         component->execute(std::move(request), std::forward<Handler>(handler));
         return;
       } else {
-        // Analytics/search/views/management over couchbase2 are not wired yet. Reject cleanly
-        // rather than falling through to the MCBP session manager, which is never bootstrapped on
-        // this path.
+        // Search/views/management over couchbase2 are not wired yet. Reject cleanly rather than
+        // falling through to the MCBP session manager, which is never bootstrapped on this path.
         return handler(
           request.make_response({ errc::common::feature_not_available }, response_type{}));
       }
@@ -939,7 +939,8 @@ public:
         protostellar::component_config{ std::move(channel),
                                         origin_.credentials(),
                                         options.key_value_timeout,
-                                        options.query_timeout });
+                                        options.query_timeout,
+                                        options.analytics_timeout });
     }
     CB_LOG_INFO(R"(open couchbase2 cluster, id: "{}", endpoint: "{}")", id_, endpoint);
     return handler({});

--- a/core/protostellar/analytics_converter.hxx
+++ b/core/protostellar/analytics_converter.hxx
@@ -1,0 +1,171 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+// Translates the core analytics request/response to and from the couchbase.analytics.v1 protobuf
+// messages, mirroring query_converter. Rows arrive across streamed AnalyticsQueryResponse messages
+// and are buffered into analytics_response::rows; the terminal message carries the metadata.
+//
+// Features with no couchbase2 equivalent are reported by can_encode() so the component can surface
+// feature_not_available rather than silently dropping them: the `raw` passthrough map, the
+// streaming row_callback (only the buffered result path is wired), and scoped analytics.
+//
+// Scoped analytics is refused because the schema cannot express it, not merely because it is
+// unimplemented. AnalyticsQueryRequest at the pinned protostellar revision retired the field the
+// older schema used for this: field 8 is `reserved // bucket_name`, and field 9 was renamed from
+// `scope_name` to `analytics_scope_name` -- one analytics-scope identifier rather than the
+// bucket/scope pair the core request carries in bucket_name/scope_name/scope_qualifier. Collapsing
+// a two-part qualification into that single name would be a guess about which the gateway means, so
+// the request is refused instead. (Vendored copies in couchbase-jvm-clients and
+// couchbase-net-client still carry the older bucket_name=8/scope_name=9 shape, so a mapping cribbed
+// from them would target a schema this client does not speak.)
+
+#include "core/operations/document_analytics.hxx"
+#include "core/protostellar/json_payload.hxx"
+
+#include <couchbase/analytics_scan_consistency.hxx>
+
+#include <couchbase/analytics/v1/analytics.pb.h>
+
+#include <chrono>
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace couchbase::core::protostellar::analytics
+{
+namespace v1 = ::couchbase::analytics::v1;
+
+[[nodiscard]] inline auto
+can_encode(const operations::analytics_request& request) -> bool
+{
+  return request.raw.empty() && !request.row_callback.has_value() &&
+         !request.bucket_name.has_value() && !request.scope_name.has_value() &&
+         !request.scope_qualifier.has_value();
+}
+
+inline auto
+encode(const operations::analytics_request& request) -> v1::AnalyticsQueryRequest
+{
+  v1::AnalyticsQueryRequest proto;
+  proto.set_statement(request.statement);
+  proto.set_read_only(request.readonly);
+  proto.set_priority(request.priority);
+  if (request.client_context_id.has_value()) {
+    proto.set_client_context_id(*request.client_context_id);
+  }
+  if (request.scan_consistency.has_value()) {
+    switch (*request.scan_consistency) {
+      case analytics_scan_consistency::not_bounded:
+        proto.set_scan_consistency(
+          v1::AnalyticsQueryRequest_ScanConsistency_SCAN_CONSISTENCY_NOT_BOUNDED);
+        break;
+      case analytics_scan_consistency::request_plus:
+        proto.set_scan_consistency(
+          v1::AnalyticsQueryRequest_ScanConsistency_SCAN_CONSISTENCY_REQUEST_PLUS);
+        break;
+    }
+  }
+  for (const auto& parameter : request.positional_parameters) {
+    proto.add_positional_parameters(json_payload(parameter));
+  }
+  for (const auto& [name, value] : request.named_parameters) {
+    (*proto.mutable_named_parameters())[name] = json_payload(value);
+  }
+  return proto;
+}
+
+[[nodiscard]] inline auto
+to_nanoseconds(const google::protobuf::Duration& duration) -> std::chrono::nanoseconds
+{
+  return std::chrono::seconds{ duration.seconds() } + std::chrono::nanoseconds{ duration.nanos() };
+}
+
+// The gateway reports status as a lowercase string; map it onto the core enum.
+[[nodiscard]] inline auto
+status_from_string(const std::string& status) -> operations::analytics_response::analytics_status
+{
+  using s = operations::analytics_response::analytics_status;
+  if (status == "running") {
+    return s::running;
+  }
+  if (status == "success") {
+    return s::success;
+  }
+  if (status == "errors") {
+    return s::errors;
+  }
+  if (status == "completed") {
+    return s::completed;
+  }
+  if (status == "stopped") {
+    return s::stopped;
+  }
+  if (status == "timeout" || status == "timedout") {
+    return s::timedout;
+  }
+  if (status == "closed") {
+    return s::closed;
+  }
+  if (status == "fatal") {
+    return s::fatal;
+  }
+  if (status == "aborted") {
+    return s::aborted;
+  }
+  return s::unknown;
+}
+
+inline void
+decode_meta_data(const v1::AnalyticsQueryResponse_MetaData& proto,
+                 operations::analytics_response::analytics_meta_data& meta)
+{
+  meta.request_id = proto.request_id();
+  meta.client_context_id = proto.client_context_id();
+  meta.status = status_from_string(proto.status());
+  if (!proto.signature().empty()) {
+    meta.signature = proto.signature();
+  }
+  if (proto.has_metrics()) {
+    const auto& m = proto.metrics();
+    meta.metrics.elapsed_time = to_nanoseconds(m.elapsed_time());
+    meta.metrics.execution_time = to_nanoseconds(m.execution_time());
+    meta.metrics.result_count = m.result_count();
+    meta.metrics.result_size = m.result_size();
+    meta.metrics.error_count = m.error_count();
+    meta.metrics.processed_objects = m.processed_objects();
+    meta.metrics.warning_count = m.warning_count();
+  }
+  // Replaced rather than appended, matching query_converter: decode_meta_data runs once per
+  // MetaData message, and appending would accumulate duplicates without bound if a gateway ever
+  // sent more than one.
+  if (proto.warnings_size() > 0) {
+    std::vector<operations::analytics_response::analytics_problem> warnings;
+    warnings.reserve(static_cast<std::size_t>(proto.warnings_size()));
+    for (const auto& w : proto.warnings()) {
+      operations::analytics_response::analytics_problem problem;
+      problem.code = w.code();
+      problem.message = w.message();
+      warnings.push_back(std::move(problem));
+    }
+    meta.warnings = std::move(warnings);
+  }
+}
+
+} // namespace couchbase::core::protostellar::analytics

--- a/core/protostellar/component.cxx
+++ b/core/protostellar/component.cxx
@@ -17,9 +17,12 @@
 
 #include "core/protostellar/component.hxx"
 
+#include "core/error_context/analytics.hxx"
 #include "core/error_context/key_value.hxx"
 #include "core/error_context/query.hxx"
+#include "core/operations/analytics_response_parsing.hxx"
 #include "core/operations/query_response_parsing.hxx"
+#include "core/protostellar/analytics_converter.hxx"
 #include "core/protostellar/credentials.hxx"
 #include "core/protostellar/error_utils.hxx"
 #include "core/protostellar/kv_converter.hxx"
@@ -28,6 +31,7 @@
 #include <couchbase/error_codes.hxx>
 
 #include "core/protostellar/query_proto.hxx"
+#include <couchbase/analytics/v1/analytics.grpc.pb.h>
 
 #include <couchbase/kv/v1/kv.grpc.pb.h>
 
@@ -46,12 +50,14 @@ namespace couchbase::core::protostellar
 {
 namespace v1 = ::couchbase::kv::v1;
 namespace query_v1 = ::couchbase::query::v1;
+namespace analytics_v1 = ::couchbase::analytics::v1;
 
 // Defined here rather than in the header so the generated gRPC types stay out of every consumer of
 // component.hxx.
 struct component::stubs {
   std::unique_ptr<v1::KvService::Stub> kv;
   std::unique_ptr<query_v1::QueryService::Stub> query;
+  std::unique_ptr<analytics_v1::AnalyticsService::Stub> analytics;
 };
 
 namespace
@@ -98,11 +104,14 @@ fail_expired_ctx(asio::io_context& io, Handler& handler, Response response) -> p
 
 component::component(asio::io_context& io, component_config config)
   : io_{ io }
-  , stubs_{ std::make_unique<stubs>(stubs{ v1::KvService::NewStub(config.channel),
-                                           query_v1::QueryService::NewStub(config.channel) }) }
+  , stubs_{ std::make_unique<stubs>(
+      stubs{ v1::KvService::NewStub(config.channel),
+             query_v1::QueryService::NewStub(config.channel),
+             analytics_v1::AnalyticsService::NewStub(config.channel) }) }
   , authorization_{ authorization_header(config.credentials) }
   , default_kv_timeout_{ config.default_kv_timeout }
   , default_query_timeout_{ config.default_query_timeout }
+  , default_analytics_timeout_{ config.default_analytics_timeout }
   // Initialised last (see the declaration order in the header), so the channel can be moved in.
   , dispatcher_{ io, std::move(config.channel) }
 {
@@ -712,6 +721,107 @@ component::execute(operations::query_request request,
       // A transport-level error already in ctx.ec is more specific, so it wins.
       if (!response.ctx.ec && *meta_received) {
         response.ctx.ec = operations::map_query_error(response.meta);
+      }
+      handler(std::move(response));
+    });
+}
+
+auto
+component::execute(operations::analytics_request request,
+                   utils::movable_function<void(operations::analytics_response)>&& handler)
+  -> pending_call
+{
+  auto statement = request.statement;
+  auto client_context_id = request.client_context_id.value_or(std::string{});
+  // Stamped even on the paths that send nothing: the error context identifies which statement
+  // failed, and a caller correlating by statement or client_context_id has no other handle on it.
+  const auto stamped = [&statement, &client_context_id]() {
+    operations::analytics_response response;
+    response.ctx.statement = statement;
+    response.ctx.client_context_id = client_context_id;
+    return response;
+  };
+
+  const auto timeout = request.timeout.value_or(default_analytics_timeout_);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped());
+  }
+
+  // Scoped analytics, raw passthrough, and the streaming row_callback have no couchbase2 mapping:
+  // fail cleanly rather than dropping the caller's intent.
+  if (!analytics::can_encode(request)) {
+    auto response = stamped();
+    response.ctx.ec = errc::common::feature_not_available;
+    // Posted rather than invoked here, for the reason fail_expired above gives: completions arrive
+    // on the SDK's execution context, and calling back inline would re-enter the caller before it
+    // has its pending_call.
+    asio::post(io_, [handler = std::move(handler), response = std::move(response)]() mutable {
+      handler(std::move(response));
+    });
+    return {};
+  }
+
+  auto proto = std::make_shared<analytics_v1::AnalyticsQueryRequest>(analytics::encode(request));
+  const auto auth = authorization_;
+  // Analytics carries the same readonly flag as N1QL, so the same RFC 77 rule applies.
+  const auto kind = request.readonly ? operation_kind::read_only : operation_kind::mutating;
+  auto* stub = stubs_->analytics.get();
+
+  auto rows = std::make_shared<std::vector<std::string>>();
+  auto meta = std::make_shared<operations::analytics_response::analytics_meta_data>();
+  // Whether a MetaData message arrived, which the status alone cannot tell us: analytics_status's
+  // first enumerator is `running`, so a default-constructed meta is indistinguishable from one the
+  // gateway reported as running. Classifying without this would turn a stream that ended OK with no
+  // metadata into an error.
+  auto meta_received = std::make_shared<bool>(false);
+
+  return dispatcher_.server_stream<analytics_v1::AnalyticsQueryResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        grpc::ClientReadReactor<analytics_v1::AnalyticsQueryResponse>* reactor) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->AnalyticsQuery(&ctx, proto.get(), reactor);
+    },
+    [rows, meta, meta_received](analytics_v1::AnalyticsQueryResponse message) {
+      for (const auto& row : message.rows()) {
+        rows->push_back(row);
+      }
+      if (message.has_meta_data()) {
+        *meta_received = true;
+        analytics::decode_meta_data(message.meta_data(), *meta);
+      }
+    },
+    // `proto` is captured so the request outlives the in-flight stream.
+    [handler = std::move(handler),
+     rows,
+     meta,
+     meta_received,
+     proto,
+     statement,
+     client_context_id,
+     kind](grpc::Status status) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      operations::analytics_response response;
+      response.ctx.ec = map_status(status, kind);
+      response.ctx.statement = std::move(statement);
+      response.ctx.client_context_id =
+        meta->client_context_id.empty() ? std::move(client_context_id) : meta->client_context_id;
+      if (!status.ok()) {
+        response.ctx.first_error_message = error_message(status);
+      }
+      response.meta = std::move(*meta);
+      response.rows = std::move(*rows);
+      // A terminal status other than success arriving with an OK trailer would otherwise be
+      // reported as a successful query whose own metadata says it failed. map_analytics_error is
+      // the classifier the classic path uses, so both transports agree; the proto carries no errors
+      // list, and for that case it yields internal_server_failure -- the fallback its own comment
+      // documents for exactly this caller.
+      //
+      // A transport-level error already in ctx.ec is more specific, so it wins.
+      if (!response.ctx.ec && *meta_received) {
+        response.ctx.ec = operations::map_analytics_error(response.meta);
       }
       handler(std::move(response));
     });

--- a/core/protostellar/component.hxx
+++ b/core/protostellar/component.hxx
@@ -23,6 +23,7 @@
 // context. cluster_impl routes KV ops here when the cluster was opened with couchbase2://.
 
 #include "core/cluster_credentials.hxx"
+#include "core/operations/document_analytics.hxx"
 #include "core/operations/document_append.hxx"
 #include "core/operations/document_decrement.hxx"
 #include "core/operations/document_exists.hxx"
@@ -62,6 +63,7 @@ struct component_config {
   cluster_credentials credentials{};
   std::chrono::milliseconds default_kv_timeout{ timeout_defaults::key_value_timeout };
   std::chrono::milliseconds default_query_timeout{ timeout_defaults::query_timeout };
+  std::chrono::milliseconds default_analytics_timeout{ timeout_defaults::analytics_timeout };
 };
 
 // The core KV request types the component can execute over couchbase2. cluster_impl routes only
@@ -159,6 +161,11 @@ public:
   auto execute(operations::query_request request,
                utils::movable_function<void(operations::query_response)>&& handler) -> pending_call;
 
+  // Analytics over the couchbase2 server-streaming transport; same shape as query.
+  auto execute(operations::analytics_request request,
+               utils::movable_function<void(operations::analytics_response)>&& handler)
+    -> pending_call;
+
 private:
   // The generated gRPC stubs are held behind an opaque pointer so the generated protobuf and gRPC
   // surface stays out of every translation unit that includes this header -- none of it appears in
@@ -170,6 +177,7 @@ private:
   std::string authorization_;
   std::chrono::milliseconds default_kv_timeout_;
   std::chrono::milliseconds default_query_timeout_;
+  std::chrono::milliseconds default_analytics_timeout_;
   // Declared last, so it is destroyed first: ~dispatcher() cancels and drains the calls issued
   // through the stubs above, which must therefore still be alive while it runs.
   dispatcher dispatcher_;

--- a/test/cng/CMakeLists.txt
+++ b/test/cng/CMakeLists.txt
@@ -140,4 +140,10 @@ if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 AND TARGET couchbase_cxx_protostellar)
 
   # Live N1QL query verification (CXXCBC-897).
   add_cng_test(protostellar/live_query LINK_CLIENT LIBS couchbase_cxx_protostellar)
+
+  # Analytics query converter (CXXCBC-898).
+  add_cng_test(protostellar/analytics_converter LINK_CLIENT LIBS couchbase_cxx_protostellar)
+
+  # Live Analytics query verification (CXXCBC-898).
+  add_cng_test(protostellar/live_analytics LINK_CLIENT LIBS couchbase_cxx_protostellar)
 endif()

--- a/test/cng/protostellar/analytics_converter.cxx
+++ b/test/cng/protostellar/analytics_converter.cxx
@@ -1,0 +1,246 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Unit tests for the analytics <-> couchbase.analytics.v1 converter (CXXCBC-898). Pure, no
+// server.
+
+#include "framework/test_runner.hxx"
+
+#include "core/protostellar/analytics_converter.hxx"
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace pa = ::couchbase::core::protostellar::analytics;
+namespace ops = ::couchbase::core::operations;
+namespace v1 = ::couchbase::analytics::v1;
+
+// Builds the variant arm the public API actually populates. couchbase/analytics_options.hxx carries
+// parameters as codec::binary, so a test that constructs a json_string from a std::string exercises
+// an arm production never selects -- and passes whether or not the converter reads the right one.
+auto
+binary_json(const std::string& json) -> couchbase::core::json_string
+{
+  std::vector<std::byte> bytes;
+  bytes.reserve(json.size());
+  for (const char c : json) {
+    bytes.push_back(static_cast<std::byte>(c));
+  }
+  return couchbase::core::json_string{ std::move(bytes) };
+}
+
+void
+encode_maps_core_fields()
+{
+  ops::analytics_request request;
+  request.statement = "SELECT 1";
+  request.client_context_id = "ctx-9";
+  request.readonly = true;
+  request.priority = true;
+  request.scan_consistency = couchbase::core::analytics_scan_consistency::request_plus;
+  request.positional_parameters.emplace_back(R"("pos")");
+  request.named_parameters.emplace("a", couchbase::core::json_string{ R"("named")" });
+
+  const auto proto = pa::encode(request);
+  assert_eq(proto.statement(), std::string{ "SELECT 1" }, "statement mapped");
+  assert_eq(proto.client_context_id(), std::string{ "ctx-9" }, "client_context_id mapped");
+  assert_true(proto.read_only(), "readonly mapped");
+  assert_true(proto.priority(), "priority mapped");
+  assert_true(proto.scan_consistency() ==
+                v1::AnalyticsQueryRequest_ScanConsistency_SCAN_CONSISTENCY_REQUEST_PLUS,
+              "scan_consistency mapped");
+  assert_eq(proto.positional_parameters_size(), 1, "one positional parameter");
+  assert_eq(proto.positional_parameters(0), std::string{ R"("pos")" }, "positional value mapped");
+  assert_eq(proto.named_parameters().at("a"), std::string{ R"("named")" }, "named value mapped");
+}
+
+// The regression guard for the parameter defect: json_string::str() returns a reference to a static
+// empty string unless the std::string arm is active, so reading a binary-arm parameter with it
+// sends
+// "". Asserting the length as well as the value keeps an empty-vs-empty comparison from passing.
+void
+parameters_from_the_binary_arm_carry_their_payload()
+{
+  const std::string payload{ R"({"a":1})" };
+
+  ops::analytics_request request;
+  request.statement = "SELECT $1, $named";
+  request.positional_parameters.emplace_back(binary_json(payload));
+  request.named_parameters.emplace("named", binary_json(payload));
+
+  const auto proto = pa::encode(request);
+  assert_eq(proto.positional_parameters(0).size(), std::size_t{ 7 }, "positional length preserved");
+  assert_true(proto.positional_parameters(0) == payload, "positional payload bytes preserved");
+  assert_eq(
+    proto.named_parameters().at("named").size(), std::size_t{ 7 }, "named length preserved");
+  assert_true(proto.named_parameters().at("named") == payload, "named payload bytes preserved");
+}
+
+// A default-constructed json_string holds neither arm; it must encode as empty rather than trip
+// over the variant.
+void
+an_empty_parameter_encodes_as_empty()
+{
+  ops::analytics_request request;
+  request.statement = "SELECT $1";
+  request.positional_parameters.emplace_back();
+
+  const auto proto = pa::encode(request);
+  assert_eq(proto.positional_parameters_size(), 1, "the parameter is still sent");
+  assert_true(proto.positional_parameters(0).empty(), "an unset parameter encodes as empty");
+}
+
+void
+can_encode_rejects_unsupported_features()
+{
+  ops::analytics_request base;
+  base.statement = "SELECT 1";
+  assert_true(pa::can_encode(base), "plain analytics encodes");
+
+  ops::analytics_request with_raw = base;
+  with_raw.raw.emplace("timeout", couchbase::core::json_string{ "\"1s\"" });
+  assert_false(pa::can_encode(with_raw), "raw passthrough is not supported");
+}
+
+// Every way of naming a scope has to be refused, not just the one the original test covered. The
+// pinned schema reserves field 8 (the old bucket_name) and field 9 is a single
+// analytics_scope_name, so there is nowhere to put a bucket/scope pair; encoding any of these would
+// drop the qualification and run the statement against the wrong scope.
+void
+can_encode_rejects_every_scope_qualification()
+{
+  ops::analytics_request base;
+  base.statement = "SELECT 1";
+
+  ops::analytics_request with_bucket = base;
+  with_bucket.bucket_name = "b";
+  assert_false(pa::can_encode(with_bucket), "bucket_name alone is refused");
+
+  ops::analytics_request with_scope = base;
+  with_scope.scope_name = "s";
+  assert_false(pa::can_encode(with_scope), "scope_name alone is refused");
+
+  ops::analytics_request with_qualifier = base;
+  with_qualifier.scope_qualifier = "default:`b`.`s`";
+  assert_false(pa::can_encode(with_qualifier), "scope_qualifier is refused");
+}
+
+void
+decode_meta_data_maps_status_metrics_warnings()
+{
+  v1::AnalyticsQueryResponse_MetaData proto;
+  proto.set_request_id("req-9");
+  proto.set_client_context_id("ctx-9");
+  proto.set_status("success");
+  auto* metrics = proto.mutable_metrics();
+  metrics->set_result_count(2);
+  metrics->set_processed_objects(10);
+  metrics->mutable_execution_time()->set_seconds(2);
+  auto* warning = proto.add_warnings();
+  warning->set_code(99);
+  warning->set_message("careful");
+
+  ops::analytics_response::analytics_meta_data meta;
+  pa::decode_meta_data(proto, meta);
+
+  assert_eq(meta.request_id, std::string{ "req-9" }, "request_id decoded");
+  assert_true(meta.status == ops::analytics_response::success, "status string -> enum");
+  assert_eq(meta.metrics.result_count, std::uint64_t{ 2 }, "result_count decoded");
+  assert_eq(meta.metrics.processed_objects, std::uint64_t{ 10 }, "processed_objects decoded");
+  assert_true(meta.metrics.execution_time == std::chrono::seconds{ 2 }, "execution_time decoded");
+  assert_eq(meta.warnings.size(), std::size_t{ 1 }, "one warning decoded");
+  assert_eq(meta.warnings.at(0).code, std::uint64_t{ 99 }, "warning code decoded");
+}
+
+// decode_meta_data replaces the warning list rather than appending to it, matching the query
+// converter. Appending would duplicate warnings on this path only, and would grow without bound if
+// a gateway ever sent more than one MetaData message on a stream.
+void
+warnings_are_replaced_when_metadata_is_decoded_again()
+{
+  v1::AnalyticsQueryResponse_MetaData proto;
+  proto.set_status("success");
+  auto* warning = proto.add_warnings();
+  warning->set_code(99);
+  warning->set_message("careful");
+
+  ops::analytics_response::analytics_meta_data meta;
+  pa::decode_meta_data(proto, meta);
+  pa::decode_meta_data(proto, meta);
+
+  assert_eq(meta.warnings.size(), std::size_t{ 1 }, "the second decode replaced rather than added");
+  assert_eq(
+    meta.warnings.at(0).code, std::uint64_t{ 99 }, "the surviving warning is the decoded one");
+}
+
+// The gateway sends the analytics status as a lowercase string. "timeout" and "timedout" both have
+// to reach the same enumerator, and anything unrecognised must land on `unknown` rather than on the
+// zero-valued `running`, which would read as a query still in flight.
+void
+status_strings_map_to_the_core_enum()
+{
+  const auto decode = [](const char* status) {
+    v1::AnalyticsQueryResponse_MetaData proto;
+    proto.set_status(status);
+    ops::analytics_response::analytics_meta_data meta;
+    pa::decode_meta_data(proto, meta);
+    return meta.status;
+  };
+
+  assert_true(decode("success") == ops::analytics_response::success, "success mapped");
+  assert_true(decode("errors") == ops::analytics_response::errors, "errors mapped");
+  assert_true(decode("fatal") == ops::analytics_response::fatal, "fatal mapped");
+  assert_true(decode("aborted") == ops::analytics_response::aborted, "aborted mapped");
+  assert_true(decode("timeout") == ops::analytics_response::timedout, "timeout aliased");
+  assert_true(decode("timedout") == ops::analytics_response::timedout, "timedout mapped");
+  assert_true(decode("something-new") == ops::analytics_response::unknown,
+              "an unrecognised status is unknown, not running");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_analytics_converter",
+    {
+      { "encode_maps_core_fields", encode_maps_core_fields },
+      { "parameters_from_the_binary_arm_carry_their_payload",
+        parameters_from_the_binary_arm_carry_their_payload },
+      { "an_empty_parameter_encodes_as_empty", an_empty_parameter_encodes_as_empty },
+      { "can_encode_rejects_unsupported_features", can_encode_rejects_unsupported_features },
+      { "can_encode_rejects_every_scope_qualification",
+        can_encode_rejects_every_scope_qualification },
+      { "decode_meta_data_maps_status_metrics_warnings",
+        decode_meta_data_maps_status_metrics_warnings },
+      { "warnings_are_replaced_when_metadata_is_decoded_again",
+        warnings_are_replaced_when_metadata_is_decoded_again },
+      { "status_strings_map_to_the_core_enum", status_strings_map_to_the_core_enum },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test

--- a/test/cng/protostellar/live_analytics.cxx
+++ b/test/cng/protostellar/live_analytics.cxx
@@ -1,0 +1,173 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Live tests for analytics over the couchbase2:// streaming transport (CXXCBC-898), driving
+// core::cluster open()/execute(analytics_query_request) against a real CNG gateway.
+//
+// The gateway does not serve couchbase.analytics.v1 yet -- gateway/system/system.go registers
+// query, search and their admin services and no analytics service at all, so the whole service
+// answers UNIMPLEMENTED. Only the round-trip case needs a gateway that serves it, and that case
+// skips through skip_unless_service_implemented(), which requires the gateway's own UNIMPLEMENTED
+// message and so cannot be satisfied by the client refusing the request by itself.
+//
+// The remaining cases are about what this client does before anything is sent, so they run and
+// assert against today's gateway rather than skipping: a request the schema cannot express is
+// refused, and the refusal is stamped and delivered on the io context.
+
+#define COUCHBASE_CXX_CLIENT_IGNORE_CORE_DEPRECATIONS
+
+#include "framework/live_fixture.hxx"
+#include "framework/test_runner.hxx"
+
+#include <couchbase/error_codes.hxx>
+
+#include <chrono>
+#include <string>
+#include <thread>
+#include <utility>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace ops = ::couchbase::core::operations;
+
+auto
+analytics(const std::string& statement) -> ops::analytics_request
+{
+  ops::analytics_request request;
+  request.statement = statement;
+  return request;
+}
+
+void
+analytics_round_trip_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  const auto result = fixture.execute(analytics(R"(SELECT "cng" AS greeting)"));
+
+  skip_unless_service_implemented(result.ctx, "analytics.v1");
+
+  assert_false(static_cast<bool>(result.ctx.ec), "analytics over couchbase2 succeeds");
+  assert_eq(result.rows.size(), std::size_t{ 1 }, "single projected row buffered");
+  assert_true(result.rows.at(0).find("cng") != std::string::npos, "row carries the projection");
+  assert_true(result.meta.status == ops::analytics_response::success, "terminal status decoded");
+  assert_false(result.meta.request_id.empty(), "request_id decoded from metadata");
+}
+
+// Scope-qualified analytics is refused by the converter, because the pinned schema has no field for
+// it: AnalyticsQueryRequest reserves field 8 (the old bucket_name) and field 9 is now a single
+// analytics_scope_name rather than the bucket/scope pair the core request carries.
+//
+// The assertion on first_error_message is the point of the case. It is what separates this refusal
+// from a gateway UNIMPLEMENTED, which carries a gRPC message -- and it is the same signal
+// skip_unless_service_implemented() relies on, so this case is what keeps that helper honest.
+void
+scope_qualified_analytics_is_refused_by_the_client()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  auto request = analytics(R"(SELECT "cng" AS greeting)");
+  request.bucket_name = fixture.bucket();
+  request.scope_name = "_default";
+  const auto [result, handler_thread] = fixture.execute_on(std::move(request));
+
+  assert_true(result.ctx.ec == errc::common::feature_not_available,
+              "scoped analytics is refused rather than silently unscoped");
+  assert_true(result.rows.empty(), "nothing was executed");
+  assert_true(result.ctx.first_error_message.empty(),
+              "the refusal is the client's own, so it carries no gateway status message");
+  assert_eq(result.ctx.statement,
+            std::string{ R"(SELECT "cng" AS greeting)" },
+            "the refusal still identifies the statement");
+  assert_true(handler_thread != std::this_thread::get_id(),
+              "the refusal is delivered on the io context, not inline out of execute()");
+}
+
+void
+an_unsupported_option_is_refused_without_a_round_trip()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  auto request = analytics(R"(SELECT "cng" AS greeting)");
+  request.raw.emplace("some_future_option", couchbase::core::json_string{ std::string{ "true" } });
+  const auto [result, handler_thread] = fixture.execute_on(std::move(request));
+
+  assert_true(result.ctx.ec == errc::common::feature_not_available,
+              "the raw passthrough is refused rather than dropped");
+  assert_true(result.rows.empty(), "nothing was executed");
+  assert_true(handler_thread != std::this_thread::get_id(),
+              "the refusal is delivered on the io context, not inline out of execute()");
+}
+
+// A budget that is already spent must not be dispatched: dispatcher::server_stream only sets a
+// deadline for a positive timeout, so passing a non-positive one would produce a stream with no
+// deadline at all. Nothing is sent, which is why the timeout is unambiguous even though analytics
+// statements can mutate.
+void
+an_expired_budget_is_refused_on_the_io_context()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  auto request = analytics(R"(SELECT "cng" AS greeting)");
+  request.client_context_id = "expired-budget";
+  request.timeout = std::chrono::milliseconds::zero();
+  const auto [result, handler_thread] = fixture.execute_on(std::move(request));
+
+  assert_true(result.ctx.ec == errc::common::unambiguous_timeout,
+              "an exhausted budget is unambiguous because nothing was sent");
+  assert_eq(result.ctx.client_context_id,
+            std::string{ "expired-budget" },
+            "the expired refusal still identifies the caller's request");
+  assert_true(handler_thread != std::this_thread::get_id(),
+              "the refusal is delivered on the io context, not inline out of execute()");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_live_analytics",
+    {
+      { "analytics_round_trip_against_live_gateway",
+        analytics_round_trip_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "scope_qualified_analytics_is_refused_by_the_client",
+        scope_qualified_analytics_is_refused_by_the_client,
+        timeout::integration,
+        test_env::cluster_only },
+      { "an_unsupported_option_is_refused_without_a_round_trip",
+        an_unsupported_option_is_refused_without_a_round_trip,
+        timeout::integration,
+        test_env::cluster_only },
+      { "an_expired_budget_is_refused_on_the_io_context",
+        an_expired_budget_is_refused_on_the_io_context,
+        timeout::integration,
+        test_env::cluster_only },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test


### PR DESCRIPTION
Analytics was rejected by the HTTP execute front-door gate on couchbase2. Wire
it onto the server-streaming primitive, mirroring the query path.

Add an analytics converter (core operations <-> couchbase.analytics.v1): encode
statement, parameters, scan consistency, read-only and priority; decode the
terminal metadata (status string -> core enum, request_id, metrics, warnings).
Rows are buffered into analytics_response.rows. The component gains an
AnalyticsService stub and an analytics execute() driving
dispatcher::server_stream; cluster_impl routes analytics_request to it alongside
query. The component constructor takes an analytics timeout; its direct-ctor
test callers are updated to match.

A non-success terminal status arriving with an OK gRPC trailer is turned into an
error through `map_analytics_error`, the same classifier the HTTP path uses, so a
caller cannot see a successful result whose own metadata says it failed. This is
conditional on a MetaData message having been received: `analytics_status`
numbers `running` as zero, so an absent status is otherwise indistinguishable
from a reported one, and the gateway does end a stream OK with no metadata when
its own `result.MetaData()` fails.

Features the couchbase2 schema cannot express are reported up front as
`feature_not_available` rather than silently dropped: the `raw` passthrough map
and any scope qualification.

**Scope-qualified analytics is not supported over couchbase2**, so
`scope.analytics_query(...)` returns `feature_not_available`. This is a schema
limitation rather than a missing mapping: at the pinned protostellar revision
(36d4d9ab) `AnalyticsQueryRequest` reserves field 8 (the former `bucket_name`)
and field 9 is `analytics_scope_name` -- a single analytics-scope identifier, not
the bucket/scope pair the core request carries. Collapsing a two-part
qualification into that one name would guess at which the gateway means, and
guessing wrong runs the statement against the wrong scope, so the request is
refused. Note that the protos vendored by couchbase-jvm-clients and
couchbase-net-client still carry the older `bucket_name = 8` / `scope_name = 9`
shape, so a mapping copied from those clients would target a schema this client
does not speak. Lifting this needs a schema decision, not a client change.

Note: the CNG gateway does not serve `couchbase.analytics.v1` at all.
`gateway/system/system.go` registers kv, query, search, the four admin services,
xdcr and routing, and no analytics service, so every method on it answers
UNIMPLEMENTED -- observed as `unknown service
couchbase.analytics.v1.AnalyticsService`, which the client maps to
`feature_not_available`.

The live suite therefore covers what this client does before anything is sent --
a scope-qualified request is refused, an unsupported option is refused, an
exhausted budget is refused, and each refusal is stamped with the statement and
delivered on the io context rather than inline. Those three cases run and assert
against today's gateway. Only the end-to-end round trip skips, and it skips on
the gateway's own UNIMPLEMENTED message rather than on the bare error code, so
deleting this commit's routing turns it into a failure instead of a skip.

---
Stacked PR **15/29** in the CNG (`couchbase2://`) transport series. This branch includes every commit from PRs 01–15; the change specific to this PR is its top commit. Depends on #1036 — merge the series bottom-up.
