### PR TITLE
CXXCBC-900: route scope and collection management over couchbase2

### DIFF
--- a/.github/actions/create-cng-cluster/action.yml
+++ b/.github/actions/create-cng-cluster/action.yml
@@ -116,28 +116,32 @@ runs:
     - name: Raise the data service quota
       shell: bash
       run: |
-        # The bucket management cases create a bucket of their own, and at the operator's 256 MiB
-        # default the 100 MB test bucket leaves too little room for one -- they would report the
-        # gateway's "ram quota specified is too large" and skip, so the suite would stay green while
-        # testing less. 512 MiB is the smallest quota that fits the test bucket plus a 128 MB bucket
-        # under update, and is nothing against the runner's 16 GB.
+        # The bucket and collection management cases create buckets of their own, and at the
+        # operator's 256 MiB default the 100 MB test bucket leaves no room for one -- the create
+        # would report the gateway's "ram quota specified is too large" and fail the case.
+        #
+        # 1280 MiB is set by the largest of those buckets: the collection history retention case
+        # needs a magma bucket, and the gateway refuses to create one below 1024 MB whatever the
+        # server would accept. With the 100 MB test bucket alongside it that is 1124 MB, and ctest
+        # runs the CNG suites serially, so no two test buckets are ever allocated at once. Three KV
+        # nodes reserve it each, which is 3.8 GiB of the runner's 15.
         #
         # It has to be a patch: the quota cannot be expressed in the cluster definition, and setting
         # it through /pools/default is reconciled away by the operator within the minute.
         kubectl -n "cbdc2-$CBDC_ID" patch couchbasecluster cluster --type=merge \
-          -p '{"spec":{"cluster":{"dataServiceMemoryQuota":"512Mi"}}}'
+          -p '{"spec":{"cluster":{"dataServiceMemoryQuota":"1280Mi"}}}'
         # Waiting on condition=Available would prove nothing: it is already true from before the
         # patch, so the wait returns instantly and the bucket could be created against the old
-        # quota. Poll the cluster itself for the applied value, and fail rather than let the
-        # bucket-management cases quietly skip for want of room.
+        # quota. Poll the cluster itself for the applied value, and fail here rather than leave the
+        # management cases to fail one by one on a bucket create.
         MGMT=$(cbdinocluster mgmt "$CBDC_ID" | tail -1)
         for _ in $(seq 1 30); do
           QUOTA=$(curl -sS -u Administrator:password "$MGMT/pools/default" | jq -r '.memoryQuota')
           echo "data service quota: $QUOTA"
-          [ "$QUOTA" = "512" ] && break
+          [ "$QUOTA" = "1280" ] && break
           sleep 5
         done
-        [ "$QUOTA" = "512" ] || { echo "::error::data service quota never reached 512 MiB"; exit 1; }
+        [ "$QUOTA" = "1280" ] || { echo "::error::data service quota never reached 1280 MiB"; exit 1; }
     - name: Add bucket
       shell: bash
       env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -214,9 +214,9 @@ jobs:
         run: |
           chmod -R +x ./cmake-build-tests
           # --verbose rather than --output-on-failure, which prints nothing for a passing suite.
-          # Several cluster-only cases skip themselves on a condition of the cluster -- no spare
-          # KV quota, too few data servers for a minimum durability level, a service the gateway
-          # does not implement -- and each of those decisions is invisible in a green log without
+          # Several cluster-only cases skip themselves on a condition of the cluster -- too few
+          # data servers for a minimum durability level, a service the gateway does not implement
+          # -- and each of those decisions is invisible in a green log without
           # this. A suite that quietly stops exercising a case still reports 100% passed, which is
           # the failure mode these tests exist to prevent, so the log has to say what ran.
           ctest --test-dir ./cmake-build-tests --verbose --label-regex 'cng' \

--- a/core/cluster.cxx
+++ b/core/cluster.cxx
@@ -782,7 +782,13 @@ public:
                     std::is_same_v<Request, operations::management::bucket_create_request> ||
                     std::is_same_v<Request, operations::management::bucket_update_request> ||
                     std::is_same_v<Request, operations::management::bucket_drop_request> ||
-                    std::is_same_v<Request, operations::management::bucket_flush_request>) {
+                    std::is_same_v<Request, operations::management::bucket_flush_request> ||
+                    std::is_same_v<Request, operations::management::scope_get_all_request> ||
+                    std::is_same_v<Request, operations::management::scope_create_request> ||
+                    std::is_same_v<Request, operations::management::scope_drop_request> ||
+                    std::is_same_v<Request, operations::management::collection_create_request> ||
+                    std::is_same_v<Request, operations::management::collection_update_request> ||
+                    std::is_same_v<Request, operations::management::collection_drop_request>) {
         component->execute(std::move(request), std::forward<Handler>(handler));
         return;
       } else {
@@ -815,6 +821,16 @@ public:
                                             bucket_capability cap,
                                             Handler&& handler)
   {
+    // There is no bucket capability to read over couchbase2, and no MCBP connection to read it
+    // over: open_bucket() below would bootstrap a session against a port the gateway does not
+    // serve, so a request that only wants a capability checked would fail on the check rather
+    // than on what it asked for. The gateway still validates the capability the request depends
+    // on -- history retention needs a magma bucket wherever the request arrives from -- so
+    // routing straight through refuses the same requests, one hop later and in the server's own
+    // words.
+    if (is_protostellar()) {
+      return execute(std::move(request), std::forward<Handler>(handler));
+    }
     auto bucket_name = request.bucket_name;
     return open_bucket(
       bucket_name,

--- a/core/protostellar/collection_admin_converter.hxx
+++ b/core/protostellar/collection_admin_converter.hxx
@@ -1,0 +1,92 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+// Decodes couchbase.admin.collection.v1 ListCollections into a core collections_manifest, and maps
+// a collection's max_expiry onto the wire in the other direction. The rest of the scope/collection
+// encodes are string setters and live inline in the component; max_expiry does not, because its
+// two halves only agree if they are read together. Per-scope and per-collection uids are not
+// carried by the proto, so only the top-level manifest uid is populated.
+
+#include "core/topology/collections_manifest.hxx"
+
+#include <couchbase/admin/collection/v1/collection.pb.h>
+
+#include <cstdint>
+#include <optional>
+#include <utility>
+
+namespace couchbase::core::protostellar::collection_admin
+{
+namespace v1 = ::couchbase::admin::collection::v1;
+
+// Maps the core max_expiry sentinel onto max_expiry_secs. The proto field is unsigned, so the sign
+// the core struct carries has to become the field's presence: a negative value ("no expiry") is an
+// explicit 0, and 0 has no encoding at all -- nullopt here means leave the field unset. What an
+// unset field then means belongs to the caller, and it differs between the two RPCs: on create it
+// is "inherit the bucket default", which is what 0 asked for, and on update it is "leave the
+// collection as it is", which is not.
+//
+// -1 is the only negative the core struct gives a meaning; the caller refuses anything below it
+// with invalid_argument before reaching here, as the classic path does. Every negative maps to the
+// same wire form, so an unvalidated -5 would silently become "no expiry".
+[[nodiscard]] inline auto
+encode_max_expiry(std::int32_t max_expiry) -> std::optional<std::uint32_t>
+{
+  if (max_expiry < 0) {
+    return 0U;
+  }
+  if (max_expiry == 0) {
+    return {};
+  }
+  return static_cast<std::uint32_t>(max_expiry);
+}
+
+[[nodiscard]] inline auto
+decode_manifest(const v1::ListCollectionsResponse& proto) -> topology::collections_manifest
+{
+  topology::collections_manifest manifest;
+  manifest.uid = proto.manifest_uid();
+  for (const auto& proto_scope : proto.scopes()) {
+    topology::collections_manifest::scope scope;
+    scope.name = proto_scope.name();
+    for (const auto& proto_collection : proto_scope.collections()) {
+      topology::collections_manifest::collection collection;
+      collection.name = proto_collection.name();
+      // max_expiry_secs is an unsigned optional, so the gateway spends the presence bit on the
+      // distinction the core struct makes with a sign: the field left unset is "inherit the bucket
+      // default" (0), an explicit 0 is "no expiry" (-1). The value getter alone collapses the two,
+      // because it returns 0 for an absent field as well.
+      if (!proto_collection.has_max_expiry_secs()) {
+        collection.max_expiry = 0;
+      } else if (proto_collection.max_expiry_secs() == 0) {
+        collection.max_expiry = -1;
+      } else {
+        collection.max_expiry = static_cast<std::int32_t>(proto_collection.max_expiry_secs());
+      }
+      if (proto_collection.has_history_retention_enabled()) {
+        collection.history = proto_collection.history_retention_enabled();
+      }
+      scope.collections.push_back(std::move(collection));
+    }
+    manifest.scopes.push_back(std::move(scope));
+  }
+  return manifest;
+}
+
+} // namespace couchbase::core::protostellar::collection_admin

--- a/core/protostellar/component.cxx
+++ b/core/protostellar/component.cxx
@@ -26,6 +26,7 @@
 #include "core/operations/query_response_parsing.hxx"
 #include "core/protostellar/analytics_converter.hxx"
 #include "core/protostellar/bucket_admin_converter.hxx"
+#include "core/protostellar/collection_admin_converter.hxx"
 #include "core/protostellar/credentials.hxx"
 #include "core/protostellar/error_utils.hxx"
 #include "core/protostellar/kv_converter.hxx"
@@ -39,6 +40,7 @@
 #include <couchbase/analytics/v1/analytics.grpc.pb.h>
 
 #include <couchbase/admin/bucket/v1/bucket.grpc.pb.h>
+#include <couchbase/admin/collection/v1/collection.grpc.pb.h>
 #include <couchbase/kv/v1/kv.grpc.pb.h>
 #include <couchbase/search/v1/search.grpc.pb.h>
 #include <couchbase/view/v1/view.grpc.pb.h>
@@ -62,6 +64,7 @@ namespace analytics_v1 = ::couchbase::analytics::v1;
 namespace search_v1 = ::couchbase::search::v1;
 namespace view_v1 = ::couchbase::view::v1;
 namespace bucket_admin_v1 = ::couchbase::admin::bucket::v1;
+namespace collection_admin_v1 = ::couchbase::admin::collection::v1;
 
 // Defined here rather than in the header so the generated gRPC types stay out of every consumer of
 // component.hxx.
@@ -72,6 +75,7 @@ struct component::stubs {
   std::unique_ptr<search_v1::SearchService::Stub> search;
   std::unique_ptr<view_v1::ViewService::Stub> view;
   std::unique_ptr<bucket_admin_v1::BucketAdminService::Stub> bucket_admin;
+  std::unique_ptr<collection_admin_v1::CollectionAdminService::Stub> collection_admin;
 };
 
 namespace
@@ -142,7 +146,8 @@ component::component(asio::io_context& io, component_config config)
              analytics_v1::AnalyticsService::NewStub(config.channel),
              search_v1::SearchService::NewStub(config.channel),
              view_v1::ViewService::NewStub(config.channel),
-             bucket_admin_v1::BucketAdminService::NewStub(config.channel) }) }
+             bucket_admin_v1::BucketAdminService::NewStub(config.channel),
+             collection_admin_v1::CollectionAdminService::NewStub(config.channel) }) }
   , authorization_{ authorization_header(config.credentials) }
   , timeouts_{ config.timeouts }
   // Initialised last (see the declaration order in the header), so the channel can be moved in.
@@ -1233,6 +1238,294 @@ component::execute(
       operations::management::bucket_flush_response response;
       response.ctx.client_context_id = client_context_id;
       response.ctx.ec = map_status(status, operation_kind::mutating);
+      handler(std::move(response));
+    });
+}
+
+auto
+component::execute(
+  operations::management::scope_get_all_request request,
+  utils::movable_function<void(operations::management::scope_get_all_response)>&& handler)
+  -> pending_call
+{
+  const auto client_context_id = request.client_context_id.value_or(std::string{});
+  auto proto = std::make_shared<collection_admin_v1::ListCollectionsRequest>();
+  proto->set_bucket_name(request.bucket_name);
+  const auto timeout = request.timeout.value_or(timeouts_.management);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped_management(request));
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->collection_admin.get();
+  return dispatcher_.unary<collection_admin_v1::ListCollectionsResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        collection_admin_v1::ListCollectionsResponse& resp,
+                        std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->ListCollections(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), proto, client_context_id](
+      grpc::Status status, collection_admin_v1::ListCollectionsResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      operations::management::scope_get_all_response response;
+      response.ctx.client_context_id = client_context_id;
+      response.ctx.ec = map_status(status, operation_kind::read_only);
+      if (!response.ctx.ec) {
+        response.manifest = collection_admin::decode_manifest(resp);
+      }
+      handler(std::move(response));
+    });
+}
+
+auto
+component::execute(
+  operations::management::scope_create_request request,
+  utils::movable_function<void(operations::management::scope_create_response)>&& handler)
+  -> pending_call
+{
+  const auto client_context_id = request.client_context_id.value_or(std::string{});
+  auto proto = std::make_shared<collection_admin_v1::CreateScopeRequest>();
+  proto->set_bucket_name(request.bucket_name);
+  proto->set_scope_name(request.scope_name);
+  const auto timeout = request.timeout.value_or(timeouts_.management);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped_management(request));
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->collection_admin.get();
+  return dispatcher_.unary<collection_admin_v1::CreateScopeResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        collection_admin_v1::CreateScopeResponse& resp,
+                        std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->CreateScope(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), proto, client_context_id](
+      grpc::Status status, collection_admin_v1::CreateScopeResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      operations::management::scope_create_response response;
+      response.ctx.client_context_id = client_context_id;
+      response.ctx.ec = map_status(status, operation_kind::mutating);
+      response.uid = resp.manifest_uid();
+      handler(std::move(response));
+    });
+}
+
+auto
+component::execute(
+  operations::management::scope_drop_request request,
+  utils::movable_function<void(operations::management::scope_drop_response)>&& handler)
+  -> pending_call
+{
+  const auto client_context_id = request.client_context_id.value_or(std::string{});
+  auto proto = std::make_shared<collection_admin_v1::DeleteScopeRequest>();
+  proto->set_bucket_name(request.bucket_name);
+  proto->set_scope_name(request.scope_name);
+  const auto timeout = request.timeout.value_or(timeouts_.management);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped_management(request));
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->collection_admin.get();
+  return dispatcher_.unary<collection_admin_v1::DeleteScopeResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        collection_admin_v1::DeleteScopeResponse& resp,
+                        std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->DeleteScope(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), proto, client_context_id](
+      grpc::Status status, collection_admin_v1::DeleteScopeResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      operations::management::scope_drop_response response;
+      response.ctx.client_context_id = client_context_id;
+      response.ctx.ec = map_status(status, operation_kind::mutating);
+      response.uid = resp.manifest_uid();
+      handler(std::move(response));
+    });
+}
+
+auto
+component::execute(
+  operations::management::collection_create_request request,
+  utils::movable_function<void(operations::management::collection_create_response)>&& handler)
+  -> pending_call
+{
+  const auto client_context_id = request.client_context_id.value_or(std::string{});
+  // -1 is the lowest value the sign carries a meaning for, and the classic path refuses anything
+  // below it before encoding (collection_create.cxx:39-44). encode_max_expiry maps every negative
+  // onto the no-expiry wire form, so without this the same request would be invalid over
+  // couchbase:// and create a never-expiring collection over couchbase2://.
+  if (request.max_expiry.value_or(0) < -1) {
+    auto response = stamped_management(request);
+    response.ctx.ec = errc::common::invalid_argument;
+    asio::post(io_, [handler = std::move(handler), response = std::move(response)]() mutable {
+      handler(std::move(response));
+    });
+    return {};
+  }
+
+  auto proto = std::make_shared<collection_admin_v1::CreateCollectionRequest>();
+  proto->set_bucket_name(request.bucket_name);
+  proto->set_scope_name(request.scope_name);
+  proto->set_collection_name(request.collection_name);
+  // A created collection inherits the bucket default from an unset max_expiry_secs, which is what
+  // a core max_expiry of 0 asks for, so encode_max_expiry declining to produce a value is already
+  // the right wire form here.
+  if (request.max_expiry.has_value()) {
+    if (const auto secs = collection_admin::encode_max_expiry(*request.max_expiry);
+        secs.has_value()) {
+      proto->set_max_expiry_secs(secs.value());
+    }
+  }
+  if (request.history.has_value()) {
+    proto->set_history_retention_enabled(*request.history);
+  }
+  const auto timeout = request.timeout.value_or(timeouts_.management);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped_management(request));
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->collection_admin.get();
+  return dispatcher_.unary<collection_admin_v1::CreateCollectionResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        collection_admin_v1::CreateCollectionResponse& resp,
+                        std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->CreateCollection(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), proto, client_context_id](
+      grpc::Status status, collection_admin_v1::CreateCollectionResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      operations::management::collection_create_response response;
+      response.ctx.client_context_id = client_context_id;
+      response.ctx.ec = map_status(status, operation_kind::mutating);
+      response.uid = resp.manifest_uid();
+      handler(std::move(response));
+    });
+}
+
+auto
+component::execute(
+  operations::management::collection_update_request request,
+  utils::movable_function<void(operations::management::collection_update_response)>&& handler)
+  -> pending_call
+{
+  const auto client_context_id = request.client_context_id.value_or(std::string{});
+  // The sentinel translation create does, minus the one value update cannot express, and with the
+  // same lower bound. Below -1 the classic path refuses the request (collection_update.cxx:39-45).
+  // An explicit 0 is the reset to the bucket's own expiry that the classic path sends as maxTTL=0,
+  // and there is no wire form left for it: an explicit 0 already means "no expiry", and an unset
+  // field means "leave the collection as it is" rather than "inherit the bucket default". Refuse
+  // it, because reporting success for a setting the gateway was never asked to apply would leave
+  // the caller's documents expiring on the old policy.
+  if (request.max_expiry.has_value()) {
+    std::error_code refusal{};
+    if (*request.max_expiry < -1) {
+      refusal = errc::common::invalid_argument;
+    } else if (*request.max_expiry == 0) {
+      refusal = errc::common::feature_not_available;
+    }
+    if (refusal) {
+      auto response = stamped_management(request);
+      response.ctx.ec = refusal;
+      // Posted rather than invoked inline, so the completion arrives on the SDK's execution context
+      // after the caller holds its pending_call.
+      asio::post(io_, [handler = std::move(handler), response = std::move(response)]() mutable {
+        handler(std::move(response));
+      });
+      return {};
+    }
+  }
+
+  auto proto = std::make_shared<collection_admin_v1::UpdateCollectionRequest>();
+  proto->set_bucket_name(request.bucket_name);
+  proto->set_scope_name(request.scope_name);
+  proto->set_collection_name(request.collection_name);
+  // Zero is refused above, so what reaches here is a no-expiry sentinel or a positive TTL, and
+  // both of those encode to a value.
+  if (request.max_expiry.has_value()) {
+    if (const auto secs = collection_admin::encode_max_expiry(*request.max_expiry);
+        secs.has_value()) {
+      proto->set_max_expiry_secs(secs.value());
+    }
+  }
+  if (request.history.has_value()) {
+    proto->set_history_retention_enabled(*request.history);
+  }
+  const auto timeout = request.timeout.value_or(timeouts_.management);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped_management(request));
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->collection_admin.get();
+  return dispatcher_.unary<collection_admin_v1::UpdateCollectionResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        collection_admin_v1::UpdateCollectionResponse& resp,
+                        std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->UpdateCollection(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), proto, client_context_id](
+      grpc::Status status, collection_admin_v1::UpdateCollectionResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      operations::management::collection_update_response response;
+      response.ctx.client_context_id = client_context_id;
+      response.ctx.ec = map_status(status, operation_kind::mutating);
+      response.uid = resp.manifest_uid();
+      handler(std::move(response));
+    });
+}
+
+auto
+component::execute(
+  operations::management::collection_drop_request request,
+  utils::movable_function<void(operations::management::collection_drop_response)>&& handler)
+  -> pending_call
+{
+  const auto client_context_id = request.client_context_id.value_or(std::string{});
+  auto proto = std::make_shared<collection_admin_v1::DeleteCollectionRequest>();
+  proto->set_bucket_name(request.bucket_name);
+  proto->set_scope_name(request.scope_name);
+  proto->set_collection_name(request.collection_name);
+  const auto timeout = request.timeout.value_or(timeouts_.management);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped_management(request));
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->collection_admin.get();
+  return dispatcher_.unary<collection_admin_v1::DeleteCollectionResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        collection_admin_v1::DeleteCollectionResponse& resp,
+                        std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->DeleteCollection(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), proto, client_context_id](
+      grpc::Status status, collection_admin_v1::DeleteCollectionResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      operations::management::collection_drop_response response;
+      response.ctx.client_context_id = client_context_id;
+      response.ctx.ec = map_status(status, operation_kind::mutating);
+      response.uid = resp.manifest_uid();
       handler(std::move(response));
     });
 }

--- a/core/protostellar/component.hxx
+++ b/core/protostellar/component.hxx
@@ -55,6 +55,12 @@
 #include "core/operations/management/bucket_get.hxx"
 #include "core/operations/management/bucket_get_all.hxx"
 #include "core/operations/management/bucket_update.hxx"
+#include "core/operations/management/collection_create.hxx"
+#include "core/operations/management/collection_drop.hxx"
+#include "core/operations/management/collection_update.hxx"
+#include "core/operations/management/scope_create.hxx"
+#include "core/operations/management/scope_drop.hxx"
+#include "core/operations/management/scope_get_all.hxx"
 #include "core/protostellar/dispatcher.hxx"
 #include "core/timeout_defaults.hxx"
 #include "core/utils/movable_function.hxx"
@@ -228,6 +234,31 @@ public:
   auto execute(
     operations::management::bucket_flush_request request,
     utils::movable_function<void(operations::management::bucket_flush_response)>&& handler)
+    -> pending_call;
+
+  // Scope/collection management (unary admin RPCs over admin.collection.v1).
+  auto execute(
+    operations::management::scope_get_all_request request,
+    utils::movable_function<void(operations::management::scope_get_all_response)>&& handler)
+    -> pending_call;
+  auto execute(
+    operations::management::scope_create_request request,
+    utils::movable_function<void(operations::management::scope_create_response)>&& handler)
+    -> pending_call;
+  auto execute(operations::management::scope_drop_request request,
+               utils::movable_function<void(operations::management::scope_drop_response)>&& handler)
+    -> pending_call;
+  auto execute(
+    operations::management::collection_create_request request,
+    utils::movable_function<void(operations::management::collection_create_response)>&& handler)
+    -> pending_call;
+  auto execute(
+    operations::management::collection_update_request request,
+    utils::movable_function<void(operations::management::collection_update_response)>&& handler)
+    -> pending_call;
+  auto execute(
+    operations::management::collection_drop_request request,
+    utils::movable_function<void(operations::management::collection_drop_response)>&& handler)
     -> pending_call;
 
 private:

--- a/test/cng/CMakeLists.txt
+++ b/test/cng/CMakeLists.txt
@@ -162,4 +162,9 @@ if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 AND TARGET couchbase_cxx_protostellar)
 
   # Live Bucket management verification (CXXCBC-900).
   add_cng_test(protostellar/live_bucket_admin LINK_CLIENT LIBS couchbase_cxx_protostellar)
+  # Scope & Collection management converter (CXXCBC-900).
+  add_cng_test(protostellar/collection_admin_converter LINK_CLIENT LIBS couchbase_cxx_protostellar)
+
+  # Live Scope & Collection management verification (CXXCBC-900).
+  add_cng_test(protostellar/live_collection_admin LINK_CLIENT LIBS couchbase_cxx_protostellar)
 endif()

--- a/test/cng/README.md
+++ b/test/cng/README.md
@@ -140,9 +140,11 @@ $ kubectl -n cbdc2-"$CBDC_ID" patch couchbasecluster cluster --type=merge -p '{
 ```
 
 **Data service.** One 256 MB `default` bucket consumes the whole 256 MiB data quota, leaving the
-bucket-management round trip — which creates a bucket, reads it back and asserts the settings
-survived — with nowhere to put one. It reports the gateway's own "ram quota specified is too large"
-and skips, so the suite stays green while quietly testing less. Creating the bucket smaller
+cases that create a bucket of their own with nowhere to put one — the bucket-management round trip,
+which reads its bucket back and asserts the settings survived, and the collection-management case
+that gives a bucket its own maximum expiry to check that a collection's expiry is layered over it
+rather than merged into it. Both report the gateway's own "ram quota specified is too large" and
+skip, so the suite stays green while quietly testing less. Creating the bucket smaller
 (`--ram-quota-mb 128`) frees enough room for the couchstore case; the 1024 MiB above is what a magma
 bucket needs, since the gateway rejects a magma bucket under a 1024 MB quota (and history retention
 requires a further 2048 MB).

--- a/test/cng/framework/live_fixture.hxx
+++ b/test/cng/framework/live_fixture.hxx
@@ -45,6 +45,10 @@
 #include "core/tls_verify_mode.hxx"
 #include "core/utils/connection_string.hxx"
 
+// Inside the guarded region, not above it: this header reaches core/protostellar/dispatcher.hxx,
+// and a core header parsed before the #define above is what the comment there describes.
+#include "protostellar/callback_queue_keepalive.hxx"
+
 #include <couchbase/error_codes.hxx>
 
 #include <asio/executor_work_guard.hpp>
@@ -149,6 +153,12 @@ class live_kv_fixture
 public:
   live_kv_fixture()
   {
+    // A fixture per case means the last channel is destroyed between cases, and gRPC tears down its
+    // process-global callback queue when the last reference goes -- racing the threads still
+    // polling it and aborting the process. See callback_queue_keepalive.hxx (CXXCBC-919); the
+    // in-process harnesses pin it for the same reason.
+    pin_callback_queue();
+
     const auto connection_string = safe_getenv("TEST_CONNECTION_STRING");
     if (!connection_string.has_value()) {
       skip("TEST_CONNECTION_STRING is not set");
@@ -243,6 +253,8 @@ class live_cluster_fixture
 public:
   live_cluster_fixture()
   {
+    pin_callback_queue(); // see live_kv_fixture: a channel per case cycles gRPC's callback queue
+
     const auto connection_string = safe_getenv("TEST_CONNECTION_STRING");
     if (!connection_string.has_value()) {
       skip("TEST_CONNECTION_STRING is not set");

--- a/test/cng/protostellar/collection_admin_converter.cxx
+++ b/test/cng/protostellar/collection_admin_converter.cxx
@@ -1,0 +1,145 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Unit tests for the collection-admin <-> couchbase.admin.collection.v1 manifest decode and the
+// max_expiry encode that has to agree with it (CXXCBC-900). Pure, no server.
+
+#include "framework/test_runner.hxx"
+
+#include "core/protostellar/collection_admin_converter.hxx"
+
+#include <cstdint>
+#include <string>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace ca = ::couchbase::core::protostellar::collection_admin;
+namespace v1 = ::couchbase::admin::collection::v1;
+
+void
+decode_manifest_maps_scopes_and_collections()
+{
+  v1::ListCollectionsResponse proto;
+  proto.set_manifest_uid(42);
+  auto* scope = proto.add_scopes();
+  scope->set_name("inventory");
+  auto* products = scope->add_collections();
+  products->set_name("products");
+  products->set_max_expiry_secs(3600);
+  products->set_history_retention_enabled(true);
+  auto* orders = scope->add_collections();
+  orders->set_name("orders");
+
+  const auto manifest = ca::decode_manifest(proto);
+  assert_eq(manifest.uid, std::uint64_t{ 42 }, "manifest uid decoded");
+  assert_eq(manifest.scopes.size(), std::size_t{ 1 }, "one scope decoded");
+  assert_eq(manifest.scopes.at(0).name, std::string{ "inventory" }, "scope name decoded");
+  assert_eq(manifest.scopes.at(0).collections.size(), std::size_t{ 2 }, "two collections decoded");
+  assert_eq(manifest.scopes.at(0).collections.at(0).name,
+            std::string{ "products" },
+            "collection name decoded");
+  assert_eq(manifest.scopes.at(0).collections.at(0).max_expiry,
+            std::int32_t{ 3600 },
+            "collection max_expiry decoded");
+  assert_true(manifest.scopes.at(0).collections.at(0).history.has_value() &&
+                manifest.scopes.at(0).collections.at(0).history.value(),
+              "collection history decoded");
+  assert_false(manifest.scopes.at(0).collections.at(1).history.has_value(),
+               "unset history stays nullopt");
+}
+
+// max_expiry is the one collection field whose meaning is carried by a sign the wire cannot hold,
+// so the two halves of the mapping are pinned separately and then against each other.
+void
+encode_max_expiry_moves_the_sentinel_into_field_presence()
+{
+  const auto no_expiry = ca::encode_max_expiry(-1);
+  assert_true(no_expiry.has_value(), "no-expiry is written to the wire");
+  assert_eq(no_expiry.value(), std::uint32_t{ 0 }, "no-expiry is an explicit 0");
+
+  assert_false(ca::encode_max_expiry(0).has_value(), "inherit-the-bucket-default leaves it unset");
+
+  const auto ttl = ca::encode_max_expiry(3600);
+  assert_true(ttl.has_value(), "a positive TTL is written to the wire");
+  assert_eq(ttl.value(), std::uint32_t{ 3600 }, "a positive TTL is written unchanged");
+}
+
+void
+decode_max_expiry_reads_field_presence_back_as_the_sentinel()
+{
+  v1::ListCollectionsResponse proto;
+  auto* scope = proto.add_scopes();
+  scope->set_name("_default");
+  scope->add_collections()->set_name("inherits");
+  auto* never = scope->add_collections();
+  never->set_name("never_expires");
+  never->set_max_expiry_secs(0);
+  auto* hour = scope->add_collections();
+  hour->set_name("hourly");
+  hour->set_max_expiry_secs(3600);
+
+  const auto manifest = ca::decode_manifest(proto);
+  const auto& collections = manifest.scopes.at(0).collections;
+  assert_eq(collections.at(0).max_expiry,
+            std::int32_t{ 0 },
+            "an absent field is inherit-the-bucket-default");
+  assert_eq(collections.at(1).max_expiry, std::int32_t{ -1 }, "an explicit 0 is no-expiry");
+  assert_eq(collections.at(2).max_expiry, std::int32_t{ 3600 }, "a positive TTL survives");
+}
+
+// The encode and decode above are only correct together: reading a collection back has to return
+// the max_expiry it was created with, which is what a caller comparing the two ever sees.
+void
+max_expiry_round_trips_through_the_wire_form()
+{
+  for (const auto expected : { std::int32_t{ -1 }, std::int32_t{ 0 }, std::int32_t{ 900 } }) {
+    v1::ListCollectionsResponse proto;
+    auto* collection = proto.add_scopes()->add_collections();
+    collection->set_name("c");
+    if (const auto secs = ca::encode_max_expiry(expected); secs.has_value()) {
+      collection->set_max_expiry_secs(secs.value());
+    }
+
+    assert_eq(ca::decode_manifest(proto).scopes.at(0).collections.at(0).max_expiry,
+              expected,
+              "max_expiry " + std::to_string(expected) + " round-trips");
+  }
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_collection_admin_converter",
+    {
+      { "decode_manifest_maps_scopes_and_collections",
+        decode_manifest_maps_scopes_and_collections },
+      { "encode_max_expiry_moves_the_sentinel_into_field_presence",
+        encode_max_expiry_moves_the_sentinel_into_field_presence },
+      { "decode_max_expiry_reads_field_presence_back_as_the_sentinel",
+        decode_max_expiry_reads_field_presence_back_as_the_sentinel },
+      { "max_expiry_round_trips_through_the_wire_form",
+        max_expiry_round_trips_through_the_wire_form },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test

--- a/test/cng/protostellar/live_collection_admin.cxx
+++ b/test/cng/protostellar/live_collection_admin.cxx
@@ -1,0 +1,641 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Live probes of scope and collection management over the couchbase2:// transport (CXXCBC-900),
+// against admin.collection.v1: that the manifest arrives, and that a collection's max_expiry is
+// the value it was created with when it is read back.
+//
+// max_expiry is where the two protocols disagree in shape. The core struct spends a sign on it
+// (-1 no expiry, 0 inherit the bucket default, a positive value a TTL) and the proto field is an
+// unsigned optional, so the sentinel has to travel as the field's presence. Only a round trip
+// against a real gateway shows whether both halves of that mapping agree with the server.
+//
+// Expiry is layered: a bucket carries one and a collection may carry its own. A scope carries
+// none -- there is no expiry field on CreateScopeRequest and none in the manifest -- so the layers
+// are bucket and collection only, and the cases below cover both of them. What the layering does
+// to a *document* is out of reach here: the effective expiry of a stored document is only
+// observable through subdoc ($document.exptime), which the couchbase2 transport does not carry
+// yet.
+//
+// History retention is here for a different reason. It is the one collection setting the classic
+// path gates on a bucket capability before it sends anything, and that capability is read from a
+// cluster map couchbase2 does not have -- so the request has to be sent and the server's answer
+// taken, and only a live case shows what that answer is.
+
+#include "framework/live_fixture.hxx"
+#include "framework/test_runner.hxx"
+
+#include "core/management/bucket_settings.hxx"
+#include "core/operations/management/bucket_create.hxx"
+#include "core/operations/management/bucket_drop.hxx"
+#include "core/operations/management/collection_create.hxx"
+#include "core/operations/management/collection_update.hxx"
+#include "core/operations/management/scope_create.hxx"
+#include "core/operations/management/scope_drop.hxx"
+#include "core/operations/management/scope_get_all.hxx"
+
+#include <couchbase/error_codes.hxx>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <thread>
+#include <utility>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace ops = ::couchbase::core::operations;
+namespace mgmt = ::couchbase::core::management::cluster;
+namespace topology = ::couchbase::core::topology;
+
+// Lists the manifest, failing the case for anything but the gateway not serving the service.
+[[nodiscard]] auto
+manifest_or_skip(live_cluster_fixture& fixture) -> topology::collections_manifest
+{
+  ops::management::scope_get_all_request request{};
+  request.bucket_name = fixture.bucket();
+  auto listed = fixture.execute(std::move(request));
+  // Nothing on the client side answers this request with feature_not_available -- cluster.cxx
+  // routes it and the component has no refusal path for it -- so the code can only have come from
+  // a gateway that does not serve admin.collection.v1.
+  if (listed.ctx.ec == couchbase::errc::common::feature_not_available) {
+    skip("gateway does not implement admin.collection.v1 (feature_not_available)");
+  }
+  assert_false(static_cast<bool>(listed.ctx.ec), "list collections over couchbase2 succeeds");
+  return std::move(listed.manifest);
+}
+
+[[nodiscard]] auto
+find_collection(const topology::collections_manifest& manifest,
+                const std::string& scope_name,
+                const std::string& collection_name)
+  -> std::optional<topology::collections_manifest::collection>
+{
+  const auto scope =
+    std::find_if(manifest.scopes.begin(), manifest.scopes.end(), [&scope_name](const auto& s) {
+      return s.name == scope_name;
+    });
+  if (scope == manifest.scopes.end()) {
+    return {};
+  }
+  const auto collection = std::find_if(
+    scope->collections.begin(), scope->collections.end(), [&collection_name](const auto& c) {
+      return c.name == collection_name;
+    });
+  if (collection == scope->collections.end()) {
+    return {};
+  }
+  return *collection;
+}
+
+// -999 for a collection that is not in the manifest at all, so a missing collection cannot pass an
+// assertion by matching one of the three states the mapping produces.
+[[nodiscard]] auto
+find_max_expiry(const topology::collections_manifest& manifest,
+                const std::string& scope_name,
+                const std::string& collection_name) -> std::int32_t
+{
+  const auto collection = find_collection(manifest, scope_name, collection_name);
+  if (!collection.has_value()) {
+    return -999;
+  }
+  return collection->max_expiry;
+}
+
+// Reports history retention as a word rather than an optional<bool>, so a failure names which of
+// the four states it found: on, off, a manifest entry carrying no history field, or no such
+// collection. The last two are different defects and comparing optionals cannot tell them apart --
+// both read as "not what was expected".
+[[nodiscard]] auto
+find_history(const topology::collections_manifest& manifest,
+             const std::string& scope_name,
+             const std::string& collection_name) -> std::string
+{
+  const auto collection = find_collection(manifest, scope_name, collection_name);
+  if (!collection.has_value()) {
+    return "no such collection";
+  }
+  if (!collection->history.has_value()) {
+    return "no history field";
+  }
+  return *collection->history ? "on" : "off";
+}
+
+// Every case builds on the fixture's bucket, so each one begins by proving it is there and served:
+// skipped if the gateway does not implement admin.collection.v1, failed if the bucket answers with
+// a manifest that has no default scope and collection. Without it a bucket that is missing, empty
+// or not the one the suite was pointed at surfaces several requests later, as whatever the first
+// create happens to report.
+void
+require_default_collection(live_cluster_fixture& fixture)
+{
+  const auto manifest = manifest_or_skip(fixture);
+  assert_true(find_collection(manifest, "_default", "_default").has_value(),
+              "the fixture's bucket has a default scope and collection");
+}
+
+// A killed run leaves its scope or bucket behind and the next create then fails on "already
+// exists" rather than on anything the case is about, so each one drops first. Not-found is the
+// ordinary answer; any other error is the transport rather than the leftover, and discarding it
+// here would make the create that follows fail for a reason this run had already seen.
+void
+drop_stale_scope(live_cluster_fixture& fixture, const std::string& scope_name)
+{
+  ops::management::scope_drop_request request{};
+  request.bucket_name = fixture.bucket();
+  request.scope_name = scope_name;
+  const auto dropped = fixture.execute(std::move(request));
+  assert_true(!dropped.ctx.ec || dropped.ctx.ec == couchbase::errc::common::scope_not_found,
+              "dropping a leftover scope reports success or scope_not_found");
+}
+
+void
+drop_stale_bucket(live_cluster_fixture& fixture, const std::string& bucket_name)
+{
+  ops::management::bucket_drop_request request{};
+  request.name = bucket_name;
+  const auto dropped = fixture.execute(std::move(request));
+  assert_true(!dropped.ctx.ec || dropped.ctx.ec == couchbase::errc::common::bucket_not_found,
+              "dropping a leftover bucket reports success or bucket_not_found");
+}
+
+// Lists the manifest of a named bucket. Polls, because a bucket does not serve its manifest the
+// instant create() returns, and every caller here has just made one.
+[[nodiscard]] auto
+manifest_of(live_cluster_fixture& fixture, const std::string& bucket_name)
+  -> topology::collections_manifest
+{
+  ops::management::scope_get_all_request request{};
+  request.bucket_name = bucket_name;
+  topology::collections_manifest manifest;
+  for (int attempt = 0; attempt < 30; ++attempt) {
+    auto listed = fixture.execute(request);
+    if (!listed.ctx.ec) {
+      manifest = std::move(listed.manifest);
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds{ 500 });
+  }
+  assert_false(manifest.scopes.empty(), "the new bucket serves its manifest");
+  return manifest;
+}
+
+// Drops the scope however the case leaves -- an assertion failure unwinds, and a scope left behind
+// makes the next run fail on "already exists". Dropping the scope takes its collections with it.
+class scope_guard
+{
+public:
+  scope_guard(live_cluster_fixture& fixture, std::string name)
+    : fixture_{ fixture }
+    , name_{ std::move(name) }
+  {
+  }
+
+  scope_guard(const scope_guard&) = delete;
+  scope_guard(scope_guard&&) = delete;
+  auto operator=(const scope_guard&) -> scope_guard& = delete;
+  auto operator=(scope_guard&&) -> scope_guard& = delete;
+
+  // The one place the result cannot be asserted on: this runs while a failed assertion is
+  // unwinding, and throwing a second exception out of a destructor terminates the process, which
+  // would replace the failure message with a crash. A drop that fails here is picked up by the
+  // next run instead, where drop_stale_scope() reports it before anything else.
+  ~scope_guard()
+  {
+    ops::management::scope_drop_request request{};
+    request.bucket_name = fixture_.bucket();
+    request.scope_name = name_;
+    static_cast<void>(fixture_.execute(std::move(request)));
+  }
+
+private:
+  live_cluster_fixture& fixture_;
+  std::string name_;
+};
+
+// Drops the bucket however the case leaves, for the reason scope_guard gives above.
+class bucket_guard
+{
+public:
+  bucket_guard(live_cluster_fixture& fixture, std::string name)
+    : fixture_{ fixture }
+    , name_{ std::move(name) }
+  {
+  }
+
+  bucket_guard(const bucket_guard&) = delete;
+  bucket_guard(bucket_guard&&) = delete;
+  auto operator=(const bucket_guard&) -> bucket_guard& = delete;
+  auto operator=(bucket_guard&&) -> bucket_guard& = delete;
+
+  // Unasserted for the reason scope_guard's destructor gives.
+  ~bucket_guard()
+  {
+    ops::management::bucket_drop_request request{};
+    request.name = name_;
+    static_cast<void>(fixture_.execute(std::move(request)));
+  }
+
+private:
+  live_cluster_fixture& fixture_;
+  std::string name_;
+};
+
+// A no-expiry collection needs a server that accepts maxTTL=-1, which is 7.6 and later. That is
+// asserted rather than skipped on: collection_create_response carries no message field, so the
+// server's own account of a refusal is not reachable here, and a skip keyed on the error code
+// alone would also swallow the encode bug these cases exist to catch.
+void
+create_collection(live_cluster_fixture& fixture,
+                  const std::string& scope_name,
+                  const std::string& collection_name,
+                  std::optional<std::int32_t> max_expiry)
+{
+  ops::management::collection_create_request request{};
+  request.bucket_name = fixture.bucket();
+  request.scope_name = scope_name;
+  request.collection_name = collection_name;
+  request.max_expiry = max_expiry;
+  const auto created = fixture.execute(std::move(request));
+  assert_false(static_cast<bool>(created.ctx.ec), "create collection over couchbase2 succeeds");
+}
+
+void
+create_scope(live_cluster_fixture& fixture, const std::string& scope_name)
+{
+  drop_stale_scope(fixture, scope_name);
+
+  ops::management::scope_create_request create{};
+  create.bucket_name = fixture.bucket();
+  create.scope_name = scope_name;
+  const auto created = fixture.execute(std::move(create));
+  assert_false(static_cast<bool>(created.ctx.ec), "create scope over couchbase2 succeeds");
+}
+
+void
+list_collections_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+
+  const auto manifest = manifest_or_skip(fixture);
+  // Naming the default scope and collection, rather than counting: a non-empty manifest is also
+  // what a gateway pointed at some other bucket returns.
+  assert_true(find_collection(manifest, "_default", "_default").has_value(),
+              "the _default scope and collection are present");
+}
+
+// The case the two halves of the max_expiry mapping exist for: each of the three states written
+// through create() is the state read back by the manifest. The two that collapse into each other
+// are "no expiry" and "inherit the bucket default" -- a decode that reads max_expiry_secs without
+// its presence bit reports every collection as the second, and an encode that writes an explicit 0
+// for the second stores the first. Either way the collection has an expiry policy its creator did
+// not ask for, and nothing fails.
+void
+collection_max_expiry_round_trips_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+  require_default_collection(fixture);
+
+  const std::string scope_name{ "cng_expiry" };
+  create_scope(fixture, scope_name);
+  scope_guard guard{ fixture, scope_name };
+
+  // Unset and an explicit 0 are separate cases even though both mean "inherit the bucket default".
+  // Only the second one reaches the sentinel encode, and it is the one that goes wrong quietly: an
+  // explicit 0 written to the wire is what the gateway reads as no expiry.
+  create_collection(fixture, scope_name, "inherits", {});
+  create_collection(fixture, scope_name, "inherits_explicitly", 0);
+  create_collection(fixture, scope_name, "never_expires", -1);
+  create_collection(fixture, scope_name, "hourly", 3600);
+
+  const auto manifest = manifest_or_skip(fixture);
+  assert_eq(find_max_expiry(manifest, scope_name, "inherits"),
+            std::int32_t{ 0 },
+            "a collection created without a max expiry inherits the bucket default");
+  assert_eq(find_max_expiry(manifest, scope_name, "inherits_explicitly"),
+            std::int32_t{ 0 },
+            "a collection created with max expiry 0 inherits the bucket default");
+  assert_eq(find_max_expiry(manifest, scope_name, "never_expires"),
+            std::int32_t{ -1 },
+            "a collection created with no expiry reads back as no expiry");
+  assert_eq(find_max_expiry(manifest, scope_name, "hourly"),
+            std::int32_t{ 3600 },
+            "a collection created with a TTL reads back with that TTL");
+}
+
+// The update path has its own encode, and one state it cannot express: an explicit 0 means "put
+// this collection back on the bucket default", and on UpdateCollection an unset field means "leave
+// it alone" instead. The component refuses it, and the collection has to be left as it was.
+void
+collection_update_max_expiry_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+  require_default_collection(fixture);
+
+  const std::string scope_name{ "cng_expiry_update" };
+  create_scope(fixture, scope_name);
+  scope_guard guard{ fixture, scope_name };
+
+  create_collection(fixture, scope_name, "retuned", 3600);
+
+  ops::management::collection_update_request to_no_expiry{};
+  to_no_expiry.bucket_name = fixture.bucket();
+  to_no_expiry.scope_name = scope_name;
+  to_no_expiry.collection_name = "retuned";
+  to_no_expiry.max_expiry = -1;
+  const auto updated = fixture.execute(std::move(to_no_expiry));
+  assert_false(static_cast<bool>(updated.ctx.ec), "update collection over couchbase2 succeeds");
+  assert_eq(find_max_expiry(manifest_or_skip(fixture), scope_name, "retuned"),
+            std::int32_t{ -1 },
+            "an updated max expiry reads back as no expiry");
+
+  ops::management::collection_update_request to_bucket_default{};
+  to_bucket_default.bucket_name = fixture.bucket();
+  to_bucket_default.scope_name = scope_name;
+  to_bucket_default.collection_name = "retuned";
+  to_bucket_default.max_expiry = 0;
+  const auto refused = fixture.execute(std::move(to_bucket_default));
+  assert_true(refused.ctx.ec == couchbase::errc::common::feature_not_available,
+              "resetting a collection to the bucket default is refused over couchbase2");
+  // The refusal is only worth anything if it kept its hands off the collection: a request that
+  // reported an error and applied something anyway is worse than one that applied nothing.
+  assert_eq(find_max_expiry(manifest_or_skip(fixture), scope_name, "retuned"),
+            std::int32_t{ -1 },
+            "the refused update left the collection as it was");
+}
+
+// -1 is the lowest value max_expiry gives a meaning, and the classic path refuses anything below
+// it before encoding. The sentinel mapping cannot: every negative produces the same wire form, so
+// without the refusal -2 would create a never-expiring collection and report success. Both RPCs
+// carry the field, so both are checked.
+void
+collection_max_expiry_below_the_sentinel_is_refused_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+  require_default_collection(fixture);
+
+  const std::string scope_name{ "cng_expiry_invalid" };
+  create_scope(fixture, scope_name);
+  scope_guard guard{ fixture, scope_name };
+
+  ops::management::collection_create_request create{};
+  create.bucket_name = fixture.bucket();
+  create.scope_name = scope_name;
+  create.collection_name = "below_the_sentinel";
+  create.max_expiry = -2;
+  const auto created = fixture.execute(std::move(create));
+  assert_true(created.ctx.ec == couchbase::errc::common::invalid_argument,
+              "creating a collection with a max expiry below -1 is refused");
+  assert_false(
+    find_collection(manifest_or_skip(fixture), scope_name, "below_the_sentinel").has_value(),
+    "the refused create sent nothing");
+
+  create_collection(fixture, scope_name, "retuned", 3600);
+  ops::management::collection_update_request update{};
+  update.bucket_name = fixture.bucket();
+  update.scope_name = scope_name;
+  update.collection_name = "retuned";
+  update.max_expiry = -2;
+  const auto updated = fixture.execute(std::move(update));
+  assert_true(updated.ctx.ec == couchbase::errc::common::invalid_argument,
+              "updating a collection to a max expiry below -1 is refused");
+  assert_eq(find_max_expiry(manifest_or_skip(fixture), scope_name, "retuned"),
+            std::int32_t{ 3600 },
+            "the refused update left the collection as it was");
+}
+
+// The second layer. A bucket carries its own maximum expiry, and a collection either takes it
+// (the manifest reports 0, not the bucket's value) or overrides it. The two never merge on the
+// wire, so a collection read back carrying the bucket's TTL would mean the layers had been
+// flattened somewhere between the server and the core struct.
+void
+collection_max_expiry_is_layered_over_the_bucket_default()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+  require_default_collection(fixture);
+
+  const std::string bucket_name{ "cng_expiry_bucket" };
+  mgmt::bucket_settings settings;
+  settings.name = bucket_name;
+  settings.ram_quota_mb = 100;
+  settings.num_replicas = 0;
+  settings.max_expiry = 300;
+
+  // Dropped first for the reason create_scope gives: a killed run leaves the bucket behind.
+  drop_stale_bucket(fixture, bucket_name);
+
+  ops::management::bucket_create_request create_bucket{};
+  create_bucket.bucket = std::move(settings);
+  const auto bucket_created = fixture.execute(std::move(create_bucket));
+  // A cluster with no spare KV quota is asserted on rather than skipped over. It is a property of
+  // the cluster and not of the client, but a case that skips itself is a case that cannot report a
+  // regression, and the quota is something the test cluster is configured to have: the CI action
+  // raises it and fails the job if the new value never applies.
+  assert_false(static_cast<bool>(bucket_created.ctx.ec),
+               "create bucket over couchbase2 succeeds (" + bucket_created.error_message + ")");
+
+  bucket_guard guard{ fixture, bucket_name };
+
+  assert_eq(find_max_expiry(manifest_of(fixture, bucket_name), "_default", "_default"),
+            std::int32_t{ 0 },
+            "the bucket's own maximum expiry is not reported as the collection's");
+}
+
+// History retention is the one collection setting the classic path gates before it sends anything:
+// cluster.cxx checks the bucket's non_deduped_history capability, which is read from a cluster map
+// this transport does not have. Over couchbase2 the request is sent and the server answers, so
+// these two cases cover what that answer is on each kind of bucket.
+//
+// The bucket sets history_retention_collection_default false so that a new collection starts with
+// history off. Against a magma bucket's own default -- on -- a case asserting "on" would pass just
+// as well against a client that dropped the field before sending it.
+//
+// Only "on" is observable. The gateway populates history_retention_enabled when the collection has
+// history and leaves it unset otherwise (collectionadminserver.go:86-88), so off and "the server
+// did not say" arrive identically, and the manifest cannot report a collection as history-off. The
+// classic path reads ns_server's own `"history": false` and does report it.
+void
+collection_history_retention_round_trips_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+  require_default_collection(fixture);
+
+  const std::string bucket_name{ "cng_history_bucket" };
+  mgmt::bucket_settings settings;
+  settings.name = bucket_name;
+  // 1024 is the gateway's own floor for a magma bucket (bucketadminserver.go), not the server's --
+  // ns_server creates one at 100. The CI cluster's data quota is sized for this bucket.
+  settings.ram_quota_mb = 1024;
+  settings.num_replicas = 0;
+  // History retention is a magma feature; the same requests against the couchstore bucket are the
+  // case below.
+  settings.storage_backend = mgmt::bucket_storage_backend::magma;
+  settings.history_retention_collection_default = false;
+
+  drop_stale_bucket(fixture, bucket_name);
+
+  ops::management::bucket_create_request create_bucket{};
+  create_bucket.bucket = std::move(settings);
+  const auto bucket_created = fixture.execute(std::move(create_bucket));
+  assert_false(static_cast<bool>(bucket_created.ctx.ec),
+               "create magma bucket over couchbase2 succeeds (" + bucket_created.error_message +
+                 ")");
+  bucket_guard guard{ fixture, bucket_name };
+
+  ops::management::collection_create_request with_history{};
+  with_history.bucket_name = bucket_name;
+  with_history.scope_name = "_default";
+  with_history.collection_name = "history_on";
+  with_history.history = true;
+  const auto created = fixture.execute(std::move(with_history));
+  assert_false(static_cast<bool>(created.ctx.ec),
+               "create collection with history retention over couchbase2 succeeds");
+  assert_eq(find_history(manifest_of(fixture, bucket_name), "_default", "history_on"),
+            std::string{ "on" },
+            "a collection created with history retention on reads back on");
+
+  ops::management::collection_create_request without_history{};
+  without_history.bucket_name = bucket_name;
+  without_history.scope_name = "_default";
+  without_history.collection_name = "defaulted";
+  const auto defaulted = fixture.execute(std::move(without_history));
+  assert_false(static_cast<bool>(defaulted.ctx.ec), "create collection over couchbase2 succeeds");
+  // A tripwire rather than a property of the client: this collection has history off, and no
+  // client change can make the manifest say so. It fails the day the gateway starts sending the
+  // field for an off collection, which is the day the state becomes readable.
+  assert_eq(find_history(manifest_of(fixture, bucket_name), "_default", "defaulted"),
+            std::string{ "no history field" },
+            "a collection with history retention off is not reported as off");
+
+  ops::management::collection_update_request update{};
+  update.bucket_name = bucket_name;
+  update.scope_name = "_default";
+  update.collection_name = "defaulted";
+  update.history = true;
+  const auto updated = fixture.execute(std::move(update));
+  assert_false(static_cast<bool>(updated.ctx.ec),
+               "update collection history retention over couchbase2 succeeds");
+  assert_eq(find_history(manifest_of(fixture, bucket_name), "_default", "defaulted"),
+            std::string{ "on" },
+            "an updated history retention reads back on");
+}
+
+// The other side of the same routing, and the one that shows where the refusal now comes from.
+// Couchstore does not carry history retention: the classic path reports that from the bucket
+// capability without sending anything, and over couchbase2 the server says it instead. What the
+// caller sees is therefore not the same code, and it is not the same code on the two RPCs either --
+// the gateway maps this refusal on UpdateCollection and not on CreateCollection
+// (collectionadminserver.go: only the update chain tests cbmgmtx.ErrServerInvalidArg).
+//
+// These assertions record what the codes are, not what they should be. They fail if the gateway
+// starts mapping them alike, which is the point: the difference is worth noticing.
+void
+collection_history_retention_on_a_couchstore_bucket_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+  const auto manifest = manifest_or_skip(fixture);
+  // The fixture's bucket is whatever the suite was pointed at, and nothing here guarantees its
+  // storage backend. Asserting history is off on _default names what makes this case mean
+  // something: a magma bucket reports it on, and the refusals below would then not be about
+  // couchstore at all.
+  const auto default_history = find_history(manifest, "_default", "_default");
+  assert_true(default_history != "on",
+              "the fixture's bucket does not have history retention on its default collection (" +
+                default_history + ")");
+
+  const std::string scope_name{ "cng_history_refused" };
+  create_scope(fixture, scope_name);
+  scope_guard guard{ fixture, scope_name };
+
+  ops::management::collection_create_request create{};
+  create.bucket_name = fixture.bucket();
+  create.scope_name = scope_name;
+  create.collection_name = "history_on";
+  create.history = true;
+  const auto created = fixture.execute(std::move(create));
+  assert_true(created.ctx.ec == couchbase::errc::common::internal_server_failure,
+              "creating a collection with history retention on couchstore is refused (" +
+                created.ctx.ec.message() + ")");
+  assert_false(find_collection(manifest_or_skip(fixture), scope_name, "history_on").has_value(),
+               "the refused create left no collection behind");
+
+  create_collection(fixture, scope_name, "plain", {});
+  ops::management::collection_update_request update{};
+  update.bucket_name = fixture.bucket();
+  update.scope_name = scope_name;
+  update.collection_name = "plain";
+  update.history = true;
+  const auto updated = fixture.execute(std::move(update));
+  assert_true(updated.ctx.ec == couchbase::errc::common::invalid_argument,
+              "updating a collection to history retention on couchstore is refused (" +
+                updated.ctx.ec.message() + ")");
+  assert_true(find_history(manifest_or_skip(fixture), scope_name, "plain") != "on",
+              "the refused update did not turn history retention on");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_live_collection_admin",
+    {
+      { "list_collections_against_live_gateway",
+        list_collections_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "collection_max_expiry_round_trips_against_live_gateway",
+        collection_max_expiry_round_trips_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "collection_update_max_expiry_against_live_gateway",
+        collection_update_max_expiry_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "collection_max_expiry_below_the_sentinel_is_refused_against_live_gateway",
+        collection_max_expiry_below_the_sentinel_is_refused_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "collection_max_expiry_is_layered_over_the_bucket_default",
+        collection_max_expiry_is_layered_over_the_bucket_default,
+        timeout::integration,
+        test_env::cluster_only },
+      { "collection_history_retention_round_trips_against_live_gateway",
+        collection_history_retention_round_trips_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "collection_history_retention_on_a_couchstore_bucket_against_live_gateway",
+        collection_history_retention_on_a_couchstore_bucket_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test


### PR DESCRIPTION
Complete the bucket & collection management ticket with the six scope/collection
admin operations over admin.collection.v1 (unary).

scope_get_all decodes ListCollections into a core collections_manifest (per-scope
and per-collection uids are not carried by the proto, so only the manifest uid is
populated). scope_create/drop and collection_create/update/drop are thin unary
calls returning the new manifest uid; collection create/update carry the optional
max_expiry and history-retention settings. The component gains a
CollectionAdminService stub and the six execute() overloads; cluster_impl routes
them.

A collection's max_expiry holds three states in one signed field -- a positive
TTL, 0 to inherit the bucket default, -1 for no expiry -- while max_expiry_secs
is an unsigned optional, so the sentinel travels as the field's presence: no
expiry is an explicit 0 on the wire and inherit is the field left unset. Below -1
the sign carries no state and the request is refused with invalid_argument before
the encode, as the classic path does, since every negative otherwise maps onto
the no-expiry wire form. Update has no encoding left for inherit, because an
unset field there means "leave the collection as it is", so a collection update
asking for it is refused with feature_not_available rather than reported as
applied.

A create or update carrying history retention is routed to the component like any
other. execute_with_bucket_capability_check reads a bucket capability from a
cluster map couchbase2 does not have, and reaching it bootstraps an MCBP session
against a port the gateway does not serve; the server validates the setting
either way.

Every management response carries the caller's client_context_id into its error
context -- on the completion and on the paths that never reach the server, which
have nothing else to correlate them by.

The live fixtures pin gRPC's process-global callback queue for the lifetime of
the binary. A fixture per case destroys the last channel between cases, and the
teardown that follows races the threads still polling the queue and aborts the
process; the in-process harnesses already hold it open for the same reason.

The CNG cluster's data service quota covers a magma bucket, which the history
retention cases need and the gateway will not create below 1024 MB.

---
Stacked PR **18/30** in the CNG (`couchbase2://`) transport series. The change specific to this PR is its top commit; the commits beneath it belong to earlier PRs in the series. Depends on #1039 — merge the series bottom-up.
