### PR TITLE
CXXCBC-896: retry couchbase2 KV operations via the SDK retry strategy

### DIFF
--- a/core/cluster.cxx
+++ b/core/cluster.cxx
@@ -20,6 +20,11 @@
 #ifdef COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2
 #include "core/protostellar/component.hxx"
 #include "core/protostellar/credentials.hxx"
+#include "core/protostellar/error_utils.hxx"
+
+#include <couchbase/retry_strategy.hxx>
+
+#include <asio/steady_timer.hpp>
 #endif
 
 #define COUCHBASE_CXX_CLIENT_IGNORE_CORE_DEPRECATIONS
@@ -304,6 +309,23 @@ is_feature_supported(const operations::management::search_index_upsert_request& 
 {
   return !request.index.is_vector_index() || capabilities.supports_vector_search();
 }
+
+#ifdef COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2
+// Extract the error_code from a response's error context. KV responses carry a
+// key_value_error_context (ec() accessor); the query/analytics/search/view/management responses
+// carry a plain error_context::* struct with an `ec` field.
+inline auto
+protostellar_response_ec(const key_value_error_context& ctx) -> std::error_code
+{
+  return ctx.ec();
+}
+template<typename Context>
+inline auto
+protostellar_response_ec(const Context& ctx) -> std::error_code
+{
+  return ctx.ec;
+}
+#endif
 } // namespace
 
 #ifdef COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2
@@ -754,7 +776,7 @@ public:
 #ifdef COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2
     if (auto component = protostellar_component(); component) {
       if constexpr (protostellar::component_supports_v<Request>) {
-        component->execute(std::move(request), std::forward<Handler>(handler));
+        execute_protostellar(std::move(request), std::forward<Handler>(handler));
         return;
       } else {
         return handler(request.make_response(
@@ -797,7 +819,9 @@ public:
 #ifdef COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2
     if (auto component = protostellar_component(); component) {
       if constexpr (component_routes<Request>::value) {
-        component->execute(std::move(request), std::forward<Handler>(handler));
+        // Query/analytics/search/view/management requests do not carry a retry_context, so they
+        // dispatch directly; transport-level retry applies to the KV path (which does).
+        component->execute(request, std::forward<Handler>(handler));
         return;
       } else {
         // Remaining management ops over couchbase2 are not wired yet. Reject cleanly rather than
@@ -1007,6 +1031,116 @@ public:
     return false;
 #endif
   }
+
+#ifdef COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2
+  // Execute a couchbase2 operation through the component with transport-level retry. Retryable
+  // errors (see protostellar::retry_reason_for) consult the request's retry strategy (falling back
+  // to the origin default), and on a positive decision the request is re-issued after a backoff.
+  // Idempotency is enforced by the strategy, so ambiguous mutations are not replayed.
+  //
+  // The deadline is resolved here, before the first attempt, and every attempt is issued against
+  // it. Falling back to the cluster's KV default when the request carries no timeout is what bounds
+  // the loop at all: the public API leaves the per-operation timeout unset unless the caller asks
+  // for one, and the strategy never refuses a retry for service_not_available, so a request issued
+  // with default options against an unavailable gateway would otherwise retry until the process
+  // ended -- never completing, and never reporting an error either.
+  template<class Request, class Handler>
+  void execute_protostellar(Request request, Handler&& handler)
+  {
+    // The fallback below is the KV default, so routing anything else here would bound it with a
+    // budget belonging to another service. Non-KV requests carry no retry_context and have their
+    // own path.
+    static_assert(protostellar::component_supports_v<Request>,
+                  "execute_protostellar resolves the key-value timeout");
+    const auto deadline = std::chrono::steady_clock::now() +
+                          request.timeout.value_or(origin_.options().key_value_timeout);
+    // Held by shared_ptr and re-issued from there. The request owns the document body for a
+    // mutation, so copying it to keep a re-issue possible charged every operation on the data plane
+    // for a retry that in normal operation never happens.
+    dispatch_protostellar(
+      std::make_shared<Request>(std::move(request)), std::forward<Handler>(handler), deadline);
+  }
+
+  // One attempt of the above, re-entered from the backoff timer for each retry.
+  template<class Request, class Handler>
+  void dispatch_protostellar(std::shared_ptr<Request> request,
+                             Handler&& handler,
+                             std::chrono::steady_clock::time_point deadline)
+  {
+    // Each attempt gets what is LEFT of the operation's budget rather than a fresh full-length one.
+    // Without this an attempt started just inside the deadline would run for the whole timeout
+    // again, so a retried operation could take roughly twice its nominal budget. Narrowing keeps
+    // the request carrying a duration -- which is all the component accepts -- while making that
+    // duration mean "until the operation's deadline". A non-positive remainder is not
+    // special-cased, and is in fact how the loop ends: the component rejects an exhausted budget
+    // as a timeout instead of dispatching a call with no deadline.
+    request->timeout = std::chrono::duration_cast<std::chrono::milliseconds>(
+      deadline - std::chrono::steady_clock::now());
+    // Re-read through the locked accessor on every attempt: a retry re-enters this
+    // function from a timer, long after the caller checked.
+    auto component = protostellar_component();
+    if (!component) {
+      return handler(
+        request->make_response(make_key_value_error_context(errc::network::cluster_closed,
+                                                            request->id,
+                                                            request->retries.retry_attempts(),
+                                                            request->retries.retry_reasons()),
+                               typename Request::encoded_response_type{}));
+    }
+    component->execute(
+      *request,
+      [self = shared_from_this(), request, handler = std::forward<Handler>(handler), deadline](
+        auto response) mutable {
+        if (!self->stopped_) {
+          if (auto reason = protostellar::retry_reason_for(protostellar_response_ec(response.ctx));
+              reason.has_value()) {
+            auto strategy = request->retries.strategy()
+                              ? request->retries.strategy()
+                              : self->origin_.options().default_retry_strategy_;
+            if (strategy) {
+              const auto action = strategy->retry_after(request->retries, reason.value());
+              // The wait is capped at the deadline rather than the retry being refused for landing
+              // past it. Refusing would end the operation early on the last attempt's transport
+              // error -- temporary_failure for an unreachable gateway -- while the caller's budget
+              // was still running, so the same condition that times out over the classic transport
+              // would report a different code here. Capping lets the operation use its whole budget
+              // and end on the deadline: the attempt scheduled at it gets a non-positive remainder
+              // above, which the component answers as a timeout carrying the accumulated attempts
+              // and reasons. That is terminal, so the loop cannot spin on it -- retry_reason_for
+              // does not classify a timeout as retryable. Both other implementations of this loop
+              // cap the same way (io/retry_orchestrator.hxx cap_duration, and Java's
+              // RetryOrchestratorProtostellar.capDuration).
+              const auto when =
+                std::min(std::chrono::steady_clock::now() + action.duration(), deadline);
+              if (action.need_to_retry()) {
+                // Recorded before the re-issue, so the next attempt carries the accumulated count
+                // and the error context it builds reports the retries that preceded it.
+                request->retries.record_retry_attempt(reason.value());
+                auto timer = std::make_shared<asio::steady_timer>(self->ctx_);
+                timer->expires_at(when);
+                timer->async_wait([self,
+                                   request,
+                                   handler = std::move(handler),
+                                   deadline,
+                                   response = std::move(response),
+                                   timer](const std::error_code& timer_ec) mutable {
+                  if (timer_ec) {
+                    // timer cancelled (e.g. cluster closed): deliver the last retryable response
+                    // rather than dropping the caller's completion, which would hang it.
+                    handler(std::move(response));
+                    return;
+                  }
+                  self->dispatch_protostellar(std::move(request), std::move(handler), deadline);
+                });
+                return;
+              }
+            }
+          }
+        }
+        handler(std::move(response));
+      });
+  }
+#endif
 
   void do_open(utils::movable_function<void(std::error_code)> handler)
   {

--- a/core/protostellar/component.cxx
+++ b/core/protostellar/component.cxx
@@ -93,15 +93,23 @@ namespace
 // deadline at all -- an RPC that runs until the channel breaks, and that cluster::close() then
 // blocks on. Turning "no time left" into "no limit" is the wrong direction for the mistake to go.
 //
-// Nothing is sent, so the operation provably did not reach the server. That makes it an
-// unambiguous timeout for every operation, mutating ones included: the ambiguity that
-// ambiguous_timeout warns about is whether the server applied the write, and here it never saw it.
+// This attempt sends nothing, but that does not make the operation unsent: the retry loop reaches
+// here to end an operation whose earlier attempts were dispatched. The ambiguity ambiguous_timeout
+// warns about is whether the server applied a write, so it is decided by whether anything was ever
+// sent, not by whether this attempt was -- the same rule the MCBP path applies in
+// mcbp_command::cancel(). An idempotent operation is safe to replay either way, and a first attempt
+// (no retries recorded) provably reached nobody.
 template<typename Request, typename Handler>
 auto
 fail_expired(asio::io_context& io, const Request& request, Handler& handler) -> pending_call
 {
+  const auto ec =
+    (request.retries.idempotent() || request.retries.retry_attempts() == 0)
+      ? errc::common::unambiguous_timeout // safe to retry, or never sent to the server
+      : errc::common::ambiguous_timeout;  // non-idempotent and dispatched at least once
   auto response = request.make_response(
-    make_key_value_error_context(errc::common::unambiguous_timeout, request.id),
+    make_key_value_error_context(
+      ec, request.id, request.retries.retry_attempts(), request.retries.retry_reasons()),
     typename Request::encoded_response_type{});
   // Delivered through the io_context, not inline on the caller's thread: "completions arrive on the
   // SDK's execution context" is the contract every other path here honours, and a synchronous
@@ -193,7 +201,7 @@ component::component(asio::io_context& io, component_config config)
 component::~component() = default;
 
 auto
-component::execute(operations::get_request request,
+component::execute(const operations::get_request& request,
                    utils::movable_function<void(operations::get_response)>&& handler)
   -> pending_call
 {
@@ -203,6 +211,8 @@ component::execute(operations::get_request request,
   }
   auto proto = std::make_shared<v1::GetRequest>(kv::encode(request));
   const auto id = request.id;
+  const auto retry_attempts = request.retries.retry_attempts();
+  const auto retry_reasons = request.retries.retry_reasons();
   const auto auth = authorization_;
   auto* stub = stubs_->kv.get();
   return dispatcher_.unary<v1::GetResponse>(
@@ -215,23 +225,27 @@ component::execute(operations::get_request request,
       stub->async()->Get(&ctx, proto.get(), &resp, std::move(cb));
     },
     // `proto` is captured here too so the request outlives the in-flight call.
-    [handler = std::move(handler), id, proto](grpc::Status status, v1::GetResponse resp) mutable {
+    [handler = std::move(handler), id, proto, retry_attempts, retry_reasons](
+      grpc::Status status, v1::GetResponse resp) mutable {
       (void)proto; // kept only to keep the request alive for the call
       // A get reads and nothing more, so a deadline here is unambiguous: the document cannot have
       // changed. kv::decode owns the compressed-content rule (it reports feature_not_available
       // rather than handing back an empty value with a success status).
-      auto ctx = make_error_context(status, id, operation_kind::read_only);
+      auto ctx =
+        make_error_context(status, id, operation_kind::read_only, retry_attempts, retry_reasons);
       handler(kv::decode(resp, std::move(ctx)));
     });
 }
 
 auto
-component::execute(operations::get_projected_request request,
+component::execute(const operations::get_projected_request& request,
                    utils::movable_function<void(operations::get_projected_response)>&& handler)
   -> pending_call
 {
   auto proto = std::make_shared<v1::GetRequest>(kv::encode(request));
   const auto id = request.id;
+  const auto retry_attempts = request.retries.retry_attempts();
+  const auto retry_reasons = request.retries.retry_reasons();
   const auto timeout = request.timeout.value_or(timeouts_.key_value);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
@@ -247,19 +261,21 @@ component::execute(operations::get_projected_request request,
       }
       stub->async()->Get(&ctx, proto.get(), &resp, std::move(cb));
     },
-    [handler = std::move(handler), id, proto, request](grpc::Status status,
-                                                       v1::GetResponse resp) mutable {
+    [handler = std::move(handler), id, proto, request, retry_attempts, retry_reasons](
+      grpc::Status status, v1::GetResponse resp) mutable {
       (void)proto; // kept only to keep the request alive for the call
-      auto ctx = make_error_context(status, id, operation_kind::read_only);
+      auto ctx =
+        make_error_context(status, id, operation_kind::read_only, retry_attempts, retry_reasons);
       if (status.ok() && resp.content_case() == v1::GetResponse::kContentCompressed) {
-        ctx = make_key_value_error_context(errc::common::feature_not_available, id);
+        ctx = make_key_value_error_context(
+          errc::common::feature_not_available, id, retry_attempts, retry_reasons);
       }
       handler(kv::decode(resp, std::move(ctx), request));
     });
 }
 
 auto
-component::execute(operations::upsert_request request,
+component::execute(const operations::upsert_request& request,
                    utils::movable_function<void(operations::upsert_response)>&& handler)
   -> pending_call
 {
@@ -269,6 +285,8 @@ component::execute(operations::upsert_request request,
   }
   auto proto = std::make_shared<v1::UpsertRequest>(kv::encode(request));
   const auto id = request.id;
+  const auto retry_attempts = request.retries.retry_attempts();
+  const auto retry_reasons = request.retries.retry_reasons();
   const auto auth = authorization_;
   auto* stub = stubs_->kv.get();
   return dispatcher_.unary<v1::UpsertResponse>(
@@ -280,16 +298,17 @@ component::execute(operations::upsert_request request,
       }
       stub->async()->Upsert(&ctx, proto.get(), &resp, std::move(cb));
     },
-    [handler = std::move(handler), id, proto](grpc::Status status,
-                                              v1::UpsertResponse resp) mutable {
+    [handler = std::move(handler), id, proto, retry_attempts, retry_reasons](
+      grpc::Status status, v1::UpsertResponse resp) mutable {
       (void)proto; // kept only to keep the request alive for the call
-      auto ctx = make_error_context(status, id, operation_kind::mutating);
+      auto ctx =
+        make_error_context(status, id, operation_kind::mutating, retry_attempts, retry_reasons);
       handler(kv::decode(resp, std::move(ctx)));
     });
 }
 
 auto
-component::execute(operations::insert_request request,
+component::execute(const operations::insert_request& request,
                    utils::movable_function<void(operations::insert_response)>&& handler)
   -> pending_call
 {
@@ -299,6 +318,8 @@ component::execute(operations::insert_request request,
   }
   auto proto = std::make_shared<v1::InsertRequest>(kv::encode(request));
   const auto id = request.id;
+  const auto retry_attempts = request.retries.retry_attempts();
+  const auto retry_reasons = request.retries.retry_reasons();
   const auto auth = authorization_;
   auto* stub = stubs_->kv.get();
   return dispatcher_.unary<v1::InsertResponse>(
@@ -310,16 +331,17 @@ component::execute(operations::insert_request request,
       }
       stub->async()->Insert(&ctx, proto.get(), &resp, std::move(cb));
     },
-    [handler = std::move(handler), id, proto](grpc::Status status,
-                                              v1::InsertResponse resp) mutable {
+    [handler = std::move(handler), id, proto, retry_attempts, retry_reasons](
+      grpc::Status status, v1::InsertResponse resp) mutable {
       (void)proto; // kept only to keep the request alive for the call
-      auto ctx = make_error_context(status, id, operation_kind::mutating);
+      auto ctx =
+        make_error_context(status, id, operation_kind::mutating, retry_attempts, retry_reasons);
       handler(kv::decode(resp, std::move(ctx)));
     });
 }
 
 auto
-component::execute(operations::replace_request request,
+component::execute(const operations::replace_request& request,
                    utils::movable_function<void(operations::replace_response)>&& handler)
   -> pending_call
 {
@@ -329,6 +351,8 @@ component::execute(operations::replace_request request,
   }
   auto proto = std::make_shared<v1::ReplaceRequest>(kv::encode(request));
   const auto id = request.id;
+  const auto retry_attempts = request.retries.retry_attempts();
+  const auto retry_reasons = request.retries.retry_reasons();
   const auto auth = authorization_;
   auto* stub = stubs_->kv.get();
   return dispatcher_.unary<v1::ReplaceResponse>(
@@ -340,16 +364,17 @@ component::execute(operations::replace_request request,
       }
       stub->async()->Replace(&ctx, proto.get(), &resp, std::move(cb));
     },
-    [handler = std::move(handler), id, proto](grpc::Status status,
-                                              v1::ReplaceResponse resp) mutable {
+    [handler = std::move(handler), id, proto, retry_attempts, retry_reasons](
+      grpc::Status status, v1::ReplaceResponse resp) mutable {
       (void)proto; // kept only to keep the request alive for the call
-      auto ctx = make_error_context(status, id, operation_kind::mutating);
+      auto ctx =
+        make_error_context(status, id, operation_kind::mutating, retry_attempts, retry_reasons);
       handler(kv::decode(resp, std::move(ctx)));
     });
 }
 
 auto
-component::execute(operations::remove_request request,
+component::execute(const operations::remove_request& request,
                    utils::movable_function<void(operations::remove_response)>&& handler)
   -> pending_call
 {
@@ -359,6 +384,8 @@ component::execute(operations::remove_request request,
   }
   auto proto = std::make_shared<v1::RemoveRequest>(kv::encode(request));
   const auto id = request.id;
+  const auto retry_attempts = request.retries.retry_attempts();
+  const auto retry_reasons = request.retries.retry_reasons();
   const auto auth = authorization_;
   auto* stub = stubs_->kv.get();
   return dispatcher_.unary<v1::RemoveResponse>(
@@ -370,21 +397,24 @@ component::execute(operations::remove_request request,
       }
       stub->async()->Remove(&ctx, proto.get(), &resp, std::move(cb));
     },
-    [handler = std::move(handler), id, proto](grpc::Status status,
-                                              v1::RemoveResponse resp) mutable {
+    [handler = std::move(handler), id, proto, retry_attempts, retry_reasons](
+      grpc::Status status, v1::RemoveResponse resp) mutable {
       (void)proto; // kept only to keep the request alive for the call
-      auto ctx = make_error_context(status, id, operation_kind::mutating);
+      auto ctx =
+        make_error_context(status, id, operation_kind::mutating, retry_attempts, retry_reasons);
       handler(kv::decode(resp, std::move(ctx)));
     });
 }
 
 auto
-component::execute(operations::touch_request request,
+component::execute(const operations::touch_request& request,
                    utils::movable_function<void(operations::touch_response)>&& handler)
   -> pending_call
 {
   auto proto = std::make_shared<v1::TouchRequest>(kv::encode(request));
   const auto id = request.id;
+  const auto retry_attempts = request.retries.retry_attempts();
+  const auto retry_reasons = request.retries.retry_reasons();
   const auto timeout = request.timeout.value_or(timeouts_.key_value);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
@@ -400,20 +430,24 @@ component::execute(operations::touch_request request,
       }
       stub->async()->Touch(&ctx, proto.get(), &resp, std::move(cb));
     },
-    [handler = std::move(handler), id, proto](grpc::Status status, v1::TouchResponse resp) mutable {
+    [handler = std::move(handler), id, proto, retry_attempts, retry_reasons](
+      grpc::Status status, v1::TouchResponse resp) mutable {
       (void)proto; // kept only to keep the request alive for the call
-      auto ctx = make_error_context(status, id, operation_kind::mutating);
+      auto ctx =
+        make_error_context(status, id, operation_kind::mutating, retry_attempts, retry_reasons);
       handler(kv::decode(resp, std::move(ctx)));
     });
 }
 
 auto
-component::execute(operations::exists_request request,
+component::execute(const operations::exists_request& request,
                    utils::movable_function<void(operations::exists_response)>&& handler)
   -> pending_call
 {
   auto proto = std::make_shared<v1::ExistsRequest>(kv::encode(request));
   const auto id = request.id;
+  const auto retry_attempts = request.retries.retry_attempts();
+  const auto retry_reasons = request.retries.retry_reasons();
   const auto timeout = request.timeout.value_or(timeouts_.key_value);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
@@ -429,21 +463,24 @@ component::execute(operations::exists_request request,
       }
       stub->async()->Exists(&ctx, proto.get(), &resp, std::move(cb));
     },
-    [handler = std::move(handler), id, proto](grpc::Status status,
-                                              v1::ExistsResponse resp) mutable {
+    [handler = std::move(handler), id, proto, retry_attempts, retry_reasons](
+      grpc::Status status, v1::ExistsResponse resp) mutable {
       (void)proto; // kept only to keep the request alive for the call
-      auto ctx = make_error_context(status, id, operation_kind::read_only);
+      auto ctx =
+        make_error_context(status, id, operation_kind::read_only, retry_attempts, retry_reasons);
       handler(kv::decode(resp, std::move(ctx)));
     });
 }
 
 auto
-component::execute(operations::get_and_lock_request request,
+component::execute(const operations::get_and_lock_request& request,
                    utils::movable_function<void(operations::get_and_lock_response)>&& handler)
   -> pending_call
 {
   auto proto = std::make_shared<v1::GetAndLockRequest>(kv::encode(request));
   const auto id = request.id;
+  const auto retry_attempts = request.retries.retry_attempts();
+  const auto retry_reasons = request.retries.retry_reasons();
   const auto timeout = request.timeout.value_or(timeouts_.key_value);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
@@ -460,24 +497,28 @@ component::execute(operations::get_and_lock_request request,
       }
       stub->async()->GetAndLock(&ctx, proto.get(), &resp, std::move(cb));
     },
-    [handler = std::move(handler), id, proto](grpc::Status status,
-                                              v1::GetAndLockResponse resp) mutable {
+    [handler = std::move(handler), id, proto, retry_attempts, retry_reasons](
+      grpc::Status status, v1::GetAndLockResponse resp) mutable {
       (void)proto; // kept only to keep the request alive for the call
-      auto ctx = make_error_context(status, id, operation_kind::mutating);
+      auto ctx =
+        make_error_context(status, id, operation_kind::mutating, retry_attempts, retry_reasons);
       if (status.ok() && resp.content_case() == v1::GetAndLockResponse::kContentCompressed) {
-        ctx = make_key_value_error_context(errc::common::feature_not_available, id);
+        ctx = make_key_value_error_context(
+          errc::common::feature_not_available, id, retry_attempts, retry_reasons);
       }
       handler(kv::decode(resp, std::move(ctx)));
     });
 }
 
 auto
-component::execute(operations::unlock_request request,
+component::execute(const operations::unlock_request& request,
                    utils::movable_function<void(operations::unlock_response)>&& handler)
   -> pending_call
 {
   auto proto = std::make_shared<v1::UnlockRequest>(kv::encode(request));
   const auto id = request.id;
+  const auto retry_attempts = request.retries.retry_attempts();
+  const auto retry_reasons = request.retries.retry_reasons();
   const auto timeout = request.timeout.value_or(timeouts_.key_value);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
@@ -493,21 +534,24 @@ component::execute(operations::unlock_request request,
       }
       stub->async()->Unlock(&ctx, proto.get(), &resp, std::move(cb));
     },
-    [handler = std::move(handler), id, proto](grpc::Status status,
-                                              v1::UnlockResponse resp) mutable {
+    [handler = std::move(handler), id, proto, retry_attempts, retry_reasons](
+      grpc::Status status, v1::UnlockResponse resp) mutable {
       (void)proto; // kept only to keep the request alive for the call
-      auto ctx = make_error_context(status, id, operation_kind::mutating);
+      auto ctx =
+        make_error_context(status, id, operation_kind::mutating, retry_attempts, retry_reasons);
       handler(kv::decode(resp, std::move(ctx)));
     });
 }
 
 auto
-component::execute(operations::get_and_touch_request request,
+component::execute(const operations::get_and_touch_request& request,
                    utils::movable_function<void(operations::get_and_touch_response)>&& handler)
   -> pending_call
 {
   auto proto = std::make_shared<v1::GetAndTouchRequest>(kv::encode(request));
   const auto id = request.id;
+  const auto retry_attempts = request.retries.retry_attempts();
+  const auto retry_reasons = request.retries.retry_reasons();
   const auto timeout = request.timeout.value_or(timeouts_.key_value);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
@@ -524,12 +568,14 @@ component::execute(operations::get_and_touch_request request,
       }
       stub->async()->GetAndTouch(&ctx, proto.get(), &resp, std::move(cb));
     },
-    [handler = std::move(handler), id, proto](grpc::Status status,
-                                              v1::GetAndTouchResponse resp) mutable {
+    [handler = std::move(handler), id, proto, retry_attempts, retry_reasons](
+      grpc::Status status, v1::GetAndTouchResponse resp) mutable {
       (void)proto; // kept only to keep the request alive for the call
-      auto ctx = make_error_context(status, id, operation_kind::mutating);
+      auto ctx =
+        make_error_context(status, id, operation_kind::mutating, retry_attempts, retry_reasons);
       if (status.ok() && resp.content_case() == v1::GetAndTouchResponse::kContentCompressed) {
-        ctx = make_key_value_error_context(errc::common::feature_not_available, id);
+        ctx = make_key_value_error_context(
+          errc::common::feature_not_available, id, retry_attempts, retry_reasons);
       }
       handler(kv::decode(resp, std::move(ctx)));
     });
@@ -570,7 +616,7 @@ fail_invalid_argument(asio::io_context& io, const Request& request, Handler& han
 } // namespace
 
 auto
-component::execute(operations::increment_request request,
+component::execute(const operations::increment_request& request,
                    utils::movable_function<void(operations::increment_response)>&& handler)
   -> pending_call
 {
@@ -579,6 +625,8 @@ component::execute(operations::increment_request request,
   }
   auto proto = std::make_shared<v1::IncrementRequest>(kv::encode(request));
   const auto id = request.id;
+  const auto retry_attempts = request.retries.retry_attempts();
+  const auto retry_reasons = request.retries.retry_reasons();
   const auto timeout = request.timeout.value_or(timeouts_.key_value);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
@@ -594,16 +642,17 @@ component::execute(operations::increment_request request,
       }
       stub->async()->Increment(&ctx, proto.get(), &resp, std::move(cb));
     },
-    [handler = std::move(handler), id, proto](grpc::Status status,
-                                              v1::IncrementResponse resp) mutable {
+    [handler = std::move(handler), id, proto, retry_attempts, retry_reasons](
+      grpc::Status status, v1::IncrementResponse resp) mutable {
       (void)proto; // kept only to keep the request alive for the call
-      auto ctx = make_error_context(status, id, operation_kind::mutating);
+      auto ctx =
+        make_error_context(status, id, operation_kind::mutating, retry_attempts, retry_reasons);
       handler(kv::decode(resp, std::move(ctx)));
     });
 }
 
 auto
-component::execute(operations::decrement_request request,
+component::execute(const operations::decrement_request& request,
                    utils::movable_function<void(operations::decrement_response)>&& handler)
   -> pending_call
 {
@@ -612,6 +661,8 @@ component::execute(operations::decrement_request request,
   }
   auto proto = std::make_shared<v1::DecrementRequest>(kv::encode(request));
   const auto id = request.id;
+  const auto retry_attempts = request.retries.retry_attempts();
+  const auto retry_reasons = request.retries.retry_reasons();
   const auto timeout = request.timeout.value_or(timeouts_.key_value);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
@@ -627,21 +678,24 @@ component::execute(operations::decrement_request request,
       }
       stub->async()->Decrement(&ctx, proto.get(), &resp, std::move(cb));
     },
-    [handler = std::move(handler), id, proto](grpc::Status status,
-                                              v1::DecrementResponse resp) mutable {
+    [handler = std::move(handler), id, proto, retry_attempts, retry_reasons](
+      grpc::Status status, v1::DecrementResponse resp) mutable {
       (void)proto; // kept only to keep the request alive for the call
-      auto ctx = make_error_context(status, id, operation_kind::mutating);
+      auto ctx =
+        make_error_context(status, id, operation_kind::mutating, retry_attempts, retry_reasons);
       handler(kv::decode(resp, std::move(ctx)));
     });
 }
 
 auto
-component::execute(operations::append_request request,
+component::execute(const operations::append_request& request,
                    utils::movable_function<void(operations::append_response)>&& handler)
   -> pending_call
 {
   auto proto = std::make_shared<v1::AppendRequest>(kv::encode(request));
   const auto id = request.id;
+  const auto retry_attempts = request.retries.retry_attempts();
+  const auto retry_reasons = request.retries.retry_reasons();
   const auto timeout = request.timeout.value_or(timeouts_.key_value);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
@@ -657,21 +711,24 @@ component::execute(operations::append_request request,
       }
       stub->async()->Append(&ctx, proto.get(), &resp, std::move(cb));
     },
-    [handler = std::move(handler), id, proto](grpc::Status status,
-                                              v1::AppendResponse resp) mutable {
+    [handler = std::move(handler), id, proto, retry_attempts, retry_reasons](
+      grpc::Status status, v1::AppendResponse resp) mutable {
       (void)proto; // kept only to keep the request alive for the call
-      auto ctx = make_error_context(status, id, operation_kind::mutating);
+      auto ctx =
+        make_error_context(status, id, operation_kind::mutating, retry_attempts, retry_reasons);
       handler(kv::decode(resp, std::move(ctx)));
     });
 }
 
 auto
-component::execute(operations::prepend_request request,
+component::execute(const operations::prepend_request& request,
                    utils::movable_function<void(operations::prepend_response)>&& handler)
   -> pending_call
 {
   auto proto = std::make_shared<v1::PrependRequest>(kv::encode(request));
   const auto id = request.id;
+  const auto retry_attempts = request.retries.retry_attempts();
+  const auto retry_reasons = request.retries.retry_reasons();
   const auto timeout = request.timeout.value_or(timeouts_.key_value);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
@@ -687,16 +744,17 @@ component::execute(operations::prepend_request request,
       }
       stub->async()->Prepend(&ctx, proto.get(), &resp, std::move(cb));
     },
-    [handler = std::move(handler), id, proto](grpc::Status status,
-                                              v1::PrependResponse resp) mutable {
+    [handler = std::move(handler), id, proto, retry_attempts, retry_reasons](
+      grpc::Status status, v1::PrependResponse resp) mutable {
       (void)proto; // kept only to keep the request alive for the call
-      auto ctx = make_error_context(status, id, operation_kind::mutating);
+      auto ctx =
+        make_error_context(status, id, operation_kind::mutating, retry_attempts, retry_reasons);
       handler(kv::decode(resp, std::move(ctx)));
     });
 }
 
 auto
-component::execute(operations::query_request request,
+component::execute(const operations::query_request& request,
                    utils::movable_function<void(operations::query_response)>&& handler)
   -> pending_call
 {
@@ -800,7 +858,7 @@ component::execute(operations::query_request request,
 }
 
 auto
-component::execute(operations::analytics_request request,
+component::execute(const operations::analytics_request& request,
                    utils::movable_function<void(operations::analytics_response)>&& handler)
   -> pending_call
 {
@@ -901,7 +959,7 @@ component::execute(operations::analytics_request request,
 }
 
 auto
-component::execute(operations::search_request request,
+component::execute(const operations::search_request& request,
                    utils::movable_function<void(operations::search_response)>&& handler)
   -> pending_call
 {
@@ -971,7 +1029,7 @@ component::execute(operations::search_request request,
 }
 
 auto
-component::execute(operations::document_view_request request,
+component::execute(const operations::document_view_request& request,
                    utils::movable_function<void(operations::document_view_response)>&& handler)
   -> pending_call
 {
@@ -1036,7 +1094,7 @@ component::execute(operations::document_view_request request,
 
 auto
 component::execute(
-  operations::management::bucket_get_all_request request,
+  const operations::management::bucket_get_all_request& request,
   utils::movable_function<void(operations::management::bucket_get_all_response)>&& handler)
   -> pending_call
 {
@@ -1073,7 +1131,7 @@ component::execute(
 
 auto
 component::execute(
-  operations::management::bucket_get_request request,
+  const operations::management::bucket_get_request& request,
   utils::movable_function<void(operations::management::bucket_get_response)>&& handler)
   -> pending_call
 {
@@ -1122,7 +1180,7 @@ component::execute(
 
 auto
 component::execute(
-  operations::management::bucket_create_request request,
+  const operations::management::bucket_create_request& request,
   utils::movable_function<void(operations::management::bucket_create_response)>&& handler)
   -> pending_call
 {
@@ -1171,7 +1229,7 @@ component::execute(
 
 auto
 component::execute(
-  operations::management::bucket_update_request request,
+  const operations::management::bucket_update_request& request,
   utils::movable_function<void(operations::management::bucket_update_response)>&& handler)
   -> pending_call
 {
@@ -1209,7 +1267,7 @@ component::execute(
 
 auto
 component::execute(
-  operations::management::bucket_drop_request request,
+  const operations::management::bucket_drop_request& request,
   utils::movable_function<void(operations::management::bucket_drop_response)>&& handler)
   -> pending_call
 {
@@ -1244,7 +1302,7 @@ component::execute(
 
 auto
 component::execute(
-  operations::management::bucket_flush_request request,
+  const operations::management::bucket_flush_request& request,
   utils::movable_function<void(operations::management::bucket_flush_response)>&& handler)
   -> pending_call
 {
@@ -1279,7 +1337,7 @@ component::execute(
 
 auto
 component::execute(
-  operations::management::scope_get_all_request request,
+  const operations::management::scope_get_all_request& request,
   utils::movable_function<void(operations::management::scope_get_all_response)>&& handler)
   -> pending_call
 {
@@ -1317,7 +1375,7 @@ component::execute(
 
 auto
 component::execute(
-  operations::management::scope_create_request request,
+  const operations::management::scope_create_request& request,
   utils::movable_function<void(operations::management::scope_create_response)>&& handler)
   -> pending_call
 {
@@ -1354,7 +1412,7 @@ component::execute(
 
 auto
 component::execute(
-  operations::management::scope_drop_request request,
+  const operations::management::scope_drop_request& request,
   utils::movable_function<void(operations::management::scope_drop_response)>&& handler)
   -> pending_call
 {
@@ -1391,7 +1449,7 @@ component::execute(
 
 auto
 component::execute(
-  operations::management::collection_create_request request,
+  const operations::management::collection_create_request& request,
   utils::movable_function<void(operations::management::collection_create_response)>&& handler)
   -> pending_call
 {
@@ -1454,7 +1512,7 @@ component::execute(
 
 auto
 component::execute(
-  operations::management::collection_update_request request,
+  const operations::management::collection_update_request& request,
   utils::movable_function<void(operations::management::collection_update_response)>&& handler)
   -> pending_call
 {
@@ -1529,7 +1587,7 @@ component::execute(
 
 auto
 component::execute(
-  operations::management::collection_drop_request request,
+  const operations::management::collection_drop_request& request,
   utils::movable_function<void(operations::management::collection_drop_response)>&& handler)
   -> pending_call
 {
@@ -1567,7 +1625,7 @@ component::execute(
 
 auto
 component::execute(
-  operations::management::query_index_get_all_request request,
+  const operations::management::query_index_get_all_request& request,
   utils::movable_function<void(operations::management::query_index_get_all_response)>&& handler)
   -> pending_call
 {
@@ -1605,7 +1663,7 @@ component::execute(
 
 auto
 component::execute(
-  operations::management::query_index_create_request request,
+  const operations::management::query_index_create_request& request,
   utils::movable_function<void(operations::management::query_index_create_response)>&& handler)
   -> pending_call
 {
@@ -1674,7 +1732,7 @@ component::execute(
 
 auto
 component::execute(
-  operations::management::query_index_drop_request request,
+  const operations::management::query_index_drop_request& request,
   utils::movable_function<void(operations::management::query_index_drop_response)>&& handler)
   -> pending_call
 {
@@ -1733,7 +1791,7 @@ component::execute(
 
 auto
 component::execute(
-  operations::management::query_index_build_deferred_request request,
+  const operations::management::query_index_build_deferred_request& request,
   utils::movable_function<void(operations::management::query_index_build_deferred_response)>&&
     handler) -> pending_call
 {
@@ -1768,7 +1826,7 @@ component::execute(
 
 auto
 component::execute(
-  operations::management::search_index_upsert_request request,
+  const operations::management::search_index_upsert_request& request,
   utils::movable_function<void(operations::management::search_index_upsert_response)>&& handler)
   -> pending_call
 {
@@ -1862,7 +1920,7 @@ component::execute(
 
 auto
 component::execute(
-  operations::management::search_index_get_request request,
+  const operations::management::search_index_get_request& request,
   utils::movable_function<void(operations::management::search_index_get_response)>&& handler)
   -> pending_call
 {
@@ -1919,7 +1977,7 @@ component::execute(
 
 auto
 component::execute(
-  operations::management::search_index_get_all_request request,
+  const operations::management::search_index_get_all_request& request,
   utils::movable_function<void(operations::management::search_index_get_all_response)>&& handler)
   -> pending_call
 {
@@ -1971,7 +2029,7 @@ component::execute(
 
 auto
 component::execute(
-  operations::management::search_index_drop_request request,
+  const operations::management::search_index_drop_request& request,
   utils::movable_function<void(operations::management::search_index_drop_response)>&& handler)
   -> pending_call
 {
@@ -2016,7 +2074,7 @@ component::execute(
 
 auto
 component::execute(
-  operations::management::search_index_analyze_document_request request,
+  const operations::management::search_index_analyze_document_request& request,
   utils::movable_function<void(operations::management::search_index_analyze_document_response)>&&
     handler) -> pending_call
 {
@@ -2069,7 +2127,7 @@ component::execute(
 
 auto
 component::execute(
-  operations::management::search_index_get_documents_count_request request,
+  const operations::management::search_index_get_documents_count_request& request,
   utils::movable_function<void(operations::management::search_index_get_documents_count_response)>&&
     handler) -> pending_call
 {
@@ -2112,7 +2170,7 @@ component::execute(
 
 auto
 component::execute(
-  operations::management::search_index_control_ingest_request request,
+  const operations::management::search_index_control_ingest_request& request,
   utils::movable_function<void(operations::management::search_index_control_ingest_response)>&&
     handler) -> pending_call
 {
@@ -2186,7 +2244,7 @@ component::execute(
 
 auto
 component::execute(
-  operations::management::search_index_control_query_request request,
+  const operations::management::search_index_control_query_request& request,
   utils::movable_function<void(operations::management::search_index_control_query_response)>&&
     handler) -> pending_call
 {
@@ -2260,7 +2318,7 @@ component::execute(
 
 auto
 component::execute(
-  operations::management::search_index_control_plan_freeze_request request,
+  const operations::management::search_index_control_plan_freeze_request& request,
   utils::movable_function<void(operations::management::search_index_control_plan_freeze_response)>&&
     handler) -> pending_call
 {

--- a/core/protostellar/component.hxx
+++ b/core/protostellar/component.hxx
@@ -160,172 +160,172 @@ public:
   // Out of line: `stubs` is incomplete here, so its deleter cannot be instantiated in this header.
   ~component();
 
-  auto execute(operations::get_request request,
+  auto execute(const operations::get_request& request,
                utils::movable_function<void(operations::get_response)>&& handler) -> pending_call;
-  auto execute(operations::get_projected_request request,
+  auto execute(const operations::get_projected_request& request,
                utils::movable_function<void(operations::get_projected_response)>&& handler)
     -> pending_call;
-  auto execute(operations::upsert_request request,
+  auto execute(const operations::upsert_request& request,
                utils::movable_function<void(operations::upsert_response)>&& handler)
     -> pending_call;
-  auto execute(operations::insert_request request,
+  auto execute(const operations::insert_request& request,
                utils::movable_function<void(operations::insert_response)>&& handler)
     -> pending_call;
-  auto execute(operations::replace_request request,
+  auto execute(const operations::replace_request& request,
                utils::movable_function<void(operations::replace_response)>&& handler)
     -> pending_call;
-  auto execute(operations::remove_request request,
+  auto execute(const operations::remove_request& request,
                utils::movable_function<void(operations::remove_response)>&& handler)
     -> pending_call;
-  auto execute(operations::touch_request request,
+  auto execute(const operations::touch_request& request,
                utils::movable_function<void(operations::touch_response)>&& handler) -> pending_call;
-  auto execute(operations::exists_request request,
+  auto execute(const operations::exists_request& request,
                utils::movable_function<void(operations::exists_response)>&& handler)
     -> pending_call;
-  auto execute(operations::get_and_lock_request request,
+  auto execute(const operations::get_and_lock_request& request,
                utils::movable_function<void(operations::get_and_lock_response)>&& handler)
     -> pending_call;
-  auto execute(operations::unlock_request request,
+  auto execute(const operations::unlock_request& request,
                utils::movable_function<void(operations::unlock_response)>&& handler)
     -> pending_call;
-  auto execute(operations::get_and_touch_request request,
+  auto execute(const operations::get_and_touch_request& request,
                utils::movable_function<void(operations::get_and_touch_response)>&& handler)
     -> pending_call;
-  auto execute(operations::increment_request request,
+  auto execute(const operations::increment_request& request,
                utils::movable_function<void(operations::increment_response)>&& handler)
     -> pending_call;
-  auto execute(operations::decrement_request request,
+  auto execute(const operations::decrement_request& request,
                utils::movable_function<void(operations::decrement_response)>&& handler)
     -> pending_call;
-  auto execute(operations::append_request request,
+  auto execute(const operations::append_request& request,
                utils::movable_function<void(operations::append_response)>&& handler)
     -> pending_call;
-  auto execute(operations::prepend_request request,
+  auto execute(const operations::prepend_request& request,
                utils::movable_function<void(operations::prepend_response)>&& handler)
     -> pending_call;
 
   // N1QL query over the couchbase2 server-streaming transport. Rows are buffered into the response;
   // the terminal message carries the metadata.
-  auto execute(operations::query_request request,
+  auto execute(const operations::query_request& request,
                utils::movable_function<void(operations::query_response)>&& handler) -> pending_call;
 
   // Analytics over the couchbase2 server-streaming transport; same shape as query.
-  auto execute(operations::analytics_request request,
+  auto execute(const operations::analytics_request& request,
                utils::movable_function<void(operations::analytics_response)>&& handler)
     -> pending_call;
 
   // FTS search over the couchbase2 server-streaming transport. Hits are buffered into the response.
-  auto execute(operations::search_request request,
+  auto execute(const operations::search_request& request,
                utils::movable_function<void(operations::search_response)>&& handler)
     -> pending_call;
 
   // Map/reduce views over the couchbase2 server-streaming transport.
-  auto execute(operations::document_view_request request,
+  auto execute(const operations::document_view_request& request,
                utils::movable_function<void(operations::document_view_response)>&& handler)
     -> pending_call;
 
   // Bucket management (unary admin RPCs over admin.bucket.v1).
   auto execute(
-    operations::management::bucket_get_all_request request,
+    const operations::management::bucket_get_all_request& request,
     utils::movable_function<void(operations::management::bucket_get_all_response)>&& handler)
     -> pending_call;
-  auto execute(operations::management::bucket_get_request request,
+  auto execute(const operations::management::bucket_get_request& request,
                utils::movable_function<void(operations::management::bucket_get_response)>&& handler)
     -> pending_call;
   auto execute(
-    operations::management::bucket_create_request request,
+    const operations::management::bucket_create_request& request,
     utils::movable_function<void(operations::management::bucket_create_response)>&& handler)
     -> pending_call;
   auto execute(
-    operations::management::bucket_update_request request,
+    const operations::management::bucket_update_request& request,
     utils::movable_function<void(operations::management::bucket_update_response)>&& handler)
     -> pending_call;
   auto execute(
-    operations::management::bucket_drop_request request,
+    const operations::management::bucket_drop_request& request,
     utils::movable_function<void(operations::management::bucket_drop_response)>&& handler)
     -> pending_call;
   auto execute(
-    operations::management::bucket_flush_request request,
+    const operations::management::bucket_flush_request& request,
     utils::movable_function<void(operations::management::bucket_flush_response)>&& handler)
     -> pending_call;
 
   // Scope/collection management (unary admin RPCs over admin.collection.v1).
   auto execute(
-    operations::management::scope_get_all_request request,
+    const operations::management::scope_get_all_request& request,
     utils::movable_function<void(operations::management::scope_get_all_response)>&& handler)
     -> pending_call;
   auto execute(
-    operations::management::scope_create_request request,
+    const operations::management::scope_create_request& request,
     utils::movable_function<void(operations::management::scope_create_response)>&& handler)
     -> pending_call;
-  auto execute(operations::management::scope_drop_request request,
+  auto execute(const operations::management::scope_drop_request& request,
                utils::movable_function<void(operations::management::scope_drop_response)>&& handler)
     -> pending_call;
   auto execute(
-    operations::management::collection_create_request request,
+    const operations::management::collection_create_request& request,
     utils::movable_function<void(operations::management::collection_create_response)>&& handler)
     -> pending_call;
   auto execute(
-    operations::management::collection_update_request request,
+    const operations::management::collection_update_request& request,
     utils::movable_function<void(operations::management::collection_update_response)>&& handler)
     -> pending_call;
   auto execute(
-    operations::management::collection_drop_request request,
+    const operations::management::collection_drop_request& request,
     utils::movable_function<void(operations::management::collection_drop_response)>&& handler)
     -> pending_call;
 
   // Query index management (unary admin RPCs over admin.query.v1).
   auto execute(
-    operations::management::query_index_get_all_request request,
+    const operations::management::query_index_get_all_request& request,
     utils::movable_function<void(operations::management::query_index_get_all_response)>&& handler)
     -> pending_call;
   auto execute(
-    operations::management::query_index_create_request request,
+    const operations::management::query_index_create_request& request,
     utils::movable_function<void(operations::management::query_index_create_response)>&& handler)
     -> pending_call;
   auto execute(
-    operations::management::query_index_drop_request request,
+    const operations::management::query_index_drop_request& request,
     utils::movable_function<void(operations::management::query_index_drop_response)>&& handler)
     -> pending_call;
   auto execute(
-    operations::management::query_index_build_deferred_request request,
+    const operations::management::query_index_build_deferred_request& request,
     utils::movable_function<void(operations::management::query_index_build_deferred_response)>&&
       handler) -> pending_call;
 
   // Search index management (unary admin RPCs over admin.search.v1).
   auto execute(
-    operations::management::search_index_upsert_request request,
+    const operations::management::search_index_upsert_request& request,
     utils::movable_function<void(operations::management::search_index_upsert_response)>&& handler)
     -> pending_call;
   auto execute(
-    operations::management::search_index_get_request request,
+    const operations::management::search_index_get_request& request,
     utils::movable_function<void(operations::management::search_index_get_response)>&& handler)
     -> pending_call;
   auto execute(
-    operations::management::search_index_get_all_request request,
+    const operations::management::search_index_get_all_request& request,
     utils::movable_function<void(operations::management::search_index_get_all_response)>&& handler)
     -> pending_call;
   auto execute(
-    operations::management::search_index_drop_request request,
+    const operations::management::search_index_drop_request& request,
     utils::movable_function<void(operations::management::search_index_drop_response)>&& handler)
     -> pending_call;
   auto execute(
-    operations::management::search_index_analyze_document_request request,
+    const operations::management::search_index_analyze_document_request& request,
     utils::movable_function<void(operations::management::search_index_analyze_document_response)>&&
       handler) -> pending_call;
-  auto execute(operations::management::search_index_get_documents_count_request request,
+  auto execute(const operations::management::search_index_get_documents_count_request& request,
                utils::movable_function<
                  void(operations::management::search_index_get_documents_count_response)>&& handler)
     -> pending_call;
   auto execute(
-    operations::management::search_index_control_ingest_request request,
+    const operations::management::search_index_control_ingest_request& request,
     utils::movable_function<void(operations::management::search_index_control_ingest_response)>&&
       handler) -> pending_call;
   auto execute(
-    operations::management::search_index_control_query_request request,
+    const operations::management::search_index_control_query_request& request,
     utils::movable_function<void(operations::management::search_index_control_query_response)>&&
       handler) -> pending_call;
-  auto execute(operations::management::search_index_control_plan_freeze_request request,
+  auto execute(const operations::management::search_index_control_plan_freeze_request& request,
                utils::movable_function<
                  void(operations::management::search_index_control_plan_freeze_response)>&& handler)
     -> pending_call;

--- a/core/protostellar/error_utils.cxx
+++ b/core/protostellar/error_utils.cxx
@@ -241,8 +241,28 @@ error_message(const grpc::Status& status) -> std::string
 }
 
 auto
-make_error_context(const grpc::Status& status, const document_id& id, operation_kind kind)
-  -> key_value_error_context
+retry_reason_for(std::error_code ec) -> std::optional<couchbase::retry_reason>
+{
+  // UNAVAILABLE maps to temporary_failure (error_utils map_status_code): the call did not reach a
+  // healthy server, so it is safe to retry (even for mutations — the strategy's
+  // allows_non_idempotent_retry(service_not_available) permits it). Everything else is terminal at
+  // the transport: timeouts consumed the budget, cas_mismatch/auth/not_found are semantic.
+  if (ec == errc::common::temporary_failure) {
+    return couchbase::retry_reason::service_not_available;
+  }
+  // A locked document (FAILED_PRECONDITION "LOCKED") is retried with backoff per RFC 77.
+  if (ec == errc::key_value::document_locked) {
+    return couchbase::retry_reason::key_value_locked;
+  }
+  return std::nullopt;
+}
+
+auto
+make_error_context(const grpc::Status& status,
+                   const document_id& id,
+                   operation_kind kind,
+                   std::size_t retry_attempts,
+                   std::set<couchbase::retry_reason> retry_reasons) -> key_value_error_context
 {
   const auto ec = map_status(status, kind);
   std::optional<key_value_extended_error_info> extended{};
@@ -256,8 +276,8 @@ make_error_context(const grpc::Status& status, const document_id& id, operation_
     ec,
     {},
     {},
-    0,
-    {},
+    retry_attempts,
+    std::move(retry_reasons),
     id.key(),
     id.bucket(),
     id.scope(),

--- a/core/protostellar/error_utils.hxx
+++ b/core/protostellar/error_utils.hxx
@@ -17,8 +17,13 @@
 
 #pragma once
 
+#include <couchbase/retry_reason.hxx>
+
 #include <grpcpp/grpcpp.h>
 
+#include <cstddef>
+#include <optional>
+#include <set>
 #include <string>
 #include <system_error>
 
@@ -68,8 +73,25 @@ error_message(const grpc::Status& status) -> std::string;
 // Build a KV error context from a gRPC status: maps the status code to an error_code and, on
 // failure, attaches the server-provided message (see error_message) as the context's
 // human-readable explanation so callers see why the gateway rejected the operation.
+//
+// The retry counters are parameters rather than fixed at zero because only the caller knows them:
+// the retry loop lives in cluster_impl and accumulates them across attempts, while this function
+// sees one attempt at a time. RFC 77 makes them part of the error context, so a couchbase2
+// operation that was retried has to report it the way the classic transport does
+// (core/error_context/key_value.cxx carries the same pair for the same reason).
 [[nodiscard]] auto
-make_error_context(const grpc::Status& status, const document_id& id, operation_kind kind)
-  -> key_value_error_context;
+make_error_context(const grpc::Status& status,
+                   const document_id& id,
+                   operation_kind kind,
+                   std::size_t retry_attempts = 0,
+                   std::set<couchbase::retry_reason> retry_reasons = {}) -> key_value_error_context;
+
+// Classify a mapped error_code for the couchbase2 retry loop: returns the retry_reason to feed the
+// retry strategy, or nullopt when the error is not retryable at the transport. Transport-level
+// unavailability (UNAVAILABLE -> temporary_failure) and a locked document (document_locked ->
+// key_value_locked, RFC 77) retry; timeouts, cas mismatches, auth, etc. are terminal. Idempotency
+// is enforced downstream by the retry strategy, not here.
+[[nodiscard]] auto
+retry_reason_for(std::error_code ec) -> std::optional<couchbase::retry_reason>;
 
 } // namespace couchbase::core::protostellar

--- a/test/cng/CMakeLists.txt
+++ b/test/cng/CMakeLists.txt
@@ -123,6 +123,9 @@ if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 AND TARGET couchbase_cxx_protostellar)
   add_cng_test(protostellar/component_kv_operations LINK_CLIENT LIBS couchbase_cxx_protostellar)
   add_cng_test(protostellar/live_kv_operations LINK_CLIENT LIBS couchbase_cxx_protostellar)
 
+  # KV transport-level retry, including the overall time budget (CXXCBC-896).
+  add_cng_test(protostellar/kv_retry LINK_CLIENT LIBS couchbase_cxx_protostellar)
+
   # Live KV verification vs a real gateway (CXXCBC-891).
   add_cng_test(protostellar/live_kv LINK_CLIENT LIBS couchbase_cxx_protostellar)
 
@@ -179,4 +182,5 @@ if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 AND TARGET couchbase_cxx_protostellar)
 
   # Live Search index management verification (CXXCBC-901).
   add_cng_test(protostellar/live_search_index_admin LINK_CLIENT LIBS couchbase_cxx_protostellar)
+
 endif()

--- a/test/cng/protostellar/error_utils.cxx
+++ b/test/cng/protostellar/error_utils.cxx
@@ -270,6 +270,30 @@ make_error_context_maps_code_and_attaches_message()
   assert_false(ok_ctx.extended_error_info().has_value(), "success carries no extended error info");
 }
 
+void
+retry_reason_for_classifies_retryable_errors()
+{
+  // UNAVAILABLE -> temporary_failure is the one transport-level retryable condition.
+  const auto retryable = ps::retry_reason_for(couchbase::errc::common::temporary_failure);
+  assert_true(retryable.has_value() &&
+                retryable.value() == couchbase::retry_reason::service_not_available,
+              "temporary_failure retries as service_not_available");
+
+  // Terminal conditions must not retry.
+  assert_false(ps::retry_reason_for(couchbase::errc::common::ambiguous_timeout).has_value(),
+               "ambiguous timeout is terminal");
+  assert_false(ps::retry_reason_for(couchbase::errc::common::cas_mismatch).has_value(),
+               "cas mismatch is terminal");
+
+  // A locked document retries with the KV_LOCKED reason (RFC 77).
+  const auto locked = ps::retry_reason_for(couchbase::errc::key_value::document_locked);
+  assert_true(locked.has_value() && locked.value() == couchbase::retry_reason::key_value_locked,
+              "document_locked retries as key_value_locked");
+  assert_false(ps::retry_reason_for(couchbase::errc::key_value::document_not_found).has_value(),
+               "not found is terminal");
+  assert_false(ps::retry_reason_for(std::error_code{}).has_value(), "success does not retry");
+}
+
 } // namespace
 
 auto
@@ -290,6 +314,8 @@ tests() -> test_suite
       { "error_message_prefers_rich_details", error_message_prefers_rich_details },
       { "make_error_context_maps_code_and_attaches_message",
         make_error_context_maps_code_and_attaches_message },
+      { "retry_reason_for_classifies_retryable_errors",
+        retry_reason_for_classifies_retryable_errors },
     },
   };
 }

--- a/test/cng/protostellar/kv_retry.cxx
+++ b/test/cng/protostellar/kv_retry.cxx
@@ -1,0 +1,549 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Transport-level retry for KV couchbase2 operations (CXXCBC-896), specifically the property that a
+// retried operation stays inside its overall time budget. Drives a real core::cluster against a
+// localhost KvService so the whole path -- routing, retry decision, backoff, re-dispatch and the
+// per-attempt deadline -- is exercised together; the budget is a property of their interaction and
+// is not observable from any one of them. Env-agnostic: local server, no external gateway.
+
+#define COUCHBASE_CXX_CLIENT_IGNORE_CORE_DEPRECATIONS
+
+#include "framework/test_runner.hxx"
+
+#include "core/operations.hxx"
+
+#include "core/cluster.hxx"
+
+#include "core/cluster_credentials.hxx"
+#include "core/document_id.hxx"
+#include "core/origin.hxx"
+#include "core/utils/connection_string.hxx"
+
+#include <couchbase/best_effort_retry_strategy.hxx>
+#include <couchbase/error_codes.hxx>
+#include <couchbase/retry_reason.hxx>
+
+#include <couchbase/kv/v1/kv.grpc.pb.h>
+
+#include <asio/executor_work_guard.hpp>
+#include <asio/io_context.hpp>
+
+#include <grpcpp/security/server_credentials.h>
+#include <grpcpp/server_builder.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <future>
+#include <string>
+#include <thread>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace ops = ::couchbase::core::operations;
+namespace v1 = ::couchbase::kv::v1;
+using ::couchbase::core::cluster_credentials;
+using ::couchbase::core::document_id;
+using ::couchbase::core::origin;
+using ::couchbase::core::utils::parse_connection_string;
+using namespace std::chrono_literals;
+
+// Answers UNAVAILABLE (retryable: service_not_available) immediately for the first two dispatches,
+// then stops answering. The pause is what exposes the budget: by the time the third attempt is
+// issued most of the operation's time is already spent on backoff, so the deadline that attempt
+// receives is the whole question.
+class stalling_kv_service final : public v1::KvService::Service
+{
+public:
+  std::atomic<int> calls{ 0 };
+
+  auto Get(grpc::ServerContext* context,
+           const v1::GetRequest* /* request */,
+           v1::GetResponse* /* response */) -> grpc::Status override
+  {
+    if (++calls <= 2) {
+      return { grpc::StatusCode::UNAVAILABLE, "try again" };
+    }
+    // Outlasts any budget this test grants, so the client's deadline is what ends the call -- but
+    // polled rather than slept through, so the handler returns once the client gives up instead of
+    // running on into the suite's teardown and holding the server past Shutdown().
+    const auto give_up_by = std::chrono::steady_clock::now() + 5s;
+    while (!context->IsCancelled() && std::chrono::steady_clock::now() < give_up_by) {
+      std::this_thread::sleep_for(5ms);
+    }
+    return { grpc::StatusCode::UNAVAILABLE, "still unavailable" };
+  }
+};
+
+// Never answers anything but UNAVAILABLE, and answers it immediately. The retry strategy always
+// permits a retry for service_not_available, so nothing here ever ends the loop from below: what
+// ends it is the operation's own deadline.
+class unavailable_kv_service final : public v1::KvService::Service
+{
+public:
+  std::atomic<int> calls{ 0 };
+
+  auto Get(grpc::ServerContext* /* context */,
+           const v1::GetRequest* /* request */,
+           v1::GetResponse* /* response */) -> grpc::Status override
+  {
+    ++calls;
+    return { grpc::StatusCode::UNAVAILABLE, "never available" };
+  }
+
+  // An unimplemented RPC answers UNIMPLEMENTED, which is terminal rather than retryable, so a
+  // mutation against a Get-only service would end on its first attempt without ever entering the
+  // loop this file exists to test -- and the dispatch counter, incremented only in Get, would sit
+  // at zero.
+  auto Upsert(grpc::ServerContext* /* context */,
+              const v1::UpsertRequest* /* request */,
+              v1::UpsertResponse* /* response */) -> grpc::Status override
+  {
+    ++calls;
+    return { grpc::StatusCode::UNAVAILABLE, "never available" };
+  }
+};
+
+// Fails a fixed number of dispatches with UNAVAILABLE and then serves the document, so the number
+// of retries the operation performs is decided by the service rather than by timing.
+class flaky_kv_service final : public v1::KvService::Service
+{
+public:
+  explicit flaky_kv_service(int failures)
+    : failures_{ failures }
+  {
+  }
+
+  std::atomic<int> calls{ 0 };
+
+  auto Get(grpc::ServerContext* /* context */,
+           const v1::GetRequest* /* request */,
+           v1::GetResponse* response) -> grpc::Status override
+  {
+    if (++calls <= failures_) {
+      return { grpc::StatusCode::UNAVAILABLE, "not yet" };
+    }
+    response->set_content_uncompressed("{}");
+    response->set_cas(42);
+    return grpc::Status::OK;
+  }
+
+private:
+  const int failures_;
+};
+
+// A retried operation must finish at its deadline, not at "deadline + one more full timeout".
+//
+// The budget is 400ms and the backoff is a flat 150ms, so the third attempt starts around 300ms in
+// with roughly 100ms of budget left, against a server that has stopped answering. Given the
+// remaining budget the operation ends at ~400ms; given a fresh full-length one it ends at ~700ms.
+// The assertion is placed between those two outcomes, so it fails if an attempt is ever handed more
+// time than the operation has left.
+void
+a_retried_kv_operation_stays_within_its_budget()
+{
+  int port = 0;
+  stalling_kv_service service;
+  grpc::ServerBuilder builder;
+  builder.RegisterService(&service);
+  builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
+  auto server = builder.BuildAndStart();
+
+  auto parsed = parse_connection_string("couchbase2://127.0.0.1:" + std::to_string(port));
+  origin cluster_origin{ cluster_credentials{}, parsed }; // no credentials -> plaintext allowed
+  cluster_origin.options().enable_tls = false;
+  cluster_origin.options().default_retry_strategy_ =
+    couchbase::make_best_effort_retry_strategy([](std::size_t) {
+      return 150ms;
+    });
+
+  asio::io_context io;
+  auto guard = asio::make_work_guard(io);
+  std::thread io_thread([&io]() {
+    io.run();
+  });
+  couchbase::core::cluster cluster{ io };
+
+  std::promise<std::error_code> opened;
+  cluster.open(cluster_origin, [&opened](std::error_code ec) {
+    opened.set_value(ec);
+  });
+  assert_false(static_cast<bool>(opened.get_future().get()), "open(couchbase2://) succeeds");
+
+  ops::get_request request;
+  request.id = document_id{ "b", "s", "c", "k" };
+  request.timeout = 400ms;
+
+  const auto started = std::chrono::steady_clock::now();
+  std::promise<ops::get_response> done;
+  cluster.execute(std::move(request), [&done](ops::get_response response) {
+    done.set_value(std::move(response));
+  });
+  const auto result = done.get_future().get();
+  const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+    std::chrono::steady_clock::now() - started);
+
+  // Tear down before asserting. A failed assertion throws, and unwinding past a still-joinable
+  // std::thread calls std::terminate -- which would replace the assertion's message with a bare
+  // "terminate called", hiding exactly the failure this case exists to report.
+  std::promise<void> closed;
+  cluster.close([&closed]() {
+    closed.set_value();
+  });
+  closed.get_future().get();
+  guard.reset();
+  io_thread.join();
+  server->Shutdown(std::chrono::system_clock::now());
+
+  // The call count is reported, not just tested: the two ways this can fail -- the first attempt
+  // never reaching the service, or a retry not being issued -- are indistinguishable from a bare
+  // "expected >= 2", and this case previously failed about one run in seven on a loaded machine
+  // with no way to tell which had happened.
+  assert_true(service.calls.load() >= 2,
+              "the operation was retried at least once (dispatches reaching the service: " +
+                std::to_string(service.calls.load()) + ")");
+  // A timeout, not the last attempt's transport error: the operation is entitled to its whole
+  // budget, so it ends on its deadline rather than on whichever UNAVAILABLE arrived last. The read
+  // is idempotent, so the timeout is the unambiguous one.
+  assert_true(result.ctx.ec() == couchbase::errc::common::unambiguous_timeout,
+              "the operation ends on its deadline, reported as a timeout, got: " +
+                result.ctx.ec().message());
+  assert_true(elapsed < 600ms,
+              "a retried operation finishes at its deadline, not a full timeout past it");
+}
+
+// A request issued through the public API carries no timeout unless the caller asked for one, and
+// the strategy never refuses a retry for service_not_available. The bound therefore has to come
+// from the cluster's own key_value_timeout; without that fallback the loop has nothing to stop it
+// and the caller's handler is never invoked -- not a timeout, not an error, no completion at all.
+//
+// key_value_timeout is set well below the stock default so the case both runs quickly and names
+// where the bound comes from: a bound sourced from anywhere else would not honour it. The wait is
+// bounded so that "never completes" fails the case rather than hanging the suite.
+void
+an_operation_without_a_timeout_is_bounded_by_the_cluster_default()
+{
+  int port = 0;
+  unavailable_kv_service service;
+  grpc::ServerBuilder builder;
+  builder.RegisterService(&service);
+  builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
+  auto server = builder.BuildAndStart();
+
+  auto parsed = parse_connection_string("couchbase2://127.0.0.1:" + std::to_string(port));
+  origin cluster_origin{ cluster_credentials{}, parsed };
+  cluster_origin.options().enable_tls = false;
+  cluster_origin.options().key_value_timeout = 400ms;
+  cluster_origin.options().default_retry_strategy_ =
+    couchbase::make_best_effort_retry_strategy([](std::size_t) {
+      return 50ms;
+    });
+
+  asio::io_context io;
+  auto guard = asio::make_work_guard(io);
+  std::thread io_thread([&io]() {
+    io.run();
+  });
+  couchbase::core::cluster cluster{ io };
+
+  std::promise<std::error_code> opened;
+  cluster.open(cluster_origin, [&opened](std::error_code ec) {
+    opened.set_value(ec);
+  });
+  assert_false(static_cast<bool>(opened.get_future().get()), "open(couchbase2://) succeeds");
+
+  ops::get_request request;
+  request.id = document_id{ "b", "s", "c", "k" };
+  // No request.timeout: this is what a caller who passes no options sends.
+
+  const auto started = std::chrono::steady_clock::now();
+  std::promise<ops::get_response> done;
+  auto answered = done.get_future();
+  cluster.execute(std::move(request), [&done](ops::get_response response) {
+    done.set_value(std::move(response));
+  });
+  const auto arrived = answered.wait_for(5s) == std::future_status::ready;
+  const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+    std::chrono::steady_clock::now() - started);
+  // Only retrieved once known ready: get() on an unfulfilled future would block here, turning a
+  // dropped completion into a hung suite rather than the named failure asserted below.
+  const auto terminal_ec = arrived ? answered.get().ctx.ec() : std::error_code{};
+
+  std::promise<void> closed;
+  cluster.close([&closed]() {
+    closed.set_value();
+  });
+  closed.get_future().get();
+  guard.reset();
+  io_thread.join();
+  server->Shutdown(std::chrono::system_clock::now());
+
+  assert_true(arrived, "an operation carrying no timeout of its own still completes");
+  assert_true(elapsed < 2s, "and is bounded by the cluster's key_value_timeout");
+  assert_true(service.calls.load() >= 2,
+              "it did retry before giving up (dispatches reaching the service: " +
+                std::to_string(service.calls.load()) + ")");
+  // Which answer the bound produces, not merely that one arrives. Ending on the deadline is a
+  // timeout; ending on the last attempt's response would surface the transport's temporary_failure
+  // instead, which is what the classic transport would never report for this condition.
+  assert_true(terminal_ec == couchbase::errc::common::unambiguous_timeout,
+              "and reports the deadline as a timeout, got: " + terminal_ec.message());
+}
+
+// The loop accumulates attempts and reasons across re-issues, and RFC 77 makes both part of the
+// error context. They are reported from the request the loop carries, so what the caller reads is
+// what the loop actually did -- the count was previously pinned at zero in make_error_context, so
+// an operation retried twenty-nine times reported none of them.
+//
+// The service decides the number of retries rather than the clock, which is what makes the exact
+// count assertable.
+void
+a_retried_operation_reports_its_attempts_and_reasons()
+{
+  int port = 0;
+  flaky_kv_service service{ 2 };
+  grpc::ServerBuilder builder;
+  builder.RegisterService(&service);
+  builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
+  auto server = builder.BuildAndStart();
+
+  auto parsed = parse_connection_string("couchbase2://127.0.0.1:" + std::to_string(port));
+  origin cluster_origin{ cluster_credentials{}, parsed };
+  cluster_origin.options().enable_tls = false;
+  cluster_origin.options().default_retry_strategy_ =
+    couchbase::make_best_effort_retry_strategy([](std::size_t) {
+      return 50ms;
+    });
+
+  asio::io_context io;
+  auto guard = asio::make_work_guard(io);
+  std::thread io_thread([&io]() {
+    io.run();
+  });
+  couchbase::core::cluster cluster{ io };
+
+  std::promise<std::error_code> opened;
+  cluster.open(cluster_origin, [&opened](std::error_code ec) {
+    opened.set_value(ec);
+  });
+  assert_false(static_cast<bool>(opened.get_future().get()), "open(couchbase2://) succeeds");
+
+  ops::get_request request;
+  request.id = document_id{ "b", "s", "c", "k" };
+  request.timeout = 5s; // generous: the service, not the deadline, ends the retrying here
+
+  std::promise<ops::get_response> done;
+  cluster.execute(std::move(request), [&done](ops::get_response response) {
+    done.set_value(std::move(response));
+  });
+  const auto result = done.get_future().get();
+
+  std::promise<void> closed;
+  cluster.close([&closed]() {
+    closed.set_value();
+  });
+  closed.get_future().get();
+  guard.reset();
+  io_thread.join();
+  server->Shutdown(std::chrono::system_clock::now());
+
+  assert_false(static_cast<bool>(result.ctx.ec()), "the third attempt succeeds");
+  assert_eq(result.ctx.retry_attempts(), std::size_t{ 2 }, "both retries are reported");
+  assert_eq(result.ctx.retry_reasons().count(couchbase::retry_reason::service_not_available),
+            std::size_t{ 1 },
+            "and the reason they were retried for is reported with them");
+}
+
+// A mutation that exhausted its budget after being dispatched is ambiguous, and must say so.
+//
+// Once the loop ends an operation on its deadline rather than on the last attempt's response, the
+// path that reports it has to decide the same question the classic transport decides in
+// mcbp_command::cancel(): whether the server may have applied the write. It is decided by whether
+// anything was ever sent, not by whether the final attempt was -- the attempt that ends the
+// operation sends nothing, but its predecessors did. A caller that declines to replay ambiguous
+// mutations depends on this, and unambiguous_timeout would tell it the write provably never landed.
+//
+// The read in the sibling cases covers the other arm: idempotent, so unambiguous either way.
+void
+a_retried_mutation_that_runs_out_of_budget_is_ambiguous()
+{
+  int port = 0;
+  unavailable_kv_service service;
+  grpc::ServerBuilder builder;
+  builder.RegisterService(&service);
+  builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
+  auto server = builder.BuildAndStart();
+
+  auto parsed = parse_connection_string("couchbase2://127.0.0.1:" + std::to_string(port));
+  origin cluster_origin{ cluster_credentials{}, parsed };
+  cluster_origin.options().enable_tls = false;
+  cluster_origin.options().default_retry_strategy_ =
+    couchbase::make_best_effort_retry_strategy([](std::size_t) {
+      return 50ms;
+    });
+
+  asio::io_context io;
+  auto guard = asio::make_work_guard(io);
+  std::thread io_thread([&io]() {
+    io.run();
+  });
+  couchbase::core::cluster cluster{ io };
+
+  std::promise<std::error_code> opened;
+  cluster.open(cluster_origin, [&opened](std::error_code ec) {
+    opened.set_value(ec);
+  });
+  assert_false(static_cast<bool>(opened.get_future().get()), "open(couchbase2://) succeeds");
+
+  ops::upsert_request request;
+  request.id = document_id{ "b", "s", "c", "k" };
+  request.value = couchbase::core::utils::to_binary("{}");
+  request.timeout = 400ms;
+
+  std::promise<ops::upsert_response> done;
+  auto answered = done.get_future();
+  cluster.execute(std::move(request), [&done](ops::upsert_response response) {
+    done.set_value(std::move(response));
+  });
+  const auto arrived = answered.wait_for(5s) == std::future_status::ready;
+  const auto terminal_ec = arrived ? answered.get().ctx.ec() : std::error_code{};
+
+  std::promise<void> closed;
+  cluster.close([&closed]() {
+    closed.set_value();
+  });
+  closed.get_future().get();
+  guard.reset();
+  io_thread.join();
+  server->Shutdown(std::chrono::system_clock::now());
+
+  assert_true(arrived, "the mutation completes");
+  assert_true(service.calls.load() >= 2,
+              "it was dispatched more than once, so the server may have seen it (dispatches: " +
+                std::to_string(service.calls.load()) + ")");
+  assert_true(terminal_ec == couchbase::errc::common::ambiguous_timeout,
+              "a dispatched mutation that ran out of budget is ambiguous, got: " +
+                terminal_ec.message());
+}
+
+// Closing the cluster while an operation sits in its backoff must still answer the caller. The
+// re-entry does not touch protostellar_ directly -- it re-reads through the locked accessor, which
+// returns an empty pointer once close() has run, and answers cluster_closed. What this pins is the
+// property that matters to a caller: the completion is delivered exactly once and is not dropped,
+// whichever side of the close the timer lands on.
+//
+// The bounded wait is what keeps a dropped completion a failing assertion rather than a hung suite.
+void
+closing_the_cluster_during_a_backoff_still_answers()
+{
+  int port = 0;
+  unavailable_kv_service service;
+  grpc::ServerBuilder builder;
+  builder.RegisterService(&service);
+  builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
+  auto server = builder.BuildAndStart();
+
+  auto parsed = parse_connection_string("couchbase2://127.0.0.1:" + std::to_string(port));
+  origin cluster_origin{ cluster_credentials{}, parsed };
+  cluster_origin.options().enable_tls = false;
+  // Long enough that the close below lands inside a backoff rather than between attempts.
+  cluster_origin.options().default_retry_strategy_ =
+    couchbase::make_best_effort_retry_strategy([](std::size_t) {
+      return 300ms;
+    });
+
+  asio::io_context io;
+  auto guard = asio::make_work_guard(io);
+  std::thread io_thread([&io]() {
+    io.run();
+  });
+  couchbase::core::cluster cluster{ io };
+
+  std::promise<std::error_code> opened;
+  cluster.open(cluster_origin, [&opened](std::error_code ec) {
+    opened.set_value(ec);
+  });
+  assert_false(static_cast<bool>(opened.get_future().get()), "open(couchbase2://) succeeds");
+
+  ops::get_request request;
+  request.id = document_id{ "b", "s", "c", "k" };
+  request.timeout = 10s; // the close, not the deadline, is what ends this operation
+
+  std::promise<ops::get_response> done;
+  auto answered = done.get_future();
+  cluster.execute(std::move(request), [&done](ops::get_response response) {
+    done.set_value(std::move(response));
+  });
+
+  // Wait for the first attempt to have been made and failed, so the operation is provably in a
+  // backoff when the cluster closes rather than still connecting. Bounded: if the attempt never
+  // reaches the service the case has not set up what it claims to test, and that should be a named
+  // failure rather than a spin until the harness times the whole suite out.
+  const auto first_attempt_by = std::chrono::steady_clock::now() + 5s;
+  while (service.calls.load() < 1 && std::chrono::steady_clock::now() < first_attempt_by) {
+    std::this_thread::sleep_for(5ms);
+  }
+  const auto reached_the_service = service.calls.load() >= 1;
+
+  std::promise<void> closed;
+  cluster.close([&closed]() {
+    closed.set_value();
+  });
+  closed.get_future().get();
+
+  const auto arrived = answered.wait_for(5s) == std::future_status::ready;
+
+  guard.reset();
+  io_thread.join();
+  server->Shutdown(std::chrono::system_clock::now());
+
+  assert_true(reached_the_service,
+              "the first attempt reached the service, so a backoff was entered");
+  assert_true(arrived, "closing the cluster mid-backoff still answers the caller");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_kv_retry",
+    {
+      { "a_retried_kv_operation_stays_within_its_budget",
+        a_retried_kv_operation_stays_within_its_budget,
+        timeout::slow },
+      { "an_operation_without_a_timeout_is_bounded_by_the_cluster_default",
+        an_operation_without_a_timeout_is_bounded_by_the_cluster_default,
+        timeout::slow },
+      { "a_retried_operation_reports_its_attempts_and_reasons",
+        a_retried_operation_reports_its_attempts_and_reasons,
+        timeout::slow },
+      { "a_retried_mutation_that_runs_out_of_budget_is_ambiguous",
+        a_retried_mutation_that_runs_out_of_budget_is_ambiguous,
+        timeout::slow },
+      { "closing_the_cluster_during_a_backoff_still_answers",
+        closing_the_cluster_during_a_backoff_still_answers,
+        timeout::slow },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test

--- a/test/cng/protostellar/live_observability.cxx
+++ b/test/cng/protostellar/live_observability.cxx
@@ -310,12 +310,14 @@ kv_op_emits_span_and_metric_over_couchbase2()
             std::string{ "_default" },
             "the metric is tagged with the collection");
 
-  // couchbase.retries is deliberately NOT asserted. It is emitted, but make_error_context pins
-  // retry_attempts at 0 and the retry loops never write the accumulated state back, so its value is
-  // always "0" regardless of what happened. Asserting "0" would lock that defect in as expected
-  // behaviour; it is tracked separately (CXXCBC-921).
+  // Only the presence of couchbase.retries is asserted here. The value is real for KV -- the retry
+  // loop's accumulated count reaches the error context -- but this upsert succeeds on its first
+  // attempt, so the only value it can carry is "0", and asserting that would pass just as well if
+  // the plumbing were removed again. What the count reports is pinned where it can fail:
+  // protostellar/kv_retry.cxx drives an operation that is actually retried. The other services
+  // still report zero whatever happened (CXXCBC-921).
   assert_false(observed->tag("upsert", "couchbase.retries").empty(),
-               "the retry attribute is present (its value is tracked by CXXCBC-921)");
+               "the retry attribute is present");
 }
 
 } // namespace


### PR DESCRIPTION
couchbase2 operations executed once and returned immediately, ignoring the transport-agnostic retry machinery every request already carries. Feed the KV path into it.

error_utils gains retry_reason_for(error_code): a transport UNAVAILABLE (mapped to temporary_failure) becomes service_not_available; everything else -- timeouts, cas mismatch, auth, not-found -- is terminal. cluster_impl wraps the KV protostellar dispatch in execute_protostellar: on a retryable error it consults request.retries' strategy (falling back to the origin default) and, if it says retry, re-issues after the backoff. Query/analytics/search/view/management carry no retry_context and continue to dispatch directly.

Every operation is bounded by a deadline resolved before the first attempt -- the request's own timeout, or the cluster's key_value_timeout when it carries none -- and each attempt is issued against what is left of that deadline rather than a fresh full-length one. The fallback is what bounds the loop at all: the public API leaves the per-operation timeout unset unless the caller asks for one, and the strategy never refuses a retry for service_not_available. Idempotency is enforced by the strategy, so ambiguous mutations are not replayed. A backoff that would land past the deadline is capped to it rather than refusing the retry, so the operation spends its whole budget and ends on the deadline as a timeout instead of on the last attempt's transport error. The attempt scheduled at the deadline receives a non-positive remainder, which the component answers as a timeout carrying the accumulated attempts and reasons. That timeout is the ambiguous one for a non-idempotent operation already dispatched at least once, and the unambiguous one otherwise -- the rule mcbp_command::cancel() applies on the classic path.

The request is held by shared_ptr and re-issued from it, and component::execute takes it by const reference, so an operation no longer copies its whole request -- for a mutation, the document body -- before every dispatch.

make_error_context takes the retry attempt count and reason set rather than pinning them at zero, sourced from the request the loop carries. A retried KV operation reports both in its error context, as RFC 77 requires and as the classic transport already does; the other services still report zero over couchbase2 (CXXCBC-921).

--- Stacked PR **21/30** in the CNG (`couchbase2://`) transport series. The change specific to this PR is its top commit; the commits beneath it belong to earlier PRs in the series. Depends on #1042 — merge the series bottom-up.
