### PR TITLE
CXXCBC-901: route search index management over couchbase2

### DIFF
--- a/.github/actions/create-cng-cluster/action.yml
+++ b/.github/actions/create-cng-cluster/action.yml
@@ -85,12 +85,9 @@ runs:
         # `cao:` section has no quota fields either, so the operator's 256 MiB service defaults apply
         # until the resource is patched below.
         #
-        # fts is in the list because the live search case needs a search service to answer, not an
-        # index. It queries an index that was never created and accepts the gateway's
-        # index-not-found, which is an answer only a cluster running fts can give; without the
-        # service the request fails as an internal error instead and the case goes red. No index is
-        # built here, so the default search quota is enough -- one that has to serve queries needs
-        # considerably more, which is what search index management will have to provision for.
+        # fts is in the list because the live search cases need a search service to answer. The
+        # search index management cases go further and build real indexes on it, so the operator's
+        # default search quota is no longer enough and is raised alongside the data one below.
         CLUSTER_CONFIG: |
           nodes:
             - count: 1
@@ -113,7 +110,7 @@ runs:
         # The tests set tls_verify_mode::none themselves, so the bare connstr is what they want:
         # couchbase2 is always TLS and the gateway's dev certificate is not chainable.
         echo "connstr=$(cbdinocluster -v connstr --couchbase2 $CBDC_ID)" >> "$GITHUB_OUTPUT"
-    - name: Raise the data service quota
+    - name: Raise the data and search service quotas
       shell: bash
       run: |
         # The bucket and collection management cases create buckets of their own, and at the
@@ -126,22 +123,30 @@ runs:
         # runs the CNG suites serially, so no two test buckets are ever allocated at once. Three KV
         # nodes reserve it each, which is 3.8 GiB of the runner's 15.
         #
-        # It has to be a patch: the quota cannot be expressed in the cluster definition, and setting
-        # it through /pools/default is reconciled away by the operator within the minute.
+        # Search is raised because the search index management cases build real fulltext indexes and
+        # analyze a document against one, where before nothing was built on this service and the
+        # default was sized only to answer a request. What that default would in fact support was
+        # not measured; the quota follows what the cases now do.
+        #
+        # It has to be a patch: neither quota can be expressed in the cluster definition, and
+        # setting them through /pools/default is reconciled away by the operator within the minute.
         kubectl -n "cbdc2-$CBDC_ID" patch couchbasecluster cluster --type=merge \
-          -p '{"spec":{"cluster":{"dataServiceMemoryQuota":"1280Mi"}}}'
+          -p '{"spec":{"cluster":{"dataServiceMemoryQuota":"1280Mi","searchServiceMemoryQuota":"1Gi"}}}'
         # Waiting on condition=Available would prove nothing: it is already true from before the
         # patch, so the wait returns instantly and the bucket could be created against the old
-        # quota. Poll the cluster itself for the applied value, and fail here rather than leave the
-        # management cases to fail one by one on a bucket create.
+        # quota. Poll the cluster itself for the applied values, and fail here rather than leave
+        # the management cases to fail one by one on a bucket create.
         MGMT=$(cbdinocluster mgmt "$CBDC_ID" | tail -1)
         for _ in $(seq 1 30); do
-          QUOTA=$(curl -sS -u Administrator:password "$MGMT/pools/default" | jq -r '.memoryQuota')
-          echo "data service quota: $QUOTA"
-          [ "$QUOTA" = "1280" ] && break
+          POOLS=$(curl -sS -u Administrator:password "$MGMT/pools/default")
+          QUOTA=$(echo "$POOLS" | jq -r '.memoryQuota')
+          FTS_QUOTA=$(echo "$POOLS" | jq -r '.ftsMemoryQuota')
+          echo "data service quota: $QUOTA, search service quota: $FTS_QUOTA"
+          [ "$QUOTA" = "1280" ] && [ "$FTS_QUOTA" = "1024" ] && break
           sleep 5
         done
         [ "$QUOTA" = "1280" ] || { echo "::error::data service quota never reached 1280 MiB"; exit 1; }
+        [ "$FTS_QUOTA" = "1024" ] || { echo "::error::search service quota never reached 1 GiB"; exit 1; }
     - name: Add bucket
       shell: bash
       env:

--- a/core/protostellar/component.cxx
+++ b/core/protostellar/component.cxx
@@ -33,6 +33,7 @@
 #include "core/protostellar/query_converter.hxx"
 #include "core/protostellar/query_index_admin_converter.hxx"
 #include "core/protostellar/search_converter.hxx"
+#include "core/protostellar/search_index_admin_converter.hxx"
 #include "core/protostellar/view_converter.hxx"
 
 #include <couchbase/error_codes.hxx>
@@ -43,6 +44,7 @@
 #include <couchbase/admin/bucket/v1/bucket.grpc.pb.h>
 #include <couchbase/admin/collection/v1/collection.grpc.pb.h>
 #include <couchbase/admin/query/v1/query.grpc.pb.h>
+#include <couchbase/admin/search/v1/search.grpc.pb.h>
 #include <couchbase/kv/v1/kv.grpc.pb.h>
 #include <couchbase/search/v1/search.grpc.pb.h>
 #include <couchbase/view/v1/view.grpc.pb.h>
@@ -68,6 +70,7 @@ namespace view_v1 = ::couchbase::view::v1;
 namespace bucket_admin_v1 = ::couchbase::admin::bucket::v1;
 namespace collection_admin_v1 = ::couchbase::admin::collection::v1;
 namespace query_admin_v1 = ::couchbase::admin::query::v1;
+namespace search_admin_v1 = ::couchbase::admin::search::v1;
 
 // Defined here rather than in the header so the generated gRPC types stay out of every consumer of
 // component.hxx.
@@ -80,6 +83,7 @@ struct component::stubs {
   std::unique_ptr<bucket_admin_v1::BucketAdminService::Stub> bucket_admin;
   std::unique_ptr<collection_admin_v1::CollectionAdminService::Stub> collection_admin;
   std::unique_ptr<query_admin_v1::QueryAdminService::Stub> query_admin;
+  std::unique_ptr<search_admin_v1::SearchAdminService::Stub> search_admin;
 };
 
 namespace
@@ -108,6 +112,21 @@ fail_expired(asio::io_context& io, const Request& request, Handler& handler) -> 
   return {};
 }
 
+// Deliver a prepared response carrying ec without sending anything. Posted rather than invoked:
+// completions arrive on the io context, never inline out of execute(), which would re-enter the
+// caller before it holds its pending_call.
+template<typename Response, typename Handler>
+auto
+fail_ctx(asio::io_context& io, Handler& handler, Response response, std::error_code ec)
+  -> pending_call
+{
+  response.ctx.ec = ec;
+  asio::post(io, [handler = std::move(handler), response = std::move(response)]() mutable {
+    handler(std::move(response));
+  });
+  return {};
+}
+
 // The same rule for the services whose responses carry their own error context rather than a
 // key_value one: they resolve a timeout exactly as the KV overloads do, so a non-positive one
 // would reach the dispatcher and produce a call with no deadline there too. The response the
@@ -116,11 +135,7 @@ template<typename Response, typename Handler>
 auto
 fail_expired_ctx(asio::io_context& io, Handler& handler, Response response) -> pending_call
 {
-  response.ctx.ec = errc::common::unambiguous_timeout;
-  asio::post(io, [handler = std::move(handler), response = std::move(response)]() mutable {
-    handler(std::move(response));
-  });
-  return {};
+  return fail_ctx(io, handler, std::move(response), errc::common::unambiguous_timeout);
 }
 
 // A management response carrying the caller's client_context_id, which is what correlates it with
@@ -140,6 +155,20 @@ stamped_management(const Request& request) -> typename Request::response_type
   response.ctx.client_context_id = request.client_context_id.value_or(std::string{});
   return response;
 }
+
+// FTS answers each of the search index management endpoints with {"status":"ok"} on success, and
+// the classic path copies that string into the response, where core-API consumers read it.
+// admin.search.v1 replies with empty messages, so a successful RPC is the same signal and carries
+// the same meaning. A failed one leaves the field empty rather than inventing a status the server
+// never reported; the error code is what describes it.
+template<typename Response>
+void
+set_ok_status(Response& response)
+{
+  if (!response.ctx.ec) {
+    response.status = "ok";
+  }
+}
 } // namespace
 
 component::component(asio::io_context& io, component_config config)
@@ -152,7 +181,8 @@ component::component(asio::io_context& io, component_config config)
              view_v1::ViewService::NewStub(config.channel),
              bucket_admin_v1::BucketAdminService::NewStub(config.channel),
              collection_admin_v1::CollectionAdminService::NewStub(config.channel),
-             query_admin_v1::QueryAdminService::NewStub(config.channel) }) }
+             query_admin_v1::QueryAdminService::NewStub(config.channel),
+             search_admin_v1::SearchAdminService::NewStub(config.channel) }) }
   , authorization_{ authorization_header(config.credentials) }
   , timeouts_{ config.timeouts }
   // Initialised last (see the declaration order in the header), so the channel can be moved in.
@@ -1733,6 +1763,572 @@ component::execute(
       response.ctx.client_context_id = client_context_id;
       response.ctx.ec = map_status(status, operation_kind::mutating);
       handler(std::move(response));
+    });
+}
+
+auto
+component::execute(
+  operations::management::search_index_upsert_request request,
+  utils::movable_function<void(operations::management::search_index_upsert_response)>&& handler)
+  -> pending_call
+{
+  const auto client_context_id = request.client_context_id.value_or(std::string{});
+  if (request.index.name.empty()) {
+    return fail_ctx(io_, handler, stamped_management(request), errc::common::invalid_argument);
+  }
+  const auto timeout = request.timeout.value_or(timeouts_.management);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped_management(request));
+  }
+  const auto auth = authorization_;
+  const auto name = request.index.name;
+  auto* stub = stubs_->search_admin.get();
+
+  // A uuid identifies a definition that already exists, so an upsert carrying one is an update and
+  // an upsert without one is a create. That is the same rule the classic path applies -- it sends
+  // the uuid as the body's "uuid" member, which FTS reads as prevIndexUUID -- and the two RPCs
+  // divide along the same line: UpdateIndex refuses a request with no uuid, and CreateIndex refuses
+  // a name that already exists.
+  //
+  // The proto is built before the handler is moved into the completion, so a definition the
+  // converter refuses is still reported through the handler the caller passed.
+  std::shared_ptr<search_admin_v1::UpdateIndexRequest> update_proto;
+  std::shared_ptr<search_admin_v1::CreateIndexRequest> create_proto;
+  if (!request.index.uuid.empty()) {
+    update_proto = std::make_shared<search_admin_v1::UpdateIndexRequest>();
+    if (!search_index_admin::apply_index(request.index, *update_proto->mutable_index())) {
+      return fail_ctx(io_, handler, stamped_management(request), errc::common::invalid_argument);
+    }
+    if (request.bucket_name.has_value()) {
+      update_proto->set_bucket_name(*request.bucket_name);
+    }
+    if (request.scope_name.has_value()) {
+      update_proto->set_scope_name(*request.scope_name);
+    }
+  } else {
+    create_proto = std::make_shared<search_admin_v1::CreateIndexRequest>();
+    if (!search_index_admin::apply_index(request.index, *create_proto)) {
+      return fail_ctx(io_, handler, stamped_management(request), errc::common::invalid_argument);
+    }
+    if (request.bucket_name.has_value()) {
+      create_proto->set_bucket_name(*request.bucket_name);
+    }
+    if (request.scope_name.has_value()) {
+      create_proto->set_scope_name(*request.scope_name);
+    }
+  }
+
+  auto invoke =
+    [handler = std::move(handler), client_context_id, name](grpc::Status status) mutable {
+      operations::management::search_index_upsert_response response;
+      response.ctx.client_context_id = client_context_id;
+      response.ctx.ec = map_status(status, operation_kind::mutating);
+      response.name = name;
+      set_ok_status(response);
+      handler(std::move(response));
+    };
+
+  if (update_proto) {
+    return dispatcher_.unary<search_admin_v1::UpdateIndexResponse>(
+      timeout,
+      [stub, proto = update_proto, auth](grpc::ClientContext& ctx,
+                                         search_admin_v1::UpdateIndexResponse& resp,
+                                         std::function<void(grpc::Status)> cb) {
+        if (!auth.empty()) {
+          ctx.AddMetadata("authorization", auth);
+        }
+        stub->async()->UpdateIndex(&ctx, proto.get(), &resp, std::move(cb));
+      },
+      [invoke = std::move(invoke), proto = update_proto](
+        grpc::Status status, search_admin_v1::UpdateIndexResponse /* r */) mutable {
+        invoke(std::move(status));
+      });
+  }
+  return dispatcher_.unary<search_admin_v1::CreateIndexResponse>(
+    timeout,
+    [stub, proto = create_proto, auth](grpc::ClientContext& ctx,
+                                       search_admin_v1::CreateIndexResponse& resp,
+                                       std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->CreateIndex(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [invoke = std::move(invoke), proto = create_proto](
+      grpc::Status status, search_admin_v1::CreateIndexResponse /* r */) mutable {
+      invoke(std::move(status));
+    });
+}
+
+auto
+component::execute(
+  operations::management::search_index_get_request request,
+  utils::movable_function<void(operations::management::search_index_get_response)>&& handler)
+  -> pending_call
+{
+  const auto client_context_id = request.client_context_id.value_or(std::string{});
+  if (request.index_name.empty()) {
+    return fail_ctx(io_, handler, stamped_management(request), errc::common::invalid_argument);
+  }
+  auto proto = std::make_shared<search_admin_v1::GetIndexRequest>();
+  proto->set_name(request.index_name);
+  if (request.bucket_name.has_value()) {
+    proto->set_bucket_name(*request.bucket_name);
+  }
+  if (request.scope_name.has_value()) {
+    proto->set_scope_name(*request.scope_name);
+  }
+  const auto timeout = request.timeout.value_or(timeouts_.management);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped_management(request));
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->search_admin.get();
+  return dispatcher_.unary<search_admin_v1::GetIndexResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        search_admin_v1::GetIndexResponse& resp,
+                        std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->GetIndex(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), proto, client_context_id](
+      grpc::Status status, search_admin_v1::GetIndexResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      operations::management::search_index_get_response response;
+      response.ctx.client_context_id = client_context_id;
+      response.ctx.ec = map_status(status, operation_kind::read_only);
+      if (!response.ctx.ec) {
+        // A success carrying no index describes no index. Reporting it as one -- the response
+        // would hold a default-constructed definition with an empty name -- is worse than saying
+        // the index is not there.
+        if (!resp.has_index()) {
+          response.ctx.ec = errc::common::index_not_found;
+        } else if (auto index = search_index_admin::decode_index(resp.index()); index.has_value()) {
+          response.index = std::move(*index);
+        } else {
+          response.ctx.ec = errc::common::parsing_failure;
+        }
+      }
+      set_ok_status(response);
+      handler(std::move(response));
+    });
+}
+
+auto
+component::execute(
+  operations::management::search_index_get_all_request request,
+  utils::movable_function<void(operations::management::search_index_get_all_response)>&& handler)
+  -> pending_call
+{
+  const auto client_context_id = request.client_context_id.value_or(std::string{});
+  auto proto = std::make_shared<search_admin_v1::ListIndexesRequest>();
+  if (request.bucket_name.has_value()) {
+    proto->set_bucket_name(*request.bucket_name);
+  }
+  if (request.scope_name.has_value()) {
+    proto->set_scope_name(*request.scope_name);
+  }
+  const auto timeout = request.timeout.value_or(timeouts_.management);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped_management(request));
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->search_admin.get();
+  return dispatcher_.unary<search_admin_v1::ListIndexesResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        search_admin_v1::ListIndexesResponse& resp,
+                        std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->ListIndexes(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), proto, client_context_id](
+      grpc::Status status, search_admin_v1::ListIndexesResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      operations::management::search_index_get_all_response response;
+      response.ctx.client_context_id = client_context_id;
+      response.ctx.ec = map_status(status, operation_kind::read_only);
+      for (const auto& index : resp.indexes()) {
+        auto decoded = search_index_admin::decode_index(index);
+        if (!decoded.has_value()) {
+          // One definition that cannot be represented fails the listing. Skipping it would return
+          // a list shorter than the server's, which reads as "that index does not exist".
+          response.ctx.ec = errc::common::parsing_failure;
+          response.indexes.clear();
+          break;
+        }
+        response.indexes.push_back(std::move(*decoded));
+      }
+      set_ok_status(response);
+      handler(std::move(response));
+    });
+}
+
+auto
+component::execute(
+  operations::management::search_index_drop_request request,
+  utils::movable_function<void(operations::management::search_index_drop_response)>&& handler)
+  -> pending_call
+{
+  const auto client_context_id = request.client_context_id.value_or(std::string{});
+  if (request.index_name.empty()) {
+    return fail_ctx(io_, handler, stamped_management(request), errc::common::invalid_argument);
+  }
+  auto proto = std::make_shared<search_admin_v1::DeleteIndexRequest>();
+  proto->set_name(request.index_name);
+  if (request.bucket_name.has_value()) {
+    proto->set_bucket_name(*request.bucket_name);
+  }
+  if (request.scope_name.has_value()) {
+    proto->set_scope_name(*request.scope_name);
+  }
+  const auto timeout = request.timeout.value_or(timeouts_.management);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped_management(request));
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->search_admin.get();
+  return dispatcher_.unary<search_admin_v1::DeleteIndexResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        search_admin_v1::DeleteIndexResponse& resp,
+                        std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->DeleteIndex(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), proto, client_context_id](
+      grpc::Status status, search_admin_v1::DeleteIndexResponse /* r */) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      operations::management::search_index_drop_response response;
+      response.ctx.client_context_id = client_context_id;
+      response.ctx.ec = map_status(status, operation_kind::mutating);
+      set_ok_status(response);
+      handler(std::move(response));
+    });
+}
+
+auto
+component::execute(
+  operations::management::search_index_analyze_document_request request,
+  utils::movable_function<void(operations::management::search_index_analyze_document_response)>&&
+    handler) -> pending_call
+{
+  const auto client_context_id = request.client_context_id.value_or(std::string{});
+  if (request.index_name.empty()) {
+    return fail_ctx(io_, handler, stamped_management(request), errc::common::invalid_argument);
+  }
+  auto proto = std::make_shared<search_admin_v1::AnalyzeDocumentRequest>();
+  proto->set_name(request.index_name);
+  proto->set_doc(request.encoded_document);
+  if (request.bucket_name.has_value()) {
+    proto->set_bucket_name(*request.bucket_name);
+  }
+  if (request.scope_name.has_value()) {
+    proto->set_scope_name(*request.scope_name);
+  }
+  const auto timeout = request.timeout.value_or(timeouts_.management);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped_management(request));
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->search_admin.get();
+  return dispatcher_.unary<search_admin_v1::AnalyzeDocumentResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        search_admin_v1::AnalyzeDocumentResponse& resp,
+                        std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->AnalyzeDocument(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), proto, client_context_id](
+      grpc::Status status, search_admin_v1::AnalyzeDocumentResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      operations::management::search_index_analyze_document_response response;
+      response.ctx.client_context_id = client_context_id;
+      response.ctx.ec = map_status(status, operation_kind::read_only);
+      response.analysis = resp.analyzed();
+      // The only response in this service that relays FTS's own status string; the rest infer it
+      // from the RPC. Prefer what the server said, and fall back only when it said nothing.
+      if (!response.ctx.ec && !resp.status().empty()) {
+        response.status = resp.status();
+      } else {
+        set_ok_status(response);
+      }
+      handler(std::move(response));
+    });
+}
+
+auto
+component::execute(
+  operations::management::search_index_get_documents_count_request request,
+  utils::movable_function<void(operations::management::search_index_get_documents_count_response)>&&
+    handler) -> pending_call
+{
+  const auto client_context_id = request.client_context_id.value_or(std::string{});
+  auto proto = std::make_shared<search_admin_v1::GetIndexedDocumentsCountRequest>();
+  proto->set_name(request.index_name);
+  if (request.bucket_name.has_value()) {
+    proto->set_bucket_name(*request.bucket_name);
+  }
+  if (request.scope_name.has_value()) {
+    proto->set_scope_name(*request.scope_name);
+  }
+  const auto timeout = request.timeout.value_or(timeouts_.management);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped_management(request));
+  }
+  const auto auth = authorization_;
+  auto* stub = stubs_->search_admin.get();
+  return dispatcher_.unary<search_admin_v1::GetIndexedDocumentsCountResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        search_admin_v1::GetIndexedDocumentsCountResponse& resp,
+                        std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->GetIndexedDocumentsCount(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [handler = std::move(handler), proto, client_context_id](
+      grpc::Status status, search_admin_v1::GetIndexedDocumentsCountResponse resp) mutable {
+      (void)proto; // kept only to keep the request alive for the call
+      operations::management::search_index_get_documents_count_response response;
+      response.ctx.client_context_id = client_context_id;
+      response.ctx.ec = map_status(status, operation_kind::read_only);
+      response.count = resp.count();
+      set_ok_status(response);
+      handler(std::move(response));
+    });
+}
+
+auto
+component::execute(
+  operations::management::search_index_control_ingest_request request,
+  utils::movable_function<void(operations::management::search_index_control_ingest_response)>&&
+    handler) -> pending_call
+{
+  const auto client_context_id = request.client_context_id.value_or(std::string{});
+  if (request.index_name.empty()) {
+    return fail_ctx(io_, handler, stamped_management(request), errc::common::invalid_argument);
+  }
+  const auto timeout = request.timeout.value_or(timeouts_.management);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped_management(request));
+  }
+  const auto auth = authorization_;
+  const auto name = request.index_name;
+  const auto bucket = request.bucket_name;
+  const auto scope = request.scope_name;
+  auto* stub = stubs_->search_admin.get();
+  auto invoke = [handler = std::move(handler), client_context_id](grpc::Status status) mutable {
+    operations::management::search_index_control_ingest_response response;
+    response.ctx.client_context_id = client_context_id;
+    response.ctx.ec = map_status(status, operation_kind::mutating);
+    set_ok_status(response);
+    handler(std::move(response));
+  };
+  if (request.pause) {
+    auto proto = std::make_shared<search_admin_v1::PauseIndexIngestRequest>();
+    proto->set_name(name);
+    if (bucket.has_value()) {
+      proto->set_bucket_name(*bucket);
+    }
+    if (scope.has_value()) {
+      proto->set_scope_name(*scope);
+    }
+    return dispatcher_.unary<search_admin_v1::PauseIndexIngestResponse>(
+      timeout,
+      [stub, proto, auth](grpc::ClientContext& ctx,
+                          search_admin_v1::PauseIndexIngestResponse& resp,
+                          std::function<void(grpc::Status)> cb) {
+        if (!auth.empty()) {
+          ctx.AddMetadata("authorization", auth);
+        }
+        stub->async()->PauseIndexIngest(&ctx, proto.get(), &resp, std::move(cb));
+      },
+      [invoke = std::move(invoke),
+       proto](grpc::Status status, search_admin_v1::PauseIndexIngestResponse /* r */) mutable {
+        invoke(std::move(status));
+      });
+  }
+  auto proto = std::make_shared<search_admin_v1::ResumeIndexIngestRequest>();
+  proto->set_name(name);
+  if (bucket.has_value()) {
+    proto->set_bucket_name(*bucket);
+  }
+  if (scope.has_value()) {
+    proto->set_scope_name(*scope);
+  }
+  return dispatcher_.unary<search_admin_v1::ResumeIndexIngestResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        search_admin_v1::ResumeIndexIngestResponse& resp,
+                        std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->ResumeIndexIngest(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [invoke = std::move(invoke),
+     proto](grpc::Status status, search_admin_v1::ResumeIndexIngestResponse /* r */) mutable {
+      invoke(std::move(status));
+    });
+}
+
+auto
+component::execute(
+  operations::management::search_index_control_query_request request,
+  utils::movable_function<void(operations::management::search_index_control_query_response)>&&
+    handler) -> pending_call
+{
+  const auto client_context_id = request.client_context_id.value_or(std::string{});
+  if (request.index_name.empty()) {
+    return fail_ctx(io_, handler, stamped_management(request), errc::common::invalid_argument);
+  }
+  const auto timeout = request.timeout.value_or(timeouts_.management);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped_management(request));
+  }
+  const auto auth = authorization_;
+  const auto name = request.index_name;
+  const auto bucket = request.bucket_name;
+  const auto scope = request.scope_name;
+  auto* stub = stubs_->search_admin.get();
+  auto invoke = [handler = std::move(handler), client_context_id](grpc::Status status) mutable {
+    operations::management::search_index_control_query_response response;
+    response.ctx.client_context_id = client_context_id;
+    response.ctx.ec = map_status(status, operation_kind::mutating);
+    set_ok_status(response);
+    handler(std::move(response));
+  };
+  if (request.allow) {
+    auto proto = std::make_shared<search_admin_v1::AllowIndexQueryingRequest>();
+    proto->set_name(name);
+    if (bucket.has_value()) {
+      proto->set_bucket_name(*bucket);
+    }
+    if (scope.has_value()) {
+      proto->set_scope_name(*scope);
+    }
+    return dispatcher_.unary<search_admin_v1::AllowIndexQueryingResponse>(
+      timeout,
+      [stub, proto, auth](grpc::ClientContext& ctx,
+                          search_admin_v1::AllowIndexQueryingResponse& resp,
+                          std::function<void(grpc::Status)> cb) {
+        if (!auth.empty()) {
+          ctx.AddMetadata("authorization", auth);
+        }
+        stub->async()->AllowIndexQuerying(&ctx, proto.get(), &resp, std::move(cb));
+      },
+      [invoke = std::move(invoke),
+       proto](grpc::Status status, search_admin_v1::AllowIndexQueryingResponse /* r */) mutable {
+        invoke(std::move(status));
+      });
+  }
+  auto proto = std::make_shared<search_admin_v1::DisallowIndexQueryingRequest>();
+  proto->set_name(name);
+  if (bucket.has_value()) {
+    proto->set_bucket_name(*bucket);
+  }
+  if (scope.has_value()) {
+    proto->set_scope_name(*scope);
+  }
+  return dispatcher_.unary<search_admin_v1::DisallowIndexQueryingResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        search_admin_v1::DisallowIndexQueryingResponse& resp,
+                        std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->DisallowIndexQuerying(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [invoke = std::move(invoke),
+     proto](grpc::Status status, search_admin_v1::DisallowIndexQueryingResponse /* r */) mutable {
+      invoke(std::move(status));
+    });
+}
+
+auto
+component::execute(
+  operations::management::search_index_control_plan_freeze_request request,
+  utils::movable_function<void(operations::management::search_index_control_plan_freeze_response)>&&
+    handler) -> pending_call
+{
+  const auto client_context_id = request.client_context_id.value_or(std::string{});
+  if (request.index_name.empty()) {
+    return fail_ctx(io_, handler, stamped_management(request), errc::common::invalid_argument);
+  }
+  const auto timeout = request.timeout.value_or(timeouts_.management);
+  if (timeout <= std::chrono::milliseconds::zero()) {
+    return fail_expired_ctx(io_, handler, stamped_management(request));
+  }
+  const auto auth = authorization_;
+  const auto name = request.index_name;
+  const auto bucket = request.bucket_name;
+  const auto scope = request.scope_name;
+  auto* stub = stubs_->search_admin.get();
+  auto invoke = [handler = std::move(handler), client_context_id](grpc::Status status) mutable {
+    operations::management::search_index_control_plan_freeze_response response;
+    response.ctx.client_context_id = client_context_id;
+    response.ctx.ec = map_status(status, operation_kind::mutating);
+    set_ok_status(response);
+    handler(std::move(response));
+  };
+  if (request.freeze) {
+    auto proto = std::make_shared<search_admin_v1::FreezeIndexPlanRequest>();
+    proto->set_name(name);
+    if (bucket.has_value()) {
+      proto->set_bucket_name(*bucket);
+    }
+    if (scope.has_value()) {
+      proto->set_scope_name(*scope);
+    }
+    return dispatcher_.unary<search_admin_v1::FreezeIndexPlanResponse>(
+      timeout,
+      [stub, proto, auth](grpc::ClientContext& ctx,
+                          search_admin_v1::FreezeIndexPlanResponse& resp,
+                          std::function<void(grpc::Status)> cb) {
+        if (!auth.empty()) {
+          ctx.AddMetadata("authorization", auth);
+        }
+        stub->async()->FreezeIndexPlan(&ctx, proto.get(), &resp, std::move(cb));
+      },
+      [invoke = std::move(invoke),
+       proto](grpc::Status status, search_admin_v1::FreezeIndexPlanResponse /* r */) mutable {
+        invoke(std::move(status));
+      });
+  }
+  auto proto = std::make_shared<search_admin_v1::UnfreezeIndexPlanRequest>();
+  proto->set_name(name);
+  if (bucket.has_value()) {
+    proto->set_bucket_name(*bucket);
+  }
+  if (scope.has_value()) {
+    proto->set_scope_name(*scope);
+  }
+  return dispatcher_.unary<search_admin_v1::UnfreezeIndexPlanResponse>(
+    timeout,
+    [stub, proto, auth](grpc::ClientContext& ctx,
+                        search_admin_v1::UnfreezeIndexPlanResponse& resp,
+                        std::function<void(grpc::Status)> cb) {
+      if (!auth.empty()) {
+        ctx.AddMetadata("authorization", auth);
+      }
+      stub->async()->UnfreezeIndexPlan(&ctx, proto.get(), &resp, std::move(cb));
+    },
+    [invoke = std::move(invoke),
+     proto](grpc::Status status, search_admin_v1::UnfreezeIndexPlanResponse /* r */) mutable {
+      invoke(std::move(status));
     });
 }
 

--- a/core/protostellar/component.hxx
+++ b/core/protostellar/component.hxx
@@ -65,6 +65,15 @@
 #include "core/operations/management/scope_create.hxx"
 #include "core/operations/management/scope_drop.hxx"
 #include "core/operations/management/scope_get_all.hxx"
+#include "core/operations/management/search_index_analyze_document.hxx"
+#include "core/operations/management/search_index_control_ingest.hxx"
+#include "core/operations/management/search_index_control_plan_freeze.hxx"
+#include "core/operations/management/search_index_control_query.hxx"
+#include "core/operations/management/search_index_drop.hxx"
+#include "core/operations/management/search_index_get.hxx"
+#include "core/operations/management/search_index_get_all.hxx"
+#include "core/operations/management/search_index_get_documents_count.hxx"
+#include "core/operations/management/search_index_upsert.hxx"
 #include "core/protostellar/dispatcher.hxx"
 #include "core/timeout_defaults.hxx"
 #include "core/utils/movable_function.hxx"
@@ -282,6 +291,44 @@ public:
     operations::management::query_index_build_deferred_request request,
     utils::movable_function<void(operations::management::query_index_build_deferred_response)>&&
       handler) -> pending_call;
+
+  // Search index management (unary admin RPCs over admin.search.v1).
+  auto execute(
+    operations::management::search_index_upsert_request request,
+    utils::movable_function<void(operations::management::search_index_upsert_response)>&& handler)
+    -> pending_call;
+  auto execute(
+    operations::management::search_index_get_request request,
+    utils::movable_function<void(operations::management::search_index_get_response)>&& handler)
+    -> pending_call;
+  auto execute(
+    operations::management::search_index_get_all_request request,
+    utils::movable_function<void(operations::management::search_index_get_all_response)>&& handler)
+    -> pending_call;
+  auto execute(
+    operations::management::search_index_drop_request request,
+    utils::movable_function<void(operations::management::search_index_drop_response)>&& handler)
+    -> pending_call;
+  auto execute(
+    operations::management::search_index_analyze_document_request request,
+    utils::movable_function<void(operations::management::search_index_analyze_document_response)>&&
+      handler) -> pending_call;
+  auto execute(operations::management::search_index_get_documents_count_request request,
+               utils::movable_function<
+                 void(operations::management::search_index_get_documents_count_response)>&& handler)
+    -> pending_call;
+  auto execute(
+    operations::management::search_index_control_ingest_request request,
+    utils::movable_function<void(operations::management::search_index_control_ingest_response)>&&
+      handler) -> pending_call;
+  auto execute(
+    operations::management::search_index_control_query_request request,
+    utils::movable_function<void(operations::management::search_index_control_query_response)>&&
+      handler) -> pending_call;
+  auto execute(operations::management::search_index_control_plan_freeze_request request,
+               utils::movable_function<
+                 void(operations::management::search_index_control_plan_freeze_response)>&& handler)
+    -> pending_call;
 
 private:
   // The generated gRPC stubs are held behind an opaque pointer so the generated protobuf and gRPC

--- a/core/protostellar/search_index_admin_converter.hxx
+++ b/core/protostellar/search_index_admin_converter.hxx
@@ -1,0 +1,156 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+// Translates core FTS index settings to and from couchbase.admin.search.v1. The one non-trivial
+// bit: core stores params/plan_params/source_params as single JSON-object strings, while the proto
+// Index uses map<string,bytes> keyed by the object's top-level members (each value a raw-JSON
+// blob). fill_params/params_to_json round-trip between the two representations.
+//
+// Every conversion that can lose a member reports failure instead. A definition that cannot be
+// represented must not be truncated in silence: the caller edits what get_index returned and
+// upserts it back, so a dropped member deletes part of the index definition while the call reports
+// success.
+
+#include "core/management/search_index.hxx"
+#include "core/utils/json.hxx"
+
+#include <tao/json/value.hpp>
+
+#include <couchbase/admin/search/v1/search.pb.h>
+
+#include <google/protobuf/map.h>
+
+#include <optional>
+#include <string>
+
+namespace couchbase::core::protostellar::search_index_admin
+{
+namespace v1 = ::couchbase::admin::search::v1;
+
+// Explode a JSON-object string into the proto map: one entry per top-level member, value = the
+// member's raw JSON. An empty input is the "unset" convention and contributes nothing. Anything
+// that is not a JSON object has no representation in the map and is refused.
+[[nodiscard]] inline auto
+fill_params(const std::string& json, ::google::protobuf::Map<std::string, std::string>* target)
+  -> bool
+{
+  if (json.empty()) {
+    return true;
+  }
+  tao::json::value parsed;
+  try {
+    parsed = utils::json::parse(json);
+  } catch (...) {
+    return false;
+  }
+  if (!parsed.is_object()) {
+    return false;
+  }
+  for (const auto& [key, value] : parsed.get_object()) {
+    (*target)[key] = utils::json::generate(value);
+  }
+  return true;
+}
+
+// Rebuild a JSON-object string from the proto map (inverse of fill_params). Empty map -> empty
+// string so the core struct keeps its "unset" convention. A member whose bytes are not JSON cannot
+// be placed in the object, and dropping it would hand back a definition short of what the server
+// holds, so the whole conversion fails.
+[[nodiscard]] inline auto
+params_to_json(const ::google::protobuf::Map<std::string, std::string>& source)
+  -> std::optional<std::string>
+{
+  if (source.empty()) {
+    return std::string{};
+  }
+  tao::json::value object = tao::json::empty_object;
+  for (const auto& [key, value] : source) {
+    try {
+      object[key] = utils::json::parse(value);
+    } catch (...) {
+      return {};
+    }
+  }
+  return utils::json::generate(object);
+}
+
+// The fields shared by CreateIndexRequest and Index. The two messages carry the same index
+// definition under the same field names, but they are unrelated proto types and neither derives
+// from the other, so the assignments are written once against whichever is passed.
+template<typename Proto>
+[[nodiscard]] auto
+apply_index_fields(const management::search::index& index, Proto& proto) -> bool
+{
+  proto.set_name(index.name);
+  proto.set_type(index.type);
+  if (!index.source_name.empty()) {
+    proto.set_source_name(index.source_name);
+  }
+  if (!index.source_type.empty()) {
+    proto.set_source_type(index.source_type);
+  }
+  if (!index.source_uuid.empty()) {
+    proto.set_source_uuid(index.source_uuid);
+  }
+  return fill_params(index.params_json, proto.mutable_params()) &&
+         fill_params(index.plan_params_json, proto.mutable_plan_params()) &&
+         fill_params(index.source_params_json, proto.mutable_source_params());
+}
+
+// Encode a core index into a CreateIndexRequest. A create carries no uuid: an upsert that supplies
+// one is an update and goes to UpdateIndex instead.
+[[nodiscard]] inline auto
+apply_index(const management::search::index& index, v1::CreateIndexRequest& proto) -> bool
+{
+  return apply_index_fields(index, proto);
+}
+
+// Encode a core index into the Index of an UpdateIndexRequest. The uuid is what makes it an
+// update: the gateway rejects the call without one, and the server matches it against the current
+// definition so a concurrent update is not overwritten.
+[[nodiscard]] inline auto
+apply_index(const management::search::index& index, v1::Index& proto) -> bool
+{
+  proto.set_uuid(index.uuid);
+  return apply_index_fields(index, proto);
+}
+
+[[nodiscard]] inline auto
+decode_index(const v1::Index& proto) -> std::optional<management::search::index>
+{
+  auto params = params_to_json(proto.params());
+  auto plan_params = params_to_json(proto.plan_params());
+  auto source_params = params_to_json(proto.source_params());
+  if (!params.has_value() || !plan_params.has_value() || !source_params.has_value()) {
+    return {};
+  }
+  management::search::index index;
+  index.uuid = proto.uuid();
+  index.name = proto.name();
+  index.type = proto.type();
+  index.source_uuid = proto.source_uuid();
+  index.source_name = proto.source_name();
+  index.source_type = proto.source_type();
+  index.params_json = std::move(*params);
+  index.plan_params_json = std::move(*plan_params);
+  index.source_params_json = std::move(*source_params);
+  return index;
+}
+
+} // namespace couchbase::core::protostellar::search_index_admin

--- a/test/cng/CMakeLists.txt
+++ b/test/cng/CMakeLists.txt
@@ -173,4 +173,10 @@ if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 AND TARGET couchbase_cxx_protostellar)
 
   # Live Query index management verification (CXXCBC-901).
   add_cng_test(protostellar/live_query_index_admin LINK_CLIENT LIBS couchbase_cxx_protostellar)
+  # Search index management converter (CXXCBC-901).
+  add_cng_test(protostellar/search_index_admin_converter LINK_CLIENT LIBS couchbase_cxx_protostellar)
+  add_cng_test(protostellar/search_index_admin_component LINK_CLIENT LIBS couchbase_cxx_protostellar)
+
+  # Live Search index management verification (CXXCBC-901).
+  add_cng_test(protostellar/live_search_index_admin LINK_CLIENT LIBS couchbase_cxx_protostellar)
 endif()

--- a/test/cng/protostellar/live_search_index_admin.cxx
+++ b/test/cng/protostellar/live_search_index_admin.cxx
@@ -1,0 +1,600 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Live probes of search index management over the couchbase2:// transport (CXXCBC-901), against
+// admin.search.v1.
+//
+// Two things here are only observable against a real server.
+//
+// Whether an upsert updates is decided by FTS, not by the client: the gateway forwards the
+// definition to PUT /api/index/<name>, and FTS reads the body's "uuid" member as prevIndexUUID and
+// refuses a create for a name that already exists. Which of CreateIndex/UpdateIndex the client
+// chooses is therefore visible only in whether the second upsert of a name succeeds.
+//
+// And FTS augments an index definition with its own defaults, so what comes back from get_index is
+// never byte-identical to what was sent. Whether the three parameter blobs stay separate can only
+// be checked against a real definition, by looking for each blob's own member in its own blob.
+
+#include "framework/live_fixture.hxx"
+#include "framework/test_runner.hxx"
+
+#include "core/operations/management/search_index_analyze_document.hxx"
+#include "core/operations/management/search_index_control_ingest.hxx"
+#include "core/operations/management/search_index_control_plan_freeze.hxx"
+#include "core/operations/management/search_index_control_query.hxx"
+#include "core/operations/management/search_index_drop.hxx"
+#include "core/operations/management/search_index_get.hxx"
+#include "core/operations/management/search_index_get_all.hxx"
+#include "core/operations/management/search_index_get_documents_count.hxx"
+#include "core/operations/management/search_index_get_stats.hxx"
+#include "core/operations/management/search_index_upsert.hxx"
+#include "core/utils/json.hxx"
+
+#include <couchbase/error_codes.hxx>
+
+#include <algorithm>
+#include <chrono>
+#include <optional>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace ops = ::couchbase::core::operations;
+using ::couchbase::core::management::search::index;
+
+// Distinct probe members, one per parameter blob, so a converter that crossed two of them is
+// visible in what comes back. FTS keeps all three verbatim alongside the defaults it adds.
+constexpr auto plan_params_probe = R"({"maxPartitionsPerPIndex":512})";
+constexpr auto source_params_probe = R"({"feedBufferSizeBytes":1048576})";
+
+[[nodiscard]] auto
+unique_name(const std::string& prefix) -> std::string
+{
+  static int counter{ 0 };
+  return prefix + "_cng_" + std::to_string(++counter) + "_" +
+         std::to_string(std::chrono::steady_clock::now().time_since_epoch().count() %
+                        1'000'000'000);
+}
+
+// The member of a JSON object, or nothing when the blob is unset, is not an object, or has no such
+// member. Used to look for a probe in a blob it does not belong to as well as in the one it does,
+// so "absent" has to be a value rather than a failure.
+[[nodiscard]] auto
+member(const std::string& json, const std::string& key) -> std::optional<tao::json::value>
+{
+  if (json.empty()) {
+    return {};
+  }
+  tao::json::value parsed;
+  try {
+    parsed = couchbase::core::utils::json::parse(json);
+  } catch (...) {
+    return {};
+  }
+  if (!parsed.is_object()) {
+    return {};
+  }
+  const auto* found = parsed.find(key);
+  if (found == nullptr) {
+    return {};
+  }
+  return *found;
+}
+
+[[nodiscard]] auto
+definition(const std::string& name, const std::string& bucket) -> index
+{
+  index definition;
+  definition.name = name;
+  definition.type = "fulltext-index";
+  definition.source_type = "couchbase";
+  definition.source_name = bucket;
+  return definition;
+}
+
+// Lists the indexes, failing the case for anything but the gateway not serving the service.
+//
+// Nothing on the client side answers this request with feature_not_available -- cluster.cxx routes
+// it and the component has no refusal path for it -- so the code can only have come from a gateway
+// that does not serve admin.search.v1. Every other case calls this first and then asserts rather
+// than skips: once the service is known to be served, a later refusal is the client declining to
+// send something, which is a failure and not a reason to skip.
+[[nodiscard]] auto
+indexes_or_skip(live_cluster_fixture& fixture) -> std::vector<index>
+{
+  ops::management::search_index_get_all_request request{};
+  auto listed = fixture.execute(std::move(request));
+  if (listed.ctx.ec == couchbase::errc::common::feature_not_available) {
+    skip("gateway does not implement admin.search.v1 (feature_not_available)");
+  }
+  assert_false(static_cast<bool>(listed.ctx.ec), "list search indexes over couchbase2 succeeds");
+  return std::move(listed.indexes);
+}
+
+[[nodiscard]] auto
+find_index(const std::vector<index>& indexes, const std::string& name) -> std::optional<index>
+{
+  const auto found = std::find_if(indexes.begin(), indexes.end(), [&name](const auto& candidate) {
+    return candidate.name == name;
+  });
+  if (found == indexes.end()) {
+    return {};
+  }
+  return *found;
+}
+
+// Drops the index however the case leaves -- an assertion failure unwinds, and an index left
+// behind changes what every later case lists.
+class index_guard
+{
+public:
+  index_guard(live_cluster_fixture& fixture, std::string name)
+    : fixture_{ fixture }
+    , name_{ std::move(name) }
+  {
+  }
+
+  index_guard(const index_guard&) = delete;
+  index_guard(index_guard&&) = delete;
+  auto operator=(const index_guard&) -> index_guard& = delete;
+  auto operator=(index_guard&&) -> index_guard& = delete;
+
+  ~index_guard()
+  {
+    ops::management::search_index_drop_request request{};
+    request.index_name = name_;
+    [[maybe_unused]] auto dropped = fixture_.execute(std::move(request));
+  }
+
+private:
+  live_cluster_fixture& fixture_;
+  std::string name_;
+};
+
+[[nodiscard]] auto
+get_index(live_cluster_fixture& fixture, const std::string& name)
+  -> ops::management::search_index_get_response
+{
+  ops::management::search_index_get_request request{};
+  request.index_name = name;
+  return fixture.execute(std::move(request));
+}
+
+void
+list_search_indexes_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+  [[maybe_unused]] auto indexes = indexes_or_skip(fixture);
+}
+
+void
+the_search_index_lifecycle_round_trips_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+  [[maybe_unused]] auto listed = indexes_or_skip(fixture);
+
+  const auto name = unique_name("lifecycle");
+  {
+    index_guard guard{ fixture, name };
+
+    ops::management::search_index_upsert_request create{};
+    create.index = definition(name, fixture.bucket());
+    const auto created = fixture.execute(std::move(create));
+    assert_false(static_cast<bool>(created.ctx.ec), "create search index over couchbase2 succeeds");
+    assert_eq(created.status, std::string{ "ok" }, "a successful upsert reports status ok");
+
+    const auto fetched = get_index(fixture, name);
+    assert_false(static_cast<bool>(fetched.ctx.ec), "get search index succeeds");
+    assert_eq(fetched.index.name, name, "the index comes back under the name it was created with");
+    assert_eq(fetched.index.type, std::string{ "fulltext-index" }, "type round-trips");
+    assert_false(fetched.index.uuid.empty(), "the server assigned a uuid");
+    assert_eq(fetched.status, std::string{ "ok" }, "a successful get reports status ok");
+
+    assert_true(find_index(indexes_or_skip(fixture), name).has_value(),
+                "the new index appears in the listing");
+
+    ops::management::search_index_get_documents_count_request count{};
+    count.index_name = name;
+    const auto counted = fixture.execute(std::move(count));
+    assert_false(static_cast<bool>(counted.ctx.ec), "indexed documents count succeeds");
+    assert_eq(counted.status, std::string{ "ok" }, "a successful count reports status ok");
+  }
+
+  ops::management::search_index_drop_request drop{};
+  drop.index_name = name;
+  const auto dropped = fixture.execute(std::move(drop));
+  // The guard already dropped it, so this second drop is expected to fail; what it must not do is
+  // succeed against an index that is still there.
+  assert_false(find_index(indexes_or_skip(fixture), name).has_value(),
+               "the index is gone from the listing after the drop");
+  assert_true(static_cast<bool>(dropped.ctx.ec), "dropping an index that is gone reports an error");
+}
+
+void
+an_existing_index_is_updated_through_upsert_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+  [[maybe_unused]] auto listed = indexes_or_skip(fixture);
+
+  const auto name = unique_name("update");
+  index_guard guard{ fixture, name };
+
+  ops::management::search_index_upsert_request create{};
+  create.index = definition(name, fixture.bucket());
+  const auto created = fixture.execute(std::move(create));
+  assert_false(static_cast<bool>(created.ctx.ec), "create succeeds");
+
+  const auto fetched = get_index(fixture, name);
+  assert_false(static_cast<bool>(fetched.ctx.ec), "get after create succeeds");
+  assert_false(fetched.index.uuid.empty(), "the created index has a uuid to update against");
+
+  // The upsert the review describes: take what get_index returned, change one thing, put it back.
+  // Sending this through CreateIndex is refused by FTS because the name exists, so a success here
+  // is the client having chosen UpdateIndex and carried the uuid.
+  auto modified = fetched.index;
+  modified.plan_params_json = plan_params_probe;
+  ops::management::search_index_upsert_request update{};
+  update.index = std::move(modified);
+  const auto updated = fixture.execute(std::move(update));
+  assert_false(static_cast<bool>(updated.ctx.ec),
+               "upserting a definition that carries its uuid updates it");
+  assert_eq(updated.status, std::string{ "ok" }, "a successful update reports status ok");
+
+  const auto reread = get_index(fixture, name);
+  assert_false(static_cast<bool>(reread.ctx.ec), "get after update succeeds");
+  const auto partitions = member(reread.index.plan_params_json, "maxPartitionsPerPIndex");
+  assert_true(partitions.has_value(), "the updated plan_params reached the server");
+  assert_true(partitions->is_number() && partitions->as<int>() == 512,
+              "the updated plan_params holds the value that was sent");
+  assert_true(reread.index.uuid != fetched.index.uuid,
+              "the server issued a new uuid for the updated definition");
+}
+
+void
+an_upsert_without_a_uuid_for_an_existing_name_is_refused_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+  [[maybe_unused]] auto listed = indexes_or_skip(fixture);
+
+  const auto name = unique_name("exists");
+  index_guard guard{ fixture, name };
+
+  ops::management::search_index_upsert_request create{};
+  create.index = definition(name, fixture.bucket());
+  assert_false(static_cast<bool>(fixture.execute(std::move(create)).ctx.ec), "create succeeds");
+
+  // Same definition, still no uuid: this is a create of a name that exists, and it must stay an
+  // error. Routing every upsert through UpdateIndex would turn it into a silent overwrite.
+  ops::management::search_index_upsert_request again{};
+  again.index = definition(name, fixture.bucket());
+  const auto refused = fixture.execute(std::move(again));
+  assert_eq(refused.ctx.ec,
+            std::error_code{ couchbase::errc::common::index_exists },
+            "a second create of the same name reports index_exists");
+}
+
+void
+the_three_parameter_blobs_stay_separate_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+  [[maybe_unused]] auto listed = indexes_or_skip(fixture);
+
+  const auto name = unique_name("blobs");
+  index_guard guard{ fixture, name };
+
+  auto definition_with_blobs = definition(name, fixture.bucket());
+  definition_with_blobs.plan_params_json = plan_params_probe;
+  definition_with_blobs.source_params_json = source_params_probe;
+
+  ops::management::search_index_upsert_request create{};
+  create.index = std::move(definition_with_blobs);
+  assert_false(static_cast<bool>(fixture.execute(std::move(create)).ctx.ec),
+               "create with plan and source params succeeds");
+
+  const auto fetched = get_index(fixture, name);
+  assert_false(static_cast<bool>(fetched.ctx.ec), "get succeeds");
+
+  // Each probe in its own blob. FTS adds its own defaults, so this is a membership check rather
+  // than an equality one -- what must hold is that the value sent is the value stored.
+  const auto partitions = member(fetched.index.plan_params_json, "maxPartitionsPerPIndex");
+  assert_true(partitions.has_value(), "plan_params survives the round trip");
+  assert_true(partitions->is_number() && partitions->as<int>() == 512,
+              "plan_params holds the value that was sent");
+  const auto feed_buffer = member(fetched.index.source_params_json, "feedBufferSizeBytes");
+  assert_true(feed_buffer.has_value(), "source_params survives the round trip");
+  assert_true(feed_buffer->is_number() && feed_buffer->as<int>() == 1048576,
+              "source_params holds the value that was sent");
+
+  // And in no other blob. A converter that read all three maps into one string, or wrote one blob
+  // into another's map, passes every assertion above and fails these.
+  assert_false(member(fetched.index.params_json, "maxPartitionsPerPIndex").has_value(),
+               "the plan_params probe did not leak into params");
+  assert_false(member(fetched.index.params_json, "feedBufferSizeBytes").has_value(),
+               "the source_params probe did not leak into params");
+  assert_false(member(fetched.index.source_params_json, "maxPartitionsPerPIndex").has_value(),
+               "the plan_params probe did not leak into source_params");
+  assert_false(member(fetched.index.plan_params_json, "feedBufferSizeBytes").has_value(),
+               "the source_params probe did not leak into plan_params");
+}
+
+void
+a_definition_that_cannot_be_represented_is_refused_before_it_is_sent()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+  const auto before = indexes_or_skip(fixture);
+
+  const auto name = unique_name("unrepresentable");
+  auto broken = definition(name, fixture.bucket());
+  // Valid JSON with nowhere to go in a map<string,bytes> keyed by an object's members. Dropping it
+  // would create an index whose definition is missing everything the caller put in that blob.
+  broken.params_json = R"(["not","an","object"])";
+
+  ops::management::search_index_upsert_request create{};
+  create.index = std::move(broken);
+  const auto refused = fixture.execute(std::move(create));
+  assert_eq(refused.ctx.ec,
+            std::error_code{ couchbase::errc::common::invalid_argument },
+            "a params blob that is not an object is reported as invalid_argument");
+
+  assert_false(find_index(indexes_or_skip(fixture), name).has_value(), "and no index was created");
+  assert_eq(indexes_or_skip(fixture).size(), before.size(), "the listing is unchanged");
+}
+
+void
+an_empty_index_name_is_reported_as_invalid_argument_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+  [[maybe_unused]] auto listed = indexes_or_skip(fixture);
+
+  // Parity with the classic transport, which rejects an empty name in encode_to. Which side
+  // refuses it is not visible here -- the gateway answers an empty name with InvalidArgument too --
+  // so that this transport sends nothing is pinned by the component suite instead.
+  ops::management::search_index_get_request get{};
+  get.index_name = "";
+  assert_eq(fixture.execute(std::move(get)).ctx.ec,
+            std::error_code{ couchbase::errc::common::invalid_argument },
+            "get with an empty index name is invalid_argument");
+
+  ops::management::search_index_drop_request drop{};
+  drop.index_name = "";
+  assert_eq(fixture.execute(std::move(drop)).ctx.ec,
+            std::error_code{ couchbase::errc::common::invalid_argument },
+            "drop with an empty index name is invalid_argument");
+
+  ops::management::search_index_upsert_request upsert{};
+  upsert.index = definition("", fixture.bucket());
+  assert_eq(fixture.execute(std::move(upsert)).ctx.ec,
+            std::error_code{ couchbase::errc::common::invalid_argument },
+            "upsert with an empty index name is invalid_argument");
+
+  ops::management::search_index_control_ingest_request ingest{};
+  ingest.index_name = "";
+  ingest.pause = true;
+  assert_eq(fixture.execute(std::move(ingest)).ctx.ec,
+            std::error_code{ couchbase::errc::common::invalid_argument },
+            "control ingest with an empty index name is invalid_argument");
+
+  ops::management::search_index_control_query_request query{};
+  query.index_name = "";
+  query.allow = true;
+  assert_eq(fixture.execute(std::move(query)).ctx.ec,
+            std::error_code{ couchbase::errc::common::invalid_argument },
+            "control query with an empty index name is invalid_argument");
+
+  ops::management::search_index_control_plan_freeze_request freeze{};
+  freeze.index_name = "";
+  freeze.freeze = true;
+  assert_eq(fixture.execute(std::move(freeze)).ctx.ec,
+            std::error_code{ couchbase::errc::common::invalid_argument },
+            "control plan freeze with an empty index name is invalid_argument");
+
+  ops::management::search_index_analyze_document_request analyze{};
+  analyze.index_name = "";
+  analyze.encoded_document = R"({"a":1})";
+  assert_eq(fixture.execute(std::move(analyze)).ctx.ec,
+            std::error_code{ couchbase::errc::common::invalid_argument },
+            "analyze document with an empty index name is invalid_argument");
+}
+
+void
+getting_a_missing_index_reports_index_not_found_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+  [[maybe_unused]] auto listed = indexes_or_skip(fixture);
+
+  const auto fetched = get_index(fixture, unique_name("absent"));
+  assert_eq(fetched.ctx.ec,
+            std::error_code{ couchbase::errc::common::index_not_found },
+            "getting an index that does not exist reports index_not_found");
+  assert_true(fetched.index.name.empty(), "and hands back no definition");
+}
+
+void
+the_control_operations_round_trip_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+  [[maybe_unused]] auto listed = indexes_or_skip(fixture);
+
+  const auto name = unique_name("control");
+  index_guard guard{ fixture, name };
+
+  ops::management::search_index_upsert_request create{};
+  create.index = definition(name, fixture.bucket());
+  assert_false(static_cast<bool>(fixture.execute(std::move(create)).ctx.ec), "create succeeds");
+
+  // Each pair goes through both RPCs, so a bool wired to the wrong branch is visible: the two
+  // calls would hit the same endpoint and the second would not be a no-op the server accepts.
+  for (const auto pause : { true, false }) {
+    ops::management::search_index_control_ingest_request request{};
+    request.index_name = name;
+    request.pause = pause;
+    const auto response = fixture.execute(std::move(request));
+    assert_false(static_cast<bool>(response.ctx.ec),
+                 pause ? "pause ingest succeeds" : "resume ingest succeeds");
+    assert_eq(response.status, std::string{ "ok" }, "control ingest reports status ok");
+  }
+
+  for (const auto allow : { false, true }) {
+    ops::management::search_index_control_query_request request{};
+    request.index_name = name;
+    request.allow = allow;
+    const auto response = fixture.execute(std::move(request));
+    assert_false(static_cast<bool>(response.ctx.ec),
+                 allow ? "allow querying succeeds" : "disallow querying succeeds");
+    assert_eq(response.status, std::string{ "ok" }, "control query reports status ok");
+  }
+
+  for (const auto freeze : { true, false }) {
+    ops::management::search_index_control_plan_freeze_request request{};
+    request.index_name = name;
+    request.freeze = freeze;
+    const auto response = fixture.execute(std::move(request));
+    assert_false(static_cast<bool>(response.ctx.ec),
+                 freeze ? "freeze plan succeeds" : "unfreeze plan succeeds");
+    assert_eq(response.status, std::string{ "ok" }, "control plan freeze reports status ok");
+  }
+}
+
+void
+get_stats_is_refused_over_couchbase2_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+  // The listing establishes that the gateway serves admin.search.v1 before anything is asserted
+  // about a refusal. Without it, feature_not_available below would read the same whether the one
+  // operation is deliberately unrouted or the whole service is missing -- and the case could not
+  // fail. With it, the two are distinguishable, which is the only reason it is worth asserting.
+  [[maybe_unused]] auto listed = indexes_or_skip(fixture);
+
+  ops::management::search_index_get_stats_request stats{};
+  stats.index_name = unique_name("stats");
+  const auto refused = fixture.execute(std::move(stats));
+  assert_eq(refused.ctx.ec,
+            std::error_code{ couchbase::errc::common::feature_not_available },
+            "get_stats has no admin.search.v1 RPC and is refused as feature_not_available");
+}
+
+void
+analyze_document_against_live_gateway()
+{
+  live_cluster_fixture fixture;
+  fixture.require_open();
+  [[maybe_unused]] auto listed = indexes_or_skip(fixture);
+
+  const auto name = unique_name("analyze");
+  index_guard guard{ fixture, name };
+
+  ops::management::search_index_upsert_request create{};
+  create.index = definition(name, fixture.bucket());
+  assert_false(static_cast<bool>(fixture.execute(std::move(create)).ctx.ec), "create succeeds");
+
+  // A freshly created index has no partitions for a moment, and FTS answers analyzeDoc for one
+  // with "Search index is still being built, try again later" -- Unavailable at the gateway,
+  // temporary_failure here. Retried rather than tolerated: accepting it as an outcome would leave
+  // the case unable to fail, since every assertion below would be skipped.
+  ops::management::search_index_analyze_document_response analyzed;
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds{ 20 };
+  do {
+    ops::management::search_index_analyze_document_request analyze{};
+    analyze.index_name = name;
+    analyze.encoded_document = R"({"name":"the quick brown fox"})";
+    analyzed = fixture.execute(std::move(analyze));
+    if (analyzed.ctx.ec != couchbase::errc::common::temporary_failure) {
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds{ 200 });
+  } while (std::chrono::steady_clock::now() < deadline);
+  assert_false(static_cast<bool>(analyzed.ctx.ec), "analyze document succeeds");
+  // FTS answers analyzeDoc with "ok", which is also what this transport reports when it infers a
+  // status from a successful RPC, so this pins the value and not which of the two produced it.
+  assert_eq(analyzed.status, std::string{ "ok" }, "a successful analyze reports status ok");
+  assert_false(analyzed.analysis.empty(), "the analysis is relayed");
+  assert_true(couchbase::core::utils::json::parse(analyzed.analysis).is_array(),
+              "the analysis is the JSON array FTS returns");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_live_search_index_admin",
+    {
+      { "list_search_indexes_against_live_gateway",
+        list_search_indexes_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "the_search_index_lifecycle_round_trips_against_live_gateway",
+        the_search_index_lifecycle_round_trips_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "an_existing_index_is_updated_through_upsert_against_live_gateway",
+        an_existing_index_is_updated_through_upsert_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "an_upsert_without_a_uuid_for_an_existing_name_is_refused_against_live_gateway",
+        an_upsert_without_a_uuid_for_an_existing_name_is_refused_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "the_three_parameter_blobs_stay_separate_against_live_gateway",
+        the_three_parameter_blobs_stay_separate_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "a_definition_that_cannot_be_represented_is_refused_before_it_is_sent",
+        a_definition_that_cannot_be_represented_is_refused_before_it_is_sent,
+        timeout::integration,
+        test_env::cluster_only },
+      { "an_empty_index_name_is_reported_as_invalid_argument_against_live_gateway",
+        an_empty_index_name_is_reported_as_invalid_argument_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "getting_a_missing_index_reports_index_not_found_against_live_gateway",
+        getting_a_missing_index_reports_index_not_found_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "the_control_operations_round_trip_against_live_gateway",
+        the_control_operations_round_trip_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "get_stats_is_refused_over_couchbase2_against_live_gateway",
+        get_stats_is_refused_over_couchbase2_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "analyze_document_against_live_gateway",
+        analyze_document_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test

--- a/test/cng/protostellar/search_index_admin_component.cxx
+++ b/test/cng/protostellar/search_index_admin_component.cxx
@@ -1,0 +1,520 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// The search index management overloads against an in-process admin.search.v1 server that records
+// what it was asked (CXXCBC-901). Env-agnostic; no cluster.
+//
+// This is where the two properties a live gateway cannot show are checked.
+//
+// Which RPC an operation picks: a real gateway answers CreateIndex and UpdateIndex through the
+// same PUT, and the paired control RPCs through endpoints whose effect this transport cannot read
+// back, so from the outside the two branches of each pair are indistinguishable. Here the server
+// records the method name.
+//
+// And whether a refusal happened locally: the gateway also answers an empty index name with
+// InvalidArgument, so the error code alone does not say whether anything was sent. The recorded
+// call count does.
+
+#include "framework/test_runner.hxx"
+
+#include "callback_queue_keepalive.hxx"
+
+#include "core/cluster_credentials.hxx"
+#include "core/protostellar/component.hxx"
+
+#include <couchbase/error_codes.hxx>
+
+#include <couchbase/admin/search/v1/search.grpc.pb.h>
+
+#include <asio/executor_work_guard.hpp>
+#include <asio/io_context.hpp>
+
+#include <grpcpp/server_builder.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace v1 = ::couchbase::admin::search::v1;
+namespace ops = ::couchbase::core::operations;
+using ::couchbase::core::cluster_credentials;
+using ::couchbase::core::protostellar::component;
+using ::couchbase::core::protostellar::component_config;
+using namespace std::chrono_literals;
+
+class recording_search_admin_service final : public v1::SearchAdminService::Service
+{
+public:
+  std::vector<std::string> calls{};
+  v1::CreateIndexRequest last_create{};
+  v1::UpdateIndexRequest last_update{};
+  // What GetIndex answers with. Left unset so the default is a response with no index, which is
+  // the shape the review asks to be reported as index_not_found.
+  v1::GetIndexResponse get_response{};
+
+  auto CreateIndex(grpc::ServerContext* /* ctx */,
+                   const v1::CreateIndexRequest* request,
+                   v1::CreateIndexResponse* /* response */) -> grpc::Status override
+  {
+    calls.emplace_back("CreateIndex");
+    last_create = *request;
+    return grpc::Status::OK;
+  }
+
+  auto UpdateIndex(grpc::ServerContext* /* ctx */,
+                   const v1::UpdateIndexRequest* request,
+                   v1::UpdateIndexResponse* /* response */) -> grpc::Status override
+  {
+    calls.emplace_back("UpdateIndex");
+    last_update = *request;
+    return grpc::Status::OK;
+  }
+
+  auto GetIndex(grpc::ServerContext* /* ctx */,
+                const v1::GetIndexRequest* /* request */,
+                v1::GetIndexResponse* response) -> grpc::Status override
+  {
+    calls.emplace_back("GetIndex");
+    *response = get_response;
+    return grpc::Status::OK;
+  }
+
+  auto DeleteIndex(grpc::ServerContext* /* ctx */,
+                   const v1::DeleteIndexRequest* /* request */,
+                   v1::DeleteIndexResponse* /* response */) -> grpc::Status override
+  {
+    calls.emplace_back("DeleteIndex");
+    return grpc::Status::OK;
+  }
+
+  auto AnalyzeDocument(grpc::ServerContext* /* ctx */,
+                       const v1::AnalyzeDocumentRequest* /* request */,
+                       v1::AnalyzeDocumentResponse* response) -> grpc::Status override
+  {
+    calls.emplace_back("AnalyzeDocument");
+    response->set_status("ok");
+    response->set_analyzed("[]");
+    return grpc::Status::OK;
+  }
+
+  auto PauseIndexIngest(grpc::ServerContext* /* ctx */,
+                        const v1::PauseIndexIngestRequest* /* request */,
+                        v1::PauseIndexIngestResponse* /* response */) -> grpc::Status override
+  {
+    calls.emplace_back("PauseIndexIngest");
+    return grpc::Status::OK;
+  }
+
+  auto ResumeIndexIngest(grpc::ServerContext* /* ctx */,
+                         const v1::ResumeIndexIngestRequest* /* request */,
+                         v1::ResumeIndexIngestResponse* /* response */) -> grpc::Status override
+  {
+    calls.emplace_back("ResumeIndexIngest");
+    return grpc::Status::OK;
+  }
+
+  auto AllowIndexQuerying(grpc::ServerContext* /* ctx */,
+                          const v1::AllowIndexQueryingRequest* /* request */,
+                          v1::AllowIndexQueryingResponse* /* response */) -> grpc::Status override
+  {
+    calls.emplace_back("AllowIndexQuerying");
+    return grpc::Status::OK;
+  }
+
+  auto DisallowIndexQuerying(grpc::ServerContext* /* ctx */,
+                             const v1::DisallowIndexQueryingRequest* /* request */,
+                             v1::DisallowIndexQueryingResponse* /* response */)
+    -> grpc::Status override
+  {
+    calls.emplace_back("DisallowIndexQuerying");
+    return grpc::Status::OK;
+  }
+
+  auto FreezeIndexPlan(grpc::ServerContext* /* ctx */,
+                       const v1::FreezeIndexPlanRequest* /* request */,
+                       v1::FreezeIndexPlanResponse* /* response */) -> grpc::Status override
+  {
+    calls.emplace_back("FreezeIndexPlan");
+    return grpc::Status::OK;
+  }
+
+  auto UnfreezeIndexPlan(grpc::ServerContext* /* ctx */,
+                         const v1::UnfreezeIndexPlanRequest* /* request */,
+                         v1::UnfreezeIndexPlanResponse* /* response */) -> grpc::Status override
+  {
+    calls.emplace_back("UnfreezeIndexPlan");
+    return grpc::Status::OK;
+  }
+};
+
+class in_process_server
+{
+public:
+  in_process_server()
+  {
+    // Pin gRPC's process-global callback completion queue for the lifetime of this binary, for the
+    // reason component.cxx gives: destroying the last channel between cases otherwise races
+    // gRPC's polling threads and aborts the process (CXXCBC-919).
+    pin_callback_queue();
+
+    grpc::ServerBuilder builder;
+    builder.RegisterService(&service_);
+    server_ = builder.BuildAndStart();
+  }
+  in_process_server(const in_process_server&) = delete;
+  in_process_server(in_process_server&&) = delete;
+  auto operator=(const in_process_server&) -> in_process_server& = delete;
+  auto operator=(in_process_server&&) -> in_process_server& = delete;
+  ~in_process_server()
+  {
+    server_->Shutdown(std::chrono::system_clock::now());
+  }
+  [[nodiscard]] auto channel() -> std::shared_ptr<grpc::Channel>
+  {
+    return server_->InProcessChannel(grpc::ChannelArguments{});
+  }
+  [[nodiscard]] auto service() -> recording_search_admin_service&
+  {
+    return service_;
+  }
+
+private:
+  recording_search_admin_service service_;
+  std::unique_ptr<grpc::Server> server_;
+};
+
+// Runs one request to completion on its own io_context and hands back the response.
+template<typename Request>
+[[nodiscard]] auto
+run(in_process_server& server, Request request) -> typename Request::response_type
+{
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, { 5000ms } } };
+
+  typename Request::response_type outcome;
+  comp.execute(std::move(request), [&](typename Request::response_type response) {
+    outcome = std::move(response);
+    work.reset();
+  });
+  io.run();
+  return outcome;
+}
+
+[[nodiscard]] auto
+definition(std::string name) -> couchbase::core::management::search::index
+{
+  couchbase::core::management::search::index index;
+  index.name = std::move(name);
+  index.type = "fulltext-index";
+  index.source_type = "couchbase";
+  index.source_name = "travel";
+  return index;
+}
+
+void
+an_upsert_without_a_uuid_calls_create_index()
+{
+  in_process_server server;
+
+  ops::management::search_index_upsert_request request{};
+  request.index = definition("idx");
+  const auto response = run(server, std::move(request));
+
+  assert_false(static_cast<bool>(response.ctx.ec), "the upsert succeeds");
+  assert_eq(server.service().calls,
+            std::vector<std::string>{ "CreateIndex" },
+            "an upsert with no uuid goes to CreateIndex");
+  assert_false(server.service().last_create.has_prev_index_uuid(),
+               "and carries no prev_index_uuid");
+}
+
+void
+an_upsert_with_a_uuid_calls_update_index()
+{
+  in_process_server server;
+
+  auto index = definition("idx");
+  index.uuid = "existing-uuid";
+  ops::management::search_index_upsert_request request{};
+  request.index = std::move(index);
+  const auto response = run(server, std::move(request));
+
+  assert_false(static_cast<bool>(response.ctx.ec), "the upsert succeeds");
+  assert_eq(server.service().calls,
+            std::vector<std::string>{ "UpdateIndex" },
+            "an upsert carrying a uuid goes to UpdateIndex");
+  assert_eq(server.service().last_update.index().uuid(),
+            std::string{ "existing-uuid" },
+            "and the uuid reaches Index.uuid, which the gateway requires");
+  assert_eq(server.service().last_update.index().name(),
+            std::string{ "idx" },
+            "the rest of the definition travels with it");
+}
+
+void
+the_control_operations_select_their_paired_rpc()
+{
+  {
+    in_process_server server;
+    ops::management::search_index_control_ingest_request request{};
+    request.index_name = "idx";
+    request.pause = true;
+    assert_false(static_cast<bool>(run(server, std::move(request)).ctx.ec), "pause succeeds");
+    assert_eq(server.service().calls,
+              std::vector<std::string>{ "PauseIndexIngest" },
+              "pause selects PauseIndexIngest");
+  }
+  {
+    in_process_server server;
+    ops::management::search_index_control_ingest_request request{};
+    request.index_name = "idx";
+    request.pause = false;
+    assert_false(static_cast<bool>(run(server, std::move(request)).ctx.ec), "resume succeeds");
+    assert_eq(server.service().calls,
+              std::vector<std::string>{ "ResumeIndexIngest" },
+              "resume selects ResumeIndexIngest");
+  }
+  {
+    in_process_server server;
+    ops::management::search_index_control_query_request request{};
+    request.index_name = "idx";
+    request.allow = true;
+    assert_false(static_cast<bool>(run(server, std::move(request)).ctx.ec), "allow succeeds");
+    assert_eq(server.service().calls,
+              std::vector<std::string>{ "AllowIndexQuerying" },
+              "allow selects AllowIndexQuerying");
+  }
+  {
+    in_process_server server;
+    ops::management::search_index_control_query_request request{};
+    request.index_name = "idx";
+    request.allow = false;
+    assert_false(static_cast<bool>(run(server, std::move(request)).ctx.ec), "disallow succeeds");
+    assert_eq(server.service().calls,
+              std::vector<std::string>{ "DisallowIndexQuerying" },
+              "disallow selects DisallowIndexQuerying");
+  }
+  {
+    in_process_server server;
+    ops::management::search_index_control_plan_freeze_request request{};
+    request.index_name = "idx";
+    request.freeze = true;
+    assert_false(static_cast<bool>(run(server, std::move(request)).ctx.ec), "freeze succeeds");
+    assert_eq(server.service().calls,
+              std::vector<std::string>{ "FreezeIndexPlan" },
+              "freeze selects FreezeIndexPlan");
+  }
+  {
+    in_process_server server;
+    ops::management::search_index_control_plan_freeze_request request{};
+    request.index_name = "idx";
+    request.freeze = false;
+    assert_false(static_cast<bool>(run(server, std::move(request)).ctx.ec), "unfreeze succeeds");
+    assert_eq(server.service().calls,
+              std::vector<std::string>{ "UnfreezeIndexPlan" },
+              "unfreeze selects UnfreezeIndexPlan");
+  }
+}
+
+void
+an_empty_index_name_is_refused_without_a_round_trip()
+{
+  // The gateway answers an empty name with InvalidArgument too, so the error code on its own does
+  // not distinguish a local refusal from a round trip. The empty call list is what does.
+  const auto refused_locally = [](in_process_server& server, std::error_code ec, const char* what) {
+    assert_eq(ec, std::error_code{ couchbase::errc::common::invalid_argument }, what);
+    assert_true(server.service().calls.empty(), "and nothing was sent");
+  };
+
+  {
+    in_process_server server;
+    ops::management::search_index_upsert_request request{};
+    request.index = definition("");
+    refused_locally(server, run(server, std::move(request)).ctx.ec, "upsert refuses an empty name");
+  }
+  {
+    in_process_server server;
+    ops::management::search_index_get_request request{};
+    refused_locally(server, run(server, std::move(request)).ctx.ec, "get refuses an empty name");
+  }
+  {
+    in_process_server server;
+    ops::management::search_index_drop_request request{};
+    refused_locally(server, run(server, std::move(request)).ctx.ec, "drop refuses an empty name");
+  }
+  {
+    in_process_server server;
+    ops::management::search_index_analyze_document_request request{};
+    request.encoded_document = R"({"a":1})";
+    refused_locally(
+      server, run(server, std::move(request)).ctx.ec, "analyze refuses an empty name");
+  }
+  {
+    in_process_server server;
+    ops::management::search_index_control_ingest_request request{};
+    request.pause = true;
+    refused_locally(
+      server, run(server, std::move(request)).ctx.ec, "control ingest refuses an empty name");
+  }
+  {
+    in_process_server server;
+    ops::management::search_index_control_query_request request{};
+    request.allow = true;
+    refused_locally(
+      server, run(server, std::move(request)).ctx.ec, "control query refuses an empty name");
+  }
+  {
+    in_process_server server;
+    ops::management::search_index_control_plan_freeze_request request{};
+    request.freeze = true;
+    refused_locally(
+      server, run(server, std::move(request)).ctx.ec, "control plan freeze refuses an empty name");
+  }
+}
+
+void
+a_definition_that_cannot_be_represented_is_not_sent()
+{
+  in_process_server server;
+
+  auto index = definition("idx");
+  index.params_json = R"(["not","an","object"])";
+  ops::management::search_index_upsert_request request{};
+  request.index = std::move(index);
+  const auto response = run(server, std::move(request));
+
+  assert_eq(response.ctx.ec,
+            std::error_code{ couchbase::errc::common::invalid_argument },
+            "a params blob with no representation is reported as invalid_argument");
+  assert_true(server.service().calls.empty(),
+              "and no index was created from the part that did convert");
+}
+
+void
+a_get_response_without_an_index_reports_index_not_found()
+{
+  in_process_server server;
+
+  ops::management::search_index_get_request request{};
+  request.index_name = "idx";
+  const auto response = run(server, std::move(request));
+
+  assert_eq(response.ctx.ec,
+            std::error_code{ couchbase::errc::common::index_not_found },
+            "a success carrying no index is index_not_found, not an empty definition");
+  assert_true(response.index.name.empty(), "and no definition is handed back");
+}
+
+void
+an_index_that_cannot_be_decoded_reports_parsing_failure()
+{
+  in_process_server server;
+  (*server.service().get_response.mutable_index()->mutable_params())["mapping"] = "not json";
+  server.service().get_response.mutable_index()->set_name("idx");
+
+  ops::management::search_index_get_request request{};
+  request.index_name = "idx";
+  const auto response = run(server, std::move(request));
+
+  assert_eq(response.ctx.ec,
+            std::error_code{ couchbase::errc::common::parsing_failure },
+            "a definition that cannot be rebuilt is an error, not a truncated definition");
+  assert_true(response.index.params_json.empty(), "and no partial definition is handed back");
+}
+
+void
+a_successful_call_reports_status_ok()
+{
+  // The field the classic path fills from FTS's {"status":"ok"}; admin.search.v1 answers with
+  // empty messages, so a successful RPC is what stands in for it.
+  {
+    in_process_server server;
+    ops::management::search_index_drop_request request{};
+    request.index_name = "idx";
+    const auto response = run(server, std::move(request));
+    assert_false(static_cast<bool>(response.ctx.ec), "drop succeeds");
+    assert_eq(response.status, std::string{ "ok" }, "drop reports status ok");
+  }
+  {
+    in_process_server server;
+    server.service().get_response.mutable_index()->set_name("idx");
+    ops::management::search_index_get_request request{};
+    request.index_name = "idx";
+    const auto response = run(server, std::move(request));
+    assert_false(static_cast<bool>(response.ctx.ec), "get succeeds");
+    assert_eq(response.status, std::string{ "ok" }, "get reports status ok");
+  }
+  {
+    in_process_server server;
+    ops::management::search_index_analyze_document_request request{};
+    request.index_name = "idx";
+    request.encoded_document = R"({"a":1})";
+    const auto response = run(server, std::move(request));
+    assert_false(static_cast<bool>(response.ctx.ec), "analyze succeeds");
+    assert_eq(response.status, std::string{ "ok" }, "analyze relays the gateway's status");
+    assert_eq(response.analysis, std::string{ "[]" }, "and the analysis");
+  }
+}
+
+void
+a_failed_call_reports_no_status()
+{
+  // A status the server never reported would say the operation succeeded; the error code is what
+  // describes a failure.
+  in_process_server server;
+  ops::management::search_index_get_request request{};
+  request.index_name = "idx";
+  const auto response = run(server, std::move(request));
+  assert_true(static_cast<bool>(response.ctx.ec), "the default GetIndexResponse fails the call");
+  assert_true(response.status.empty(), "and leaves status unset");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_search_index_admin_component",
+    {
+      { "an_upsert_without_a_uuid_calls_create_index",
+        an_upsert_without_a_uuid_calls_create_index },
+      { "an_upsert_with_a_uuid_calls_update_index", an_upsert_with_a_uuid_calls_update_index },
+      { "the_control_operations_select_their_paired_rpc",
+        the_control_operations_select_their_paired_rpc },
+      { "an_empty_index_name_is_refused_without_a_round_trip",
+        an_empty_index_name_is_refused_without_a_round_trip },
+      { "a_definition_that_cannot_be_represented_is_not_sent",
+        a_definition_that_cannot_be_represented_is_not_sent },
+      { "a_get_response_without_an_index_reports_index_not_found",
+        a_get_response_without_an_index_reports_index_not_found },
+      { "an_index_that_cannot_be_decoded_reports_parsing_failure",
+        an_index_that_cannot_be_decoded_reports_parsing_failure },
+      { "a_successful_call_reports_status_ok", a_successful_call_reports_status_ok },
+      { "a_failed_call_reports_no_status", a_failed_call_reports_no_status },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test

--- a/test/cng/protostellar/search_index_admin_converter.cxx
+++ b/test/cng/protostellar/search_index_admin_converter.cxx
@@ -1,0 +1,293 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Unit tests for the search-index-admin <-> couchbase.admin.search.v1 converter (CXXCBC-901).
+// Two properties: a definition survives the round trip whole, and one that cannot be represented
+// is refused rather than truncated. Pure, no server.
+
+#include "framework/test_runner.hxx"
+
+#include "core/protostellar/search_index_admin_converter.hxx"
+#include "core/utils/json.hxx"
+
+#include <string>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace si = ::couchbase::core::protostellar::search_index_admin;
+namespace v1 = ::couchbase::admin::search::v1;
+
+// Three deliberately distinct payloads. A converter that crossed two of the blobs would still
+// round-trip each one against itself if they held the same value, so no two of these do.
+constexpr auto params = R"({"mapping":{"default_analyzer":"standard"}})";
+constexpr auto plan_params = R"({"numReplicas":2})";
+constexpr auto source_params = R"({"feedBufferSizeBytes":1048576})";
+
+[[nodiscard]] auto
+json_eq(const std::string& lhs, const std::string& rhs) -> bool
+{
+  return couchbase::core::utils::json::parse(lhs) == couchbase::core::utils::json::parse(rhs);
+}
+
+[[nodiscard]] auto
+full_index() -> couchbase::core::management::search::index
+{
+  couchbase::core::management::search::index index;
+  index.name = "idx";
+  index.type = "fulltext-index";
+  index.source_name = "travel";
+  index.source_type = "couchbase";
+  index.source_uuid = "src-uuid";
+  index.params_json = params;
+  index.plan_params_json = plan_params;
+  index.source_params_json = source_params;
+  return index;
+}
+
+void
+apply_index_maps_fields_and_params()
+{
+  auto index = full_index();
+
+  v1::CreateIndexRequest proto;
+  assert_true(si::apply_index(index, proto), "a representable definition is accepted");
+  assert_eq(proto.name(), std::string{ "idx" }, "name mapped");
+  assert_eq(proto.type(), std::string{ "fulltext-index" }, "type mapped");
+  assert_eq(proto.source_name(), std::string{ "travel" }, "source_name mapped");
+  assert_eq(proto.source_type(), std::string{ "couchbase" }, "source_type mapped");
+  assert_eq(proto.source_uuid(), std::string{ "src-uuid" }, "source_uuid mapped");
+  assert_true(proto.params().count("mapping") == 1, "params exploded into the map");
+  assert_true(proto.plan_params().count("numReplicas") == 1, "plan_params exploded into the map");
+  assert_true(proto.source_params().count("feedBufferSizeBytes") == 1,
+              "source_params exploded into the map");
+}
+
+void
+a_create_carries_no_uuid()
+{
+  auto index = full_index();
+  index.uuid = "existing-uuid";
+
+  v1::CreateIndexRequest proto;
+  assert_true(si::apply_index(index, proto), "encode accepted");
+  // prev_index_uuid is not the update channel: the gateway passes it to cbsearchx as PrevIndexUUID,
+  // which reaches FTS as a body member FTS does not read. A definition with a uuid is an update and
+  // belongs in UpdateIndexRequest, so nothing here may carry it.
+  assert_false(proto.has_prev_index_uuid(), "the create request carries no prev_index_uuid");
+}
+
+void
+an_update_carries_the_uuid()
+{
+  auto index = full_index();
+  index.uuid = "existing-uuid";
+
+  v1::UpdateIndexRequest proto;
+  assert_true(si::apply_index(index, *proto.mutable_index()), "encode accepted");
+  assert_eq(proto.index().uuid(), std::string{ "existing-uuid" }, "uuid reaches Index.uuid");
+  assert_eq(proto.index().name(), std::string{ "idx" }, "name mapped on the update path too");
+  assert_true(proto.index().params().count("mapping") == 1, "params mapped on the update path");
+}
+
+void
+all_three_parameter_blobs_survive_the_round_trip()
+{
+  const auto index = full_index();
+
+  v1::CreateIndexRequest request;
+  assert_true(si::apply_index(index, request), "encode accepted");
+
+  // The proto map is the only carrier, so rebuild an Index from the request's three maps and
+  // decode that -- the same path GetIndex takes on the way back.
+  v1::Index proto;
+  *proto.mutable_params() = request.params();
+  *proto.mutable_plan_params() = request.plan_params();
+  *proto.mutable_source_params() = request.source_params();
+
+  const auto decoded = si::decode_index(proto);
+  assert_true(decoded.has_value(), "decode accepted");
+  assert_true(json_eq(decoded->params_json, params), "params survives");
+  assert_true(json_eq(decoded->plan_params_json, plan_params), "plan_params survives");
+  assert_true(json_eq(decoded->source_params_json, source_params), "source_params survives");
+}
+
+void
+an_unset_parameter_blob_stays_unset()
+{
+  couchbase::core::management::search::index index;
+  index.name = "idx";
+  index.type = "fulltext-index";
+  index.plan_params_json = plan_params;
+
+  v1::CreateIndexRequest request;
+  assert_true(si::apply_index(index, request), "a definition with two unset blobs is accepted");
+  assert_true(request.params().empty(), "an unset params contributes no map entry");
+  assert_true(request.source_params().empty(), "an unset source_params contributes no map entry");
+
+  v1::Index proto;
+  *proto.mutable_plan_params() = request.plan_params();
+  const auto decoded = si::decode_index(proto);
+  assert_true(decoded.has_value(), "decode accepted");
+  assert_true(decoded->params_json.empty(), "an empty map decodes back to unset, not \"{}\"");
+  assert_true(decoded->source_params_json.empty(), "and so does the third one");
+  assert_true(json_eq(decoded->plan_params_json, plan_params), "the set blob is unaffected");
+}
+
+void
+an_unparseable_parameter_blob_is_refused()
+{
+  // Each position separately: a guard on one blob does not cover the other two.
+  for (const auto* position : { "params", "plan_params", "source_params" }) {
+    auto index = full_index();
+    const std::string broken{ "not json" };
+    if (std::string{ position } == "params") {
+      index.params_json = broken;
+    } else if (std::string{ position } == "plan_params") {
+      index.plan_params_json = broken;
+    } else {
+      index.source_params_json = broken;
+    }
+    v1::CreateIndexRequest request;
+    assert_false(si::apply_index(index, request),
+                 std::string{ "an unparseable " } + position + " is refused on create");
+    v1::Index update;
+    assert_false(si::apply_index(index, update),
+                 std::string{ "an unparseable " } + position + " is refused on update");
+  }
+}
+
+void
+a_non_object_parameter_blob_is_refused()
+{
+  // Valid JSON, but the map is keyed by an object's members, so an array or a scalar has nowhere
+  // to go. Dropping it is what loses a definition silently.
+  for (const auto* payload : { "[1,2,3]", "\"a string\"", "42", "null" }) {
+    auto index = full_index();
+    index.params_json = payload;
+    v1::CreateIndexRequest request;
+    assert_false(si::apply_index(index, request),
+                 std::string{ "a non-object params (" } + payload + ") is refused");
+  }
+}
+
+void
+a_map_member_that_is_not_json_is_refused()
+{
+  for (const auto* position : { "params", "plan_params", "source_params" }) {
+    v1::Index proto;
+    proto.set_name("idx");
+    if (std::string{ position } == "params") {
+      (*proto.mutable_params())["mapping"] = "not json";
+    } else if (std::string{ position } == "plan_params") {
+      (*proto.mutable_plan_params())["numReplicas"] = "not json";
+    } else {
+      (*proto.mutable_source_params())["feedBufferSizeBytes"] = "not json";
+    }
+    assert_false(si::decode_index(proto).has_value(),
+                 std::string{ "a non-JSON " } + position + " member fails the decode");
+  }
+}
+
+void
+params_to_json_keeps_the_unset_convention_for_an_empty_map()
+{
+  ::google::protobuf::Map<std::string, std::string> empty;
+  const auto rebuilt = si::params_to_json(empty);
+  assert_true(rebuilt.has_value(), "an empty map is not an error");
+  assert_true(rebuilt->empty(),
+              "an empty map rebuilds to the unset (empty) convention, not \"{}\"");
+}
+
+void
+decode_index_maps_fields()
+{
+  v1::Index proto;
+  proto.set_uuid("u1");
+  proto.set_name("idx");
+  proto.set_type("fulltext-index");
+  proto.set_source_name("travel");
+  proto.set_source_type("couchbase");
+  proto.set_source_uuid("src-uuid");
+  (*proto.mutable_params())["mapping"] = R"({"x":1})";
+
+  const auto index = si::decode_index(proto);
+  assert_true(index.has_value(), "decode accepted");
+  assert_eq(index->uuid, std::string{ "u1" }, "uuid decoded");
+  assert_eq(index->name, std::string{ "idx" }, "name decoded");
+  assert_eq(index->type, std::string{ "fulltext-index" }, "type decoded");
+  assert_eq(index->source_name, std::string{ "travel" }, "source_name decoded");
+  assert_eq(index->source_type, std::string{ "couchbase" }, "source_type decoded");
+  assert_eq(index->source_uuid, std::string{ "src-uuid" }, "source_uuid decoded");
+  assert_true(json_eq(index->params_json, R"({"mapping":{"x":1}})"),
+              "params object carries the mapping member");
+}
+
+void
+a_definition_survives_the_full_encode_decode_cycle()
+{
+  // get_index -> edit -> upsert is the cycle that loses members when a conversion drops what it
+  // cannot represent, so the whole definition is compared, not one blob.
+  auto original = full_index();
+  original.uuid = "u1";
+
+  v1::UpdateIndexRequest request;
+  assert_true(si::apply_index(original, *request.mutable_index()), "encode accepted");
+  const auto decoded = si::decode_index(request.index());
+  assert_true(decoded.has_value(), "decode accepted");
+
+  assert_eq(decoded->uuid, original.uuid, "uuid survives");
+  assert_eq(decoded->name, original.name, "name survives");
+  assert_eq(decoded->type, original.type, "type survives");
+  assert_eq(decoded->source_name, original.source_name, "source_name survives");
+  assert_eq(decoded->source_type, original.source_type, "source_type survives");
+  assert_eq(decoded->source_uuid, original.source_uuid, "source_uuid survives");
+  assert_true(json_eq(decoded->params_json, original.params_json), "params survives");
+  assert_true(json_eq(decoded->plan_params_json, original.plan_params_json),
+              "plan_params survives");
+  assert_true(json_eq(decoded->source_params_json, original.source_params_json),
+              "source_params survives");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_search_index_admin_converter",
+    {
+      { "apply_index_maps_fields_and_params", apply_index_maps_fields_and_params },
+      { "a_create_carries_no_uuid", a_create_carries_no_uuid },
+      { "an_update_carries_the_uuid", an_update_carries_the_uuid },
+      { "all_three_parameter_blobs_survive_the_round_trip",
+        all_three_parameter_blobs_survive_the_round_trip },
+      { "an_unset_parameter_blob_stays_unset", an_unset_parameter_blob_stays_unset },
+      { "an_unparseable_parameter_blob_is_refused", an_unparseable_parameter_blob_is_refused },
+      { "a_non_object_parameter_blob_is_refused", a_non_object_parameter_blob_is_refused },
+      { "a_map_member_that_is_not_json_is_refused", a_map_member_that_is_not_json_is_refused },
+      { "params_to_json_keeps_the_unset_convention_for_an_empty_map",
+        params_to_json_keeps_the_unset_convention_for_an_empty_map },
+      { "decode_index_maps_fields", decode_index_maps_fields },
+      { "a_definition_survives_the_full_encode_decode_cycle",
+        a_definition_survives_the_full_encode_decode_cycle },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test


### PR DESCRIPTION
Complete the index management ticket with the search index admin operations over
admin.search.v1 (unary).

Core search::index stores params/plan_params/source_params as JSON-object
strings; the proto Index models them as map<string,bytes> keyed by the object's
top-level members. The converter explodes each object into the map on encode and
rebuilds it on decode, and reports failure rather than dropping what it cannot
represent: a definition that lost a member would be created, or handed back,
short of what the caller wrote, and the loss would survive a get-modify-upsert.

upsert selects its RPC on the uuid -- a definition carrying one is an update and
goes to UpdateIndex, one without is a create and goes to CreateIndex. That is
the line the classic path draws and the line FTS draws behind the gateway. get,
get_all, drop, analyze_document and get_documents_count map directly; the
control operations select between paired RPCs from their bool
(ingest->Pause/Resume, query->Allow/Disallow, plan_freeze->Freeze/Unfreeze).
get_stats has no admin.search.v1 RPC and returns feature_not_available.

The operations the classic path validates locally reject an empty index name
without a round trip, a GetIndex response carrying no index is index_not_found,
and a successful call reports status "ok" -- the field the classic path fills
from FTS's own reply and core-API consumers read.

Every management response carries the caller's client_context_id into its error
context, on the completion and on the paths that never reach the server, which
have nothing else to correlate them by.

The CNG CI cluster raises the search service quota alongside the data one: these cases
build real fulltext indexes, where before nothing was built on that service.

---
Stacked PR **20/30** in the CNG (`couchbase2://`) transport series. The change specific to this PR is its top commit; the commits beneath it belong to earlier PRs in the series. Depends on #1041 — merge the series bottom-up.
