### PR TITLE
CXXCBC-899: route search and views over the couchbase2 streaming transport

### DIFF
--- a/.github/actions/create-cng-cluster/action.yml
+++ b/.github/actions/create-cng-cluster/action.yml
@@ -67,11 +67,18 @@ runs:
         # Single node: a GitHub-hosted runner has 4 vCPU / 16 GB, and the operator, the gateway and
         # a server pod all have to fit. The `docker:` memory block that create-cluster uses is
         # ignored by the cao deployer, so quotas stay at the server defaults (256 MB).
+        #
+        # fts is in the list because the live search case needs a search service to answer, not an
+        # index. It queries an index that was never created and accepts the gateway's
+        # index-not-found, which is an answer only a cluster running fts can give; without the
+        # service the request fails as an internal error instead and the case goes red. No index is
+        # built here, so the default search quota is enough -- one that has to serve queries needs
+        # considerably more, which is a problem for whoever adds search index management.
         CLUSTER_CONFIG: |
           nodes:
             - count: 1
               version: ${{ inputs.version }}
-              services: [kv, n1ql, index]
+              services: [kv, n1ql, index, fts]
           cao:
             operator-version: "${{ inputs.operator-version }}"
             gateway-version: "${{ inputs.gateway-version }}"

--- a/core/cluster.cxx
+++ b/core/cluster.cxx
@@ -774,12 +774,14 @@ public:
 #ifdef COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2
     if (auto component = protostellar_component(); component) {
       if constexpr (std::is_same_v<Request, operations::query_request> ||
-                    std::is_same_v<Request, operations::analytics_request>) {
+                    std::is_same_v<Request, operations::analytics_request> ||
+                    std::is_same_v<Request, operations::search_request> ||
+                    std::is_same_v<Request, operations::document_view_request>) {
         component->execute(std::move(request), std::forward<Handler>(handler));
         return;
       } else {
-        // Search/views/management over couchbase2 are not wired yet. Reject cleanly rather than
-        // falling through to the MCBP session manager, which is never bootstrapped on this path.
+        // Management over couchbase2 is not wired yet. Reject cleanly rather than falling through
+        // to the MCBP session manager, which is never bootstrapped on this path.
         return handler(
           request.make_response({ errc::common::feature_not_available }, response_type{}));
       }
@@ -936,11 +938,14 @@ public:
       const std::scoped_lock lock(protostellar_mutex_);
       protostellar_ = std::make_shared<protostellar::component>(
         ctx_,
-        protostellar::component_config{ std::move(channel),
-                                        origin_.credentials(),
-                                        options.key_value_timeout,
-                                        options.query_timeout,
-                                        options.analytics_timeout });
+        protostellar::component_config{
+          std::move(channel), origin_.credentials(), protostellar::component_timeouts {
+            options.key_value_timeout,
+            options.query_timeout,
+            options.analytics_timeout,
+            options.search_timeout,
+            options.view_timeout
+          } });
     }
     CB_LOG_INFO(R"(open couchbase2 cluster, id: "{}", endpoint: "{}")", id_, endpoint);
     return handler({});

--- a/core/error_context/search.hxx
+++ b/core/error_context/search.hxx
@@ -35,6 +35,11 @@ struct search {
   std::string query{};
   std::optional<std::string> parameters{};
 
+  // The message the service reported, when it reported one. Over couchbase2 this is the gRPC
+  // status message, which is the only error detail that transport carries -- http_status and
+  // http_body stay empty there.
+  std::string first_error_message{};
+
   std::string method{};
   std::string path{};
   std::uint32_t http_status{};

--- a/core/error_context/search_json.hxx
+++ b/core/error_context/search_json.hxx
@@ -48,6 +48,9 @@ struct traits<couchbase::core::error_context::search> {
     if (const auto& val = ctx.parameters; val.has_value()) {
       v["parameters"] = val.value();
     }
+    if (!ctx.first_error_message.empty()) {
+      v["first_error_message"] = ctx.first_error_message;
+    }
     if (const auto& reasons = ctx.retry_reasons; !reasons.empty()) {
       tao::json::value reasons_json = tao::json::empty_array;
       for (const auto& reason : reasons) {

--- a/core/error_context/view.hxx
+++ b/core/error_context/view.hxx
@@ -36,6 +36,11 @@ struct view {
   std::string view_name{};
   std::vector<std::string> query_string{};
 
+  // The message the service reported, when it reported one. Over couchbase2 this is the gRPC
+  // status message, which is the only error detail that transport carries -- http_status and
+  // http_body stay empty there.
+  std::string first_error_message{};
+
   std::string method{};
   std::string path{};
   std::uint32_t http_status{};

--- a/core/protostellar/component.cxx
+++ b/core/protostellar/component.cxx
@@ -20,6 +20,8 @@
 #include "core/error_context/analytics.hxx"
 #include "core/error_context/key_value.hxx"
 #include "core/error_context/query.hxx"
+#include "core/error_context/search.hxx"
+#include "core/error_context/view.hxx"
 #include "core/operations/analytics_response_parsing.hxx"
 #include "core/operations/query_response_parsing.hxx"
 #include "core/protostellar/analytics_converter.hxx"
@@ -27,6 +29,8 @@
 #include "core/protostellar/error_utils.hxx"
 #include "core/protostellar/kv_converter.hxx"
 #include "core/protostellar/query_converter.hxx"
+#include "core/protostellar/search_converter.hxx"
+#include "core/protostellar/view_converter.hxx"
 
 #include <couchbase/error_codes.hxx>
 
@@ -34,6 +38,8 @@
 #include <couchbase/analytics/v1/analytics.grpc.pb.h>
 
 #include <couchbase/kv/v1/kv.grpc.pb.h>
+#include <couchbase/search/v1/search.grpc.pb.h>
+#include <couchbase/view/v1/view.grpc.pb.h>
 
 #include <asio/post.hpp>
 
@@ -51,6 +57,8 @@ namespace couchbase::core::protostellar
 namespace v1 = ::couchbase::kv::v1;
 namespace query_v1 = ::couchbase::query::v1;
 namespace analytics_v1 = ::couchbase::analytics::v1;
+namespace search_v1 = ::couchbase::search::v1;
+namespace view_v1 = ::couchbase::view::v1;
 
 // Defined here rather than in the header so the generated gRPC types stay out of every consumer of
 // component.hxx.
@@ -58,6 +66,8 @@ struct component::stubs {
   std::unique_ptr<v1::KvService::Stub> kv;
   std::unique_ptr<query_v1::QueryService::Stub> query;
   std::unique_ptr<analytics_v1::AnalyticsService::Stub> analytics;
+  std::unique_ptr<search_v1::SearchService::Stub> search;
+  std::unique_ptr<view_v1::ViewService::Stub> view;
 };
 
 namespace
@@ -104,14 +114,13 @@ fail_expired_ctx(asio::io_context& io, Handler& handler, Response response) -> p
 
 component::component(asio::io_context& io, component_config config)
   : io_{ io }
-  , stubs_{ std::make_unique<stubs>(
-      stubs{ v1::KvService::NewStub(config.channel),
-             query_v1::QueryService::NewStub(config.channel),
-             analytics_v1::AnalyticsService::NewStub(config.channel) }) }
+  , stubs_{ std::make_unique<stubs>(stubs{ v1::KvService::NewStub(config.channel),
+                                           query_v1::QueryService::NewStub(config.channel),
+                                           analytics_v1::AnalyticsService::NewStub(config.channel),
+                                           search_v1::SearchService::NewStub(config.channel),
+                                           view_v1::ViewService::NewStub(config.channel) }) }
   , authorization_{ authorization_header(config.credentials) }
-  , default_kv_timeout_{ config.default_kv_timeout }
-  , default_query_timeout_{ config.default_query_timeout }
-  , default_analytics_timeout_{ config.default_analytics_timeout }
+  , timeouts_{ config.timeouts }
   // Initialised last (see the declaration order in the header), so the channel can be moved in.
   , dispatcher_{ io, std::move(config.channel) }
 {
@@ -124,7 +133,7 @@ component::execute(operations::get_request request,
                    utils::movable_function<void(operations::get_response)>&& handler)
   -> pending_call
 {
-  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  const auto timeout = request.timeout.value_or(timeouts_.key_value);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
   }
@@ -159,7 +168,7 @@ component::execute(operations::get_projected_request request,
 {
   auto proto = std::make_shared<v1::GetRequest>(kv::encode(request));
   const auto id = request.id;
-  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  const auto timeout = request.timeout.value_or(timeouts_.key_value);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
   }
@@ -190,7 +199,7 @@ component::execute(operations::upsert_request request,
                    utils::movable_function<void(operations::upsert_response)>&& handler)
   -> pending_call
 {
-  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  const auto timeout = request.timeout.value_or(timeouts_.key_value);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
   }
@@ -220,7 +229,7 @@ component::execute(operations::insert_request request,
                    utils::movable_function<void(operations::insert_response)>&& handler)
   -> pending_call
 {
-  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  const auto timeout = request.timeout.value_or(timeouts_.key_value);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
   }
@@ -250,7 +259,7 @@ component::execute(operations::replace_request request,
                    utils::movable_function<void(operations::replace_response)>&& handler)
   -> pending_call
 {
-  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  const auto timeout = request.timeout.value_or(timeouts_.key_value);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
   }
@@ -280,7 +289,7 @@ component::execute(operations::remove_request request,
                    utils::movable_function<void(operations::remove_response)>&& handler)
   -> pending_call
 {
-  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  const auto timeout = request.timeout.value_or(timeouts_.key_value);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
   }
@@ -312,7 +321,7 @@ component::execute(operations::touch_request request,
 {
   auto proto = std::make_shared<v1::TouchRequest>(kv::encode(request));
   const auto id = request.id;
-  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  const auto timeout = request.timeout.value_or(timeouts_.key_value);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
   }
@@ -341,7 +350,7 @@ component::execute(operations::exists_request request,
 {
   auto proto = std::make_shared<v1::ExistsRequest>(kv::encode(request));
   const auto id = request.id;
-  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  const auto timeout = request.timeout.value_or(timeouts_.key_value);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
   }
@@ -371,7 +380,7 @@ component::execute(operations::get_and_lock_request request,
 {
   auto proto = std::make_shared<v1::GetAndLockRequest>(kv::encode(request));
   const auto id = request.id;
-  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  const auto timeout = request.timeout.value_or(timeouts_.key_value);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
   }
@@ -405,7 +414,7 @@ component::execute(operations::unlock_request request,
 {
   auto proto = std::make_shared<v1::UnlockRequest>(kv::encode(request));
   const auto id = request.id;
-  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  const auto timeout = request.timeout.value_or(timeouts_.key_value);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
   }
@@ -435,7 +444,7 @@ component::execute(operations::get_and_touch_request request,
 {
   auto proto = std::make_shared<v1::GetAndTouchRequest>(kv::encode(request));
   const auto id = request.id;
-  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  const auto timeout = request.timeout.value_or(timeouts_.key_value);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
   }
@@ -506,7 +515,7 @@ component::execute(operations::increment_request request,
   }
   auto proto = std::make_shared<v1::IncrementRequest>(kv::encode(request));
   const auto id = request.id;
-  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  const auto timeout = request.timeout.value_or(timeouts_.key_value);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
   }
@@ -539,7 +548,7 @@ component::execute(operations::decrement_request request,
   }
   auto proto = std::make_shared<v1::DecrementRequest>(kv::encode(request));
   const auto id = request.id;
-  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  const auto timeout = request.timeout.value_or(timeouts_.key_value);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
   }
@@ -569,7 +578,7 @@ component::execute(operations::append_request request,
 {
   auto proto = std::make_shared<v1::AppendRequest>(kv::encode(request));
   const auto id = request.id;
-  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  const auto timeout = request.timeout.value_or(timeouts_.key_value);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
   }
@@ -599,7 +608,7 @@ component::execute(operations::prepend_request request,
 {
   auto proto = std::make_shared<v1::PrependRequest>(kv::encode(request));
   const auto id = request.id;
-  const auto timeout = request.timeout.value_or(default_kv_timeout_);
+  const auto timeout = request.timeout.value_or(timeouts_.key_value);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
   }
@@ -638,7 +647,7 @@ component::execute(operations::query_request request,
     return response;
   };
 
-  const auto timeout = request.timeout.value_or(default_query_timeout_);
+  const auto timeout = request.timeout.value_or(timeouts_.query);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired_ctx(io_, handler, stamped());
   }
@@ -742,7 +751,7 @@ component::execute(operations::analytics_request request,
     return response;
   };
 
-  const auto timeout = request.timeout.value_or(default_analytics_timeout_);
+  const auto timeout = request.timeout.value_or(timeouts_.analytics);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired_ctx(io_, handler, stamped());
   }
@@ -824,6 +833,140 @@ component::execute(operations::analytics_request request,
         response.ctx.ec = operations::map_analytics_error(response.meta);
       }
       handler(std::move(response));
+    });
+}
+
+auto
+component::execute(operations::search_request request,
+                   utils::movable_function<void(operations::search_response)>&& handler)
+  -> pending_call
+{
+  auto index_name = request.index_name;
+  auto query_str = request.query.str();
+  auto client_context_id = request.client_context_id.value_or(std::string{});
+  // Stamped even on the paths that send nothing, as the query overload does: the error context
+  // identifies which search failed, and a caller correlating by index or client_context_id has no
+  // other handle on it.
+  const auto stamped = [&index_name, &query_str, &client_context_id]() {
+    operations::search_response response;
+    response.ctx.index_name = index_name;
+    response.ctx.query = query_str;
+    response.ctx.client_context_id = client_context_id;
+    return response;
+  };
+
+  const auto timeout = request.timeout.value_or(timeouts_.search);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped());
+  }
+
+  // Unmappable query shape or gated feature (facets, sort specs, vector search, mutation tokens,
+  // raw): fail cleanly rather than dropping the caller's intent. A query that is not JSON at all is
+  // the caller's own error and is reported as invalid_argument, so a malformed query is not
+  // mistaken for a gap in couchbase2 search support.
+  auto encoded = search::encode(request);
+  if (!encoded.has_value()) {
+    auto response = stamped();
+    response.ctx.ec = search::query_is_malformed(request) ? errc::common::invalid_argument
+                                                          : errc::common::feature_not_available;
+    // Posted rather than invoked here, for the reason fail_expired above gives: completions arrive
+    // on the io context, never inline out of execute().
+    asio::post(io_, [handler = std::move(handler), response = std::move(response)]() mutable {
+      handler(std::move(response));
+    });
+    return {};
+  }
+
+  auto proto = std::make_shared<search_v1::SearchQueryRequest>(std::move(*encoded));
+  const auto auth = authorization_;
+  auto* stub = stubs_->search.get();
+  auto response = std::make_shared<operations::search_response>();
+
+  return dispatcher_.server_stream<search_v1::SearchQueryResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        grpc::ClientReadReactor<search_v1::SearchQueryResponse>* reactor) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->SearchQuery(&ctx, proto.get(), reactor);
+    },
+    [response](search_v1::SearchQueryResponse message) {
+      search::decode(message, *response);
+    },
+    [handler = std::move(handler), response, proto, index_name, query_str, client_context_id](
+      grpc::Status status) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      response->ctx.ec = map_status(status, operation_kind::read_only);
+      response->ctx.first_error_message = error_message(status);
+      response->ctx.index_name = std::move(index_name);
+      response->ctx.query = std::move(query_str);
+      response->ctx.client_context_id = std::move(client_context_id);
+      handler(std::move(*response));
+    });
+}
+
+auto
+component::execute(operations::document_view_request request,
+                   utils::movable_function<void(operations::document_view_response)>&& handler)
+  -> pending_call
+{
+  auto design_document = request.document_name;
+  auto view_name = request.view_name;
+  auto client_context_id = request.client_context_id.value_or(std::string{});
+  // Stamped on every path for the reason the query and search overloads give: a response naming no
+  // view leaves the caller nothing to correlate the failure with.
+  const auto stamped = [&design_document, &view_name, &client_context_id]() {
+    operations::document_view_response response;
+    response.ctx.design_document_name = design_document;
+    response.ctx.view_name = view_name;
+    response.ctx.client_context_id = client_context_id;
+    return response;
+  };
+
+  const auto timeout = request.timeout.value_or(timeouts_.view);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped());
+  }
+
+  // raw / query_string / full_set have no couchbase2 mapping: fail cleanly.
+  if (!view::can_encode(request)) {
+    auto response = stamped();
+    response.ctx.ec = errc::common::feature_not_available;
+    // Posted rather than invoked here, for the reason fail_expired above gives: completions arrive
+    // on the io context, never inline out of execute().
+    asio::post(io_, [handler = std::move(handler), response = std::move(response)]() mutable {
+      handler(std::move(response));
+    });
+    return {};
+  }
+
+  auto proto = std::make_shared<view_v1::ViewQueryRequest>(view::encode(request));
+  const auto auth = authorization_;
+  auto* stub = stubs_->view.get();
+  auto response = std::make_shared<operations::document_view_response>();
+
+  return dispatcher_.server_stream<view_v1::ViewQueryResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        grpc::ClientReadReactor<view_v1::ViewQueryResponse>* reactor) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->ViewQuery(&ctx, proto.get(), reactor);
+    },
+    [response](view_v1::ViewQueryResponse message) {
+      view::decode_rows(message, *response);
+    },
+    [handler = std::move(handler), response, proto, design_document, view_name, client_context_id](
+      grpc::Status status) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      response->ctx.ec = map_status(status, operation_kind::read_only);
+      response->ctx.first_error_message = error_message(status);
+      response->ctx.design_document_name = std::move(design_document);
+      response->ctx.view_name = std::move(view_name);
+      response->ctx.client_context_id = std::move(client_context_id);
+      handler(std::move(*response));
     });
 }
 

--- a/core/protostellar/component.hxx
+++ b/core/protostellar/component.hxx
@@ -17,6 +17,13 @@
 
 #pragma once
 
+// Views are deprecated in the core API but still routable over couchbase2, so the component names
+// document_view_request in its interface. Suppress the core-deprecation attribute for this header's
+// includes and declarations (portable convention shared with cluster.cxx). push/pop the macro so an
+// including translation unit that already defined it keeps its state restored.
+#pragma push_macro("COUCHBASE_CXX_CLIENT_IGNORE_CORE_DEPRECATIONS")
+#define COUCHBASE_CXX_CLIENT_IGNORE_CORE_DEPRECATIONS
+
 // The Protostellar KV component: the couchbase2 counterpart to the MCBP data-plane. It owns the
 // gRPC stubs over a channel and executes core KV operations by encoding the request (kv_converter),
 // dispatching it through the gRPC<->asio bridge, and decoding the reply plus a mapped error
@@ -37,9 +44,11 @@
 #include "core/operations/document_query.hxx"
 #include "core/operations/document_remove.hxx"
 #include "core/operations/document_replace.hxx"
+#include "core/operations/document_search.hxx"
 #include "core/operations/document_touch.hxx"
 #include "core/operations/document_unlock.hxx"
 #include "core/operations/document_upsert.hxx"
+#include "core/operations/document_view.hxx"
 #include "core/protostellar/dispatcher.hxx"
 #include "core/timeout_defaults.hxx"
 #include "core/utils/movable_function.hxx"
@@ -53,6 +62,18 @@
 namespace couchbase::core::protostellar
 {
 
+// Per-service defaults, used when a request does not carry its own timeout. Each field is defaulted
+// from timeout_defaults rather than left value-initialised: a zero here no longer means "no limit"
+// but "budget already spent", so a default-constructed aggregate would reject every request that
+// relies on the default instead of running it.
+struct component_timeouts {
+  std::chrono::milliseconds key_value{ timeout_defaults::key_value_timeout };
+  std::chrono::milliseconds query{ timeout_defaults::query_timeout };
+  std::chrono::milliseconds analytics{ timeout_defaults::analytics_timeout };
+  std::chrono::milliseconds search{ timeout_defaults::search_timeout };
+  std::chrono::milliseconds view{ timeout_defaults::view_timeout };
+};
+
 // Construction parameters for `component`, grouped so that adding one is a source-compatible
 // change. Every field a caller can reasonably omit carries a default, so a new trailing field
 // leaves existing initialisers compiling instead of silently shifting a positional argument onto
@@ -61,9 +82,7 @@ namespace couchbase::core::protostellar
 struct component_config {
   std::shared_ptr<grpc::Channel> channel{};
   cluster_credentials credentials{};
-  std::chrono::milliseconds default_kv_timeout{ timeout_defaults::key_value_timeout };
-  std::chrono::milliseconds default_query_timeout{ timeout_defaults::query_timeout };
-  std::chrono::milliseconds default_analytics_timeout{ timeout_defaults::analytics_timeout };
+  component_timeouts timeouts{};
 };
 
 // The core KV request types the component can execute over couchbase2. cluster_impl routes only
@@ -100,6 +119,9 @@ template<>
 inline constexpr bool component_supports_v<operations::append_request> = true;
 template<>
 inline constexpr bool component_supports_v<operations::prepend_request> = true;
+
+// Default per-service operation timeouts applied when a request does not carry its own. Grouped in
+// a struct so adding a service does not grow the component constructor's positional argument list.
 
 class component
 {
@@ -166,6 +188,16 @@ public:
                utils::movable_function<void(operations::analytics_response)>&& handler)
     -> pending_call;
 
+  // FTS search over the couchbase2 server-streaming transport. Hits are buffered into the response.
+  auto execute(operations::search_request request,
+               utils::movable_function<void(operations::search_response)>&& handler)
+    -> pending_call;
+
+  // Map/reduce views over the couchbase2 server-streaming transport.
+  auto execute(operations::document_view_request request,
+               utils::movable_function<void(operations::document_view_response)>&& handler)
+    -> pending_call;
+
 private:
   // The generated gRPC stubs are held behind an opaque pointer so the generated protobuf and gRPC
   // surface stays out of every translation unit that includes this header -- none of it appears in
@@ -175,12 +207,12 @@ private:
   asio::io_context& io_;
   std::unique_ptr<stubs> stubs_;
   std::string authorization_;
-  std::chrono::milliseconds default_kv_timeout_;
-  std::chrono::milliseconds default_query_timeout_;
-  std::chrono::milliseconds default_analytics_timeout_;
+  component_timeouts timeouts_;
   // Declared last, so it is destroyed first: ~dispatcher() cancels and drains the calls issued
   // through the stubs above, which must therefore still be alive while it runs.
   dispatcher dispatcher_;
 };
 
 } // namespace couchbase::core::protostellar
+
+#pragma pop_macro("COUCHBASE_CXX_CLIENT_IGNORE_CORE_DEPRECATIONS")

--- a/core/protostellar/search_converter.hxx
+++ b/core/protostellar/search_converter.hxx
@@ -1,0 +1,240 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+// Translates the core FTS search request/response to and from couchbase.search.v1. Hits arrive
+// across streamed SearchQueryResponse messages and are buffered into search_response::rows; the
+// terminal message carries the metadata.
+//
+// The couchbase2 SearchQueryRequest models the FTS query as a structured `Query` oneof of 21 types,
+// whereas the core request carries an opaque pre-serialized JSON `query`. This converter translates
+// the trivial forms -- query_string (optionally boosted), match_all and match_none -- and reports
+// every other shape as unmappable so the component surfaces feature_not_available. Structured
+// facets, structured sort specs, vector search, mutation-token consistency, and the `raw`
+// passthrough have no couchbase2 home and are likewise gated. Translating the remaining eighteen
+// query arms is a follow-up; the gate is what keeps an untranslated one from being dropped in
+// silence in the meantime.
+
+#include "core/operations/document_search.hxx"
+#include "core/utils/json.hxx"
+
+#include <couchbase/search/v1/search.pb.h>
+
+// core/utils/json.hxx only forward-declares tao::json::value; this header instantiates one and
+// calls its members, so it needs the full definition.
+#include <tao/json/value.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace couchbase::core::protostellar::search
+{
+namespace v1 = ::couchbase::search::v1;
+
+// Coarse, cheap gate for request features with no couchbase2 mapping. Query-shape support is
+// decided in encode() (which must parse the query JSON).
+[[nodiscard]] inline auto
+can_encode(const operations::search_request& request) -> bool
+{
+  return request.raw.empty() && request.facets.empty() && request.sort_specs.empty() &&
+         request.mutation_state.empty() && !request.vector_search.has_value() &&
+         !request.vector_query_combination.has_value() && !request.row_callback.has_value();
+}
+
+// True when request.query does not parse as JSON at all, as opposed to parsing into a shape this
+// converter does not translate. The component maps the two to different errors: a query the caller
+// failed to serialize is their own invalid_argument, not a gap in couchbase2 support.
+[[nodiscard]] inline auto
+query_is_malformed(const operations::search_request& request) -> bool
+{
+  try {
+    static_cast<void>(utils::json::parse(request.query));
+  } catch (...) {
+    return true;
+  }
+  return false;
+}
+
+// Translate the parsed core query JSON into the structured Query oneof, for the trivial forms only.
+// Returns false, leaving proto.query unset, for every shape this converter does not translate.
+[[nodiscard]] inline auto
+apply_query(const tao::json::value& parsed, v1::SearchQueryRequest& proto) -> bool
+{
+  if (!parsed.is_object()) {
+    return false;
+  }
+  // A boost is serialized beside the query key rather than inside it: query_string("foo").boost(2)
+  // encodes as {"query":"foo","boost":2}. Rejecting every two-key object would therefore make an
+  // ordinary boosted query unroutable, so a boost is read as a modifier of the recognized key.
+  // Whether it can actually be carried depends on the arm, and is decided below. Any other sibling
+  // (an analyzer, a field) would be lost in translation, so a wider object is reported as
+  // unmappable and the component surfaces feature_not_available.
+  const auto* boost = parsed.find("boost");
+  if (parsed.get_object().size() > (boost == nullptr ? 1U : 2U)) {
+    return false;
+  }
+  const auto* match_all = parsed.find("match_all");
+  const auto* match_none = parsed.find("match_none");
+  if (match_all != nullptr || match_none != nullptr) {
+    // MatchAllQuery and MatchNoneQuery are empty messages, so a boost on either has nowhere to go.
+    // Refusing the request keeps it from being run at a weight the caller did not ask for.
+    if (boost != nullptr) {
+      return false;
+    }
+    if (match_all != nullptr) {
+      proto.mutable_query()->mutable_match_all_query();
+    } else {
+      proto.mutable_query()->mutable_match_none_query();
+    }
+    return true;
+  }
+  if (const auto* q = parsed.find("query"); q != nullptr && q->is_string()) {
+    auto* query_string = proto.mutable_query()->mutable_query_string_query();
+    query_string->set_query_string(q->get_string());
+    if (boost != nullptr) {
+      if (!boost->is_number()) {
+        return false;
+      }
+      query_string->set_boost(static_cast<float>(boost->as<double>()));
+    }
+    return true;
+  }
+  return false;
+}
+
+// Encode the request; returns nullopt for a gated feature, an untranslated query shape, or a query
+// that is not JSON. The component separates the last case with query_is_malformed().
+[[nodiscard]] inline auto
+encode(const operations::search_request& request) -> std::optional<v1::SearchQueryRequest>
+{
+  if (!can_encode(request)) {
+    return std::nullopt;
+  }
+  v1::SearchQueryRequest proto;
+  proto.set_index_name(request.index_name);
+  if (request.bucket_name.has_value()) {
+    proto.set_bucket_name(*request.bucket_name);
+  }
+  if (request.scope_name.has_value()) {
+    proto.set_scope_name(*request.scope_name);
+  }
+  tao::json::value parsed;
+  try {
+    parsed = utils::json::parse(request.query);
+  } catch (...) {
+    return std::nullopt;
+  }
+  if (!apply_query(parsed, proto)) {
+    return std::nullopt;
+  }
+  if (request.limit.has_value()) {
+    proto.set_limit(*request.limit);
+  }
+  if (request.skip.has_value()) {
+    proto.set_skip(*request.skip);
+  }
+  if (request.explain.value_or(false)) {
+    proto.set_include_explanation(true);
+  }
+  proto.set_disable_scoring(request.disable_scoring);
+  proto.set_include_locations(request.include_locations);
+  proto.set_scan_consistency(v1::SearchQueryRequest_ScanConsistency_SCAN_CONSISTENCY_NOT_BOUNDED);
+  if (request.highlight_style.has_value()) {
+    proto.set_highlight_style(*request.highlight_style == search_highlight_style::ansi
+                                ? v1::SearchQueryRequest_HighlightStyle_HIGHLIGHT_STYLE_ANSI
+                                : v1::SearchQueryRequest_HighlightStyle_HIGHLIGHT_STYLE_HTML);
+  }
+  for (const auto& field : request.highlight_fields) {
+    proto.add_highlight_fields(field);
+  }
+  for (const auto& field : request.fields) {
+    proto.add_fields(field);
+  }
+  for (const auto& collection : request.collections) {
+    proto.add_collections(collection);
+  }
+  return proto;
+}
+
+// Append the hits from one streamed message onto the buffered response and, if present, decode the
+// terminal metadata. Structured facets are gated by can_encode(), so a response cannot carry any.
+inline void
+decode(const v1::SearchQueryResponse& message, operations::search_response& response)
+{
+  for (const auto& hit : message.hits()) {
+    operations::search_response::search_row row;
+    row.index = hit.index();
+    row.id = hit.id();
+    row.score = hit.score();
+    row.explanation = hit.explanation();
+    for (const auto& [field, fragment] : hit.fragments()) {
+      row.fragments[field] =
+        std::vector<std::string>{ fragment.content().begin(), fragment.content().end() };
+    }
+    // The proto keys each requested field to its value as raw JSON, whereas the core row carries
+    // the whole set as one JSON object, so the object is reassembled here.
+    if (!hit.fields().empty()) {
+      tao::json::value fields = tao::json::empty_object;
+      for (const auto& [name, value] : hit.fields()) {
+        try {
+          fields[name] = utils::json::parse(value);
+        } catch (...) {
+          // decode() runs on the io_context out of a stream callback, where an escaping exception
+          // would take down the loop. A value that is not JSON is kept verbatim as a string so the
+          // field still reaches the caller.
+          fields[name] = value;
+        }
+      }
+      row.fields = utils::json::generate(fields);
+    }
+    for (const auto& location : hit.locations()) {
+      operations::search_response::search_location out;
+      out.field = location.field();
+      out.term = location.term();
+      out.position = location.position();
+      out.start_offset = location.start();
+      out.end_offset = location.end();
+      if (location.array_positions_size() > 0) {
+        out.array_positions = std::vector<std::uint64_t>{ location.array_positions().begin(),
+                                                          location.array_positions().end() };
+      }
+      row.locations.push_back(std::move(out));
+    }
+    response.rows.push_back(std::move(row));
+  }
+  if (message.has_meta_data()) {
+    const auto& meta = message.meta_data();
+    if (meta.has_metrics()) {
+      const auto& m = meta.metrics();
+      response.meta.metrics.took = std::chrono::seconds{ m.execution_time().seconds() } +
+                                   std::chrono::nanoseconds{ m.execution_time().nanos() };
+      response.meta.metrics.total_rows = m.total_rows();
+      response.meta.metrics.max_score = m.max_score();
+      response.meta.metrics.success_partition_count = m.success_partition_count();
+      response.meta.metrics.error_partition_count = m.error_partition_count();
+    }
+    for (const auto& [location, msg] : meta.errors()) {
+      response.meta.errors.try_emplace(location, msg);
+    }
+  }
+}
+
+} // namespace couchbase::core::protostellar::search

--- a/core/protostellar/view_converter.hxx
+++ b/core/protostellar/view_converter.hxx
@@ -1,0 +1,158 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+// Views are deprecated in the core API but still routable over couchbase2; suppress the core
+// deprecation attribute for this header. push/pop the macro so an including translation unit that
+// already defined it keeps its state restored, rather than having it clobbered at the bottom.
+#pragma push_macro("COUCHBASE_CXX_CLIENT_IGNORE_CORE_DEPRECATIONS")
+#define COUCHBASE_CXX_CLIENT_IGNORE_CORE_DEPRECATIONS
+
+// Translates the core map/reduce view request/response to and from couchbase.view.v1. Rows arrive
+// across streamed ViewQueryResponse messages and are buffered into document_view_response::rows;
+// the terminal message carries the metadata.
+//
+// The couchbase2 ViewQueryRequest has no home for the core request's `raw`, `query_string`,
+// `full_set`, or streaming `row_callback` fields; can_encode() reports those so the component
+// surfaces feature_not_available rather than silently dropping them. The proto `limit`/`skip` are
+// uint32 while core carries uint64, so can_encode() also rejects values that would truncate.
+// `client_context_id`/`timeout` likewise have no proto field but do not change results, so they are
+// simply not sent.
+
+#include "core/operations/document_view.hxx"
+
+#include <couchbase/view/v1/view.pb.h>
+
+#include <cstdint>
+#include <limits>
+#include <string>
+
+namespace couchbase::core::protostellar::view
+{
+namespace v1 = ::couchbase::view::v1;
+
+[[nodiscard]] inline auto
+can_encode(const operations::document_view_request& request) -> bool
+{
+  constexpr auto u32_max = (std::numeric_limits<std::uint32_t>::max)();
+  return request.raw.empty() && request.query_string.empty() && !request.full_set.value_or(false) &&
+         !request.row_callback.has_value() && request.limit.value_or(0) <= u32_max &&
+         request.skip.value_or(0) <= u32_max;
+}
+
+inline auto
+encode(const operations::document_view_request& request) -> v1::ViewQueryRequest
+{
+  v1::ViewQueryRequest proto;
+  proto.set_bucket_name(request.bucket_name);
+  proto.set_design_document_name(request.document_name);
+  proto.set_view_name(request.view_name);
+  proto.set_namespace_(request.ns == design_document_namespace::development
+                         ? v1::ViewQueryRequest_Namespace_NAMESPACE_DEVELOPMENT
+                         : v1::ViewQueryRequest_Namespace_NAMESPACE_PRODUCTION);
+
+  for (const auto& key : request.keys) {
+    proto.add_keys(key);
+  }
+  if (request.key.has_value()) {
+    proto.set_key(*request.key);
+  }
+  if (request.start_key.has_value()) {
+    proto.set_start_key(*request.start_key);
+  }
+  if (request.end_key.has_value()) {
+    proto.set_end_key(*request.end_key);
+  }
+  if (request.start_key_doc_id.has_value()) {
+    proto.set_start_key_doc_id(*request.start_key_doc_id);
+  }
+  if (request.end_key_doc_id.has_value()) {
+    proto.set_end_key_doc_id(*request.end_key_doc_id);
+  }
+  if (request.limit.has_value()) {
+    proto.set_limit(static_cast<std::uint32_t>(*request.limit));
+  }
+  if (request.skip.has_value()) {
+    proto.set_skip(static_cast<std::uint32_t>(*request.skip));
+  }
+  if (request.reduce.has_value()) {
+    proto.set_reduce(*request.reduce);
+  }
+  if (request.group.has_value()) {
+    proto.set_group(*request.group);
+  }
+  if (request.group_level.has_value()) {
+    proto.set_group_level(*request.group_level);
+  }
+  if (request.inclusive_end.has_value()) {
+    proto.set_inclusive_end(*request.inclusive_end);
+  }
+  proto.set_debug(request.debug);
+  if (request.consistency.has_value()) {
+    switch (*request.consistency) {
+      case view_scan_consistency::not_bounded:
+        proto.set_scan_consistency(
+          v1::ViewQueryRequest_ScanConsistency_SCAN_CONSISTENCY_NOT_BOUNDED);
+        break;
+      case view_scan_consistency::update_after:
+        proto.set_scan_consistency(
+          v1::ViewQueryRequest_ScanConsistency_SCAN_CONSISTENCY_UPDATE_AFTER);
+        break;
+      case view_scan_consistency::request_plus:
+        proto.set_scan_consistency(
+          v1::ViewQueryRequest_ScanConsistency_SCAN_CONSISTENCY_REQUEST_PLUS);
+        break;
+    }
+  }
+  if (request.order.has_value()) {
+    proto.set_order(*request.order == view_sort_order::descending
+                      ? v1::ViewQueryRequest_Order_ORDER_DESCENDING
+                      : v1::ViewQueryRequest_Order_ORDER_ASCENDING);
+  }
+  if (request.on_error.has_value()) {
+    proto.set_on_error(*request.on_error == view_on_error::stop
+                         ? v1::ViewQueryRequest_ErrorMode_ERROR_MODE_STOP
+                         : v1::ViewQueryRequest_ErrorMode_ERROR_MODE_CONTINUE);
+  }
+  return proto;
+}
+
+// Append the rows from one streamed message onto the buffered response.
+inline void
+decode_rows(const v1::ViewQueryResponse& message, operations::document_view_response& response)
+{
+  for (const auto& row : message.rows()) {
+    operations::document_view_response::row out;
+    if (!row.id().empty()) {
+      out.id = row.id();
+    }
+    out.key = row.key();
+    out.value = row.value();
+    response.rows.push_back(std::move(out));
+  }
+  if (message.has_meta_data()) {
+    response.meta.total_rows = message.meta_data().total_rows();
+    if (!message.meta_data().debug().empty()) {
+      response.meta.debug_info = message.meta_data().debug();
+    }
+  }
+}
+
+} // namespace couchbase::core::protostellar::view
+
+#pragma pop_macro("COUCHBASE_CXX_CLIENT_IGNORE_CORE_DEPRECATIONS")

--- a/test/cng/CMakeLists.txt
+++ b/test/cng/CMakeLists.txt
@@ -146,4 +146,15 @@ if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 AND TARGET couchbase_cxx_protostellar)
 
   # Live Analytics query verification (CXXCBC-898).
   add_cng_test(protostellar/live_analytics LINK_CLIENT LIBS couchbase_cxx_protostellar)
+  # FTS search converter (CXXCBC-899).
+  add_cng_test(protostellar/search_converter LINK_CLIENT LIBS couchbase_cxx_protostellar)
+
+  # Views converter (CXXCBC-899).
+  add_cng_test(protostellar/view_converter LINK_CLIENT LIBS couchbase_cxx_protostellar)
+
+  # Live FTS search verification (CXXCBC-899).
+  add_cng_test(protostellar/live_search LINK_CLIENT LIBS couchbase_cxx_protostellar)
+
+  # Live Views verification (CXXCBC-899).
+  add_cng_test(protostellar/live_view LINK_CLIENT LIBS couchbase_cxx_protostellar)
 endif()

--- a/test/cng/README.md
+++ b/test/cng/README.md
@@ -95,8 +95,9 @@ outside contributor can actually pull.
 
 There is deliberately no `docker:` memory block here: the `cao` deployer ignores it, so service
 quotas stay at the server defaults regardless. That is also why the bucket below is created with a
-small explicit quota. The four nodes cover every service the suite can touch; if you only need KV
-and query, a single `services: [kv, n1ql, index]` node is enough, which is what CI allocates.
+small explicit quota. The four nodes cover every service the suite can touch, and `fts` has to be
+among them or the live search case fails rather than reporting a missing index. CI puts all of
+`kv, n1ql, index, fts` on one node, which is the smallest topology the suite runs against.
 
 Other `cao` keys cbdinocluster understands include `username` / `password` (default
 `Administrator` / `password`) and `gateway-log-level`.
@@ -183,6 +184,23 @@ be overridden:
 | `TEST_CB2_USERNAME` | `Administrator` | must be able to read and write the bucket below |
 | `TEST_CB2_PASSWORD` | `password` | |
 | `TEST_CB2_BUCKET` | `default` | must already exist; the tests do not create it |
+| `TEST_CB2_SEARCH_INDEX` | `cng-index` | the FTS index the live search case queries; see below |
+
+`TEST_CB2_SEARCH_INDEX` needs a word of its own, because the walkthrough above does **not** create
+an FTS index. The live search case still passes without one: it accepts either hits or
+`index_not_found`, and the latter is an answer only a gateway that ran the query can give, so the
+round trip is proven either way.
+
+What it does need is a cluster **running the search service** — the definition above has an `fts`
+node for that reason. Query a cluster without one and the request fails as an internal error rather
+than as a missing index, because there is no service to report the index missing, and the case goes
+red for a reason that has nothing to do with the client.
+
+What it cannot do without an index is exercise hit decoding — fragments, field values and locations
+all go untested against a real server. An index named `cng-index` over the test bucket, or this
+variable pointed at one you already have, covers that; note that an index only serves queries once
+the search service has the memory to build a partition for it, which the operator's default quota
+does not provide.
 
 Point the suite at a shared cluster, or at one whose credentials differ from cbdinocluster's, and
 these are what you set:

--- a/test/cng/framework/live_fixture.hxx
+++ b/test/cng/framework/live_fixture.hxx
@@ -62,6 +62,13 @@
 namespace couchbase::cng::test
 {
 
+// safe_getenv, not std::getenv: MSVC deprecates getenv (C4996) and these builds are -Werror.
+[[nodiscard]] inline auto
+env_or(const char* name, const char* fallback) -> std::string
+{
+  return safe_getenv(name).value_or(fallback);
+}
+
 // RAII owner of the io_context worker thread the live tests run against. It keeps a work guard so
 // io_context::run() stays alive on a dedicated thread, and on scope exit -- normal OR via an
 // assertion/skip exception -- it releases the guard and joins the thread. Declare it after the
@@ -212,11 +219,6 @@ public:
   }
 
 private:
-  [[nodiscard]] static auto env_or(const char* name, const char* fallback) -> std::string
-  {
-    return safe_getenv(name).value_or(fallback);
-  }
-
   asio::io_context io_{};
   // Declared after io_ and before component_: the component drains its gRPC calls as it is
   // destroyed, which needs the io thread still running, and the guard joins it afterwards.
@@ -324,11 +326,6 @@ public:
   }
 
 private:
-  [[nodiscard]] static auto env_or(const char* name, const char* fallback) -> std::string
-  {
-    return safe_getenv(name).value_or(fallback);
-  }
-
   asio::io_context io_{};
   // io_ -> runner_ -> cluster_, so the cluster tears down while the io thread is still running
   // and the thread is joined afterwards.

--- a/test/cng/protostellar/component.cxx
+++ b/test/cng/protostellar/component.cxx
@@ -229,7 +229,7 @@ get_round_trips_on_the_io_thread()
   in_process_server server;
   asio::io_context io;
   auto work = asio::make_work_guard(io);
-  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, { 5000ms } } };
 
   ops::get_request request;
   request.id = make_id("k1");
@@ -255,7 +255,7 @@ get_maps_not_found_into_the_error_context()
   in_process_server server;
   asio::io_context io;
   auto work = asio::make_work_guard(io);
-  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, { 5000ms } } };
 
   ops::get_request request;
   request.id = make_id("missing");
@@ -277,7 +277,7 @@ upsert_returns_cas_and_mutation_token()
   in_process_server server;
   asio::io_context io;
   auto work = asio::make_work_guard(io);
-  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, { 5000ms } } };
 
   ops::upsert_request request;
   request.id = make_id("k1");
@@ -302,7 +302,7 @@ get_handles_compressed_content_with_feature_not_available()
   in_process_server server;
   asio::io_context io;
   auto work = asio::make_work_guard(io);
-  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, { 5000ms } } };
 
   ops::get_request request;
   request.id = make_id("compressed");
@@ -324,7 +324,7 @@ insert_returns_cas_and_mutation_token()
   in_process_server server;
   asio::io_context io;
   auto work = asio::make_work_guard(io);
-  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, { 5000ms } } };
 
   ops::insert_request request;
   request.id = make_id("k1");
@@ -349,7 +349,7 @@ insert_maps_already_exists_into_error_context()
   in_process_server server;
   asio::io_context io;
   auto work = asio::make_work_guard(io);
-  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, { 5000ms } } };
 
   ops::insert_request request;
   request.id = make_id("exists");
@@ -372,7 +372,7 @@ replace_returns_cas_and_mutation_token()
   in_process_server server;
   asio::io_context io;
   auto work = asio::make_work_guard(io);
-  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, { 5000ms } } };
 
   ops::replace_request request;
   request.id = make_id("k1");
@@ -397,7 +397,7 @@ replace_maps_not_found_into_error_context()
   in_process_server server;
   asio::io_context io;
   auto work = asio::make_work_guard(io);
-  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, { 5000ms } } };
 
   ops::replace_request request;
   request.id = make_id("missing");
@@ -420,7 +420,7 @@ remove_returns_cas_and_mutation_token()
   in_process_server server;
   asio::io_context io;
   auto work = asio::make_work_guard(io);
-  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, { 5000ms } } };
 
   ops::remove_request request;
   request.id = make_id("k1");
@@ -444,7 +444,7 @@ remove_maps_not_found_into_error_context()
   in_process_server server;
   asio::io_context io;
   auto work = asio::make_work_guard(io);
-  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, { 5000ms } } };
 
   ops::remove_request request;
   request.id = make_id("missing");
@@ -470,7 +470,7 @@ authorization_header_passed_to_grpc_context()
   creds.username = "Administrator";
   creds.password = "password";
 
-  component comp{ io, component_config{ server.channel(), creds, 5000ms } };
+  component comp{ io, component_config{ server.channel(), creds, { 5000ms } } };
 
   ops::get_request request;
   request.id = make_id("k1");
@@ -504,7 +504,7 @@ get_honours_the_request_timeout()
   server.service().reply_delay.store(400ms);
   asio::io_context io;
   auto work = asio::make_work_guard(io);
-  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, { 5000ms } } };
 
   ops::get_request request;
   request.id = make_id("k1");
@@ -534,7 +534,7 @@ mutation_timeout_is_reported_as_ambiguous()
   server.service().reply_delay.store(400ms);
   asio::io_context io;
   auto work = asio::make_work_guard(io);
-  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, { 5000ms } } };
 
   ops::upsert_request request;
   request.id = make_id("k1");
@@ -565,7 +565,7 @@ an_exhausted_budget_is_rejected_before_dispatch()
   in_process_server server;
   asio::io_context io;
   auto work = asio::make_work_guard(io);
-  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, { 5000ms } } };
 
   ops::get_request request;
   request.id = make_id("k1");
@@ -600,7 +600,7 @@ an_exhausted_default_timeout_is_also_rejected()
   in_process_server server;
   asio::io_context io;
   auto work = asio::make_work_guard(io);
-  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 0ms } };
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, { 0ms } } };
 
   ops::remove_request request;
   request.id = make_id("k1");
@@ -664,7 +664,7 @@ cancellation_completes_the_handler_once()
   server.service().reply_delay.store(400ms);
   asio::io_context io;
   auto work = asio::make_work_guard(io);
-  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, { 5000ms } } };
 
   ops::get_request request;
   request.id = make_id("k1");
@@ -691,7 +691,7 @@ get_projected_encodes_projections_and_decodes_response()
   in_process_server server;
   asio::io_context io;
   auto work = asio::make_work_guard(io);
-  component comp{ io, component_config{ server.channel(), cluster_credentials{}, 5000ms } };
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, { 5000ms } } };
 
   ops::get_projected_request request;
   request.id = make_id("k1");

--- a/test/cng/protostellar/live_kv.cxx
+++ b/test/cng/protostellar/live_kv.cxx
@@ -105,8 +105,7 @@ kv_crud_round_trip_against_live_gateway()
   component_config config;
   config.channel = channel;
   config.credentials = credentials;
-  config.default_kv_timeout = 20000ms;
-  config.default_query_timeout = 20000ms;
+  config.timeouts = { 20000ms };
   component comp{ io, config };
 
   std::string failure;    // non-empty => the round-trip failed at some stage
@@ -202,8 +201,7 @@ insert_and_replace_round_trip_against_live_gateway()
   component_config config;
   config.channel = channel;
   config.credentials = credentials;
-  config.default_kv_timeout = 20000ms;
-  config.default_query_timeout = 20000ms;
+  config.timeouts = { 20000ms };
   component comp{ io, config };
 
   std::string failure;

--- a/test/cng/protostellar/live_search.cxx
+++ b/test/cng/protostellar/live_search.cxx
@@ -1,0 +1,164 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Live end-to-end test of FTS search over the couchbase2:// streaming transport (CXXCBC-899).
+//
+// The gateway serves search.v1, so the round trip is expected to reach it and come back with the
+// gateway's own answer. Asserting on a provisioned index would need index admin (CXXCBC-901), so
+// the round trip is pinned by the error the gateway returns for an index that does not exist:
+// that answer can only come from a gateway that ran the query.
+
+#include "framework/live_fixture.hxx"
+#include "framework/test_runner.hxx"
+
+#include "core/operations.hxx"
+
+#include "core/json_string.hxx"
+
+#include <couchbase/error_codes.hxx>
+
+#include <chrono>
+#include <string>
+#include <thread>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace ops = ::couchbase::core::operations;
+
+auto
+search(std::string query) -> ops::search_request
+{
+  ops::search_request request;
+  request.index_name = env_or("TEST_CB2_SEARCH_INDEX", "cng-index");
+  request.query = couchbase::core::json_string{ std::move(query) };
+  return request;
+}
+
+void
+search_round_trip_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  const auto result = fixture.execute(search(R"({"match_all":{}})"));
+
+  skip_unless_service_implemented(result.ctx, "search.v1");
+
+  // Either the index exists and the query ran, or it does not and the gateway says so. Both are
+  // answers from the search service; a transport that mis-encoded the request, or routing that
+  // never reached the gateway, produces neither.
+  assert_true(!result.ctx.ec || result.ctx.ec == errc::common::index_not_found,
+              "match_all over couchbase2 returns hits or a genuine index error");
+  if (result.ctx.ec) {
+    assert_false(result.ctx.first_error_message.empty(),
+                 "the index error carries the gateway's own message");
+  }
+}
+
+// An FTS query shape the converter does not translate must be refused before anything is sent. The
+// assertion on first_error_message is what separates this refusal from a gateway UNIMPLEMENTED --
+// the same signal skip_unless_service_implemented() relies on, so this case keeps that helper
+// honest for the search suite.
+void
+an_untranslated_query_shape_is_refused_by_the_client()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  const auto [result, handler_thread] = fixture.execute_on(search(R"({"term":"x","field":"f"})"));
+
+  assert_true(result.ctx.ec == errc::common::feature_not_available,
+              "a term query is refused rather than silently reshaped");
+  assert_true(result.rows.empty(), "nothing was executed");
+  assert_true(result.ctx.first_error_message.empty(),
+              "the refusal is the client's own, so it carries no gateway status message");
+  assert_true(handler_thread != std::this_thread::get_id(),
+              "the refusal is delivered on the io context, not inline out of execute()");
+}
+
+// A query that is not JSON is the caller's own error. Reporting it as feature_not_available would
+// tell them their cluster cannot do search, which is both wrong and unactionable.
+void
+a_malformed_query_is_reported_as_invalid_argument()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  const auto result = fixture.execute(search(R"({"match_all":)"));
+
+  assert_true(result.ctx.ec == errc::common::invalid_argument,
+              "malformed query JSON is an argument error, not a missing feature");
+  assert_true(result.rows.empty(), "nothing was executed");
+}
+
+// A budget that is already spent must not be dispatched, and the response must still say which
+// search it was: a caller correlating by index or client_context_id has no other handle on a
+// request that never reached the wire.
+void
+an_expired_budget_is_refused_on_the_io_context()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  auto request = search(R"({"match_all":{}})");
+  request.client_context_id = "cng-expired-search";
+  request.timeout = std::chrono::milliseconds::zero();
+  const auto [result, handler_thread] = fixture.execute_on(std::move(request));
+
+  assert_true(result.ctx.ec == errc::common::unambiguous_timeout,
+              "a spent budget is an unambiguous timeout: nothing reached the server");
+  assert_eq(result.ctx.index_name,
+            env_or("TEST_CB2_SEARCH_INDEX", "cng-index"),
+            "the expired response still identifies the index");
+  assert_eq(result.ctx.client_context_id,
+            std::string{ "cng-expired-search" },
+            "the expired response still carries the caller's context id");
+  assert_true(handler_thread != std::this_thread::get_id(),
+              "the expired response is delivered on the io context");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_live_search",
+    {
+      { "an_expired_budget_is_refused_on_the_io_context",
+        an_expired_budget_is_refused_on_the_io_context,
+        timeout::integration,
+        test_env::cluster_only },
+      { "search_round_trip_against_live_gateway",
+        search_round_trip_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "an_untranslated_query_shape_is_refused_by_the_client",
+        an_untranslated_query_shape_is_refused_by_the_client,
+        timeout::integration,
+        test_env::cluster_only },
+      { "a_malformed_query_is_reported_as_invalid_argument",
+        a_malformed_query_is_reported_as_invalid_argument,
+        timeout::integration,
+        test_env::cluster_only },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test

--- a/test/cng/protostellar/live_view.cxx
+++ b/test/cng/protostellar/live_view.cxx
@@ -1,0 +1,150 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Live end-to-end test of map/reduce views over the couchbase2:// streaming transport
+// (CXXCBC-899).
+//
+// The gateway registers no view service, so the round trip is expected to reach it and be declined
+// there. That is a skip rather than a failure -- but only when the gateway is what declined it:
+// skip_unless_service_implemented() requires the gRPC status message, so a client that stopped
+// routing views fails here instead of reporting "Skipped".
+
+#define COUCHBASE_CXX_CLIENT_IGNORE_CORE_DEPRECATIONS
+
+#include "framework/live_fixture.hxx"
+#include "framework/test_runner.hxx"
+
+#include "core/operations.hxx"
+#include "core/operations/document_view.hxx"
+
+#include <couchbase/error_codes.hxx>
+
+#include <chrono>
+#include <string>
+#include <thread>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace ops = ::couchbase::core::operations;
+
+auto
+view(const std::string& bucket) -> ops::document_view_request
+{
+  ops::document_view_request request;
+  request.bucket_name = bucket;
+  request.document_name = "cng";
+  request.view_name = "all";
+  return request;
+}
+
+void
+view_round_trip_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  const auto result = fixture.execute(view(fixture.bucket()));
+
+  skip_unless_service_implemented(result.ctx, "view.v1");
+
+  // Reached only against a gateway that serves view.v1, which no released gateway does, so the
+  // specific error for a missing design document is not pinned here -- asserting a mapping that
+  // cannot be exercised would be a guess. What is pinned is the provenance: any failure past this
+  // point carries the gateway's own status message, which a client-side refusal never has.
+  if (result.ctx.ec) {
+    assert_false(result.ctx.first_error_message.empty(),
+                 "the failure came from the view service, with its status message");
+  }
+}
+
+// A view option the schema cannot express must be refused before anything is sent. The assertion on
+// first_error_message is what separates this refusal from a gateway UNIMPLEMENTED -- the same
+// signal skip_unless_service_implemented() relies on, so this case keeps that helper honest for the
+// view suite. Without it the suite would consist of one case that always skips.
+void
+an_unsupported_option_is_refused_by_the_client()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  auto request = view(fixture.bucket());
+  request.full_set = true;
+  const auto [result, handler_thread] = fixture.execute_on(std::move(request));
+
+  assert_true(result.ctx.ec == errc::common::feature_not_available,
+              "full_set is refused rather than silently dropped");
+  assert_true(result.rows.empty(), "nothing was executed");
+  assert_true(result.ctx.first_error_message.empty(),
+              "the refusal is the client's own, so it carries no gateway status message");
+  assert_true(handler_thread != std::this_thread::get_id(),
+              "the refusal is delivered on the io context, not inline out of execute()");
+}
+
+// A spent budget is refused before anything is dispatched, and the response still names the view:
+// the failure has to be attributable to a request that never reached the wire.
+void
+an_expired_budget_is_refused_on_the_io_context()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  auto request = view(fixture.bucket());
+  request.client_context_id = "cng-expired-view";
+  request.timeout = std::chrono::milliseconds::zero();
+  const auto [result, handler_thread] = fixture.execute_on(std::move(request));
+
+  assert_true(result.ctx.ec == errc::common::unambiguous_timeout,
+              "a spent budget is an unambiguous timeout: nothing reached the server");
+  assert_eq(result.ctx.design_document_name,
+            std::string{ "cng" },
+            "the expired response still identifies the design document");
+  assert_eq(
+    result.ctx.view_name, std::string{ "all" }, "the expired response still names the view");
+  assert_eq(result.ctx.client_context_id,
+            std::string{ "cng-expired-view" },
+            "the expired response still carries the caller's context id");
+  assert_true(handler_thread != std::this_thread::get_id(),
+              "the expired response is delivered on the io context");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_live_view",
+    {
+      { "an_expired_budget_is_refused_on_the_io_context",
+        an_expired_budget_is_refused_on_the_io_context,
+        timeout::integration,
+        test_env::cluster_only },
+      { "view_round_trip_against_live_gateway",
+        view_round_trip_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "an_unsupported_option_is_refused_by_the_client",
+        an_unsupported_option_is_refused_by_the_client,
+        timeout::integration,
+        test_env::cluster_only },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test

--- a/test/cng/protostellar/search_converter.cxx
+++ b/test/cng/protostellar/search_converter.cxx
@@ -1,0 +1,314 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Unit tests for the FTS search <-> couchbase.search.v1 converter (CXXCBC-899). Pure, no
+// server. Only the trivial query forms are translated; everything else is reported as unmappable.
+
+#include "framework/test_runner.hxx"
+
+#include "core/protostellar/search_converter.hxx"
+
+#include "core/utils/json.hxx"
+
+#include <cstdint>
+#include <string>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace ps = ::couchbase::core::protostellar::search;
+namespace ops = ::couchbase::core::operations;
+namespace v1 = ::couchbase::search::v1;
+
+auto
+base_request() -> ops::search_request
+{
+  ops::search_request request;
+  request.index_name = "idx";
+  request.query = couchbase::core::json_string{ R"({"query":"foo"})" };
+  return request;
+}
+
+void
+encode_maps_envelope_and_query_string()
+{
+  auto request = base_request();
+  request.limit = 10;
+  request.skip = 5;
+  request.fields = { "name" };
+  request.collections = { "c1" };
+  request.include_locations = true;
+
+  const auto encoded = ps::encode(request);
+  assert_true(encoded.has_value(), "query_string request encodes");
+  assert_eq(encoded->index_name(), std::string{ "idx" }, "index_name mapped");
+  assert_eq(encoded->limit(), std::uint32_t{ 10 }, "limit mapped");
+  assert_eq(encoded->skip(), std::uint32_t{ 5 }, "skip mapped");
+  assert_true(encoded->include_locations(), "include_locations mapped");
+  assert_eq(encoded->fields_size(), 1, "fields mapped");
+  assert_eq(encoded->collections_size(), 1, "collections mapped");
+  assert_true(encoded->has_query(), "query set");
+  assert_true(encoded->query().has_query_string_query(), "query_string form");
+  assert_eq(encoded->query().query_string_query().query_string(),
+            std::string{ "foo" },
+            "query string carried");
+}
+
+void
+encode_maps_match_all_and_match_none()
+{
+  auto all = base_request();
+  all.query = couchbase::core::json_string{ R"({"match_all":{}})" };
+  const auto encoded_all = ps::encode(all);
+  assert_true(encoded_all.has_value() && encoded_all->query().has_match_all_query(),
+              "match_all mapped");
+
+  auto none = base_request();
+  none.query = couchbase::core::json_string{ R"({"match_none":{}})" };
+  const auto encoded_none = ps::encode(none);
+  assert_true(encoded_none.has_value() && encoded_none->query().has_match_none_query(),
+              "match_none mapped");
+}
+
+void
+encode_returns_nullopt_for_unmappable_query()
+{
+  auto request = base_request();
+  request.query = couchbase::core::json_string{ R"({"term":"x","field":"f"})" };
+  assert_false(ps::encode(request).has_value(), "structured term query is not yet mapped");
+
+  auto extra = base_request();
+  extra.query = couchbase::core::json_string{ R"({"query":"foo","analyzer":"standard"})" };
+  assert_false(ps::encode(extra).has_value(),
+               "a recognized query with an unmappable sibling key is not mapped");
+
+  // MatchAllQuery and MatchNoneQuery are empty proto messages, so a boost on either would be lost.
+  auto boosted_match_all = base_request();
+  boosted_match_all.query = couchbase::core::json_string{ R"({"match_all":{},"boost":2})" };
+  assert_false(ps::encode(boosted_match_all).has_value(),
+               "match_all cannot carry a boost, so a boosted one is refused rather than flattened");
+}
+
+// A boost is serialized beside the query key, so rejecting every two-key object would make
+// query_string("foo").boost(2) -- an ordinary supported query -- unroutable.
+void
+encode_maps_a_boosted_query_string()
+{
+  auto request = base_request();
+  request.query = couchbase::core::json_string{ R"({"query":"foo","boost":2.5})" };
+
+  const auto encoded = ps::encode(request);
+  assert_true(encoded.has_value(), "a boosted query_string encodes");
+  assert_eq(encoded->query().query_string_query().query_string(),
+            std::string{ "foo" },
+            "query string mapped alongside the boost");
+  assert_true(encoded->query().query_string_query().boost() == 2.5F, "boost mapped");
+}
+
+// Reported as invalid_argument by the component rather than feature_not_available: a query the
+// caller failed to serialize is their own error, not a gap in couchbase2 support.
+void
+malformed_query_json_is_distinguished_from_an_unmappable_shape()
+{
+  auto malformed = base_request();
+  malformed.query = couchbase::core::json_string{ R"({"match_all":)" };
+  assert_false(ps::encode(malformed).has_value(), "a malformed query does not encode");
+  assert_true(ps::query_is_malformed(malformed), "a malformed query is reported as malformed");
+
+  auto unmappable = base_request();
+  unmappable.query = couchbase::core::json_string{ R"({"term":"x","field":"f"})" };
+  assert_false(ps::query_is_malformed(unmappable),
+               "a well-formed query this converter cannot translate is not malformed");
+}
+
+void
+can_encode_rejects_gated_features()
+{
+  assert_true(ps::can_encode(base_request()), "plain search passes the coarse gate");
+
+  auto with_facets = base_request();
+  with_facets.facets.emplace("f", "{}");
+  assert_false(ps::can_encode(with_facets), "facets are gated");
+
+  auto with_sort = base_request();
+  with_sort.sort_specs = { R"("-_score")" };
+  assert_false(ps::can_encode(with_sort), "sort specs are gated");
+
+  auto with_vector = base_request();
+  with_vector.vector_search = couchbase::core::json_string{ "{}" };
+  assert_false(ps::can_encode(with_vector), "vector search is gated");
+
+  auto with_combo = base_request();
+  with_combo.vector_query_combination = couchbase::core::vector_query_combination::combination_and;
+  assert_false(ps::can_encode(with_combo), "vector query combination is gated");
+}
+
+void
+decode_maps_hits_and_metrics()
+{
+  v1::SearchQueryResponse message;
+  auto* hit = message.add_hits();
+  hit->set_id("doc-1");
+  hit->set_index("idx");
+  hit->set_score(1.5);
+  hit->set_explanation("why");
+  auto* loc = hit->add_locations();
+  loc->set_field("name");
+  loc->set_term("foo");
+  loc->set_position(2);
+  loc->set_start(3);
+  loc->set_end(6);
+  auto* metrics = message.mutable_meta_data()->mutable_metrics();
+  metrics->set_total_rows(42);
+  metrics->set_max_score(1.5);
+  metrics->set_success_partition_count(8);
+  metrics->mutable_execution_time()->set_nanos(500);
+
+  ops::search_response response;
+  ps::decode(message, response);
+
+  assert_eq(response.rows.size(), std::size_t{ 1 }, "one hit decoded");
+  assert_eq(response.rows.at(0).id, std::string{ "doc-1" }, "hit id decoded");
+  assert_true(response.rows.at(0).score == 1.5, "hit score decoded");
+  assert_eq(response.rows.at(0).locations.size(), std::size_t{ 1 }, "location decoded");
+  assert_eq(response.rows.at(0).locations.at(0).field, std::string{ "name" }, "location field");
+  assert_eq(response.meta.metrics.total_rows, std::uint64_t{ 42 }, "total_rows decoded");
+  assert_eq(response.meta.metrics.success_partition_count,
+            std::uint64_t{ 8 },
+            "success_partition_count decoded");
+}
+
+// An FTS query whose partitions did not all answer still returns the hits it has, and reports the
+// rest through the per-partition error map and the failed count. That is a successful response with
+// incomplete results on both transports, not an error: the HTTP path records the same two things
+// and leaves ctx.ec unset, so mapping them to an error code here would make couchbase2 fail a query
+// that couchbase:// answers. Carrying them is what lets a caller notice the results are partial.
+void
+decode_carries_partial_partition_failures()
+{
+  v1::SearchQueryResponse message;
+  auto* metrics = message.mutable_meta_data()->mutable_metrics();
+  metrics->set_success_partition_count(5);
+  metrics->set_error_partition_count(2);
+  (*message.mutable_meta_data()->mutable_errors())["pindex_3"] = "context deadline exceeded";
+  (*message.mutable_meta_data()->mutable_errors())["pindex_7"] = "pindex not available";
+
+  ops::search_response response;
+  ps::decode(message, response);
+
+  assert_eq(response.meta.metrics.error_partition_count,
+            std::uint64_t{ 2 },
+            "the failed partition count is carried");
+  assert_eq(response.meta.errors.size(), std::size_t{ 2 }, "both partition errors are carried");
+  assert_eq(response.meta.errors.at("pindex_7"),
+            std::string{ "pindex not available" },
+            "the partition's own message is carried verbatim");
+  assert_false(static_cast<bool>(response.ctx.ec),
+               "a partial result is not turned into an error, as on the HTTP path");
+}
+
+// can_encode() accepts highlight_style, highlight_fields and fields, so a response can carry
+// fragments and per-hit field values. Dropping them here would answer such a request with rows
+// whose highlighting is silently empty -- an outcome the caller cannot distinguish from a document
+// that simply had no match in that field.
+void
+decode_maps_fragments_fields_and_array_positions()
+{
+  v1::SearchQueryResponse message;
+  auto* hit = message.add_hits();
+  hit->set_id("doc-1");
+  (*hit->mutable_fragments())["name"].add_content("<em>foo</em> bar");
+  (*hit->mutable_fragments())["name"].add_content("baz <em>foo</em>");
+  // The gateway keys each requested field to its value as raw JSON.
+  (*hit->mutable_fields())["name"] = R"("foo")";
+  (*hit->mutable_fields())["age"] = "42";
+  auto* loc = hit->add_locations();
+  loc->set_field("name");
+  loc->set_term("foo");
+  loc->add_array_positions(1);
+  loc->add_array_positions(7);
+
+  ops::search_response response;
+  ps::decode(message, response);
+
+  const auto& row = response.rows.at(0);
+  assert_eq(row.fragments.size(), std::size_t{ 1 }, "fragment field decoded");
+  assert_eq(row.fragments.at("name").size(), std::size_t{ 2 }, "both fragments decoded");
+  assert_eq(row.fragments.at("name").at(0),
+            std::string{ "<em>foo</em> bar" },
+            "fragment content decoded in order");
+
+  // Reassembled as one JSON object, which is how the core row carries the field set.
+  const auto fields = couchbase::core::utils::json::parse(row.fields);
+  assert_eq(fields.at("name").get_string(), std::string{ "foo" }, "string field value decoded");
+  assert_eq(
+    fields.at("age").as<std::uint64_t>(), std::uint64_t{ 42 }, "numeric field stays a number");
+
+  const auto& positions = row.locations.at(0).array_positions;
+  assert_true(positions.has_value(), "array positions decoded");
+  assert_eq(positions->size(), std::size_t{ 2 }, "both array positions decoded");
+  assert_eq(positions->at(1), std::uint64_t{ 7 }, "array position value decoded");
+}
+
+// A hit with no highlighting must leave the row's optional members unset rather than carrying an
+// empty object, so a caller can tell "no fragments were requested" from "the field did not match".
+void
+decode_leaves_absent_fragments_and_positions_unset()
+{
+  v1::SearchQueryResponse message;
+  auto* hit = message.add_hits();
+  hit->set_id("doc-1");
+  hit->add_locations()->set_field("name");
+
+  ops::search_response response;
+  ps::decode(message, response);
+
+  const auto& row = response.rows.at(0);
+  assert_true(row.fragments.empty(), "no fragments decoded when none were sent");
+  assert_true(row.fields.empty(), "fields stays empty rather than becoming an empty JSON object");
+  assert_false(row.locations.at(0).array_positions.has_value(),
+               "array positions stays unset when the location carried none");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_search_converter",
+    {
+      { "encode_maps_envelope_and_query_string", encode_maps_envelope_and_query_string },
+      { "encode_maps_match_all_and_match_none", encode_maps_match_all_and_match_none },
+      { "encode_returns_nullopt_for_unmappable_query",
+        encode_returns_nullopt_for_unmappable_query },
+      { "encode_maps_a_boosted_query_string", encode_maps_a_boosted_query_string },
+      { "malformed_query_json_is_distinguished_from_an_unmappable_shape",
+        malformed_query_json_is_distinguished_from_an_unmappable_shape },
+      { "can_encode_rejects_gated_features", can_encode_rejects_gated_features },
+      { "decode_maps_hits_and_metrics", decode_maps_hits_and_metrics },
+      { "decode_carries_partial_partition_failures", decode_carries_partial_partition_failures },
+      { "decode_maps_fragments_fields_and_array_positions",
+        decode_maps_fragments_fields_and_array_positions },
+      { "decode_leaves_absent_fragments_and_positions_unset",
+        decode_leaves_absent_fragments_and_positions_unset },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test

--- a/test/cng/protostellar/view_converter.cxx
+++ b/test/cng/protostellar/view_converter.cxx
@@ -1,0 +1,138 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Unit tests for the view <-> couchbase.view.v1 converter (CXXCBC-899). Pure, no server.
+
+#include "framework/test_runner.hxx"
+
+#include "core/protostellar/view_converter.hxx"
+
+#include <string>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace pv = ::couchbase::core::protostellar::view;
+namespace ops = ::couchbase::core::operations;
+namespace v1 = ::couchbase::view::v1;
+
+void
+encode_maps_core_fields()
+{
+  ops::document_view_request request;
+  request.bucket_name = "travel";
+  request.document_name = "dev_ddoc";
+  request.view_name = "by_country";
+  request.ns = couchbase::core::design_document_namespace::development;
+  request.keys = { R"("a")", R"("b")" };
+  request.limit = 10;
+  request.skip = 2;
+  request.reduce = false;
+  request.group = true;
+  request.group_level = 1;
+  request.debug = true;
+  request.consistency = couchbase::core::view_scan_consistency::request_plus;
+  request.order = couchbase::core::view_sort_order::descending;
+  request.on_error = couchbase::core::view_on_error::stop;
+
+  const auto proto = pv::encode(request);
+  assert_eq(proto.bucket_name(), std::string{ "travel" }, "bucket mapped");
+  assert_eq(proto.design_document_name(), std::string{ "dev_ddoc" }, "design doc mapped");
+  assert_eq(proto.view_name(), std::string{ "by_country" }, "view name mapped");
+  assert_true(proto.namespace_() == v1::ViewQueryRequest_Namespace_NAMESPACE_DEVELOPMENT,
+              "development namespace mapped");
+  assert_eq(proto.keys_size(), 2, "keys mapped");
+  assert_eq(proto.limit(), std::uint32_t{ 10 }, "limit mapped");
+  assert_eq(proto.skip(), std::uint32_t{ 2 }, "skip mapped");
+  assert_false(proto.reduce(), "reduce mapped");
+  assert_true(proto.group(), "group mapped");
+  assert_eq(proto.group_level(), std::uint32_t{ 1 }, "group_level mapped");
+  assert_true(proto.debug(), "debug mapped");
+  assert_true(proto.scan_consistency() ==
+                v1::ViewQueryRequest_ScanConsistency_SCAN_CONSISTENCY_REQUEST_PLUS,
+              "consistency mapped");
+  assert_true(proto.order() == v1::ViewQueryRequest_Order_ORDER_DESCENDING, "order mapped");
+  assert_true(proto.on_error() == v1::ViewQueryRequest_ErrorMode_ERROR_MODE_STOP,
+              "on_error stop -> STOP");
+}
+
+void
+can_encode_rejects_unsupported_features()
+{
+  ops::document_view_request base;
+  base.bucket_name = "b";
+  base.document_name = "d";
+  base.view_name = "v";
+  assert_true(pv::can_encode(base), "plain view encodes");
+
+  ops::document_view_request with_raw = base;
+  with_raw.raw.emplace("stale", "false");
+  assert_false(pv::can_encode(with_raw), "raw passthrough is not supported");
+
+  ops::document_view_request full = base;
+  full.full_set = true;
+  assert_false(pv::can_encode(full), "full_set is not supported");
+
+  ops::document_view_request with_callback = base;
+  with_callback.row_callback = [](std::string) {
+    return couchbase::core::utils::json::stream_control{};
+  };
+  assert_false(pv::can_encode(with_callback), "streaming row_callback is not supported");
+}
+
+void
+decode_rows_maps_rows_and_meta()
+{
+  v1::ViewQueryResponse message;
+  auto* row = message.add_rows();
+  row->set_id("doc-1");
+  row->set_key(R"("k")");
+  row->set_value(R"({"v":1})");
+  auto* meta = message.mutable_meta_data();
+  meta->set_total_rows(7);
+  meta->set_debug("dbg");
+
+  ops::document_view_response response;
+  pv::decode_rows(message, response);
+
+  assert_eq(response.rows.size(), std::size_t{ 1 }, "one row decoded");
+  assert_true(response.rows.at(0).id.has_value(), "row id present");
+  assert_eq(response.rows.at(0).id.value(), std::string{ "doc-1" }, "row id decoded");
+  assert_eq(response.rows.at(0).key, std::string{ R"("k")" }, "row key decoded");
+  assert_eq(response.rows.at(0).value, std::string{ R"({"v":1})" }, "row value decoded");
+  assert_true(response.meta.total_rows.has_value(), "total_rows present");
+  assert_eq(response.meta.total_rows.value(), std::uint64_t{ 7 }, "total_rows decoded");
+  assert_true(response.meta.debug_info.has_value(), "debug decoded");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_view_converter",
+    {
+      { "encode_maps_core_fields", encode_maps_core_fields },
+      { "can_encode_rejects_unsupported_features", can_encode_rejects_unsupported_features },
+      { "decode_rows_maps_rows_and_meta", decode_rows_maps_rows_and_meta },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test


### PR DESCRIPTION
FTS search and map/reduce views were rejected by the HTTP execute front-door
gate on couchbase2. Wire both onto the server-streaming primitive.

Add a view converter (core <-> couchbase.view.v1): the request maps cleanly
(keys, ranges, reduce/group, consistency, order, on_error, namespace) and rows
buffer into document_view_response; raw/query_string/full_set have no couchbase2
home and are reported as feature_not_available. Add a search converter (core
<-> couchbase.search.v1): the core query is an opaque JSON string while the
proto models a structured Query oneof, so this translates the trivial forms and
reports every other shape as unmappable. Hits decode with their fragments, field
values, locations and array positions, so a request that asks for highlighting is
either answered with it or refused, never answered with it silently empty.

The component gains SearchService and ViewService stubs and streaming execute()
overloads; cluster_impl routes both alongside query and analytics. Refusals are
delivered on the io context, like every other completion, and every path that
sends nothing still stamps the request's identifiers, so a failure the caller
never saw dispatched is still attributable to the search or view that caused it.
The search and view
error contexts carry first_error_message so the gateway's status message reaches
the caller, which is also what keeps a client-side refusal distinguishable from a
service the gateway does not implement. The per-service default timeouts move
into a component_timeouts struct so the constructor stops growing an argument per
service.

Views are deprecated in the core API but remain routable, so the CNG headers that
name document_view_request suppress the core-deprecation attribute via the shared
portable macro.

### Supported search surface

The proto models the FTS query as a oneof of 21 types; the core request carries an
opaque JSON blob. This converter translates three of them, so the routing works
but search over couchbase2 is far from complete:

| | supported |
| --- | --- |
| query shapes | `query_string` (optionally boosted), `match_all`, `match_none` |
| not translated | the other 18 arms — `match`, `match_phrase`, `phrase`, `term`, `prefix`, `regexp`, `wildcard`, `boolean`, `boolean_field`, `conjunction`, `disjunction`, `date_range`, `numeric_range`, `term_range`, `doc_id`, and the three geo arms |
| request options | limit, skip, explain, disable_scoring, include_locations, highlight style and fields, fields, collections |
| gated | structured facets, structured sort specs, vector search, mutation-token consistency, `raw` |

Everything untranslated is reported as `feature_not_available` rather than dropped,
so no request runs as something other than what was asked for. A query that is not
JSON at all is the caller's own error and surfaces as `invalid_argument` instead.

Three of twenty-one understates what is reachable and overstates what is missing.
`query_string` is FTS's full query-string syntax, so fielded terms, boolean
operators, ranges, wildcards and phrases are all expressible through the supported
arm — `{"query": "name:couchbase AND age:>40"}` works today. What does not work is
the structured builder API: `couchbase::match_query("foo")` emits `{"match":"foo"}`,
which this converter does not recognise, so the most common way to compose a query
programmatically is refused. Translating the remaining arms is follow-up work, and
nothing external blocks it — the gateway already serves all of them.

### Gateway support

The three streaming services are in three different states:

| service | gateway state |
| --- | --- |
| `search.v1` | served, with all 21 query arms translated server-side |
| `view.v1` | not implemented — no server registered |
| `analytics.v1` | deliberately not served — a stub with no RPC methods, deregistered on purpose |

Answering a search at all takes a cluster running the search service: without one the query comes
back as an internal error rather than as a missing index, so CI's single node now runs `fts`.

So the live search test round-trips a real response against a 1.2.2 gateway and
pins the outcome to hits or a genuine index error; returning hits needs a
provisioned index and is deferred to index admin. The live view test skips on the
gateway's own UNIMPLEMENTED message — and a client that stopped routing views
fails there rather than skipping, which is what makes the skip meaningful.

---
Stacked PR **16/30** in the CNG (`couchbase2://`) transport series. Everything below it in the series is merged, so this branch sits directly on `main` and its single commit is the change under review. Next in the series to merge.

