### PR TITLE
CXXCBC-901: route query index management over the couchbase2 transport

### DIFF
--- a/core/cluster.cxx
+++ b/core/cluster.cxx
@@ -306,6 +306,29 @@ is_feature_supported(const operations::management::search_index_upsert_request& 
 }
 } // namespace
 
+#ifdef COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2
+// Whether the couchbase2 component can carry this request, answered by asking whether it has an
+// execute() overload for it.
+//
+// The alternative -- a hand-maintained list of request types -- has to agree with the overload set
+// and nothing checks that it does. A type in the list with no overload fails to compile, so that
+// half is safe; an overload with no entry in the list is silently unreachable, and that is how
+// query_index_build_deferred_request came to be wired to a gateway RPC that no caller could
+// reach. Detecting the overload makes the list *be* the overload set.
+template<typename Request, typename = void>
+struct component_routes : std::false_type {
+};
+
+template<typename Request>
+struct component_routes<
+  Request,
+  std::void_t<decltype(std::declval<protostellar::component&>().execute(
+    std::declval<Request>(),
+    std::declval<utils::movable_function<void(typename Request::response_type)>>()))>>
+  : std::true_type {
+};
+#endif
+
 class cluster_impl : public std::enable_shared_from_this<cluster_impl>
 {
 public:
@@ -773,22 +796,7 @@ public:
     }
 #ifdef COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2
     if (auto component = protostellar_component(); component) {
-      if constexpr (std::is_same_v<Request, operations::query_request> ||
-                    std::is_same_v<Request, operations::analytics_request> ||
-                    std::is_same_v<Request, operations::search_request> ||
-                    std::is_same_v<Request, operations::document_view_request> ||
-                    std::is_same_v<Request, operations::management::bucket_get_all_request> ||
-                    std::is_same_v<Request, operations::management::bucket_get_request> ||
-                    std::is_same_v<Request, operations::management::bucket_create_request> ||
-                    std::is_same_v<Request, operations::management::bucket_update_request> ||
-                    std::is_same_v<Request, operations::management::bucket_drop_request> ||
-                    std::is_same_v<Request, operations::management::bucket_flush_request> ||
-                    std::is_same_v<Request, operations::management::scope_get_all_request> ||
-                    std::is_same_v<Request, operations::management::scope_create_request> ||
-                    std::is_same_v<Request, operations::management::scope_drop_request> ||
-                    std::is_same_v<Request, operations::management::collection_create_request> ||
-                    std::is_same_v<Request, operations::management::collection_update_request> ||
-                    std::is_same_v<Request, operations::management::collection_drop_request>) {
+      if constexpr (component_routes<Request>::value) {
         component->execute(std::move(request), std::forward<Handler>(handler));
         return;
       } else {

--- a/core/impl/query_index_manager.cxx
+++ b/core/impl/query_index_manager.cxx
@@ -432,6 +432,39 @@ public:
                                     collection_name,
                                     options.parent_span);
 
+    // A closed cluster is the only thing origin() reports an error for, and it cannot be asked
+    // which transport it is on. Report it here rather than routing on a state that could not be
+    // read: the composite below would open a sub-operation span for a request it never sends.
+    const auto [origin_ec, origin] = core_.origin();
+    if (origin_ec) {
+      top_obs_rec->finish(origin_ec);
+      return handler(couchbase::error{ origin_ec });
+    }
+
+    // Over couchbase2 the gateway does server-side what the two round trips below do here:
+    // BuildDeferredIndexes takes the keyspace and builds every deferred index in it. RFC 77 lists
+    // it among the single operations rather than the composite ones -- only WatchIndexes is
+    // composite there -- so it is dispatched as one request and carries no sub-operation spans.
+    if (origin.uses_protostellar()) {
+      core::operations::management::query_index_build_deferred_request request{
+        bucket_name,
+        scope_name.empty() ? std::optional<std::string>{}
+                           : std::optional<std::string>{ scope_name },
+        collection_name.empty() ? std::optional<std::string>{}
+                                : std::optional<std::string>{ collection_name },
+        {},
+        {},
+        timeout,
+        top_obs_rec->operation_span(),
+      };
+      return core_.execute(
+        std::move(request),
+        [top_obs_rec = std::move(top_obs_rec), handler = std::move(handler)](const auto& resp) {
+          top_obs_rec->finish(resp.ctx.retry_attempts, resp.ctx.ec);
+          handler(core::impl::make_error(resp.ctx));
+        });
+    }
+
     auto get_all_deferred_obs_rec = create_suboperation_observability_recorder(
       core::tracing::operation::mgr_query_get_all_deferred_indexes,
       bucket_name,

--- a/core/protostellar/component.cxx
+++ b/core/protostellar/component.cxx
@@ -31,6 +31,7 @@
 #include "core/protostellar/error_utils.hxx"
 #include "core/protostellar/kv_converter.hxx"
 #include "core/protostellar/query_converter.hxx"
+#include "core/protostellar/query_index_admin_converter.hxx"
 #include "core/protostellar/search_converter.hxx"
 #include "core/protostellar/view_converter.hxx"
 
@@ -41,6 +42,7 @@
 
 #include <couchbase/admin/bucket/v1/bucket.grpc.pb.h>
 #include <couchbase/admin/collection/v1/collection.grpc.pb.h>
+#include <couchbase/admin/query/v1/query.grpc.pb.h>
 #include <couchbase/kv/v1/kv.grpc.pb.h>
 #include <couchbase/search/v1/search.grpc.pb.h>
 #include <couchbase/view/v1/view.grpc.pb.h>
@@ -65,6 +67,7 @@ namespace search_v1 = ::couchbase::search::v1;
 namespace view_v1 = ::couchbase::view::v1;
 namespace bucket_admin_v1 = ::couchbase::admin::bucket::v1;
 namespace collection_admin_v1 = ::couchbase::admin::collection::v1;
+namespace query_admin_v1 = ::couchbase::admin::query::v1;
 
 // Defined here rather than in the header so the generated gRPC types stay out of every consumer of
 // component.hxx.
@@ -76,6 +79,7 @@ struct component::stubs {
   std::unique_ptr<view_v1::ViewService::Stub> view;
   std::unique_ptr<bucket_admin_v1::BucketAdminService::Stub> bucket_admin;
   std::unique_ptr<collection_admin_v1::CollectionAdminService::Stub> collection_admin;
+  std::unique_ptr<query_admin_v1::QueryAdminService::Stub> query_admin;
 };
 
 namespace
@@ -147,7 +151,8 @@ component::component(asio::io_context& io, component_config config)
              search_v1::SearchService::NewStub(config.channel),
              view_v1::ViewService::NewStub(config.channel),
              bucket_admin_v1::BucketAdminService::NewStub(config.channel),
-             collection_admin_v1::CollectionAdminService::NewStub(config.channel) }) }
+             collection_admin_v1::CollectionAdminService::NewStub(config.channel),
+             query_admin_v1::QueryAdminService::NewStub(config.channel) }) }
   , authorization_{ authorization_header(config.credentials) }
   , timeouts_{ config.timeouts }
   // Initialised last (see the declaration order in the header), so the channel can be moved in.
@@ -1526,6 +1531,207 @@ component::execute(
       response.ctx.client_context_id = client_context_id;
       response.ctx.ec = map_status(status, operation_kind::mutating);
       response.uid = resp.manifest_uid();
+      handler(std::move(response));
+    });
+}
+
+auto
+component::execute(
+  operations::management::query_index_get_all_request request,
+  utils::movable_function<void(operations::management::query_index_get_all_response)>&& handler)
+  -> pending_call
+{
+  const auto client_context_id = request.client_context_id.value_or(std::string{});
+  auto proto = std::make_shared<query_admin_v1::GetAllIndexesRequest>(
+    query_index_admin::encode_get_all(request));
+  const auto timeout = request.timeout.value_or(timeouts_.management);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped_management(request));
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->query_admin.get();
+  return dispatcher_.unary<query_admin_v1::GetAllIndexesResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        query_admin_v1::GetAllIndexesResponse& resp,
+                        std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->GetAllIndexes(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), proto, client_context_id](
+      grpc::Status status, query_admin_v1::GetAllIndexesResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      operations::management::query_index_get_all_response response;
+      response.ctx.client_context_id = client_context_id;
+      response.ctx.ec = map_status(status, operation_kind::read_only);
+      for (const auto& index : resp.indexes()) {
+        response.indexes.push_back(query_index_admin::decode_index(index));
+      }
+      handler(std::move(response));
+    });
+}
+
+auto
+component::execute(
+  operations::management::query_index_create_request request,
+  utils::movable_function<void(operations::management::query_index_create_response)>&& handler)
+  -> pending_call
+{
+  const auto client_context_id = request.client_context_id.value_or(std::string{});
+  if (!query_index_admin::can_encode(request)) {
+    auto response = stamped_management(request);
+    response.ctx.ec = errc::common::feature_not_available;
+    // Posted rather than invoked here, for the reason fail_expired above gives: completions arrive
+    // on the io context, never inline out of execute().
+    asio::post(io_, [handler = std::move(handler), response = std::move(response)]() mutable {
+      handler(std::move(response));
+    });
+    return {};
+  }
+  const auto timeout = request.timeout.value_or(timeouts_.management);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped_management(request));
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->query_admin.get();
+
+  if (request.is_primary) {
+    auto proto = std::make_shared<query_admin_v1::CreatePrimaryIndexRequest>(
+      query_index_admin::encode_create_primary(request));
+    return dispatcher_.unary<query_admin_v1::CreatePrimaryIndexResponse>(
+      timeout,
+      [stub, proto, auth](grpc::ClientContext& ctx,
+                          query_admin_v1::CreatePrimaryIndexResponse& resp,
+                          std::function<void(grpc::Status)> cb) {
+        if (!auth.empty()) {
+          ctx.AddMetadata("authorization", auth);
+        }
+        stub->async()->CreatePrimaryIndex(&ctx, proto.get(), &resp, std::move(cb));
+      },
+      [handler = std::move(handler), proto, client_context_id](
+        grpc::Status status, query_admin_v1::CreatePrimaryIndexResponse /* resp */) mutable {
+        (void)proto; // kept only to keep the request alive for the call
+        operations::management::query_index_create_response response;
+        response.ctx.client_context_id = client_context_id;
+        response.ctx.ec = map_status(status, operation_kind::mutating);
+        handler(std::move(response));
+      });
+  }
+
+  auto proto =
+    std::make_shared<query_admin_v1::CreateIndexRequest>(query_index_admin::encode_create(request));
+  return dispatcher_.unary<query_admin_v1::CreateIndexResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        query_admin_v1::CreateIndexResponse& resp,
+                        std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->CreateIndex(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), proto, client_context_id](
+      grpc::Status status, query_admin_v1::CreateIndexResponse /* resp */) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      operations::management::query_index_create_response response;
+      response.ctx.client_context_id = client_context_id;
+      response.ctx.ec = map_status(status, operation_kind::mutating);
+      handler(std::move(response));
+    });
+}
+
+auto
+component::execute(
+  operations::management::query_index_drop_request request,
+  utils::movable_function<void(operations::management::query_index_drop_response)>&& handler)
+  -> pending_call
+{
+  const auto client_context_id = request.client_context_id.value_or(std::string{});
+  const auto timeout = request.timeout.value_or(timeouts_.management);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped_management(request));
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->query_admin.get();
+
+  if (request.is_primary) {
+    auto proto = std::make_shared<query_admin_v1::DropPrimaryIndexRequest>(
+      query_index_admin::encode_drop_primary(request));
+    return dispatcher_.unary<query_admin_v1::DropPrimaryIndexResponse>(
+      timeout,
+      [stub, proto, auth](grpc::ClientContext& ctx,
+                          query_admin_v1::DropPrimaryIndexResponse& resp,
+                          std::function<void(grpc::Status)> cb) {
+        if (!auth.empty()) {
+          ctx.AddMetadata("authorization", auth);
+        }
+        stub->async()->DropPrimaryIndex(&ctx, proto.get(), &resp, std::move(cb));
+      },
+      [handler = std::move(handler), proto, client_context_id](
+        grpc::Status status, query_admin_v1::DropPrimaryIndexResponse /* resp */) mutable {
+        (void)proto; // kept only to keep the request alive for the call
+        operations::management::query_index_drop_response response;
+        response.ctx.client_context_id = client_context_id;
+        response.ctx.ec = map_status(status, operation_kind::mutating);
+        handler(std::move(response));
+      });
+  }
+
+  auto proto =
+    std::make_shared<query_admin_v1::DropIndexRequest>(query_index_admin::encode_drop(request));
+  return dispatcher_.unary<query_admin_v1::DropIndexResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        query_admin_v1::DropIndexResponse& resp,
+                        std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->DropIndex(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), proto, client_context_id](
+      grpc::Status status, query_admin_v1::DropIndexResponse /* resp */) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      operations::management::query_index_drop_response response;
+      response.ctx.client_context_id = client_context_id;
+      response.ctx.ec = map_status(status, operation_kind::mutating);
+      handler(std::move(response));
+    });
+}
+
+auto
+component::execute(
+  operations::management::query_index_build_deferred_request request,
+  utils::movable_function<void(operations::management::query_index_build_deferred_response)>&&
+    handler) -> pending_call
+{
+  const auto client_context_id = request.client_context_id.value_or(std::string{});
+  auto proto = std::make_shared<query_admin_v1::BuildDeferredIndexesRequest>(
+    query_index_admin::encode_build_deferred(request));
+  const auto timeout = request.timeout.value_or(timeouts_.management);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped_management(request));
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->query_admin.get();
+  return dispatcher_.unary<query_admin_v1::BuildDeferredIndexesResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        query_admin_v1::BuildDeferredIndexesResponse& resp,
+                        std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->BuildDeferredIndexes(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), proto, client_context_id](
+      grpc::Status status, query_admin_v1::BuildDeferredIndexesResponse /* resp */) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      operations::management::query_index_build_deferred_response response;
+      response.ctx.client_context_id = client_context_id;
+      response.ctx.ec = map_status(status, operation_kind::mutating);
       handler(std::move(response));
     });
 }

--- a/core/protostellar/component.hxx
+++ b/core/protostellar/component.hxx
@@ -58,6 +58,10 @@
 #include "core/operations/management/collection_create.hxx"
 #include "core/operations/management/collection_drop.hxx"
 #include "core/operations/management/collection_update.hxx"
+#include "core/operations/management/query_index_build_deferred.hxx"
+#include "core/operations/management/query_index_create.hxx"
+#include "core/operations/management/query_index_drop.hxx"
+#include "core/operations/management/query_index_get_all.hxx"
 #include "core/operations/management/scope_create.hxx"
 #include "core/operations/management/scope_drop.hxx"
 #include "core/operations/management/scope_get_all.hxx"
@@ -260,6 +264,24 @@ public:
     operations::management::collection_drop_request request,
     utils::movable_function<void(operations::management::collection_drop_response)>&& handler)
     -> pending_call;
+
+  // Query index management (unary admin RPCs over admin.query.v1).
+  auto execute(
+    operations::management::query_index_get_all_request request,
+    utils::movable_function<void(operations::management::query_index_get_all_response)>&& handler)
+    -> pending_call;
+  auto execute(
+    operations::management::query_index_create_request request,
+    utils::movable_function<void(operations::management::query_index_create_response)>&& handler)
+    -> pending_call;
+  auto execute(
+    operations::management::query_index_drop_request request,
+    utils::movable_function<void(operations::management::query_index_drop_response)>&& handler)
+    -> pending_call;
+  auto execute(
+    operations::management::query_index_build_deferred_request request,
+    utils::movable_function<void(operations::management::query_index_build_deferred_response)>&&
+      handler) -> pending_call;
 
 private:
   // The generated gRPC stubs are held behind an opaque pointer so the generated protobuf and gRPC

--- a/core/protostellar/query_index_admin_converter.hxx
+++ b/core/protostellar/query_index_admin_converter.hxx
@@ -1,0 +1,291 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+// Translates core query index management requests to and from couchbase.admin.query.v1 (unary
+// admin RPCs). The proto IndexType / IndexState enums have no `unknown` sentinel; they map to the
+// lowercase strings the rest of the SDK uses.
+//
+// The gateway builds the N1QL statement from the request rather than taking one, so the encode
+// side owns everything the statement's shape depends on: which RPC a primary index goes to, and
+// how an index key is escaped.
+
+#include "core/operations/management/query_index_build_deferred.hxx"
+#include "core/operations/management/query_index_create.hxx"
+#include "core/operations/management/query_index_drop.hxx"
+#include "core/operations/management/query_index_get_all.hxx"
+#include "couchbase/management/query_index.hxx"
+
+#include <couchbase/admin/query/v1/query.pb.h>
+
+#include <cstddef>
+#include <string>
+
+namespace couchbase::core::protostellar::query_index_admin
+{
+namespace v1 = ::couchbase::admin::query::v1;
+namespace om = ::couchbase::core::operations::management;
+
+// Whether the key is already one complete escaped identifier: an opening backtick, a body in which
+// every backslash escapes the character after it and every backtick is escaped or doubled, and the
+// closing backtick at the very end of the key.
+//
+// Ending exactly at the end is the whole question. A key whose identifier closes early -- "`a`,`b`"
+// -- leaves the remainder as loose statement text, and a key ending in a lone backslash -- "`a\" --
+// escapes its own closing backtick and swallows what follows it.
+[[nodiscard]] inline auto
+is_escaped_identifier(const std::string& key) -> bool
+{
+  if (key.size() < 2 || key.front() != '`' || key.back() != '`') {
+    return false;
+  }
+  const auto last = key.size() - 1;
+  for (std::size_t i = 1; i < last;) {
+    if (key[i] == '\\') {
+      if (i + 1 >= last) {
+        return false;
+      }
+      i += 2;
+      continue;
+    }
+    if (key[i] == '`') {
+      if (i + 1 < last && key[i + 1] == '`') {
+        i += 2;
+        continue;
+      }
+      return false;
+    }
+    i += 1;
+  }
+  return true;
+}
+
+// Escapes one index key into exactly one N1QL identifier token.
+//
+// This is the transport's only client-supplied statement text. The gateway builds the statement
+// itself and joins the field list with commas verbatim (gocbcorex cbqueryx), so whatever arrives in
+// `fields` is spliced between the parentheses of CREATE INDEX unchanged. A key that closed its own
+// quoting would add terms to the index -- or change the statement -- rather than name a field.
+//
+// The escape is the one the query parser reads back: a backslash escapes the character after it
+// (parser/n1ql/util.go), so a backtick and a backslash each arrive prefixed by one. Doubling the
+// backtick instead would parse, but reads back as two backticks in the name rather than one, and
+// leaving the backslash bare makes the parser reject the whole statement. Anything else inside the
+// quotes -- spaces, commas, parentheses, newlines -- is part of the identifier and needs no escape,
+// which is why "two words" is a key and not a syntax error.
+//
+// A key that is already one complete identifier is passed through, because that is the form
+// GetAllIndexes reports keys in and the classic query path accepts. "Already" is verified rather
+// than assumed: is_escaped_identifier() is what separates a caller's pre-quoted key from a key
+// carrying quotes that end early.
+[[nodiscard]] inline auto
+encode_index_key(const std::string& key) -> std::string
+{
+  if (is_escaped_identifier(key)) {
+    return key;
+  }
+  std::string escaped;
+  escaped.reserve(key.size() + 2);
+  escaped.push_back('`');
+  for (const auto c : key) {
+    if (c == '\\' || c == '`') {
+      escaped.push_back('\\');
+    }
+    escaped.push_back(c);
+  }
+  escaped.push_back('`');
+  return escaped;
+}
+
+// Copies the keyspace onto a request whose scope/collection fields are `optional string`. An empty
+// name is left unset: the gateway reads an unset scope as "the whole bucket", and a present-but-
+// empty one as a scope literally named "", which it rejects.
+template<typename Proto>
+void
+apply_keyspace(const std::string& bucket_name,
+               const std::string& scope_name,
+               const std::string& collection_name,
+               Proto& proto)
+{
+  proto.set_bucket_name(bucket_name);
+  if (!scope_name.empty()) {
+    proto.set_scope_name(scope_name);
+  }
+  if (!collection_name.empty()) {
+    proto.set_collection_name(collection_name);
+  }
+}
+
+// couchbase2 CreateIndexRequest has no condition field, so a secondary index with a WHERE clause
+// cannot be expressed at all -- encoding one would create an index over the whole collection under
+// the name the caller asked for. A primary index has no condition to lose.
+[[nodiscard]] inline auto
+can_encode(const om::query_index_create_request& request) -> bool
+{
+  return request.is_primary || !request.condition.has_value();
+}
+
+[[nodiscard]] inline auto
+encode_get_all(const om::query_index_get_all_request& request) -> v1::GetAllIndexesRequest
+{
+  v1::GetAllIndexesRequest proto;
+  apply_keyspace(request.bucket_name, request.scope_name, request.collection_name, proto);
+  return proto;
+}
+
+[[nodiscard]] inline auto
+encode_create_primary(const om::query_index_create_request& request)
+  -> v1::CreatePrimaryIndexRequest
+{
+  v1::CreatePrimaryIndexRequest proto;
+  apply_keyspace(request.bucket_name, request.scope_name, request.collection_name, proto);
+  // An unset name asks the server for its own default (#primary); an empty one is not a name.
+  if (!request.index_name.empty()) {
+    proto.set_name(request.index_name);
+  }
+  if (request.num_replicas.has_value()) {
+    proto.set_num_replicas(*request.num_replicas);
+  }
+  if (request.deferred.has_value()) {
+    proto.set_deferred(*request.deferred);
+  }
+  proto.set_ignore_if_exists(request.ignore_if_exists);
+  return proto;
+}
+
+[[nodiscard]] inline auto
+encode_create(const om::query_index_create_request& request) -> v1::CreateIndexRequest
+{
+  v1::CreateIndexRequest proto;
+  apply_keyspace(request.bucket_name, request.scope_name, request.collection_name, proto);
+  proto.set_name(request.index_name);
+  for (const auto& key : request.keys) {
+    proto.add_fields(encode_index_key(key));
+  }
+  if (request.num_replicas.has_value()) {
+    proto.set_num_replicas(*request.num_replicas);
+  }
+  if (request.deferred.has_value()) {
+    proto.set_deferred(*request.deferred);
+  }
+  proto.set_ignore_if_exists(request.ignore_if_exists);
+  return proto;
+}
+
+[[nodiscard]] inline auto
+encode_drop_primary(const om::query_index_drop_request& request) -> v1::DropPrimaryIndexRequest
+{
+  v1::DropPrimaryIndexRequest proto;
+  apply_keyspace(request.bucket_name, request.scope_name, request.collection_name, proto);
+  if (!request.index_name.empty()) {
+    proto.set_name(request.index_name);
+  }
+  proto.set_ignore_if_missing(request.ignore_if_does_not_exist);
+  return proto;
+}
+
+[[nodiscard]] inline auto
+encode_drop(const om::query_index_drop_request& request) -> v1::DropIndexRequest
+{
+  v1::DropIndexRequest proto;
+  apply_keyspace(request.bucket_name, request.scope_name, request.collection_name, proto);
+  proto.set_name(request.index_name);
+  proto.set_ignore_if_missing(request.ignore_if_does_not_exist);
+  return proto;
+}
+
+[[nodiscard]] inline auto
+encode_build_deferred(const om::query_index_build_deferred_request& request)
+  -> v1::BuildDeferredIndexesRequest
+{
+  v1::BuildDeferredIndexesRequest proto;
+  apply_keyspace(request.bucket_name,
+                 request.scope_name.value_or(std::string{}),
+                 request.collection_name.value_or(std::string{}),
+                 proto);
+  return proto;
+}
+
+[[nodiscard]] inline auto
+index_type_to_string(v1::IndexType type) -> std::string
+{
+  switch (type) {
+    case v1::INDEX_TYPE_VIEW:
+      return "view";
+    case v1::INDEX_TYPE_GSI:
+      return "gsi";
+    default:
+      return "unknown";
+  }
+}
+
+[[nodiscard]] inline auto
+index_state_to_string(v1::IndexState state) -> std::string
+{
+  switch (state) {
+    case v1::INDEX_STATE_DEFERRED:
+      return "deferred";
+    case v1::INDEX_STATE_BUILDING:
+      return "building";
+    case v1::INDEX_STATE_PENDING:
+      return "pending";
+    case v1::INDEX_STATE_ONLINE:
+      return "online";
+    case v1::INDEX_STATE_OFFLINE:
+      return "offline";
+    case v1::INDEX_STATE_ABRIDGED:
+      return "abridged";
+    case v1::INDEX_STATE_SCHEDULED:
+      return "scheduled";
+    default:
+      return "unknown";
+  }
+}
+
+[[nodiscard]] inline auto
+decode_index(const v1::GetAllIndexesResponse_Index& proto) -> couchbase::management::query_index
+{
+  couchbase::management::query_index index;
+  index.is_primary = proto.is_primary();
+  index.name = proto.name();
+  index.type = index_type_to_string(proto.type());
+  index.state = index_state_to_string(proto.state());
+  index.bucket_name = proto.bucket_name();
+  if (!proto.scope_name().empty()) {
+    index.scope_name = proto.scope_name();
+  }
+  if (!proto.collection_name().empty()) {
+    index.collection_name = proto.collection_name();
+  }
+  for (const auto& field : proto.fields()) {
+    index.index_key.push_back(field);
+  }
+  // Presence, not emptiness: condition and partition are `optional string`, so an index that has
+  // no WHERE clause is a different answer from one whose clause the server reports as empty.
+  // scope_name and collection_name above carry no presence, so there an empty name is the only
+  // form "not collection-qualified" can arrive in.
+  if (proto.has_condition()) {
+    index.condition = proto.condition();
+  }
+  if (proto.has_partition()) {
+    index.partition = proto.partition();
+  }
+  return index;
+}
+
+} // namespace couchbase::core::protostellar::query_index_admin

--- a/test/cng/CMakeLists.txt
+++ b/test/cng/CMakeLists.txt
@@ -167,4 +167,10 @@ if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 AND TARGET couchbase_cxx_protostellar)
 
   # Live Scope & Collection management verification (CXXCBC-900).
   add_cng_test(protostellar/live_collection_admin LINK_CLIENT LIBS couchbase_cxx_protostellar)
+  # Query index management converter (CXXCBC-901).
+  add_cng_test(protostellar/query_index_admin_converter LINK_CLIENT LIBS couchbase_cxx_protostellar)
+  add_cng_test(protostellar/query_index_admin_component LINK_CLIENT LIBS couchbase_cxx_protostellar)
+
+  # Live Query index management verification (CXXCBC-901).
+  add_cng_test(protostellar/live_query_index_admin LINK_CLIENT LIBS couchbase_cxx_protostellar)
 endif()

--- a/test/cng/protostellar/live_query_index_admin.cxx
+++ b/test/cng/protostellar/live_query_index_admin.cxx
@@ -1,0 +1,508 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Live probes of query index management over the couchbase2:// transport (CXXCBC-901), against
+// admin.query.v1.
+//
+// Two things here are only observable against a real server.
+//
+// The gateway builds the CREATE INDEX statement rather than taking one, and splices the field list
+// into it verbatim. Whether an index key is escaped correctly is therefore a property of the
+// statement the query parser reads, not of the request the client sends -- a key that leaves its
+// own quoting produces a valid statement describing a different index, which no assertion on the
+// request can see.
+//
+// And build_deferred_indexes() is two round trips over HTTP and a single RPC here, so which core
+// requests the public API issues is what decides whether the operation reaches the gateway at all.
+// The case below drives the public manager rather than the core request, because the routing hole
+// it covers was invisible from the core request that was already wired.
+
+#include "framework/live_fixture.hxx"
+#include "framework/test_runner.hxx"
+
+#include "core/operations/management/query_index_create.hxx"
+#include "core/operations/management/query_index_drop.hxx"
+#include "core/operations/management/query_index_get_all.hxx"
+
+#include <couchbase/cluster.hxx>
+#include <couchbase/error_codes.hxx>
+
+#include <algorithm>
+#include <chrono>
+#include <future>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace ops = ::couchbase::core::operations;
+
+// Lists the bucket's indexes, failing the case for anything but the gateway not serving the
+// service.
+//
+// Nothing on the client side answers this request with feature_not_available -- cluster.cxx routes
+// it and the component has no refusal path for it -- so the code can only have come from a gateway
+// that does not serve admin.query.v1. Every other case in this file calls this first and then
+// asserts rather than skips: once the service is known to be served, a later refusal is the client
+// declining to send something, which is a failure and not a reason to skip.
+[[nodiscard]] auto
+indexes_or_skip(live_cluster_fixture& fixture) -> std::vector<couchbase::management::query_index>
+{
+  ops::management::query_index_get_all_request request{};
+  request.bucket_name = fixture.bucket();
+  auto listed = fixture.execute(std::move(request));
+  if (listed.ctx.ec == couchbase::errc::common::feature_not_available) {
+    skip("gateway does not implement admin.query.v1 (feature_not_available)");
+  }
+  assert_false(static_cast<bool>(listed.ctx.ec), "list query indexes over couchbase2 succeeds");
+  return std::move(listed.indexes);
+}
+
+[[nodiscard]] auto
+find_index(const std::vector<couchbase::management::query_index>& indexes, const std::string& name)
+  -> std::optional<couchbase::management::query_index>
+{
+  const auto found = std::find_if(indexes.begin(), indexes.end(), [&name](const auto& index) {
+    return index.name == name;
+  });
+  if (found == indexes.end()) {
+    return {};
+  }
+  return *found;
+}
+
+// Drops the index however the case leaves -- an assertion failure unwinds, and an index left
+// behind makes the next run fail on "already exists".
+class index_guard
+{
+public:
+  index_guard(live_cluster_fixture& fixture, std::string name, bool is_primary = false)
+    : fixture_{ fixture }
+    , name_{ std::move(name) }
+    , is_primary_{ is_primary }
+  {
+    drop();
+  }
+
+  index_guard(const index_guard&) = delete;
+  index_guard(index_guard&&) = delete;
+  auto operator=(const index_guard&) -> index_guard& = delete;
+  auto operator=(index_guard&&) -> index_guard& = delete;
+
+  ~index_guard()
+  {
+    drop();
+  }
+
+private:
+  void drop()
+  {
+    ops::management::query_index_drop_request request{};
+    request.bucket_name = fixture_.bucket();
+    request.index_name = name_;
+    request.is_primary = is_primary_;
+    request.ignore_if_does_not_exist = true;
+    static_cast<void>(fixture_.execute(std::move(request)));
+  }
+
+  live_cluster_fixture& fixture_;
+  std::string name_;
+  bool is_primary_;
+};
+
+[[nodiscard]] auto
+create_index(live_cluster_fixture& fixture,
+             const std::string& index_name,
+             std::vector<std::string> keys,
+             bool ignore_if_exists = false) -> ops::management::query_index_create_response
+{
+  ops::management::query_index_create_request request{};
+  request.bucket_name = fixture.bucket();
+  request.index_name = index_name;
+  request.keys = std::move(keys);
+  request.ignore_if_exists = ignore_if_exists;
+  // Deferred, so the case does not wait for a build it is not measuring.
+  request.deferred = true;
+  return fixture.execute(std::move(request));
+}
+
+[[nodiscard]] auto
+drop_index(live_cluster_fixture& fixture,
+           const std::string& index_name,
+           bool is_primary,
+           bool ignore_if_does_not_exist) -> ops::management::query_index_drop_response
+{
+  ops::management::query_index_drop_request request{};
+  request.bucket_name = fixture.bucket();
+  request.index_name = index_name;
+  request.is_primary = is_primary;
+  request.ignore_if_does_not_exist = ignore_if_does_not_exist;
+  return fixture.execute(std::move(request));
+}
+
+void
+list_query_indexes_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+  static_cast<void>(indexes_or_skip(fixture));
+}
+
+// The defect this covers: the keys were reaching the gateway unquoted, and the gateway splices
+// them into the statement as they arrive. "two words" is the case the classic path's own
+// integration test pins, and it is a syntax error without the quoting.
+void
+an_index_key_that_needs_escaping_round_trips_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+  static_cast<void>(indexes_or_skip(fixture));
+
+  const std::string index_name{ "cng_escaped_key" };
+  const index_guard guard{ fixture, index_name };
+
+  const auto created = create_index(fixture, index_name, { "two words" });
+  assert_false(static_cast<bool>(created.ctx.ec),
+               "an index on a key that needs quoting is created over couchbase2");
+
+  const auto index = find_index(indexes_or_skip(fixture), index_name);
+  assert_true(index.has_value(), "the created index is listed");
+  assert_eq(index->index_key.size(), std::size_t{ 1 }, "the index has exactly one key");
+  assert_true(index->index_key.at(0).find("two words") != std::string::npos,
+              "the key names the field the caller asked for, not a mangling of it: " +
+                index->index_key.at(0));
+}
+
+// The injection case. A key carrying its own quoting -- a`,`b -- becomes two fields if the encode
+// merely wraps it in backticks, and the server builds a valid two-key index under the requested
+// name: measured against this cluster, the broken form creates an index whose index_key reads
+// ["`a`", "`b`"].
+//
+// Escaped correctly it is one identifier whose name contains a backtick. The parser reads that --
+// SELECT 1 AS `a\`b` returns the field a`b -- but the indexer refuses to index it, so the safe
+// outcome here is a refusal rather than a one-key index. Both are asserted, because which one a
+// server gives is the server's business and neither is what broken escaping produces.
+void
+a_hostile_index_key_cannot_add_terms_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+  const auto before = indexes_or_skip(fixture);
+
+  const std::string index_name{ "cng_hostile_key" };
+  const index_guard guard{ fixture, index_name };
+
+  const auto created = create_index(fixture, index_name, { "a`,`b" });
+  const auto after = indexes_or_skip(fixture);
+  const auto index = find_index(after, index_name);
+
+  // Whatever else happens, the request has to have been sent: feature_not_available is the client
+  // declining to build the statement at all, which would make this case pass without testing it.
+  assert_true(created.ctx.ec != couchbase::errc::common::feature_not_available,
+              "the request reached the gateway rather than being refused by the client");
+
+  if (created.ctx.ec) {
+    assert_false(index.has_value(), "the refused index was not created");
+    assert_eq(after.size(), before.size(), "no index was created");
+    return;
+  }
+
+  assert_true(index.has_value(), "the created index is listed");
+  std::string keys;
+  for (const auto& key : index->index_key) {
+    keys += keys.empty() ? key : ", " + key;
+  }
+  assert_eq(index->index_key.size(),
+            std::size_t{ 1 },
+            fmt::format("the hostile key is one index key and not two, so it added no term to the "
+                        "statement: [{}]",
+                        keys));
+  assert_eq(after.size(), before.size() + 1, "exactly one index was created");
+}
+
+// The one refusal this converter emits. It is asserted rather than skipped: the service is known
+// to be served by the time this runs, so feature_not_available here is the client declining to
+// send a request it cannot express -- which is the behaviour under test.
+void
+a_conditional_secondary_index_is_refused_over_couchbase2()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+  static_cast<void>(indexes_or_skip(fixture));
+
+  const std::string index_name{ "cng_conditional" };
+  const index_guard guard{ fixture, index_name };
+
+  ops::management::query_index_create_request request{};
+  request.bucket_name = fixture.bucket();
+  request.index_name = index_name;
+  request.keys = { "country" };
+  request.condition = "country = \"US\"";
+  const auto created = fixture.execute(std::move(request));
+  assert_true(created.ctx.ec == couchbase::errc::common::feature_not_available,
+              "a conditional secondary index is refused rather than created without its WHERE");
+
+  assert_false(find_index(indexes_or_skip(fixture), index_name).has_value(),
+               "the refused index was not created");
+}
+
+// Borrowed from gocb's TestCollectionQueryIndexManagerCrud. Over couchbase2 the ignore flags are
+// proto fields the gateway acts on rather than error codes the client swallows, so whether they
+// arrive is only visible against a server -- and the metadata below is the decode read back from a
+// real GetAllIndexes rather than a hand-built message.
+void
+the_secondary_index_lifecycle_round_trips_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+  static_cast<void>(indexes_or_skip(fixture));
+
+  const std::string index_name{ "cng_lifecycle" };
+  const index_guard guard{ fixture, index_name };
+
+  assert_false(static_cast<bool>(create_index(fixture, index_name, { "field" }).ctx.ec),
+               "the index is created");
+  assert_true(create_index(fixture, index_name, { "field" }).ctx.ec ==
+                couchbase::errc::common::index_exists,
+              "creating it again reports index_exists");
+  assert_false(static_cast<bool>(create_index(fixture, index_name, { "field" }, true).ctx.ec),
+               "ignore_if_exists suppresses it");
+
+  const auto index = find_index(indexes_or_skip(fixture), index_name);
+  assert_true(index.has_value(), "the created index is listed");
+  assert_false(index->is_primary, "a secondary index is not reported as primary");
+  assert_eq(index->type, std::string{ "gsi" }, "the index type is decoded");
+  assert_eq(index->bucket_name, fixture.bucket(), "the index names its bucket");
+  assert_eq(index->index_key.size(), std::size_t{ 1 }, "one index key");
+  assert_eq(index->index_key.at(0),
+            std::string{ "`field`" },
+            "the key is reported in the quoted form the classic path reports");
+  assert_false(index->condition.has_value(), "an unconditional index has no condition");
+  assert_false(index->partition.has_value(), "an unpartitioned index has no partition");
+
+  assert_false(static_cast<bool>(drop_index(fixture, index_name, false, false).ctx.ec),
+               "the index is dropped");
+  assert_true(drop_index(fixture, index_name, false, false).ctx.ec ==
+                couchbase::errc::common::index_not_found,
+              "dropping it again reports index_not_found");
+  assert_false(static_cast<bool>(drop_index(fixture, index_name, false, true).ctx.ec),
+               "ignore_if_does_not_exist suppresses it");
+}
+
+// The primary/secondary branch picks between two RPCs, and a request sent to the wrong one still
+// succeeds against a server that has both -- it just manages a different index. Named rather than
+// unnamed so the case does not touch a #primary another test may be relying on.
+void
+the_primary_index_lifecycle_round_trips_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+  static_cast<void>(indexes_or_skip(fixture));
+
+  const std::string index_name{ "cng_lifecycle_primary" };
+  const index_guard guard{ fixture, index_name, true };
+
+  ops::management::query_index_create_request request{};
+  request.bucket_name = fixture.bucket();
+  request.index_name = index_name;
+  request.is_primary = true;
+  request.deferred = true;
+  auto create = [&fixture, request](bool ignore_if_exists) {
+    auto copy = request;
+    copy.ignore_if_exists = ignore_if_exists;
+    return fixture.execute(std::move(copy));
+  };
+
+  assert_false(static_cast<bool>(create(false).ctx.ec), "the primary index is created");
+  assert_true(create(false).ctx.ec == couchbase::errc::common::index_exists,
+              "creating it again reports index_exists");
+  assert_false(static_cast<bool>(create(true).ctx.ec), "ignore_if_exists suppresses it");
+
+  const auto index = find_index(indexes_or_skip(fixture), index_name);
+  assert_true(index.has_value(), "the created primary index is listed");
+  assert_true(index->is_primary, "it is reported as primary");
+  assert_true(index->index_key.empty(), "a primary index has no keys");
+
+  assert_false(static_cast<bool>(drop_index(fixture, index_name, true, false).ctx.ec),
+               "the primary index is dropped");
+  assert_true(drop_index(fixture, index_name, true, false).ctx.ec ==
+                couchbase::errc::common::index_not_found,
+              "dropping it again reports index_not_found");
+
+  // The named index above does not separate the two drop RPCs -- DropIndex drops an index by name
+  // whether or not it is primary. An *unnamed* primary drop does: DropPrimaryIndex resolves the
+  // name server-side, and DropIndex is rejected for an empty one. That means this half owns
+  // #primary on the test bucket while it runs, so it creates the index it drops.
+  const index_guard unnamed{ fixture, {}, true };
+  ops::management::query_index_create_request primary{};
+  primary.bucket_name = fixture.bucket();
+  primary.is_primary = true;
+  primary.deferred = true;
+  primary.ignore_if_exists = true;
+  assert_false(static_cast<bool>(fixture.execute(std::move(primary)).ctx.ec),
+               "an unnamed primary index is created");
+  assert_false(static_cast<bool>(drop_index(fixture, {}, true, false).ctx.ec),
+               "an unnamed primary index is dropped by the primary RPC");
+  assert_true(drop_index(fixture, {}, true, false).ctx.ec ==
+                couchbase::errc::common::index_not_found,
+              "dropping it again reports index_not_found, not a rejected empty name");
+}
+
+// The routing hole: query_index_build_deferred_request was wired to BuildDeferredIndexes, but the
+// public build_deferred_indexes() issued two other request types that nothing routed, so the
+// operation failed at its first step over couchbase2 while the RPC it needed sat unused. This
+// drives the public manager, which is the only place that hole was visible.
+void
+build_deferred_indexes_through_the_public_api_against_live_gateway()
+{
+  const auto connection_string = safe_getenv("TEST_CONNECTION_STRING");
+  if (!connection_string.has_value()) {
+    skip("TEST_CONNECTION_STRING is not set");
+  }
+  if (connection_string->rfind("couchbase2://", 0) != 0) {
+    skip("TEST_CONNECTION_STRING is not a couchbase2:// endpoint");
+  }
+
+  couchbase::cluster_options options{ env_or("TEST_CB2_USERNAME", "Administrator"),
+                                      env_or("TEST_CB2_PASSWORD", "password") };
+  options.security().tls_verify(couchbase::tls_verify_mode::none);
+
+  auto [connect_err, cluster] = couchbase::cluster::connect(*connection_string, options).get();
+  assert_false(connect_err.ec().operator bool(), "connect(couchbase2://) succeeds");
+
+  const auto bucket = env_or("TEST_CB2_BUCKET", "default");
+  const std::string index_name{ "cng_build_deferred" };
+  auto manager = cluster.query_indexes();
+
+  const auto listed = manager.get_all_indexes(bucket, {}).get();
+  if (listed.first.ec() == couchbase::errc::common::feature_not_available) {
+    cluster.close().get();
+    skip("gateway does not implement admin.query.v1 (feature_not_available)");
+  }
+  assert_false(listed.first.ec().operator bool(), "the public manager lists indexes");
+
+  static_cast<void>(manager.drop_index(bucket, index_name, {}).get());
+  const auto created = manager
+                         .create_index(bucket,
+                                       index_name,
+                                       { "field" },
+                                       couchbase::create_query_index_options{}.build_deferred(true))
+                         .get();
+  assert_false(created.ec().operator bool(), "a deferred index is created through the public API");
+
+  const auto built = manager.build_deferred_indexes(bucket, {}).get();
+  static_cast<void>(manager.drop_index(bucket, index_name, {}).get());
+  cluster.close().get();
+
+  // The failure this replaces was feature_not_available, produced by cluster.cxx for a request
+  // type it did not route -- not by the gateway, which serves the RPC this needs.
+  assert_false(built.ec().operator bool(),
+               "build_deferred_indexes() reaches the gateway over couchbase2");
+}
+
+// A closed cluster is the one input build_deferred_indexes() answers without sending anything, and
+// the answer has to be handed back on the calling thread. cluster::close() runs io_.stop() and
+// joins the io thread before it returns (public_cluster.cxx do_close), so nothing posted to that
+// context afterwards is ever run: deferring the completion would replace a reported error with a
+// handler that never fires and a future that never becomes ready.
+//
+// The assertion is therefore that the handler arrives at all. The bounded wait is what keeps a
+// dropped completion a failure instead of a hung suite.
+void
+build_deferred_indexes_on_a_closed_cluster_answers_on_the_calling_thread()
+{
+  const auto connection_string = safe_getenv("TEST_CONNECTION_STRING");
+  if (!connection_string.has_value()) {
+    skip("TEST_CONNECTION_STRING is not set");
+  }
+  if (connection_string->rfind("couchbase2://", 0) != 0) {
+    skip("TEST_CONNECTION_STRING is not a couchbase2:// endpoint");
+  }
+
+  couchbase::cluster_options options{ env_or("TEST_CB2_USERNAME", "Administrator"),
+                                      env_or("TEST_CB2_PASSWORD", "password") };
+  options.security().tls_verify(couchbase::tls_verify_mode::none);
+
+  auto [connect_err, cluster] = couchbase::cluster::connect(*connection_string, options).get();
+  assert_false(connect_err.ec().operator bool(), "connect(couchbase2://) succeeds");
+
+  // The manager holds its own reference to the core cluster, so it outlives the close.
+  auto manager = cluster.query_indexes();
+  cluster.close().get();
+
+  std::promise<couchbase::error> barrier;
+  auto answered = barrier.get_future();
+  manager.build_deferred_indexes(
+    env_or("TEST_CB2_BUCKET", "default"), {}, [&barrier](auto err) mutable {
+      barrier.set_value(std::move(err));
+    });
+
+  assert_true(answered.wait_for(std::chrono::seconds{ 5 }) == std::future_status::ready,
+              "a closed cluster answers build_deferred_indexes rather than dropping the handler");
+  assert_true(answered.get().ec() == couchbase::errc::network::cluster_closed,
+              "and answers it with cluster_closed");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_live_query_index_admin",
+    {
+      { "list_query_indexes_against_live_gateway",
+        list_query_indexes_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "the_secondary_index_lifecycle_round_trips_against_live_gateway",
+        the_secondary_index_lifecycle_round_trips_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "the_primary_index_lifecycle_round_trips_against_live_gateway",
+        the_primary_index_lifecycle_round_trips_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "an_index_key_that_needs_escaping_round_trips_against_live_gateway",
+        an_index_key_that_needs_escaping_round_trips_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "a_hostile_index_key_cannot_add_terms_against_live_gateway",
+        a_hostile_index_key_cannot_add_terms_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "a_conditional_secondary_index_is_refused_over_couchbase2",
+        a_conditional_secondary_index_is_refused_over_couchbase2,
+        timeout::integration,
+        test_env::cluster_only },
+      { "build_deferred_indexes_through_the_public_api_against_live_gateway",
+        build_deferred_indexes_through_the_public_api_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "build_deferred_indexes_on_a_closed_cluster_answers_on_the_calling_thread",
+        build_deferred_indexes_on_a_closed_cluster_answers_on_the_calling_thread,
+        timeout::integration,
+        test_env::cluster_only },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test

--- a/test/cng/protostellar/query_index_admin_component.cxx
+++ b/test/cng/protostellar/query_index_admin_component.cxx
@@ -1,0 +1,120 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// The one query-index-admin property that needs a component rather than the converter
+// (CXXCBC-901): where the refusal of a conditional secondary index is delivered.
+//
+// A completion arriving inline out of execute() re-enters the caller before it holds the
+// pending_call the call is about to return, so a caller that cancels from its own handler cancels
+// a call it has not been given yet. The error code alone cannot see this -- it is the same code
+// either way -- so the case runs execute() against an io_context it has not started and asserts
+// that nothing has completed yet.
+//
+// No server is needed: the refusal is decided before anything is dispatched, so the channel below
+// is never connected.
+
+#include "framework/test_runner.hxx"
+
+#include "core/cluster_credentials.hxx"
+#include "core/operations/management/query_index_create.hxx"
+#include "core/protostellar/component.hxx"
+
+#include <couchbase/error_codes.hxx>
+
+#include <asio/io_context.hpp>
+
+#include <grpcpp/create_channel.h>
+#include <grpcpp/security/credentials.h>
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <utility>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace om = ::couchbase::core::operations::management;
+using ::couchbase::core::cluster_credentials;
+using ::couchbase::core::protostellar::component;
+using ::couchbase::core::protostellar::component_config;
+using namespace std::chrono_literals;
+
+[[nodiscard]] auto
+conditional_secondary_index() -> om::query_index_create_request
+{
+  om::query_index_create_request request{};
+  request.bucket_name = "travel";
+  request.index_name = "ix";
+  request.keys = { "country" };
+  request.condition = R"(country = "US")";
+  request.client_context_id = "ctx-42";
+  return request;
+}
+
+void
+a_refused_index_completes_on_the_io_context()
+{
+  asio::io_context io;
+  component comp{
+    io,
+    component_config{
+      grpc::CreateChannel("127.0.0.1:1", grpc::InsecureChannelCredentials()),
+      cluster_credentials{},
+      { 5000ms },
+    },
+  };
+
+  int completions = 0;
+  std::optional<om::query_index_create_response> outcome{};
+  const auto call =
+    comp.execute(conditional_secondary_index(), [&completions, &outcome](auto response) {
+      ++completions;
+      outcome = std::move(response);
+    });
+
+  assert_false(outcome.has_value(), "the refusal is not delivered inline out of execute()");
+
+  // A call refused before dispatch has no gRPC context to cancel, and the queued completion is
+  // owed to the caller either way.
+  call.cancel();
+
+  assert_true(io.poll() > 0, "the refusal is queued on the io context");
+  assert_eq(completions, 1, "and delivered exactly once, cancelled or not");
+  assert_true(outcome->ctx.ec == errc::common::feature_not_available,
+              "a conditional secondary index has no couchbase2 encoding");
+  assert_eq(outcome->ctx.client_context_id,
+            std::string{ "ctx-42" },
+            "a response that never reached the server still correlates to the request");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_query_index_admin_component",
+    {
+      { "a_refused_index_completes_on_the_io_context",
+        a_refused_index_completes_on_the_io_context },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test

--- a/test/cng/protostellar/query_index_admin_converter.cxx
+++ b/test/cng/protostellar/query_index_admin_converter.cxx
@@ -1,0 +1,445 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Unit tests for the query-index-admin <-> couchbase.admin.query.v1 translation (CXXCBC-901).
+// Pure, no server.
+//
+// The encode side carries the only statement text this transport lets a caller supply. The gateway
+// builds the CREATE INDEX statement from the request and joins the field list with commas
+// verbatim, so an index key that does not stay inside its own quoting adds terms to the statement.
+// The adversarial cases below reconstruct that join and count the tokens the query parser would
+// find in it.
+
+#include "framework/test_runner.hxx"
+
+#include "core/protostellar/query_index_admin_converter.hxx"
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace qi = ::couchbase::core::protostellar::query_index_admin;
+namespace om = ::couchbase::core::operations::management;
+namespace v1 = ::couchbase::admin::query::v1;
+
+// Where the escaped identifier starting at `pos` ends, or npos if it never closes.
+//
+// Transcribed from the query parser's own lexer rule for an escaped identifier
+// (parser/n1ql/n1ql.nex): a backtick opens it, the body is a sequence of doubled backticks,
+// backslash escapes, and plain characters, and a lone backtick closes it. Written out here rather
+// than reusing the converter's is_escaped_identifier(), so that a converter that mis-scans cannot
+// agree with itself.
+[[nodiscard]] auto
+identifier_end(const std::string& text, std::size_t pos) -> std::size_t
+{
+  if (pos >= text.size() || text[pos] != '`') {
+    return std::string::npos;
+  }
+  for (auto i = pos + 1; i < text.size();) {
+    if (text[i] == '\\') {
+      if (i + 1 >= text.size()) {
+        return std::string::npos; // a trailing backslash has nothing to escape
+      }
+      i += 2;
+    } else if (text[i] == '`') {
+      if (i + 1 >= text.size() || text[i + 1] != '`') {
+        return i + 1;
+      }
+      i += 2;
+    } else {
+      i += 1;
+    }
+  }
+  return std::string::npos;
+}
+
+// How many identifiers the parser would read out of the field list the gateway builds. Anything
+// other than one token per key means a key escaped its own quoting.
+[[nodiscard]] auto
+count_identifiers(const std::string& field_list) -> std::size_t
+{
+  std::size_t count = 0;
+  std::size_t pos = 0;
+  while (pos < field_list.size()) {
+    const auto end = identifier_end(field_list, pos);
+    if (end == std::string::npos) {
+      return count; // loose text: fewer tokens than keys, which is the failure being detected
+    }
+    ++count;
+    pos = end;
+    if (pos < field_list.size()) {
+      if (field_list[pos] != ',') {
+        return count; // a token followed by something other than the separator
+      }
+      ++pos;
+    }
+  }
+  return count;
+}
+
+// The name an escaped identifier denotes, by the rule the parser applies to it
+// (parser/n1ql/util.go): a backslash escapes the character after it. Only the two escapes the
+// converter emits are handled -- everything else is copied, which is what the parser does too.
+[[nodiscard]] auto
+identifier_name(const std::string& token) -> std::string
+{
+  std::string name;
+  for (std::size_t i = 1; i + 1 < token.size(); ++i) {
+    if (token[i] == '\\' && i + 2 < token.size()) {
+      ++i;
+    }
+    name.push_back(token[i]);
+  }
+  return name;
+}
+
+// Joins the encoded keys the way the gateway does before splicing them into the statement
+// (gocbcorex cbqueryx: strings.Join(opts.Fields, ",")).
+[[nodiscard]] auto
+gateway_field_list(const v1::CreateIndexRequest& proto) -> std::string
+{
+  std::string joined;
+  for (const auto& field : proto.fields()) {
+    if (!joined.empty()) {
+      joined.push_back(',');
+    }
+    joined += field;
+  }
+  return joined;
+}
+
+[[nodiscard]] auto
+create_request(std::vector<std::string> keys) -> om::query_index_create_request
+{
+  om::query_index_create_request request{};
+  request.bucket_name = "travel";
+  request.index_name = "ix";
+  request.keys = std::move(keys);
+  return request;
+}
+
+// Keys chosen to break out of the quoting the encode applies, plus the ordinary ones they must not
+// break. Every case below runs the whole list.
+[[nodiscard]] auto
+hostile_keys() -> std::vector<std::string>
+{
+  return {
+    "field",
+    "two words",                                     // only works because the key is quoted
+    "`field`",                                       // the form GetAllIndexes reports
+    "`a\\`b`",                                       // already one token, with an escaped backtick
+    "`a`,`b`",                                       // pre-quoted, but closes after `a`
+    "a`,`b",                                         // closes the quoting the encode opens
+    "a`",                                            //
+    "`a",                                            //
+    "`",                                             //
+    "``",                                            //
+    "```",                                           //
+    "a\\",                                           // trailing backslash: escapes the closer
+    "a\\\\",                                         //
+    "`a\\`",                                         // pre-quoted, but the closer is escaped
+    "a) , (1=1) OR (1",                              //
+    "x`) USING GSI WITH {\"defer_build\":true} -- ", //
+    "name`,`type`) WITH {\"num_replica\":9} -- ",    //
+    "a\nb",
+    "a,b",
+    "",
+  };
+}
+
+void
+index_keys_are_escaped_into_one_token_each()
+{
+  for (const auto& key : hostile_keys()) {
+    const auto encoded = qi::encode_index_key(key);
+    const auto message = fmt::format("key <{}> encodes to <{}>", key, encoded);
+    assert_eq(identifier_end(encoded, 0),
+              encoded.size(),
+              fmt::format("{} as a single identifier", message));
+    if (encoded != key) {
+      // Not passed through, so the escape must be reversible: the identifier denotes the key the
+      // caller asked for, with nothing added and nothing lost.
+      assert_eq(identifier_name(encoded), key, fmt::format("{} denoting the key itself", message));
+    }
+  }
+}
+
+void
+a_hostile_key_cannot_add_terms_to_the_field_list()
+{
+  const auto keys = hostile_keys();
+  const auto proto = qi::encode_create(create_request(keys));
+  assert_eq(static_cast<std::size_t>(proto.fields_size()), keys.size(), "every key is encoded");
+
+  const auto field_list = gateway_field_list(proto);
+  assert_eq(count_identifiers(field_list),
+            keys.size(),
+            fmt::format("the field list has exactly one identifier per key: <{}>", field_list));
+}
+
+void
+an_ordinary_key_is_quoted_and_a_quoted_key_is_left_alone()
+{
+  const auto proto = qi::encode_create(create_request({ "field", "two words", "`already`" }));
+  assert_eq(static_cast<std::size_t>(proto.fields_size()), std::size_t{ 3 }, "three keys");
+  assert_eq(proto.fields(0), std::string{ "`field`" }, "a bare key is quoted");
+  assert_eq(proto.fields(1), std::string{ "`two words`" }, "a key with a space is quoted");
+  assert_eq(proto.fields(2), std::string{ "`already`" }, "a quoted key is not quoted twice");
+}
+
+void
+encode_create_fills_the_secondary_request()
+{
+  auto request = create_request({ "country" });
+  request.scope_name = "inventory";
+  request.collection_name = "airport";
+  request.num_replicas = 2;
+  request.deferred = true;
+  request.ignore_if_exists = true;
+
+  const auto proto = qi::encode_create(request);
+  assert_eq(proto.bucket_name(), std::string{ "travel" }, "bucket encoded");
+  assert_eq(proto.scope_name(), std::string{ "inventory" }, "scope encoded");
+  assert_eq(proto.collection_name(), std::string{ "airport" }, "collection encoded");
+  assert_eq(proto.name(), std::string{ "ix" }, "index name encoded");
+  assert_eq(proto.num_replicas(), 2, "num_replicas encoded");
+  assert_true(proto.deferred(), "deferred encoded");
+  assert_true(proto.ignore_if_exists(), "ignore_if_exists encoded");
+
+  // An index name is not escaped here: it travels as its own field and the gateway escapes it.
+  // Escaping it a second time would create an index whose name carries the backticks.
+  auto hostile = create_request({ "country" });
+  hostile.index_name = "ix`) --";
+  assert_eq(qi::encode_create(hostile).name(),
+            std::string{ "ix`) --" },
+            "the index name is carried verbatim, for the gateway to escape");
+}
+
+void
+an_unset_keyspace_part_is_left_unset()
+{
+  // A present-but-empty scope names a scope called "", which the gateway rejects; an absent one
+  // means the whole bucket. The core request spells both as an empty string.
+  const auto proto = qi::encode_create(create_request({ "country" }));
+  assert_false(proto.has_scope_name(), "an empty scope is unset, not empty");
+  assert_false(proto.has_collection_name(), "an empty collection is unset, not empty");
+
+  om::query_index_build_deferred_request build{};
+  build.bucket_name = "travel";
+  build.scope_name = std::string{};
+  const auto build_proto = qi::encode_build_deferred(build);
+  assert_eq(build_proto.bucket_name(), std::string{ "travel" }, "bucket encoded");
+  assert_false(build_proto.has_scope_name(), "an empty optional scope is unset too");
+}
+
+void
+create_picks_the_rpc_from_is_primary()
+{
+  auto request = create_request({});
+  request.is_primary = true;
+  request.index_name = "";
+  request.num_replicas = 1;
+  request.deferred = true;
+
+  const auto proto = qi::encode_create_primary(request);
+  assert_false(proto.has_name(), "an unnamed primary index leaves the name to the server");
+  assert_eq(proto.num_replicas(), 1, "num_replicas encoded");
+  assert_true(proto.deferred(), "deferred encoded");
+
+  request.index_name = "named_primary";
+  assert_eq(qi::encode_create_primary(request).name(),
+            std::string{ "named_primary" },
+            "a named primary index carries its name");
+}
+
+void
+drop_picks_the_rpc_from_is_primary()
+{
+  om::query_index_drop_request request{};
+  request.bucket_name = "travel";
+  request.scope_name = "inventory";
+  request.collection_name = "airport";
+  request.index_name = "ix";
+  request.ignore_if_does_not_exist = true;
+
+  const auto secondary = qi::encode_drop(request);
+  assert_eq(secondary.name(), std::string{ "ix" }, "secondary drop names the index");
+  assert_eq(secondary.collection_name(), std::string{ "airport" }, "secondary drop is qualified");
+  assert_true(secondary.ignore_if_missing(), "ignore_if_does_not_exist encoded");
+
+  request.is_primary = true;
+  request.index_name = "";
+  const auto primary = qi::encode_drop_primary(request);
+  assert_false(primary.has_name(), "an unnamed primary drop leaves the name to the server");
+  assert_true(primary.ignore_if_missing(), "ignore_if_does_not_exist encoded");
+}
+
+void
+a_conditional_secondary_index_cannot_be_encoded()
+{
+  auto request = create_request({ "country" });
+  assert_true(qi::can_encode(request), "a plain secondary index is encodable");
+
+  request.condition = "country = \"US\"";
+  assert_false(qi::can_encode(request), "CreateIndexRequest has no condition field");
+
+  // The condition is not silently dropped for a primary index either -- there is nothing to drop,
+  // since a primary index indexes every key.
+  request.is_primary = true;
+  assert_true(qi::can_encode(request), "a primary index has no condition to lose");
+}
+
+void
+decode_index_maps_fields()
+{
+  v1::GetAllIndexesResponse_Index proto;
+  proto.set_name("ix1");
+  proto.set_is_primary(false);
+  proto.set_type(v1::INDEX_TYPE_GSI);
+  proto.set_state(v1::INDEX_STATE_ONLINE);
+  proto.set_bucket_name("travel");
+  proto.set_scope_name("inventory");
+  proto.set_collection_name("airport");
+  proto.add_fields("country");
+  proto.add_fields("city");
+  proto.set_condition("(`country` = \"US\")");
+
+  const auto index = qi::decode_index(proto);
+  assert_eq(index.name, std::string{ "ix1" }, "name decoded");
+  assert_false(index.is_primary, "is_primary decoded");
+  assert_eq(index.type, std::string{ "gsi" }, "type enum -> string");
+  assert_eq(index.state, std::string{ "online" }, "state enum -> string");
+  assert_eq(index.bucket_name, std::string{ "travel" }, "bucket decoded");
+  assert_true(index.scope_name.has_value() && index.scope_name.value() == "inventory",
+              "scope decoded");
+  assert_true(index.collection_name.has_value() && index.collection_name.value() == "airport",
+              "collection decoded");
+  assert_eq(index.index_key.size(), std::size_t{ 2 }, "index keys decoded");
+  assert_eq(index.index_key.at(0), std::string{ "country" }, "first key decoded");
+  assert_true(index.condition.has_value(), "condition decoded");
+}
+
+// Both enums fall back to "unknown" rather than to whichever value happens to sit first. The
+// schema has no value outside the two below today, so this is about what a schema bump decodes to:
+// naming an unrecognised type "gsi" is a claim about the index rather than an admission.
+void
+an_unrecognised_enum_decodes_as_unknown()
+{
+  const auto out_of_range = static_cast<v1::IndexType>(9999);
+  assert_eq(qi::index_type_to_string(out_of_range), std::string{ "unknown" }, "unknown index type");
+  assert_eq(qi::index_state_to_string(static_cast<v1::IndexState>(9999)),
+            std::string{ "unknown" },
+            "unknown index state");
+  assert_eq(qi::index_type_to_string(v1::INDEX_TYPE_GSI), std::string{ "gsi" }, "gsi still maps");
+  assert_eq(
+    qi::index_type_to_string(v1::INDEX_TYPE_VIEW), std::string{ "view" }, "view still maps");
+}
+
+void
+decode_primary_index_has_no_keys()
+{
+  v1::GetAllIndexesResponse_Index proto;
+  proto.set_name("#primary");
+  proto.set_is_primary(true);
+  proto.set_type(v1::INDEX_TYPE_GSI);
+  proto.set_state(v1::INDEX_STATE_DEFERRED);
+  proto.set_bucket_name("travel");
+
+  const auto index = qi::decode_index(proto);
+  assert_true(index.is_primary, "primary decoded");
+  assert_eq(index.state, std::string{ "deferred" }, "deferred state decoded");
+  assert_true(index.index_key.empty(), "primary has no keys");
+  assert_false(index.scope_name.has_value(), "unset scope stays nullopt");
+  assert_false(index.condition.has_value(), "unset condition stays nullopt");
+}
+
+// condition and partition are `optional string`, so "the server did not report one" and "the
+// server reported an empty one" are two answers and only presence separates them. Reading
+// emptiness instead collapses the second onto the first.
+void
+an_explicitly_empty_condition_is_not_an_absent_one()
+{
+  v1::GetAllIndexesResponse_Index proto;
+  proto.set_bucket_name("travel");
+  proto.set_condition("");
+  proto.set_partition("");
+
+  const auto index = qi::decode_index(proto);
+  assert_true(index.condition.has_value(),
+              "a condition the server sent empty is still a condition");
+  assert_eq(index.condition.value_or("absent"), std::string{}, "and it decodes to what was sent");
+  assert_true(index.partition.has_value(),
+              "a partition the server sent empty is still a partition");
+  assert_eq(index.partition.value_or("absent"), std::string{}, "and it decodes to what was sent");
+
+  v1::GetAllIndexesResponse_Index unset;
+  unset.set_bucket_name("travel");
+  const auto without = qi::decode_index(unset);
+  assert_false(without.condition.has_value(), "an unsent condition stays nullopt");
+  assert_false(without.partition.has_value(), "an unsent partition stays nullopt");
+}
+
+// GetAllIndexes reports keys in the quoted form, so a key read from one index and passed to
+// create_index() for another must name the same field.
+void
+a_decoded_key_re_encodes_to_itself()
+{
+  v1::GetAllIndexesResponse_Index proto;
+  proto.set_bucket_name("travel");
+  proto.add_fields("`field`");
+  proto.add_fields("`two words`");
+
+  const auto index = qi::decode_index(proto);
+  for (const auto& key : index.index_key) {
+    assert_eq(qi::encode_index_key(key), key, "a key read back from the server survives re-encode");
+  }
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_query_index_admin_converter",
+    {
+      { "index_keys_are_escaped_into_one_token_each", index_keys_are_escaped_into_one_token_each },
+      { "a_hostile_key_cannot_add_terms_to_the_field_list",
+        a_hostile_key_cannot_add_terms_to_the_field_list },
+      { "an_ordinary_key_is_quoted_and_a_quoted_key_is_left_alone",
+        an_ordinary_key_is_quoted_and_a_quoted_key_is_left_alone },
+      { "encode_create_fills_the_secondary_request", encode_create_fills_the_secondary_request },
+      { "an_unset_keyspace_part_is_left_unset", an_unset_keyspace_part_is_left_unset },
+      { "create_picks_the_rpc_from_is_primary", create_picks_the_rpc_from_is_primary },
+      { "drop_picks_the_rpc_from_is_primary", drop_picks_the_rpc_from_is_primary },
+      { "a_conditional_secondary_index_cannot_be_encoded",
+        a_conditional_secondary_index_cannot_be_encoded },
+      { "decode_index_maps_fields", decode_index_maps_fields },
+      { "an_unrecognised_enum_decodes_as_unknown", an_unrecognised_enum_decodes_as_unknown },
+      { "decode_primary_index_has_no_keys", decode_primary_index_has_no_keys },
+      { "an_explicitly_empty_condition_is_not_an_absent_one",
+        an_explicitly_empty_condition_is_not_an_absent_one },
+      { "a_decoded_key_re_encodes_to_itself", a_decoded_key_re_encodes_to_itself },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test


### PR DESCRIPTION
Query index management was rejected by the HTTP execute front-door gate on
couchbase2. Wire it onto the unary gRPC path via admin.query.v1.

The converter owns the translation in both directions. GetAllIndexes decodes
into core query_index structs -- the proto IndexType/IndexState enums have no
`unknown` sentinel and map to the lowercase strings the SDK uses. Create and
drop pick the primary or the secondary RPC from the core is_primary flag, and a
conditional secondary index is reported as feature_not_available, since the
proto CreateIndex has no condition field and encoding one would create an index
over the whole collection under the name the caller asked for.

Index keys are escaped into exactly one N1QL identifier each. The gateway builds
the CREATE INDEX statement and splices the field list into it verbatim, so a key
that leaves its own quoting adds terms to the statement rather than naming a
field. The escape is the one the query parser reads back -- a backslash escapes
the character after it -- so a backtick and a backslash each arrive prefixed by
one. A key that is already one complete identifier is passed through, which is
the form GetAllIndexes reports keys in, after being checked to end where it
claims to.

build_deferred_indexes() issues the single BuildDeferredIndexes request on
protostellar origins rather than the get-deferred + build pair, which has no
couchbase2 encoding: the RPC takes a keyspace and builds every deferred index in
it, and only the composite knows that its own list is that set. RFC 77 lists the
operation among the single ones rather than the composite ones, so it carries no
sub-operation spans there; the classic path keeps both.

Routing is declared by detecting the component's execute() overload for a
request type rather than by a separate list, so an overload the list does not
mention cannot go unreachable.

Every management response carries the caller's client_context_id into its error
context -- on the completion and on the paths that never reach the server, which
have nothing else to correlate them by.

---
Stacked PR **19/30** in the CNG (`couchbase2://`) transport series. The change specific to this PR is its top commit; the commits beneath it belong to earlier PRs in the series. Depends on #1040 — merge the series bottom-up.
