### PR TITLE
CXXCBC-900: route bucket management over the couchbase2 transport

### DIFF
--- a/.github/actions/create-cng-cluster/action.yml
+++ b/.github/actions/create-cng-cluster/action.yml
@@ -60,25 +60,48 @@ runs:
         # to the kubeconfig's current-context -- which is exactly what `k3d cluster create` sets.
         cbdinocluster -v init --auto --kube-config "$HOME/.kube/config"
         cbdinocluster ps
+    - name: Report runner capacity
+      shell: bash
+      run: |
+        # Three server pods plus k3s, the operator and the gateway share one runner, and when that
+        # does not fit the failure surfaces as a pod that never becomes ready -- which reads like a
+        # deployment problem rather than a resource one. Printed before allocation so the first
+        # failing run already carries the numbers, instead of costing a second run to collect them.
+        echo "== cpu";    nproc; cat /proc/loadavg
+        echo "== memory"; free -h
+        echo "== disk";   df -h / /var/lib/docker 2>/dev/null
+        echo "== kubernetes node capacity"
+        kubectl get nodes -o custom-columns='NAME:.metadata.name,CPU:.status.capacity.cpu,MEM:.status.capacity.memory,PODS:.status.capacity.pods'
     - name: Start Couchbase cluster with Cloud Native Gateway
       id: start-cluster
       shell: bash
       env:
-        # Single node: a GitHub-hosted runner has 4 vCPU / 16 GB, and the operator, the gateway and
-        # a server pod all have to fit. The `docker:` memory block that create-cluster uses is
-        # ignored by the cao deployer, so quotas stay at the server defaults (256 MB).
+        # Three KV nodes, which is what create-cluster allocates for the non-CNG suites on the same
+        # runner. A single node cannot satisfy any minimum durability level, so the bucket case that
+        # asks for one skips there instead of running -- and a topology that silently skips a case
+        # is how a test comes to pass everywhere except where it matters.
+        #
+        # The `docker:` memory block that create-cluster uses is ignored by the cao deployer, and its
+        # `cao:` section has no quota fields either, so the operator's 256 MiB service defaults apply
+        # until the resource is patched below.
         #
         # fts is in the list because the live search case needs a search service to answer, not an
         # index. It queries an index that was never created and accepts the gateway's
         # index-not-found, which is an answer only a cluster running fts can give; without the
         # service the request fails as an internal error instead and the case goes red. No index is
         # built here, so the default search quota is enough -- one that has to serve queries needs
-        # considerably more, which is a problem for whoever adds search index management.
+        # considerably more, which is what search index management will have to provision for.
         CLUSTER_CONFIG: |
           nodes:
             - count: 1
               version: ${{ inputs.version }}
-              services: [kv, n1ql, index, fts]
+              services: [kv, n1ql, index]
+            - count: 1
+              version: ${{ inputs.version }}
+              services: [kv, fts]
+            - count: 1
+              version: ${{ inputs.version }}
+              services: [kv]
           cao:
             operator-version: "${{ inputs.operator-version }}"
             gateway-version: "${{ inputs.gateway-version }}"
@@ -90,19 +113,53 @@ runs:
         # The tests set tls_verify_mode::none themselves, so the bare connstr is what they want:
         # couchbase2 is always TLS and the gateway's dev certificate is not chainable.
         echo "connstr=$(cbdinocluster -v connstr --couchbase2 $CBDC_ID)" >> "$GITHUB_OUTPUT"
+    - name: Raise the data service quota
+      shell: bash
+      run: |
+        # The bucket management cases create a bucket of their own, and at the operator's 256 MiB
+        # default the 100 MB test bucket leaves too little room for one -- they would report the
+        # gateway's "ram quota specified is too large" and skip, so the suite would stay green while
+        # testing less. 512 MiB is the smallest quota that fits the test bucket plus a 128 MB bucket
+        # under update, and is nothing against the runner's 16 GB.
+        #
+        # It has to be a patch: the quota cannot be expressed in the cluster definition, and setting
+        # it through /pools/default is reconciled away by the operator within the minute.
+        kubectl -n "cbdc2-$CBDC_ID" patch couchbasecluster cluster --type=merge \
+          -p '{"spec":{"cluster":{"dataServiceMemoryQuota":"512Mi"}}}'
+        # Waiting on condition=Available would prove nothing: it is already true from before the
+        # patch, so the wait returns instantly and the bucket could be created against the old
+        # quota. Poll the cluster itself for the applied value, and fail rather than let the
+        # bucket-management cases quietly skip for want of room.
+        MGMT=$(cbdinocluster mgmt "$CBDC_ID" | tail -1)
+        for _ in $(seq 1 30); do
+          QUOTA=$(curl -sS -u Administrator:password "$MGMT/pools/default" | jq -r '.memoryQuota')
+          echo "data service quota: $QUOTA"
+          [ "$QUOTA" = "512" ] && break
+          sleep 5
+        done
+        [ "$QUOTA" = "512" ] || { echo "::error::data service quota never reached 512 MiB"; exit 1; }
     - name: Add bucket
       shell: bash
       env:
         # Map input to an environment variable to prevent shell injection
         BUCKET: ${{ inputs.bucket }}
       run: |
-        # num-replicas 0: a single-node cluster cannot satisfy replicas, and the bucket would
-        # never come healthy.
-        cbdinocluster buckets add $CBDC_ID "$BUCKET" --ram-quota-mb 100 --num-replicas 0
+        # One replica, which three KV nodes can hold: a replica-less bucket is not what anything runs
+        # in production, and it hides the durability and replica-read paths behind a topology no
+        # caller has.
+        cbdinocluster buckets add $CBDC_ID "$BUCKET" --ram-quota-mb 100 --num-replicas 1
     - name: Dump cluster state on failure
       if: ${{ failure() }}
       shell: bash
       run: |
+        # Resources first: a pod that never became ready because the runner ran out of memory looks
+        # identical to one that failed to deploy, and only these two say which it was.
+        echo "== memory at failure"; free -h
+        echo "== disk at failure";   df -h / /var/lib/docker 2>/dev/null | sort -u
+        # Allocatable vs the sum of pod requests, plus any eviction or scheduling conditions.
+        kubectl describe nodes || true
+        # Pending pods and OOM kills show up here rather than in the pod description.
+        kubectl get events -A --sort-by=.lastTimestamp | tail -50 || true
         kubectl get pods,svc -A || true
         # The CouchbaseCluster CRD only exists once the operator is installed, so tolerate its
         # absence rather than letting it mask the output above.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -213,7 +213,13 @@ jobs:
           TEST_LOG_LEVEL: trace
         run: |
           chmod -R +x ./cmake-build-tests
-          ctest --test-dir ./cmake-build-tests --output-on-failure --label-regex 'cng' \
+          # --verbose rather than --output-on-failure, which prints nothing for a passing suite.
+          # Several cluster-only cases skip themselves on a condition of the cluster -- no spare
+          # KV quota, too few data servers for a minimum durability level, a service the gateway
+          # does not implement -- and each of those decisions is invisible in a green log without
+          # this. A suite that quietly stops exercising a case still reports 100% passed, which is
+          # the failure mode these tests exist to prevent, so the log has to say what ran.
+          ctest --test-dir ./cmake-build-tests --verbose --label-regex 'cng' \
                 --no-tests=error --output-junit cng-live-results.xml
       - name: Upload CNG live test results
         if: ${{ always() }}

--- a/core/cluster.cxx
+++ b/core/cluster.cxx
@@ -776,12 +776,18 @@ public:
       if constexpr (std::is_same_v<Request, operations::query_request> ||
                     std::is_same_v<Request, operations::analytics_request> ||
                     std::is_same_v<Request, operations::search_request> ||
-                    std::is_same_v<Request, operations::document_view_request>) {
+                    std::is_same_v<Request, operations::document_view_request> ||
+                    std::is_same_v<Request, operations::management::bucket_get_all_request> ||
+                    std::is_same_v<Request, operations::management::bucket_get_request> ||
+                    std::is_same_v<Request, operations::management::bucket_create_request> ||
+                    std::is_same_v<Request, operations::management::bucket_update_request> ||
+                    std::is_same_v<Request, operations::management::bucket_drop_request> ||
+                    std::is_same_v<Request, operations::management::bucket_flush_request>) {
         component->execute(std::move(request), std::forward<Handler>(handler));
         return;
       } else {
-        // Management over couchbase2 is not wired yet. Reject cleanly rather than falling through
-        // to the MCBP session manager, which is never bootstrapped on this path.
+        // Remaining management ops over couchbase2 are not wired yet. Reject cleanly rather than
+        // falling through to the MCBP session manager, which is never bootstrapped on this path.
         return handler(
           request.make_response({ errc::common::feature_not_available }, response_type{}));
       }
@@ -944,7 +950,8 @@ public:
             options.query_timeout,
             options.analytics_timeout,
             options.search_timeout,
-            options.view_timeout
+            options.view_timeout,
+            options.management_timeout
           } });
     }
     CB_LOG_INFO(R"(open couchbase2 cluster, id: "{}", endpoint: "{}")", id_, endpoint);

--- a/core/protostellar/bucket_admin_converter.hxx
+++ b/core/protostellar/bucket_admin_converter.hxx
@@ -1,0 +1,301 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+// Translates core bucket management settings to and from couchbase.admin.bucket.v1 (unary admin
+// RPCs). The proto enums have no `unknown` sentinel, so the core `unknown` values fall back to the
+// server default on encode. memcached buckets have no couchbase2 representation;
+// apply_create_only_settings() returns false for them so the component surfaces
+// feature_not_available.
+//
+// Every field the encode side writes is read back by decode_bucket(), because get-modify-update is
+// the ordinary way these settings are changed: a field that decodes to a default is sent back as a
+// default on the next update and silently resets the bucket.
+
+#include "core/management/bucket_settings.hxx"
+#include "core/operations/management/bucket_get_all.hxx"
+
+#include <couchbase/durability_level.hxx>
+
+#include <couchbase/admin/bucket/v1/bucket.pb.h>
+#include <couchbase/kv/v1/kv.pb.h>
+
+#include <cstdint>
+#include <limits>
+#include <optional>
+
+namespace couchbase::core::protostellar::bucket_admin
+{
+namespace v1 = ::couchbase::admin::bucket::v1;
+namespace mgmt = ::couchbase::core::management::cluster;
+
+[[nodiscard]] inline auto
+to_proto_durability(couchbase::durability_level level)
+  -> std::optional<::couchbase::kv::v1::DurabilityLevel>
+{
+  switch (level) {
+    case couchbase::durability_level::none:
+      return std::nullopt;
+    case couchbase::durability_level::majority:
+      return ::couchbase::kv::v1::DURABILITY_LEVEL_MAJORITY;
+    case couchbase::durability_level::majority_and_persist_to_active:
+      return ::couchbase::kv::v1::DURABILITY_LEVEL_MAJORITY_AND_PERSIST_TO_ACTIVE;
+    case couchbase::durability_level::persist_to_majority:
+      return ::couchbase::kv::v1::DURABILITY_LEVEL_PERSIST_TO_MAJORITY;
+  }
+  return std::nullopt;
+}
+
+// Populate the bucket-settings fields that are mutable on both Create and Update requests.
+template<typename Request>
+void
+apply_settings(const mgmt::bucket_settings& settings, Request& proto)
+{
+  proto.set_bucket_name(settings.name);
+  // ram_quota_mb == 0 means "unset" in the core settings (create defaults it to 100, update omits
+  // it); only send an explicit value so an unset quota does not overwrite the server-side value.
+  if (settings.ram_quota_mb != 0) {
+    proto.set_ram_quota_mb(settings.ram_quota_mb);
+  }
+
+  // Omitted when the caller expressed no opinion, so the server applies its own default. Sending an
+  // explicit zero instead would create a bucket with no replicas on their behalf.
+  if (settings.num_replicas.has_value()) {
+    proto.set_num_replicas(*settings.num_replicas);
+  }
+  if (settings.flush_enabled.has_value()) {
+    proto.set_flush_enabled(*settings.flush_enabled);
+  }
+  if (settings.max_expiry.has_value()) {
+    proto.set_max_expiry_secs(*settings.max_expiry);
+  }
+  if (settings.minimum_durability_level.has_value()) {
+    if (auto durability = to_proto_durability(*settings.minimum_durability_level);
+        durability.has_value()) {
+      proto.set_minimum_durability_level(*durability);
+    }
+  }
+  switch (settings.eviction_policy) {
+    case mgmt::bucket_eviction_policy::full:
+      proto.set_eviction_mode(v1::EVICTION_MODE_FULL);
+      break;
+    case mgmt::bucket_eviction_policy::value_only:
+      proto.set_eviction_mode(v1::EVICTION_MODE_VALUE_ONLY);
+      break;
+    case mgmt::bucket_eviction_policy::no_eviction:
+      proto.set_eviction_mode(v1::EVICTION_MODE_NONE);
+      break;
+    case mgmt::bucket_eviction_policy::not_recently_used:
+      proto.set_eviction_mode(v1::EVICTION_MODE_NOT_RECENTLY_USED);
+      break;
+    case mgmt::bucket_eviction_policy::unknown:
+      break; // leave server default
+  }
+  switch (settings.compression_mode) {
+    case mgmt::bucket_compression::off:
+      proto.set_compression_mode(v1::COMPRESSION_MODE_OFF);
+      break;
+    case mgmt::bucket_compression::active:
+      proto.set_compression_mode(v1::COMPRESSION_MODE_ACTIVE);
+      break;
+    case mgmt::bucket_compression::passive:
+      proto.set_compression_mode(v1::COMPRESSION_MODE_PASSIVE);
+      break;
+    case mgmt::bucket_compression::unknown:
+      break;
+  }
+  if (settings.history_retention_collection_default.has_value()) {
+    proto.set_history_retention_collection_default(*settings.history_retention_collection_default);
+  }
+  if (settings.history_retention_bytes.has_value()) {
+    proto.set_history_retention_bytes(*settings.history_retention_bytes);
+  }
+  if (settings.history_retention_duration.has_value()) {
+    proto.set_history_retention_duration_secs(*settings.history_retention_duration);
+  }
+}
+
+// Bucket type, replica indexes, storage backend, and conflict resolution are immutable after
+// creation, so they are only set on CreateBucketRequest. Returns false when the bucket type has no
+// couchbase2 representation (memcached).
+[[nodiscard]] inline auto
+apply_create_only_settings(const mgmt::bucket_settings& settings, v1::CreateBucketRequest& proto)
+  -> bool
+{
+  switch (settings.bucket_type) {
+    case mgmt::bucket_type::couchbase:
+      proto.set_bucket_type(v1::BUCKET_TYPE_COUCHBASE);
+      break;
+    case mgmt::bucket_type::unknown:
+      // Leave bucket_type unset so the gateway applies its server-side default rather than
+      // silently forcing a couchbase bucket.
+      break;
+    case mgmt::bucket_type::ephemeral:
+      proto.set_bucket_type(v1::BUCKET_TYPE_EPHEMERAL);
+      break;
+    case mgmt::bucket_type::memcached:
+      return false;
+  }
+  // A bucket must be created with a RAM quota. Core uses ram_quota_mb == 0 to mean "unset" (and
+  // apply_settings() omits it in that case), so mirror the classic create path and fall back to the
+  // historical 100 MiB default rather than sending a zero quota.
+  if (settings.ram_quota_mb == 0) {
+    proto.set_ram_quota_mb(100);
+  }
+  if (settings.replica_indexes.has_value()) {
+    proto.set_replica_indexes(*settings.replica_indexes);
+  }
+  switch (settings.storage_backend) {
+    case mgmt::bucket_storage_backend::couchstore:
+      proto.set_storage_backend(v1::STORAGE_BACKEND_COUCHSTORE);
+      break;
+    case mgmt::bucket_storage_backend::magma:
+      proto.set_storage_backend(v1::STORAGE_BACKEND_MAGMA);
+      break;
+    case mgmt::bucket_storage_backend::unknown:
+      break;
+  }
+  switch (settings.conflict_resolution_type) {
+    case mgmt::bucket_conflict_resolution::timestamp:
+      proto.set_conflict_resolution_type(v1::CONFLICT_RESOLUTION_TYPE_TIMESTAMP);
+      break;
+    case mgmt::bucket_conflict_resolution::sequence_number:
+      proto.set_conflict_resolution_type(v1::CONFLICT_RESOLUTION_TYPE_SEQUENCE_NUMBER);
+      break;
+    case mgmt::bucket_conflict_resolution::custom:
+      proto.set_conflict_resolution_type(v1::CONFLICT_RESOLUTION_TYPE_CUSTOM);
+      break;
+    case mgmt::bucket_conflict_resolution::unknown:
+      break;
+  }
+  return true;
+}
+
+// Decode one ListBucketsResponse bucket back into core settings.
+[[nodiscard]] inline auto
+decode_bucket(const v1::ListBucketsResponse_Bucket& proto) -> mgmt::bucket_settings
+{
+  mgmt::bucket_settings settings;
+  settings.name = proto.bucket_name();
+  settings.ram_quota_mb = proto.ram_quota_mb();
+  switch (proto.bucket_type()) {
+    case v1::BUCKET_TYPE_EPHEMERAL:
+      settings.bucket_type = mgmt::bucket_type::ephemeral;
+      break;
+    default:
+      settings.bucket_type = mgmt::bucket_type::couchbase;
+      break;
+  }
+  settings.num_replicas = proto.num_replicas();
+  settings.flush_enabled = proto.flush_enabled();
+  settings.replica_indexes = proto.replica_indexes();
+  settings.max_expiry = proto.max_expiry_secs();
+  switch (proto.eviction_mode()) {
+    case v1::EVICTION_MODE_FULL:
+      settings.eviction_policy = mgmt::bucket_eviction_policy::full;
+      break;
+    case v1::EVICTION_MODE_VALUE_ONLY:
+      settings.eviction_policy = mgmt::bucket_eviction_policy::value_only;
+      break;
+    case v1::EVICTION_MODE_NONE:
+      settings.eviction_policy = mgmt::bucket_eviction_policy::no_eviction;
+      break;
+    case v1::EVICTION_MODE_NOT_RECENTLY_USED:
+      settings.eviction_policy = mgmt::bucket_eviction_policy::not_recently_used;
+      break;
+    default:
+      break;
+  }
+  switch (proto.compression_mode()) {
+    case v1::COMPRESSION_MODE_OFF:
+      settings.compression_mode = mgmt::bucket_compression::off;
+      break;
+    case v1::COMPRESSION_MODE_ACTIVE:
+      settings.compression_mode = mgmt::bucket_compression::active;
+      break;
+    case v1::COMPRESSION_MODE_PASSIVE:
+      settings.compression_mode = mgmt::bucket_compression::passive;
+      break;
+    default:
+      break;
+  }
+  // storage_backend and minimum_durability_level are `optional` in the response, so the plain value
+  // getter cannot tell an explicit couchstore (enum 0) from a field the gateway did not send. Read
+  // through the presence bit: absent leaves the core `unknown` / empty optional, which is what the
+  // gateway means by omitting it.
+  if (proto.has_storage_backend()) {
+    switch (proto.storage_backend()) {
+      case v1::STORAGE_BACKEND_MAGMA:
+        settings.storage_backend = mgmt::bucket_storage_backend::magma;
+        break;
+      case v1::STORAGE_BACKEND_COUCHSTORE:
+        settings.storage_backend = mgmt::bucket_storage_backend::couchstore;
+        break;
+      default:
+        break;
+    }
+  }
+  if (proto.has_minimum_durability_level()) {
+    switch (proto.minimum_durability_level()) {
+      case ::couchbase::kv::v1::DURABILITY_LEVEL_MAJORITY:
+        settings.minimum_durability_level = couchbase::durability_level::majority;
+        break;
+      case ::couchbase::kv::v1::DURABILITY_LEVEL_MAJORITY_AND_PERSIST_TO_ACTIVE:
+        settings.minimum_durability_level =
+          couchbase::durability_level::majority_and_persist_to_active;
+        break;
+      case ::couchbase::kv::v1::DURABILITY_LEVEL_PERSIST_TO_MAJORITY:
+        settings.minimum_durability_level = couchbase::durability_level::persist_to_majority;
+        break;
+      default:
+        break;
+    }
+  }
+  // conflict_resolution_type carries no presence bit on this message, unlike the two above, so an
+  // unset field is indistinguishable from an explicit timestamp (enum 0) and is read as one.
+  switch (proto.conflict_resolution_type()) {
+    case v1::CONFLICT_RESOLUTION_TYPE_TIMESTAMP:
+      settings.conflict_resolution_type = mgmt::bucket_conflict_resolution::timestamp;
+      break;
+    case v1::CONFLICT_RESOLUTION_TYPE_SEQUENCE_NUMBER:
+      settings.conflict_resolution_type = mgmt::bucket_conflict_resolution::sequence_number;
+      break;
+    case v1::CONFLICT_RESOLUTION_TYPE_CUSTOM:
+      settings.conflict_resolution_type = mgmt::bucket_conflict_resolution::custom;
+      break;
+    default:
+      break;
+  }
+  if (proto.has_history_retention_collection_default()) {
+    settings.history_retention_collection_default = proto.history_retention_collection_default();
+  }
+  // The proto carries 64 bits and the core setting holds 32. Narrowing a larger value would report
+  // a retention size the bucket does not have, and the usual get-modify-update cycle would then
+  // send that smaller number back and shrink the setting. Leaving the optional empty is what the
+  // encode side omits, so the server keeps its own value.
+  if (proto.has_history_retention_bytes() &&
+      proto.history_retention_bytes() <= std::numeric_limits<std::uint32_t>::max()) {
+    settings.history_retention_bytes = static_cast<std::uint32_t>(proto.history_retention_bytes());
+  }
+  if (proto.has_history_retention_duration_secs()) {
+    settings.history_retention_duration = proto.history_retention_duration_secs();
+  }
+  return settings;
+}
+
+} // namespace couchbase::core::protostellar::bucket_admin

--- a/core/protostellar/component.cxx
+++ b/core/protostellar/component.cxx
@@ -25,6 +25,7 @@
 #include "core/operations/analytics_response_parsing.hxx"
 #include "core/operations/query_response_parsing.hxx"
 #include "core/protostellar/analytics_converter.hxx"
+#include "core/protostellar/bucket_admin_converter.hxx"
 #include "core/protostellar/credentials.hxx"
 #include "core/protostellar/error_utils.hxx"
 #include "core/protostellar/kv_converter.hxx"
@@ -37,6 +38,7 @@
 #include "core/protostellar/query_proto.hxx"
 #include <couchbase/analytics/v1/analytics.grpc.pb.h>
 
+#include <couchbase/admin/bucket/v1/bucket.grpc.pb.h>
 #include <couchbase/kv/v1/kv.grpc.pb.h>
 #include <couchbase/search/v1/search.grpc.pb.h>
 #include <couchbase/view/v1/view.grpc.pb.h>
@@ -59,6 +61,7 @@ namespace query_v1 = ::couchbase::query::v1;
 namespace analytics_v1 = ::couchbase::analytics::v1;
 namespace search_v1 = ::couchbase::search::v1;
 namespace view_v1 = ::couchbase::view::v1;
+namespace bucket_admin_v1 = ::couchbase::admin::bucket::v1;
 
 // Defined here rather than in the header so the generated gRPC types stay out of every consumer of
 // component.hxx.
@@ -68,6 +71,7 @@ struct component::stubs {
   std::unique_ptr<analytics_v1::AnalyticsService::Stub> analytics;
   std::unique_ptr<search_v1::SearchService::Stub> search;
   std::unique_ptr<view_v1::ViewService::Stub> view;
+  std::unique_ptr<bucket_admin_v1::BucketAdminService::Stub> bucket_admin;
 };
 
 namespace
@@ -110,15 +114,35 @@ fail_expired_ctx(asio::io_context& io, Handler& handler, Response response) -> p
   });
   return {};
 }
+
+// A management response carrying the caller's client_context_id, which is what correlates it with
+// the request that produced it when several are in flight. The http error context has the field and
+// the classic path fills it, so leaving it empty here would lose the identifier on the couchbase2
+// path alone -- most visibly on the paths that send nothing, where there is no server response to
+// correlate by either.
+//
+// Only what the caller supplied is echoed. The classic path substitutes a generated uuid for an
+// absent one because it travels with the HTTP request and comes back in the server's own logs;
+// couchbase2 sends no such field, so an id the caller never chose would identify nothing.
+template<typename Request>
+[[nodiscard]] auto
+stamped_management(const Request& request) -> typename Request::response_type
+{
+  typename Request::response_type response;
+  response.ctx.client_context_id = request.client_context_id.value_or(std::string{});
+  return response;
+}
 } // namespace
 
 component::component(asio::io_context& io, component_config config)
   : io_{ io }
-  , stubs_{ std::make_unique<stubs>(stubs{ v1::KvService::NewStub(config.channel),
-                                           query_v1::QueryService::NewStub(config.channel),
-                                           analytics_v1::AnalyticsService::NewStub(config.channel),
-                                           search_v1::SearchService::NewStub(config.channel),
-                                           view_v1::ViewService::NewStub(config.channel) }) }
+  , stubs_{ std::make_unique<stubs>(
+      stubs{ v1::KvService::NewStub(config.channel),
+             query_v1::QueryService::NewStub(config.channel),
+             analytics_v1::AnalyticsService::NewStub(config.channel),
+             search_v1::SearchService::NewStub(config.channel),
+             view_v1::ViewService::NewStub(config.channel),
+             bucket_admin_v1::BucketAdminService::NewStub(config.channel) }) }
   , authorization_{ authorization_header(config.credentials) }
   , timeouts_{ config.timeouts }
   // Initialised last (see the declaration order in the header), so the channel can be moved in.
@@ -967,6 +991,249 @@ component::execute(operations::document_view_request request,
       response->ctx.view_name = std::move(view_name);
       response->ctx.client_context_id = std::move(client_context_id);
       handler(std::move(*response));
+    });
+}
+
+auto
+component::execute(
+  operations::management::bucket_get_all_request request,
+  utils::movable_function<void(operations::management::bucket_get_all_response)>&& handler)
+  -> pending_call
+{
+  const auto client_context_id = request.client_context_id.value_or(std::string{});
+  auto proto = std::make_shared<bucket_admin_v1::ListBucketsRequest>();
+  const auto timeout = request.timeout.value_or(timeouts_.management);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped_management(request));
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->bucket_admin.get();
+  return dispatcher_.unary<bucket_admin_v1::ListBucketsResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        bucket_admin_v1::ListBucketsResponse& resp,
+                        std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->ListBuckets(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), proto, client_context_id](
+      grpc::Status status, bucket_admin_v1::ListBucketsResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      operations::management::bucket_get_all_response response;
+      response.ctx.client_context_id = client_context_id;
+      response.ctx.ec = map_status(status, operation_kind::read_only);
+      for (const auto& bucket : resp.buckets()) {
+        response.buckets.push_back(bucket_admin::decode_bucket(bucket));
+      }
+      handler(std::move(response));
+    });
+}
+
+auto
+component::execute(
+  operations::management::bucket_get_request request,
+  utils::movable_function<void(operations::management::bucket_get_response)>&& handler)
+  -> pending_call
+{
+  const auto client_context_id = request.client_context_id.value_or(std::string{});
+  // admin.bucket.v1 has no GetBucket RPC; filter the bucket list by name.
+  auto proto = std::make_shared<bucket_admin_v1::ListBucketsRequest>();
+  const auto timeout = request.timeout.value_or(timeouts_.management);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped_management(request));
+  }
+  const auto auth = authorization_;
+  const auto name = request.name;
+  auto* stub = stubs_->bucket_admin.get();
+  return dispatcher_.unary<bucket_admin_v1::ListBucketsResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        bucket_admin_v1::ListBucketsResponse& resp,
+                        std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->ListBuckets(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), proto, client_context_id, name](
+      grpc::Status status, bucket_admin_v1::ListBucketsResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      operations::management::bucket_get_response response;
+      response.ctx.client_context_id = client_context_id;
+      response.ctx.ec = map_status(status, operation_kind::read_only);
+      if (!response.ctx.ec) {
+        bool found = false;
+        for (const auto& bucket : resp.buckets()) {
+          if (bucket.bucket_name() == name) {
+            response.bucket = bucket_admin::decode_bucket(bucket);
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          response.ctx.ec = errc::common::bucket_not_found;
+        }
+      }
+      handler(std::move(response));
+    });
+}
+
+auto
+component::execute(
+  operations::management::bucket_create_request request,
+  utils::movable_function<void(operations::management::bucket_create_response)>&& handler)
+  -> pending_call
+{
+  const auto client_context_id = request.client_context_id.value_or(std::string{});
+  auto proto = std::make_shared<bucket_admin_v1::CreateBucketRequest>();
+  bucket_admin::apply_settings(request.bucket, *proto);
+  if (!bucket_admin::apply_create_only_settings(request.bucket, *proto)) {
+    operations::management::bucket_create_response response;
+    response.ctx.client_context_id = client_context_id;
+    response.ctx.ec = errc::common::feature_not_available;
+    // Posted rather than invoked here, for the reason fail_expired gives: completions arrive on the
+    // io context, never inline out of execute().
+    asio::post(io_, [handler = std::move(handler), response = std::move(response)]() mutable {
+      handler(std::move(response));
+    });
+    return {};
+  }
+  const auto timeout = request.timeout.value_or(timeouts_.management);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped_management(request));
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->bucket_admin.get();
+  return dispatcher_.unary<bucket_admin_v1::CreateBucketResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        bucket_admin_v1::CreateBucketResponse& resp,
+                        std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->CreateBucket(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), proto, client_context_id](
+      grpc::Status status, bucket_admin_v1::CreateBucketResponse /* resp */) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      operations::management::bucket_create_response response;
+      response.ctx.client_context_id = client_context_id;
+      response.ctx.ec = map_status(status, operation_kind::mutating);
+      if (response.ctx.ec) {
+        response.error_message = error_message(status);
+      }
+      handler(std::move(response));
+    });
+}
+
+auto
+component::execute(
+  operations::management::bucket_update_request request,
+  utils::movable_function<void(operations::management::bucket_update_response)>&& handler)
+  -> pending_call
+{
+  const auto client_context_id = request.client_context_id.value_or(std::string{});
+  auto proto = std::make_shared<bucket_admin_v1::UpdateBucketRequest>();
+  bucket_admin::apply_settings(request.bucket, *proto);
+  const auto timeout = request.timeout.value_or(timeouts_.management);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped_management(request));
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->bucket_admin.get();
+  return dispatcher_.unary<bucket_admin_v1::UpdateBucketResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        bucket_admin_v1::UpdateBucketResponse& resp,
+                        std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->UpdateBucket(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), proto, client_context_id](
+      grpc::Status status, bucket_admin_v1::UpdateBucketResponse /* resp */) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      operations::management::bucket_update_response response;
+      response.ctx.client_context_id = client_context_id;
+      response.ctx.ec = map_status(status, operation_kind::mutating);
+      if (response.ctx.ec) {
+        response.error_message = error_message(status);
+      }
+      handler(std::move(response));
+    });
+}
+
+auto
+component::execute(
+  operations::management::bucket_drop_request request,
+  utils::movable_function<void(operations::management::bucket_drop_response)>&& handler)
+  -> pending_call
+{
+  const auto client_context_id = request.client_context_id.value_or(std::string{});
+  auto proto = std::make_shared<bucket_admin_v1::DeleteBucketRequest>();
+  proto->set_bucket_name(request.name);
+  const auto timeout = request.timeout.value_or(timeouts_.management);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped_management(request));
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->bucket_admin.get();
+  return dispatcher_.unary<bucket_admin_v1::DeleteBucketResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        bucket_admin_v1::DeleteBucketResponse& resp,
+                        std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->DeleteBucket(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), proto, client_context_id](
+      grpc::Status status, bucket_admin_v1::DeleteBucketResponse /* resp */) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      operations::management::bucket_drop_response response;
+      response.ctx.client_context_id = client_context_id;
+      response.ctx.ec = map_status(status, operation_kind::mutating);
+      handler(std::move(response));
+    });
+}
+
+auto
+component::execute(
+  operations::management::bucket_flush_request request,
+  utils::movable_function<void(operations::management::bucket_flush_response)>&& handler)
+  -> pending_call
+{
+  const auto client_context_id = request.client_context_id.value_or(std::string{});
+  auto proto = std::make_shared<bucket_admin_v1::FlushBucketRequest>();
+  proto->set_bucket_name(request.name);
+  const auto timeout = request.timeout.value_or(timeouts_.management);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped_management(request));
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->bucket_admin.get();
+  return dispatcher_.unary<bucket_admin_v1::FlushBucketResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        bucket_admin_v1::FlushBucketResponse& resp,
+                        std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->FlushBucket(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), proto, client_context_id](
+      grpc::Status status, bucket_admin_v1::FlushBucketResponse /* resp */) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      operations::management::bucket_flush_response response;
+      response.ctx.client_context_id = client_context_id;
+      response.ctx.ec = map_status(status, operation_kind::mutating);
+      handler(std::move(response));
     });
 }
 

--- a/core/protostellar/component.hxx
+++ b/core/protostellar/component.hxx
@@ -49,6 +49,12 @@
 #include "core/operations/document_unlock.hxx"
 #include "core/operations/document_upsert.hxx"
 #include "core/operations/document_view.hxx"
+#include "core/operations/management/bucket_create.hxx"
+#include "core/operations/management/bucket_drop.hxx"
+#include "core/operations/management/bucket_flush.hxx"
+#include "core/operations/management/bucket_get.hxx"
+#include "core/operations/management/bucket_get_all.hxx"
+#include "core/operations/management/bucket_update.hxx"
 #include "core/protostellar/dispatcher.hxx"
 #include "core/timeout_defaults.hxx"
 #include "core/utils/movable_function.hxx"
@@ -72,6 +78,7 @@ struct component_timeouts {
   std::chrono::milliseconds analytics{ timeout_defaults::analytics_timeout };
   std::chrono::milliseconds search{ timeout_defaults::search_timeout };
   std::chrono::milliseconds view{ timeout_defaults::view_timeout };
+  std::chrono::milliseconds management{ timeout_defaults::management_timeout };
 };
 
 // Construction parameters for `component`, grouped so that adding one is a source-compatible
@@ -196,6 +203,31 @@ public:
   // Map/reduce views over the couchbase2 server-streaming transport.
   auto execute(operations::document_view_request request,
                utils::movable_function<void(operations::document_view_response)>&& handler)
+    -> pending_call;
+
+  // Bucket management (unary admin RPCs over admin.bucket.v1).
+  auto execute(
+    operations::management::bucket_get_all_request request,
+    utils::movable_function<void(operations::management::bucket_get_all_response)>&& handler)
+    -> pending_call;
+  auto execute(operations::management::bucket_get_request request,
+               utils::movable_function<void(operations::management::bucket_get_response)>&& handler)
+    -> pending_call;
+  auto execute(
+    operations::management::bucket_create_request request,
+    utils::movable_function<void(operations::management::bucket_create_response)>&& handler)
+    -> pending_call;
+  auto execute(
+    operations::management::bucket_update_request request,
+    utils::movable_function<void(operations::management::bucket_update_response)>&& handler)
+    -> pending_call;
+  auto execute(
+    operations::management::bucket_drop_request request,
+    utils::movable_function<void(operations::management::bucket_drop_response)>&& handler)
+    -> pending_call;
+  auto execute(
+    operations::management::bucket_flush_request request,
+    utils::movable_function<void(operations::management::bucket_flush_response)>&& handler)
     -> pending_call;
 
 private:

--- a/core/protostellar/error_utils.cxx
+++ b/core/protostellar/error_utils.cxx
@@ -82,6 +82,12 @@ map_precondition(const std::string& type) -> std::error_code
     // cluster is broken when their document simply is not a number.
     return errc::key_value::delta_invalid;
   }
+  if (type == "FLUSH_DISABLED") {
+    // The one management precondition the gateway raises. Without it a flush against a bucket that
+    // simply has flush turned off reports internal_server_failure, where the caller can act on
+    // knowing that flush is disabled.
+    return errc::management::bucket_not_flushable;
+  }
   if (type == "DURABILITY_IMPOSSIBLE") {
     // Fewer live nodes than the requested durability needs. Actionable by the caller (ask for less,
     // or grow the cluster), so it must not be flattened into a generic server failure either.

--- a/test/cng/CMakeLists.txt
+++ b/test/cng/CMakeLists.txt
@@ -157,4 +157,9 @@ if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 AND TARGET couchbase_cxx_protostellar)
 
   # Live Views verification (CXXCBC-899).
   add_cng_test(protostellar/live_view LINK_CLIENT LIBS couchbase_cxx_protostellar)
+  # Bucket management converter (CXXCBC-900).
+  add_cng_test(protostellar/bucket_admin_converter LINK_CLIENT LIBS couchbase_cxx_protostellar)
+
+  # Live Bucket management verification (CXXCBC-900).
+  add_cng_test(protostellar/live_bucket_admin LINK_CLIENT LIBS couchbase_cxx_protostellar)
 endif()

--- a/test/cng/README.md
+++ b/test/cng/README.md
@@ -93,11 +93,13 @@ a plain release version maps to the public `couchbase/*` images on Docker Hub an
 credentials. CI pins release versions for exactly this reason, so the definition above is what an
 outside contributor can actually pull.
 
-There is deliberately no `docker:` memory block here: the `cao` deployer ignores it, so service
-quotas stay at the server defaults regardless. That is also why the bucket below is created with a
-small explicit quota. The four nodes cover every service the suite can touch, and `fts` has to be
-among them or the live search case fails rather than reporting a missing index. CI puts all of
-`kv, n1ql, index, fts` on one node, which is the smallest topology the suite runs against.
+There is deliberately no `docker:` memory block here: the `cao` deployer ignores it, so every service
+quota stays at the operator's 256 MiB default no matter what the definition says. Two parts of the
+suite need more than that — see [Cluster quota](#cluster-quota-bucket-and-search-management) — and it
+has to be set on the allocated cluster rather than here. The four nodes cover every service the suite
+can touch, and `fts` has to be among them or the live search case fails rather than reporting a
+missing index. CI puts all of `kv, n1ql, index, fts` on one node, which is the smallest topology the
+suite runs against.
 
 Other `cao` keys cbdinocluster understands include `username` / `password` (default
 `Administrator` / `password`) and `gateway-log-level`.
@@ -120,6 +122,62 @@ try a KV operation against a non-default collection by hand:
 $ cbdinocluster collections add-scope "$CBDC_ID" default myscope
 $ cbdinocluster collections add       "$CBDC_ID" default myscope mycollection
 ```
+
+### Cluster quota: bucket and search management
+
+The operator's default service quotas are **256 MiB each**, and that is not enough for two parts of
+the suite. Nothing in the definition file can change it: the `cao` deployer builds the
+`CouchbaseCluster` spec itself and emits no `cluster:` block, and the `cao:` section of a cluster
+definition has no quota fields — so the `docker:` memory keys, which do work for the docker deployer,
+are silently ignored here. Raise the quotas on the allocated cluster:
+
+```console
+$ kubectl -n cbdc2-"$CBDC_ID" patch couchbasecluster cluster --type=merge -p '{
+    "spec": {"cluster": {
+      "dataServiceMemoryQuota":   "1024Mi",
+      "searchServiceMemoryQuota": "2048Mi"
+    }}}'
+```
+
+**Data service.** One 256 MB `default` bucket consumes the whole 256 MiB data quota, leaving the
+bucket-management round trip — which creates a bucket, reads it back and asserts the settings
+survived — with nowhere to put one. It reports the gateway's own "ram quota specified is too large"
+and skips, so the suite stays green while quietly testing less. Creating the bucket smaller
+(`--ram-quota-mb 128`) frees enough room for the couchstore case; the 1024 MiB above is what a magma
+bucket needs, since the gateway rejects a magma bucket under a 1024 MB quota (and history retention
+requires a further 2048 MB).
+
+**Search service.** At 256 MiB an FTS index is accepted and then never builds a usable partition, so
+every query against it fails with `pindex not available` rather than returning hits. This is the
+quota search index management needs to be testable end to end.
+
+The operator owns both settings. Posting to `/pools/default` returns 200 and reads back as applied,
+and is reconciled away within the minute — patch the resource and give it ~20 seconds to appear.
+
+#### From nothing to a cluster the whole suite can use
+
+Sections 1–3 in one sequence, with the quotas raised before the bucket is created so nothing has to
+be resized afterwards:
+
+```console
+$ k3d cluster create mycluster                                   # once per machine
+$ cbdinocluster init --auto --kube-config ~/.kube/config          # once per machine
+
+$ CBDC_ID=$(cbdinocluster allocate --deployer cao --def-file cluster-def.yaml)
+$ kubectl -n cbdc2-"$CBDC_ID" patch couchbasecluster cluster --type=merge -p '{
+    "spec": {"cluster": {
+      "dataServiceMemoryQuota":   "1024Mi",
+      "searchServiceMemoryQuota": "2048Mi"
+    }}}'
+$ kubectl -n cbdc2-"$CBDC_ID" wait --for=condition=Available --timeout=5m couchbasecluster/cluster
+
+$ cbdinocluster buckets add "$CBDC_ID" default --ram-quota-mb 256
+$ export TEST_CONNECTION_STRING="$(cbdinocluster connstr --couchbase2 "$CBDC_ID")?tls_verify=none"
+$ ctest --test-dir build -L cng --output-on-failure
+```
+
+The patch is a separate step because the quotas cannot be expressed in `cluster-def.yaml`, and it has
+to come after `allocate` because the resource it patches does not exist until then.
 
 ### TLS: connect with `tls_verify=none`
 
@@ -186,21 +244,20 @@ be overridden:
 | `TEST_CB2_BUCKET` | `default` | must already exist; the tests do not create it |
 | `TEST_CB2_SEARCH_INDEX` | `cng-index` | the FTS index the live search case queries; see below |
 
-`TEST_CB2_SEARCH_INDEX` needs a word of its own, because the walkthrough above does **not** create
-an FTS index. The live search case still passes without one: it accepts either hits or
-`index_not_found`, and the latter is an answer only a gateway that ran the query can give, so the
-round trip is proven either way.
+`TEST_CB2_SEARCH_INDEX` needs a word of its own, because the walkthrough above does **not** create an
+FTS index, and an index created outside the gateway is not a substitute. The live search case
+therefore accepts either hits or `index_not_found` — the latter is an answer only a gateway that ran
+the query can give, so the round trip is proven either way.
 
 What it does need is a cluster **running the search service** — the definition above has an `fts`
 node for that reason. Query a cluster without one and the request fails as an internal error rather
-than as a missing index, because there is no service to report the index missing, and the case goes
-red for a reason that has nothing to do with the client.
+than as a missing index, because there is nothing to report the index missing, and the case goes red
+for a reason that has nothing to do with the client.
 
-What it cannot do without an index is exercise hit decoding — fragments, field values and locations
-all go untested against a real server. An index named `cng-index` over the test bucket, or this
-variable pointed at one you already have, covers that; note that an index only serves queries once
-the search service has the memory to build a partition for it, which the operator's default quota
-does not provide.
+What it does not do is exercise hit decoding: fragments, field values and locations go untested
+against a real server. Closing that gap means provisioning the index over `couchbase2://` itself,
+which arrives with search index management (CXXCBC-901), and giving the search service the memory to
+build a partition for it — see [Cluster quota](#cluster-quota-bucket-and-search-management).
 
 Point the suite at a shared cluster, or at one whose credentials differ from cbdinocluster's, and
 these are what you set:

--- a/test/cng/protostellar/bucket_admin_converter.cxx
+++ b/test/cng/protostellar/bucket_admin_converter.cxx
@@ -1,0 +1,194 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Unit tests for the bucket-admin <-> couchbase.admin.bucket.v1 converter (CXXCBC-900). Pure,
+// no server.
+
+#include "framework/test_runner.hxx"
+
+#include "core/protostellar/bucket_admin_converter.hxx"
+
+#include <cstdint>
+#include <string>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace ba = ::couchbase::core::protostellar::bucket_admin;
+namespace mgmt = ::couchbase::core::management::cluster;
+namespace v1 = ::couchbase::admin::bucket::v1;
+
+void
+apply_settings_maps_fields()
+{
+  mgmt::bucket_settings settings;
+  settings.name = "b";
+  settings.ram_quota_mb = 256;
+  settings.bucket_type = mgmt::bucket_type::couchbase;
+  settings.num_replicas = 2;
+  settings.flush_enabled = true;
+  settings.max_expiry = 3600;
+  settings.eviction_policy = mgmt::bucket_eviction_policy::full;
+  settings.compression_mode = mgmt::bucket_compression::active;
+
+  v1::CreateBucketRequest proto;
+  ba::apply_settings(settings, proto);
+  assert_true(ba::apply_create_only_settings(settings, proto), "couchbase bucket encodes");
+  assert_eq(proto.bucket_name(), std::string{ "b" }, "name mapped");
+  assert_eq(proto.ram_quota_mb(), std::uint64_t{ 256 }, "ram quota mapped");
+  assert_true(proto.bucket_type() == v1::BUCKET_TYPE_COUCHBASE, "bucket type mapped");
+  assert_eq(proto.num_replicas(), std::uint32_t{ 2 }, "num_replicas mapped");
+  assert_true(proto.flush_enabled(), "flush_enabled mapped");
+  assert_eq(proto.max_expiry_secs(), std::uint32_t{ 3600 }, "max_expiry mapped");
+  assert_true(proto.eviction_mode() == v1::EVICTION_MODE_FULL, "eviction mapped");
+  assert_true(proto.compression_mode() == v1::COMPRESSION_MODE_ACTIVE, "compression mapped");
+}
+
+void
+apply_settings_omits_unset_ram_quota()
+{
+  mgmt::bucket_settings settings;
+  settings.name = "b";
+  settings.ram_quota_mb = 0; // 0 means "unset" in core; must not be sent to the gateway
+  settings.bucket_type = mgmt::bucket_type::couchbase;
+
+  v1::CreateBucketRequest proto;
+  ba::apply_settings(settings, proto);
+  assert_false(proto.has_ram_quota_mb(), "apply_settings does not send an unset (0) ram quota");
+
+  // Create still needs a quota: the create-only path backfills the historical 100 MiB default.
+  assert_true(ba::apply_create_only_settings(settings, proto), "couchbase bucket encodes");
+  assert_eq(proto.ram_quota_mb(), std::uint64_t{ 100 }, "create backfills the default ram quota");
+}
+
+void
+apply_settings_rejects_memcached()
+{
+  mgmt::bucket_settings settings;
+  settings.name = "legacy";
+  settings.bucket_type = mgmt::bucket_type::memcached;
+  v1::CreateBucketRequest proto;
+  ba::apply_settings(settings, proto);
+  assert_false(ba::apply_create_only_settings(settings, proto),
+               "memcached bucket has no couchbase2 mapping");
+}
+
+void
+decode_bucket_maps_fields()
+{
+  v1::ListBucketsResponse_Bucket proto;
+  proto.set_bucket_name("travel");
+  proto.set_ram_quota_mb(512);
+  proto.set_bucket_type(v1::BUCKET_TYPE_EPHEMERAL);
+  proto.set_num_replicas(1);
+  proto.set_flush_enabled(false);
+  proto.set_storage_backend(v1::STORAGE_BACKEND_MAGMA);
+
+  const auto settings = ba::decode_bucket(proto);
+  assert_eq(settings.name, std::string{ "travel" }, "name decoded");
+  assert_eq(settings.ram_quota_mb, std::uint64_t{ 512 }, "ram quota decoded");
+  assert_true(settings.bucket_type == mgmt::bucket_type::ephemeral, "ephemeral decoded");
+  assert_true(settings.num_replicas.has_value() && settings.num_replicas.value() == 1U,
+              "num_replicas decoded");
+  assert_true(settings.flush_enabled.has_value() && !settings.flush_enabled.value(),
+              "flush_enabled decoded");
+  assert_true(settings.storage_backend == mgmt::bucket_storage_backend::magma,
+              "storage backend decoded");
+}
+
+// Each of these settings is one the encode side writes, so a decode that skips it makes
+// get_bucket -> modify -> update_bucket send a default back and reset the bucket.
+void
+decode_bucket_reads_the_settings_update_would_resend()
+{
+  v1::ListBucketsResponse_Bucket proto;
+  proto.set_bucket_name("magma");
+  proto.set_storage_backend(v1::STORAGE_BACKEND_MAGMA);
+  proto.set_minimum_durability_level(::couchbase::kv::v1::DURABILITY_LEVEL_PERSIST_TO_MAJORITY);
+  proto.set_conflict_resolution_type(v1::CONFLICT_RESOLUTION_TYPE_SEQUENCE_NUMBER);
+  proto.set_history_retention_bytes(3221225472ULL); // 3 GiB — fits uint32, exceeds int32
+
+  const auto settings = ba::decode_bucket(proto);
+  assert_true(settings.storage_backend == mgmt::bucket_storage_backend::magma,
+              "magma does not decode as couchstore");
+  assert_true(settings.minimum_durability_level.has_value() &&
+                settings.minimum_durability_level.value() ==
+                  couchbase::durability_level::persist_to_majority,
+              "minimum durability decoded");
+  assert_true(settings.conflict_resolution_type ==
+                mgmt::bucket_conflict_resolution::sequence_number,
+              "conflict resolution decoded");
+  assert_true(settings.history_retention_bytes.has_value() &&
+                settings.history_retention_bytes.value() == 3221225472U,
+              "history retention decoded without truncation");
+}
+
+void
+decode_bucket_leaves_absent_optional_settings_unset()
+{
+  v1::ListBucketsResponse_Bucket proto;
+  proto.set_bucket_name("b");
+
+  const auto settings = ba::decode_bucket(proto);
+  assert_true(settings.storage_backend == mgmt::bucket_storage_backend::unknown,
+              "an absent storage_backend is not reported as couchstore");
+  assert_false(settings.minimum_durability_level.has_value(), "absent durability stays unset");
+  assert_false(settings.history_retention_bytes.has_value(), "absent retention stays unset");
+  // conflict_resolution_type is the one field with no presence bit, so an absent field and an
+  // explicit timestamp are the same message on the wire and decode alike.
+  assert_true(settings.conflict_resolution_type == mgmt::bucket_conflict_resolution::timestamp,
+              "an absent conflict resolution decodes as the proto's zero value");
+}
+
+void
+decode_bucket_drops_a_history_retention_the_core_field_cannot_hold()
+{
+  v1::ListBucketsResponse_Bucket proto;
+  proto.set_bucket_name("b");
+  proto.set_history_retention_bytes(std::uint64_t{ 1 } << 33U); // 8 GiB — beyond uint32
+
+  const auto settings = ba::decode_bucket(proto);
+  // Truncating would report 0 bytes and the next update would send that back, shrinking the
+  // retention. An empty optional is omitted on update, so the server keeps the value it has.
+  assert_false(settings.history_retention_bytes.has_value(),
+               "a retention size beyond the core field is dropped rather than wrapped");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_bucket_admin_converter",
+    {
+      { "apply_settings_maps_fields", apply_settings_maps_fields },
+      { "apply_settings_omits_unset_ram_quota", apply_settings_omits_unset_ram_quota },
+      { "apply_settings_rejects_memcached", apply_settings_rejects_memcached },
+      { "decode_bucket_maps_fields", decode_bucket_maps_fields },
+      { "decode_bucket_reads_the_settings_update_would_resend",
+        decode_bucket_reads_the_settings_update_would_resend },
+      { "decode_bucket_leaves_absent_optional_settings_unset",
+        decode_bucket_leaves_absent_optional_settings_unset },
+      { "decode_bucket_drops_a_history_retention_the_core_field_cannot_hold",
+        decode_bucket_drops_a_history_retention_the_core_field_cannot_hold },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test

--- a/test/cng/protostellar/error_utils.cxx
+++ b/test/cng/protostellar/error_utils.cxx
@@ -183,6 +183,14 @@ precondition_details_map_to_specific_kv_errors()
                 couchbase::errc::key_value::value_too_large,
               "VALUE_TOO_LARGE -> value_too_large");
 
+  // The one management precondition, and the only one not about a document: a bucket that has flush
+  // turned off. Falling back would report a broken cluster for a setting the caller can change.
+  assert_true(ps::map_status(status_with_detail(grpc::StatusCode::FAILED_PRECONDITION,
+                                                precondition("FLUSH_DISABLED")),
+                             ps::operation_kind::mutating) ==
+                couchbase::errc::management::bucket_not_flushable,
+              "FLUSH_DISABLED -> bucket_not_flushable");
+
   // FAILED_PRECONDITION with no (recognized) detail falls back to internal_server_failure.
   const grpc::Status bare{ grpc::StatusCode::FAILED_PRECONDITION, "no details" };
   assert_true(ps::map_status(bare, ps::operation_kind::mutating) ==

--- a/test/cng/protostellar/live_bucket_admin.cxx
+++ b/test/cng/protostellar/live_bucket_admin.cxx
@@ -1,0 +1,444 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Live probes of bucket management over the couchbase2:// transport (CXXCBC-900), against
+// admin.bucket.v1: that the bucket list arrives, and that settings written by create() are the
+// settings read back by get().
+
+#include "framework/live_fixture.hxx"
+#include "framework/test_runner.hxx"
+
+#include "core/management/bucket_settings.hxx"
+#include "core/operations/management/bucket_create.hxx"
+#include "core/operations/management/bucket_drop.hxx"
+#include "core/operations/management/bucket_flush.hxx"
+#include "core/operations/management/bucket_get.hxx"
+#include "core/operations/management/bucket_get_all.hxx"
+#include "core/operations/management/bucket_update.hxx"
+
+#include <couchbase/durability_level.hxx>
+#include <couchbase/error_codes.hxx>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <system_error>
+#include <thread>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace ops = ::couchbase::core::operations;
+namespace mgmt = ::couchbase::core::management::cluster;
+
+void
+list_buckets_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  const auto result = fixture.execute(ops::management::bucket_get_all_request{});
+  // Nothing on the client side answers this request with feature_not_available -- cluster.cxx
+  // routes it and the component has no refusal path for it -- so the code can only have come from a
+  // gateway that does not serve admin.bucket.v1.
+  if (result.ctx.ec == couchbase::errc::common::feature_not_available) {
+    skip("gateway does not implement admin.bucket.v1 (feature_not_available)");
+  }
+  assert_false(static_cast<bool>(result.ctx.ec), "list buckets over couchbase2 succeeds");
+
+  // Naming the bucket, rather than counting the list: a non-empty list is also what a gateway
+  // pointed at some other cluster returns.
+  const auto& expected = fixture.bucket();
+  const auto found = std::any_of(
+    result.buckets.begin(), result.buckets.end(), [&expected](const mgmt::bucket_settings& bucket) {
+      return bucket.name == expected;
+    });
+  assert_true(found, "the bucket under test appears in the list");
+}
+
+// Drops the bucket however the case leaves -- an assertion failure unwinds, and a bucket left
+// behind makes the next run fail on "already exists".
+class bucket_guard
+{
+public:
+  bucket_guard(live_cluster_fixture& fixture, std::string name)
+    : fixture_{ fixture }
+    , name_{ std::move(name) }
+  {
+  }
+
+  bucket_guard(const bucket_guard&) = delete;
+  bucket_guard(bucket_guard&&) = delete;
+  auto operator=(const bucket_guard&) -> bucket_guard& = delete;
+  auto operator=(bucket_guard&&) -> bucket_guard& = delete;
+
+  ~bucket_guard()
+  {
+    ops::management::bucket_drop_request request{};
+    request.name = name_;
+    static_cast<void>(fixture_.execute(std::move(request)));
+  }
+
+private:
+  live_cluster_fixture& fixture_;
+  std::string name_;
+};
+
+// Creates the bucket, or skips the case for a condition that belongs to the cluster rather than to
+// the client.
+void
+create_or_skip(live_cluster_fixture& fixture, const mgmt::bucket_settings& settings)
+{
+  ops::management::bucket_create_request create{};
+  create.bucket = settings;
+  const auto created = fixture.execute(std::move(create));
+  if (created.ctx.ec == couchbase::errc::common::feature_not_available) {
+    skip("gateway does not implement admin.bucket.v1 (feature_not_available)");
+  }
+  // A cluster whose whole KV quota is already committed cannot host another bucket, which is the
+  // state a stock cbdinocluster allocation is in. That is a property of the cluster and not of the
+  // client, so it is a skip -- but only on the server's own account of it: the message is quoted
+  // from the gateway's status, and no client-side refusal produces one.
+  if (created.ctx.ec == couchbase::errc::common::invalid_argument &&
+      created.error_message.find("ram quota") != std::string::npos) {
+    skip("cluster has no spare KV quota for a test bucket (" + created.error_message + ")");
+  }
+  // A minimum durability level needs enough data servers to satisfy it, which a single-node cluster
+  // does not have. Same reasoning as the quota above: a property of the cluster, reported in the
+  // server's own words, so it cannot be confused with the client refusing the setting.
+  if (created.ctx.ec == couchbase::errc::common::invalid_argument &&
+      created.error_message.find("DurabilityMinLevel") != std::string::npos) {
+    skip("cluster cannot satisfy the requested durability (" + created.error_message + ")");
+  }
+  assert_false(static_cast<bool>(created.ctx.ec),
+               "create bucket over couchbase2 succeeds: " + created.error_message);
+}
+
+// Neither a create nor an update is visible the instant its RPC returns, so a case that reads
+// straight back is asserting on whichever of the two it happened to win. Poll until the bucket is
+// there and carries what the case is waiting for.
+auto
+wait_for_bucket(live_cluster_fixture& fixture,
+                const std::string& name,
+                const std::function<bool(const mgmt::bucket_settings&)>& ready)
+  -> mgmt::bucket_settings
+{
+  ops::management::bucket_get_response fetched;
+  for (int attempt = 0; attempt < 30; ++attempt) {
+    ops::management::bucket_get_request get{};
+    get.name = name;
+    fetched = fixture.execute(std::move(get));
+    if (!fetched.ctx.ec && ready(fetched.bucket)) {
+      return fetched.bucket;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds{ 500 });
+  }
+  assert_false(static_cast<bool>(fetched.ctx.ec), "get bucket over couchbase2 succeeds");
+  assert_true(false, "bucket '" + name + "' did not reach the expected state");
+  return {};
+}
+
+void
+bucket_settings_round_trip_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  const std::string name{ "cng-round-trip" };
+
+  mgmt::bucket_settings settings;
+  settings.name = name;
+  settings.bucket_type = mgmt::bucket_type::couchbase;
+  settings.ram_quota_mb = 100; // the gateway's floor for a couchstore bucket
+  settings.num_replicas = 0;
+  settings.flush_enabled = true;
+  settings.max_expiry = 3600;
+  settings.compression_mode = mgmt::bucket_compression::active;
+  // Not what the gateway would choose by itself -- it defaults conflict resolution to
+  // sequence_number -- so this fails if the field is written but not read back. Minimum durability
+  // is the other such field, and it has its own case below because not every cluster can satisfy
+  // one; keeping it out of here means a single-node cluster still runs everything else.
+  settings.conflict_resolution_type = mgmt::bucket_conflict_resolution::timestamp;
+
+  create_or_skip(fixture, settings);
+  const bucket_guard guard{ fixture, name };
+
+  const auto read_back = wait_for_bucket(fixture, name, [](const mgmt::bucket_settings&) {
+    return true;
+  });
+  assert_eq(read_back.name, name, "name round-trips");
+  assert_true(read_back.conflict_resolution_type == mgmt::bucket_conflict_resolution::timestamp,
+              "conflict resolution round-trips");
+  assert_true(read_back.flush_enabled.has_value() && read_back.flush_enabled.value(),
+              "flush_enabled round-trips");
+  assert_eq(read_back.ram_quota_mb, std::uint64_t{ 100 }, "ram quota round-trips");
+  assert_true(read_back.compression_mode == mgmt::bucket_compression::active,
+              "compression mode round-trips");
+  // storage_backend and the history-retention settings are not asserted here. Reading them back
+  // only proves anything for magma, which the gateway requires a 1024 MB quota for (and history
+  // retention a further 2048 MB), more than a development cluster reliably has spare. The
+  // converter unit tests cover both against a constructed response.
+}
+
+// Its own case rather than part of the round trip above, because the server refuses a minimum
+// durability the cluster has too few data servers for, and a single-node cluster has too few for
+// any of them. Folding it in would make the whole round trip skip there instead of just this.
+void
+minimum_durability_round_trips_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  const std::string name{ "cng-durability" };
+
+  mgmt::bucket_settings settings;
+  settings.name = name;
+  settings.bucket_type = mgmt::bucket_type::couchbase;
+  settings.ram_quota_mb = 100;
+  settings.num_replicas = 1;
+  // A bucket has no minimum durability unless one is asked for, so reading this back is only
+  // possible if the field survived both directions.
+  settings.minimum_durability_level = couchbase::durability_level::majority;
+
+  create_or_skip(fixture, settings);
+  const bucket_guard guard{ fixture, name };
+
+  const auto read_back = wait_for_bucket(fixture, name, [](const mgmt::bucket_settings& bucket) {
+    return bucket.minimum_durability_level.has_value();
+  });
+  assert_true(read_back.minimum_durability_level.value() == couchbase::durability_level::majority,
+              "minimum durability round-trips");
+}
+
+// update -> flush -> drop over one bucket, which is the shape gocbcoreps' bucket admin tests use.
+// Each step is checked through a subsequent read rather than on its own status alone.
+void
+bucket_lifecycle_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  const std::string name{ "cng-lifecycle" };
+
+  mgmt::bucket_settings settings;
+  settings.name = name;
+  settings.bucket_type = mgmt::bucket_type::couchbase;
+  settings.ram_quota_mb = 100;
+  settings.num_replicas = 0;
+  settings.flush_enabled = false;
+
+  create_or_skip(fixture, settings);
+  const bucket_guard guard{ fixture, name };
+  static_cast<void>(wait_for_bucket(fixture, name, [](const mgmt::bucket_settings& bucket) {
+    return bucket.flush_enabled.has_value() && !bucket.flush_enabled.value();
+  }));
+
+  // FLUSH_DISABLED arrives as a FAILED_PRECONDITION whose violation type names it. Without that
+  // mapping the caller is told the cluster failed, rather than that the bucket has flush turned off
+  // and they can turn it on.
+  {
+    ops::management::bucket_flush_request flush{};
+    flush.name = name;
+    const auto refused = fixture.execute(std::move(flush));
+    assert_true(refused.ctx.ec == couchbase::errc::management::bucket_not_flushable,
+                "flushing a bucket with flush disabled reports bucket_not_flushable");
+  }
+
+  settings.flush_enabled = true;
+  settings.ram_quota_mb = 128;
+  {
+    ops::management::bucket_update_request update{};
+    update.bucket = settings;
+    const auto updated = fixture.execute(std::move(update));
+    assert_false(static_cast<bool>(updated.ctx.ec),
+                 "update bucket over couchbase2 succeeds: " + updated.error_message);
+  }
+
+  const auto after_update = wait_for_bucket(fixture, name, [](const mgmt::bucket_settings& bucket) {
+    return bucket.flush_enabled.value_or(false);
+  });
+  assert_eq(
+    after_update.ram_quota_mb, std::uint64_t{ 128 }, "the updated quota is what get reports");
+
+  // Enabling flush is visible in the bucket list before the server will act on it, so the first
+  // flush after the update can still be refused. Retried rather than slept on, and bounded so a
+  // permanent failure is still a failure.
+  {
+    std::error_code flush_ec{};
+    for (int attempt = 0; attempt < 20; ++attempt) {
+      ops::management::bucket_flush_request flush{};
+      flush.name = name;
+      flush_ec = fixture.execute(std::move(flush)).ctx.ec;
+      if (!flush_ec) {
+        break;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds{ 500 });
+    }
+    assert_false(static_cast<bool>(flush_ec),
+                 "flush succeeds once the bucket allows it: " + flush_ec.message());
+  }
+
+  {
+    ops::management::bucket_drop_request drop{};
+    drop.name = name;
+    const auto dropped = fixture.execute(std::move(drop));
+    assert_false(static_cast<bool>(dropped.ctx.ec), "drop bucket over couchbase2 succeeds");
+  }
+
+  ops::management::bucket_get_request get{};
+  get.name = name;
+  const auto gone = fixture.execute(std::move(get));
+  assert_true(gone.ctx.ec == couchbase::errc::common::bucket_not_found,
+              "a dropped bucket is no longer reported");
+}
+
+// The gateway distinguishes these by attaching a ResourceInfo naming the resource type, which is
+// what turns a bare NOT_FOUND into bucket_not_found rather than document_not_found. None of them
+// needs spare quota: each is refused before anything is allocated.
+void
+bucket_errors_carry_the_bucket_specific_code()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  const std::string missing{ "cng-no-such-bucket" };
+
+  {
+    mgmt::bucket_settings settings;
+    settings.name = fixture.bucket(); // already exists
+    settings.bucket_type = mgmt::bucket_type::couchbase;
+    settings.ram_quota_mb = 100;
+    ops::management::bucket_create_request create{};
+    create.bucket = std::move(settings);
+    const auto created = fixture.execute(std::move(create));
+    if (created.ctx.ec == couchbase::errc::common::feature_not_available) {
+      skip("gateway does not implement admin.bucket.v1 (feature_not_available)");
+    }
+    assert_true(created.ctx.ec == couchbase::errc::management::bucket_exists,
+                "creating an existing bucket reports bucket_exists, not document_exists");
+  }
+  {
+    mgmt::bucket_settings settings;
+    settings.name = missing;
+    ops::management::bucket_update_request update{};
+    update.bucket = std::move(settings);
+    const auto updated = fixture.execute(std::move(update));
+    assert_true(updated.ctx.ec == couchbase::errc::common::bucket_not_found,
+                "updating a missing bucket reports bucket_not_found");
+  }
+  {
+    ops::management::bucket_drop_request drop{};
+    drop.name = missing;
+    const auto dropped = fixture.execute(std::move(drop));
+    assert_true(dropped.ctx.ec == couchbase::errc::common::bucket_not_found,
+                "dropping a missing bucket reports bucket_not_found");
+  }
+  {
+    ops::management::bucket_flush_request flush{};
+    flush.name = missing;
+    const auto flushed = fixture.execute(std::move(flush));
+    assert_true(flushed.ctx.ec == couchbase::errc::common::bucket_not_found,
+                "flushing a missing bucket reports bucket_not_found");
+  }
+  {
+    ops::management::bucket_get_request get{};
+    get.name = missing;
+    const auto fetched = fixture.execute(std::move(get));
+    assert_true(fetched.ctx.ec == couchbase::errc::common::bucket_not_found,
+                "getting a missing bucket reports bucket_not_found");
+  }
+  {
+    // A replica count the cluster cannot satisfy. The gateway forwards it and the server rejects
+    // it, so this also pins that an INVALID_ARGUMENT is not flattened into a generic failure.
+    mgmt::bucket_settings settings;
+    settings.name = "cng-too-many-replicas";
+    settings.bucket_type = mgmt::bucket_type::couchbase;
+    settings.ram_quota_mb = 100;
+    settings.num_replicas = 5;
+    ops::management::bucket_create_request create{};
+    create.bucket = std::move(settings);
+    const auto created = fixture.execute(std::move(create));
+    assert_true(created.ctx.ec == couchbase::errc::common::invalid_argument,
+                "an impossible replica count reports invalid_argument");
+  }
+}
+
+// memcached buckets have no couchbase2 representation, so the request is refused by the client
+// before anything is sent, on the io context like every other completion.
+void
+a_memcached_bucket_is_refused_by_the_client()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  mgmt::bucket_settings settings;
+  settings.name = "cng-memcached";
+  settings.bucket_type = mgmt::bucket_type::memcached;
+  settings.ram_quota_mb = 100;
+
+  ops::management::bucket_create_request create{};
+  create.bucket = std::move(settings);
+  const auto [created, handler_thread] = fixture.execute_on(std::move(create));
+
+  assert_true(created.ctx.ec == couchbase::errc::common::feature_not_available,
+              "a memcached bucket is refused rather than sent");
+  assert_true(created.error_message.empty(),
+              "the refusal is the client's own, so it carries no gateway message");
+  assert_true(handler_thread != std::this_thread::get_id(),
+              "the refusal is delivered on the io context, not inline out of execute()");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_live_bucket_admin",
+    {
+      { "list_buckets_against_live_gateway",
+        list_buckets_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "bucket_settings_round_trip_against_live_gateway",
+        bucket_settings_round_trip_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "minimum_durability_round_trips_against_live_gateway",
+        minimum_durability_round_trips_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "bucket_lifecycle_against_live_gateway",
+        bucket_lifecycle_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "bucket_errors_carry_the_bucket_specific_code",
+        bucket_errors_carry_the_bucket_specific_code,
+        timeout::integration,
+        test_env::cluster_only },
+      { "a_memcached_bucket_is_refused_by_the_client",
+        a_memcached_bucket_is_refused_by_the_client,
+        timeout::integration,
+        test_env::cluster_only },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test


### PR DESCRIPTION
Bucket management was rejected by the HTTP execute front-door gate on
couchbase2. Wire the six bucket admin operations onto the unary gRPC path via
admin.bucket.v1.

Add a bucket-admin converter mapping core bucket_settings to and from the proto:
create/update encode the mutable settings (ram quota, replicas, flush, max
expiry, durability, eviction, compression, history retention), with bucket type,
replica indexes, storage backend, and conflict resolution set only on create
since they are immutable afterward. Every field the encode side writes is read
back, and the optional ones through their presence bit, so get-modify-update
does not reset a setting the caller never touched. A history retention size the
32-bit core field cannot hold is left unset rather than wrapped. The proto enums
have no `unknown` sentinel, so core `unknown` values fall through to the server
default; memcached buckets have no couchbase2 representation and are reported as
feature_not_available, on the io context like every other completion.
admin.bucket.v1 has no GetBucket RPC, so bucket_get filters the bucket list by
name. The component gains a BucketAdminService stub and six unary execute()
overloads (get_all/get/create/update/drop/flush); cluster_impl routes them.
component_timeouts gains a management entry, taken from the cluster options like
every other service.

FLUSH_DISABLED joins the mapped FAILED_PRECONDITION violations, so flushing a
bucket that has flush turned off reports bucket_not_flushable rather than a
generic server failure.

The gateway (1.2.2) serves admin.bucket.v1. The live suite covers the settings
round trip, an update/flush/drop lifecycle, and the bucket-specific error codes
the gateway's ResourceInfo details select; converter unit tests cover the
mapping and its presence-sensitive fields. A minimum durability level is checked
separately, since a cluster with too few data servers cannot host a bucket that
asks for one, and that must cost only its own case.

The live cases create a bucket of their own, which does not fit beside the test
bucket at the operator's default quota, so CI raises the data service quota
before creating it, and allocates three KV nodes so the durability case runs
there rather than skipping.

The CNG job reports the runner's cpu, memory and disk before allocating, and
runs ctest verbosely: several cluster-only cases skip themselves on a condition
of the cluster, and a green log that does not say which ones ran cannot be told
apart from one that stopped exercising them.

Every management response carries the caller's client_context_id into its error
context -- on the completion and on the paths that never reach the server, which
have nothing else to correlate them by.

---
Stacked PR **17/30** in the CNG (`couchbase2://`) transport series. The change specific to this PR is its top commit; the commits beneath it belong to earlier PRs in the series. Depends on #1038 — merge the series bottom-up.
