### PR TITLE
CXXCBC-904: honor kv_durable_timeout for durable KV mutations over couchbase2

### DIFF
--- a/core/cluster.cxx
+++ b/core/cluster.cxx
@@ -325,6 +325,24 @@ protostellar_response_ec(const Context& ctx) -> std::error_code
 {
   return ctx.ec;
 }
+
+// The cluster's configured timeouts, in the form the component and the retry loop both read them
+// from. Assigned per field rather than brace-initialised positionally: every member has the same
+// type, so a mis-ordering is not a compile error, and an omitted one silently takes the struct's
+// own default instead of the value the caller configured.
+inline auto
+make_component_timeouts(const cluster_options& options) -> protostellar::component_timeouts
+{
+  protostellar::component_timeouts timeouts{};
+  timeouts.key_value = options.key_value_timeout;
+  timeouts.key_value_durable = options.key_value_durable_timeout;
+  timeouts.query = options.query_timeout;
+  timeouts.analytics = options.analytics_timeout;
+  timeouts.search = options.search_timeout;
+  timeouts.view = options.view_timeout;
+  timeouts.management = options.management_timeout;
+  return timeouts;
+}
 #endif
 } // namespace
 
@@ -993,14 +1011,7 @@ public:
       protostellar_ = std::make_shared<protostellar::component>(
         ctx_,
         protostellar::component_config{
-          std::move(channel), origin_.credentials(), protostellar::component_timeouts {
-            options.key_value_timeout,
-            options.query_timeout,
-            options.analytics_timeout,
-            options.search_timeout,
-            options.view_timeout,
-            options.management_timeout
-          } });
+          std::move(channel), origin_.credentials(), make_component_timeouts(options) });
     }
     CB_LOG_INFO(R"(open couchbase2 cluster, id: "{}", endpoint: "{}")", id_, endpoint);
     return handler({});
@@ -1044,16 +1055,26 @@ public:
   // for one, and the strategy never refuses a retry for service_not_available, so a request issued
   // with default options against an unavailable gateway would otherwise retry until the process
   // ended -- never completing, and never reporting an error either.
+  //
+  // Which default applies is resolve_kv_timeout's rule, not a second copy of it: a durable mutation
+  // is bounded by KvDurableTimeout and everything else by the standard KV timeout. It has to be
+  // applied here, because dispatch_protostellar narrows request->timeout on every attempt including
+  // the first -- so the component is always handed an engaged timeout and its own fallback never
+  // selects for a request that arrives through this loop. Resolving with the standard default here
+  // would cap a durable mutation at the budget the durable default exists to replace.
   template<class Request, class Handler>
   void execute_protostellar(Request request, Handler&& handler)
   {
-    // The fallback below is the KV default, so routing anything else here would bound it with a
+    // The fallback below is a KV default, so routing anything else here would bound it with a
     // budget belonging to another service. Non-KV requests carry no retry_context and have their
     // own path.
     static_assert(protostellar::component_supports_v<Request>,
                   "execute_protostellar resolves the key-value timeout");
-    const auto deadline = std::chrono::steady_clock::now() +
-                          request.timeout.value_or(origin_.options().key_value_timeout);
+    const auto deadline =
+      std::chrono::steady_clock::now() +
+      protostellar::resolve_kv_timeout(request.timeout,
+                                       protostellar::requested_durability(request),
+                                       make_component_timeouts(origin_.options()));
     // Held by shared_ptr and re-issued from there. The request owns the document body for a
     // mutation, so copying it to keep a re-issue possible charged every operation on the data plane
     // for a retry that in normal operation never happens.

--- a/core/protostellar/component.cxx
+++ b/core/protostellar/component.cxx
@@ -279,7 +279,7 @@ component::execute(const operations::upsert_request& request,
                    utils::movable_function<void(operations::upsert_response)>&& handler)
   -> pending_call
 {
-  const auto timeout = request.timeout.value_or(timeouts_.key_value);
+  const auto timeout = resolve_kv_timeout(request.timeout, request.durability_level, timeouts_);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
   }
@@ -312,7 +312,7 @@ component::execute(const operations::insert_request& request,
                    utils::movable_function<void(operations::insert_response)>&& handler)
   -> pending_call
 {
-  const auto timeout = request.timeout.value_or(timeouts_.key_value);
+  const auto timeout = resolve_kv_timeout(request.timeout, request.durability_level, timeouts_);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
   }
@@ -345,7 +345,7 @@ component::execute(const operations::replace_request& request,
                    utils::movable_function<void(operations::replace_response)>&& handler)
   -> pending_call
 {
-  const auto timeout = request.timeout.value_or(timeouts_.key_value);
+  const auto timeout = resolve_kv_timeout(request.timeout, request.durability_level, timeouts_);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
   }
@@ -378,7 +378,7 @@ component::execute(const operations::remove_request& request,
                    utils::movable_function<void(operations::remove_response)>&& handler)
   -> pending_call
 {
-  const auto timeout = request.timeout.value_or(timeouts_.key_value);
+  const auto timeout = resolve_kv_timeout(request.timeout, request.durability_level, timeouts_);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
   }
@@ -627,7 +627,7 @@ component::execute(const operations::increment_request& request,
   const auto id = request.id;
   const auto retry_attempts = request.retries.retry_attempts();
   const auto retry_reasons = request.retries.retry_reasons();
-  const auto timeout = request.timeout.value_or(timeouts_.key_value);
+  const auto timeout = resolve_kv_timeout(request.timeout, request.durability_level, timeouts_);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
   }
@@ -663,7 +663,7 @@ component::execute(const operations::decrement_request& request,
   const auto id = request.id;
   const auto retry_attempts = request.retries.retry_attempts();
   const auto retry_reasons = request.retries.retry_reasons();
-  const auto timeout = request.timeout.value_or(timeouts_.key_value);
+  const auto timeout = resolve_kv_timeout(request.timeout, request.durability_level, timeouts_);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
   }
@@ -696,7 +696,7 @@ component::execute(const operations::append_request& request,
   const auto id = request.id;
   const auto retry_attempts = request.retries.retry_attempts();
   const auto retry_reasons = request.retries.retry_reasons();
-  const auto timeout = request.timeout.value_or(timeouts_.key_value);
+  const auto timeout = resolve_kv_timeout(request.timeout, request.durability_level, timeouts_);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
   }
@@ -729,7 +729,7 @@ component::execute(const operations::prepend_request& request,
   const auto id = request.id;
   const auto retry_attempts = request.retries.retry_attempts();
   const auto retry_reasons = request.retries.retry_reasons();
-  const auto timeout = request.timeout.value_or(timeouts_.key_value);
+  const auto timeout = resolve_kv_timeout(request.timeout, request.durability_level, timeouts_);
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
   }

--- a/core/protostellar/component.hxx
+++ b/core/protostellar/component.hxx
@@ -30,6 +30,7 @@
 // context. cluster_impl routes KV ops here when the cluster was opened with couchbase2://.
 
 #include "core/cluster_credentials.hxx"
+#include "core/io/mcbp_traits.hxx"
 #include "core/operations/document_analytics.hxx"
 #include "core/operations/document_append.hxx"
 #include "core/operations/document_decrement.hxx"
@@ -98,6 +99,7 @@ struct component_timeouts {
   std::chrono::milliseconds search{ timeout_defaults::search_timeout };
   std::chrono::milliseconds view{ timeout_defaults::view_timeout };
   std::chrono::milliseconds management{ timeout_defaults::management_timeout };
+  std::chrono::milliseconds key_value_durable{ timeout_defaults::key_value_durable_timeout };
 };
 
 // Construction parameters for `component`, grouped so that adding one is a source-compatible
@@ -146,8 +148,40 @@ inline constexpr bool component_supports_v<operations::append_request> = true;
 template<>
 inline constexpr bool component_supports_v<operations::prepend_request> = true;
 
-// Default per-service operation timeouts applied when a request does not carry its own. Grouped in
-// a struct so adding a service does not grow the component constructor's positional argument list.
+// Resolves the effective timeout for a KV operation: the request's own timeout if set, else the
+// per-service default — the durable default for a synchronous-durability mutation (RFC 77
+// KvDurableTimeout), the standard KV default otherwise. Free function so it is unit-testable.
+//
+// No lower bound is imposed on an explicit request timeout. The MCBP path raises a durable
+// operation's timeout to a 1500ms floor, which it needs because it has no durable default at all
+// and a durable write there inherits the 2.5s KV budget; resolving KvDurableTimeout is the
+// RFC-specified mechanism for that, and neither RFC 59 nor RFC 77 states a floor. A caller who
+// names a timeout gets the one they named.
+[[nodiscard]] inline auto
+resolve_kv_timeout(std::optional<std::chrono::milliseconds> request_timeout,
+                   couchbase::durability_level level,
+                   const component_timeouts& timeouts) -> std::chrono::milliseconds
+{
+  const auto fallback =
+    (level == couchbase::durability_level::none) ? timeouts.key_value : timeouts.key_value_durable;
+  return request_timeout.value_or(fallback);
+}
+
+// The durability level a request asks for, or `none` for a request type that cannot carry one.
+// Lets a caller generic over the request type apply the rule above without knowing which types
+// have the member; `supports_durability_v` is the same trait the MCBP path keys its own durability
+// handling on, so the two transports agree on which operations are durable.
+template<class Request>
+[[nodiscard]] auto
+requested_durability(const Request& request) -> couchbase::durability_level
+{
+  if constexpr (io::mcbp_traits::supports_durability_v<Request>) {
+    return request.durability_level;
+  } else {
+    static_cast<void>(request);
+    return couchbase::durability_level::none;
+  }
+}
 
 class component
 {

--- a/test/cng/CMakeLists.txt
+++ b/test/cng/CMakeLists.txt
@@ -183,4 +183,6 @@ if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 AND TARGET couchbase_cxx_protostellar)
   # Live Search index management verification (CXXCBC-901).
   add_cng_test(protostellar/live_search_index_admin LINK_CLIENT LIBS couchbase_cxx_protostellar)
 
+  # KV durable-timeout resolution (CXXCBC-904).
+  add_cng_test(protostellar/component_timeouts LINK_CLIENT LIBS couchbase_cxx_protostellar)
 endif()

--- a/test/cng/protostellar/component_timeouts.cxx
+++ b/test/cng/protostellar/component_timeouts.cxx
@@ -1,0 +1,325 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// KV timeout resolution over couchbase2 (CXXCBC-904): a durable mutation falls back to the durable
+// timeout (RFC 77 KvDurableTimeout), a non-durable operation to the standard KV timeout, and an
+// explicit request timeout wins over both.
+//
+// Two layers, because they fail independently. The first cases pin the rule, which is pure. The
+// last two pin the wiring -- that the value a caller configured is the one a real operation is
+// dispatched with -- by reading the gRPC deadline arriving at a localhost KvService. Nothing
+// between the cluster options and the wire reports which budget was chosen, so the deadline the
+// server observes is the only place that choice becomes visible.
+
+#define COUCHBASE_CXX_CLIENT_IGNORE_CORE_DEPRECATIONS
+
+#include "framework/test_runner.hxx"
+
+#include "core/operations.hxx"
+
+#include "core/cluster.hxx"
+
+#include "core/cluster_credentials.hxx"
+#include "core/document_id.hxx"
+#include "core/origin.hxx"
+#include "core/protostellar/component.hxx"
+#include "core/utils/binary.hxx"
+#include "core/utils/connection_string.hxx"
+
+#include <couchbase/durability_level.hxx>
+
+#include <couchbase/kv/v1/kv.grpc.pb.h>
+
+#include <asio/executor_work_guard.hpp>
+#include <asio/io_context.hpp>
+
+#include <grpcpp/security/server_credentials.h>
+#include <grpcpp/server_builder.h>
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <future>
+#include <optional>
+#include <string>
+#include <thread>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace ops = ::couchbase::core::operations;
+namespace ps = ::couchbase::core::protostellar;
+namespace v1 = ::couchbase::kv::v1;
+namespace cu = ::couchbase::core::utils;
+using ::couchbase::core::cluster_credentials;
+using ::couchbase::core::document_id;
+using ::couchbase::core::origin;
+using ::couchbase::core::utils::parse_connection_string;
+using namespace std::chrono_literals;
+
+auto
+sample_timeouts() -> ps::component_timeouts
+{
+  ps::component_timeouts t{};
+  t.key_value = 2'500ms;
+  t.key_value_durable = 10'000ms;
+  return t;
+}
+
+void
+non_durable_uses_the_standard_kv_timeout()
+{
+  const auto t = sample_timeouts();
+  assert_true(ps::resolve_kv_timeout(std::nullopt, couchbase::durability_level::none, t) == 2'500ms,
+              "no durability -> standard key_value timeout");
+}
+
+void
+durable_uses_the_durable_timeout()
+{
+  const auto t = sample_timeouts();
+  assert_true(ps::resolve_kv_timeout(std::nullopt, couchbase::durability_level::majority, t) ==
+                10'000ms,
+              "majority durability -> durable timeout");
+  assert_true(ps::resolve_kv_timeout(
+                std::nullopt, couchbase::durability_level::persist_to_majority, t) == 10'000ms,
+              "persist_to_majority -> durable timeout");
+  assert_true(ps::resolve_kv_timeout(std::nullopt,
+                                     couchbase::durability_level::majority_and_persist_to_active,
+                                     t) == 10'000ms,
+              "majority_and_persist_to_active -> durable timeout");
+}
+
+void
+explicit_request_timeout_always_wins()
+{
+  const auto t = sample_timeouts();
+  assert_true(ps::resolve_kv_timeout(1'234ms, couchbase::durability_level::none, t) == 1'234ms,
+              "request timeout wins for non-durable");
+  assert_true(ps::resolve_kv_timeout(1'234ms, couchbase::durability_level::majority, t) == 1'234ms,
+              "request timeout wins for durable");
+}
+
+// No floor is applied to an explicit timeout, at any durability level.
+//
+// The rows come from gocb's own table for this rule (kvopmanager_core_test.go), which pairs each
+// durability level with a timeout below 1500ms; gocb expects each to be coerced up to that floor,
+// on its couchbase2 path as well as its classic one. This transport expects the opposite, so the
+// levels are enumerated rather than sampled: a floor introduced later would most likely be written
+// as a single guard covering every level, and one level asserted would be enough to catch it, but
+// a guard applied to only the persistence levels -- which is the shape of the disagreement between
+// SDKs here -- would slip past a majority-only case.
+void
+an_explicit_timeout_is_never_raised_to_a_floor()
+{
+  const auto t = sample_timeouts();
+  const std::array<couchbase::durability_level, 3> durable_levels{
+    couchbase::durability_level::majority,
+    couchbase::durability_level::majority_and_persist_to_active,
+    couchbase::durability_level::persist_to_majority,
+  };
+  for (const auto level : durable_levels) {
+    assert_true(ps::resolve_kv_timeout(1'000ms, level, t) == 1'000ms,
+                "a sub-floor explicit timeout is dispatched as given");
+    assert_true(ps::resolve_kv_timeout(100ms, level, t) == 100ms,
+                "and so is one far below the floor");
+  }
+}
+
+// The rule is keyed on the level a request asks for, and a request type that cannot carry one asks
+// for none. That is what keeps a read out of the durable budget: get_request has no
+// durability_level member at all, so there is no value it could supply that selects it.
+void
+a_request_that_cannot_be_durable_asks_for_no_durability()
+{
+  const ops::get_request read;
+  assert_true(ps::requested_durability(read) == couchbase::durability_level::none,
+              "a read asks for no durability");
+
+  ops::upsert_request mutation;
+  mutation.durability_level = couchbase::durability_level::majority;
+  assert_true(ps::requested_durability(mutation) == couchbase::durability_level::majority,
+              "a mutation asks for the level it was given");
+
+  const ops::upsert_request plain_mutation;
+  assert_true(ps::requested_durability(plain_mutation) == couchbase::durability_level::none,
+              "a mutation that requested no durability asks for none");
+}
+
+// Records the deadline each call arrives with, which is the only observable that names which budget
+// the client resolved. Answers immediately, so what the case measures is the deadline and not the
+// clock.
+class deadline_recording_kv_service final : public v1::KvService::Service
+{
+public:
+  std::atomic<int> calls{ 0 };
+  std::atomic<std::int64_t> observed_budget_ms{ -1 };
+
+  auto Get(grpc::ServerContext* context,
+           const v1::GetRequest* /* request */,
+           v1::GetResponse* response) -> grpc::Status override
+  {
+    record(context);
+    response->set_content_uncompressed("{}");
+    response->set_cas(42);
+    return grpc::Status::OK;
+  }
+
+  auto Upsert(grpc::ServerContext* context,
+              const v1::UpsertRequest* /* request */,
+              v1::UpsertResponse* response) -> grpc::Status override
+  {
+    record(context);
+    response->set_cas(42);
+    return grpc::Status::OK;
+  }
+
+private:
+  void record(const grpc::ServerContext* context)
+  {
+    ++calls;
+    observed_budget_ms.store(std::chrono::duration_cast<std::chrono::milliseconds>(
+                               context->deadline() - std::chrono::system_clock::now())
+                               .count());
+  }
+};
+
+// Drives one operation against a localhost KvService and reports the budget its call carried. The
+// two timeouts are set far apart and both away from their stock defaults, so the value that comes
+// back names which one was used and whether it came from the caller's configuration at all.
+template<class Request>
+auto
+observed_budget_for(Request request) -> std::int64_t
+{
+  int port = 0;
+  deadline_recording_kv_service service;
+  grpc::ServerBuilder builder;
+  builder.RegisterService(&service);
+  builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
+  auto server = builder.BuildAndStart();
+
+  auto parsed = parse_connection_string("couchbase2://127.0.0.1:" + std::to_string(port));
+  origin cluster_origin{ cluster_credentials{}, parsed }; // no credentials -> plaintext allowed
+  cluster_origin.options().enable_tls = false;
+  cluster_origin.options().key_value_timeout = 400ms;
+  cluster_origin.options().key_value_durable_timeout = 3'000ms;
+
+  asio::io_context io;
+  auto guard = asio::make_work_guard(io);
+  std::thread io_thread([&io]() {
+    io.run();
+  });
+  couchbase::core::cluster cluster{ io };
+
+  std::promise<std::error_code> opened;
+  cluster.open(cluster_origin, [&opened](std::error_code ec) {
+    opened.set_value(ec);
+  });
+  const auto open_ec = opened.get_future().get();
+
+  std::promise<void> answered;
+  auto completion = answered.get_future();
+  cluster.execute(std::move(request), [&answered](auto /* response */) {
+    answered.set_value();
+  });
+  const auto arrived = completion.wait_for(10s) == std::future_status::ready;
+
+  // Tear down before asserting: a failed assertion throws, and unwinding past a joinable thread
+  // calls std::terminate, which would replace the message with a bare "terminate called".
+  std::promise<void> closed;
+  cluster.close([&closed]() {
+    closed.set_value();
+  });
+  closed.get_future().get();
+  guard.reset();
+  io_thread.join();
+  server->Shutdown(std::chrono::system_clock::now());
+
+  assert_false(static_cast<bool>(open_ec), "open(couchbase2://) succeeds");
+  assert_true(arrived, "the operation completes");
+  assert_true(service.calls.load() >= 1, "the operation reached the service");
+  return service.observed_budget_ms.load();
+}
+
+// A durable mutation issued with no timeout of its own is dispatched with the cluster's configured
+// KvDurableTimeout.
+//
+// Each bound catches a distinct failure. Below the lower one the operation was bounded by the
+// standard KV budget, which is what happens when the durable default is resolved only where the
+// per-attempt deadline is stamped: the retry loop hands the component an already-resolved timeout
+// on every attempt including the first, so the component's own fallback never selects. Above the
+// upper one the durable budget came from the built-in default rather than the configured value,
+// which is what happens when key_value_durable is never populated from the cluster options.
+void
+a_durable_mutation_without_a_timeout_gets_the_configured_durable_budget()
+{
+  ops::upsert_request mutation;
+  mutation.id = document_id{ "b", "s", "c", "k" };
+  mutation.value = cu::to_binary("{}");
+  mutation.flags = 0x06U;
+  mutation.durability_level = couchbase::durability_level::majority;
+
+  const auto budget = observed_budget_for(std::move(mutation));
+
+  assert_true(budget > 1'500,
+              "a durable mutation is not bounded by the standard key_value timeout");
+  assert_true(budget <= 3'000,
+              "and its durable budget is the configured key_value_durable_timeout rather than the "
+              "built-in default");
+}
+
+// The negative half: resolving a durable default must not widen an operation that did not ask for
+// durability. A read cannot carry a level at all, so it keeps the standard budget.
+void
+a_read_is_never_given_the_durable_budget()
+{
+  ops::get_request read;
+  read.id = document_id{ "b", "s", "c", "k" };
+
+  const auto budget = observed_budget_for(std::move(read));
+
+  assert_true(budget <= 400, "a read keeps the standard key_value timeout");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_component_timeouts",
+    {
+      { "non_durable_uses_the_standard_kv_timeout", non_durable_uses_the_standard_kv_timeout },
+      { "durable_uses_the_durable_timeout", durable_uses_the_durable_timeout },
+      { "explicit_request_timeout_always_wins", explicit_request_timeout_always_wins },
+      { "an_explicit_timeout_is_never_raised_to_a_floor",
+        an_explicit_timeout_is_never_raised_to_a_floor },
+      { "a_request_that_cannot_be_durable_asks_for_no_durability",
+        a_request_that_cannot_be_durable_asks_for_no_durability },
+      { "a_durable_mutation_without_a_timeout_gets_the_configured_durable_budget",
+        a_durable_mutation_without_a_timeout_gets_the_configured_durable_budget,
+        timeout::slow },
+      { "a_read_is_never_given_the_durable_budget",
+        a_read_is_never_given_the_durable_budget,
+        timeout::slow },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test

--- a/test/cng/protostellar/kv_converter.cxx
+++ b/test/cng/protostellar/kv_converter.cxx
@@ -373,6 +373,28 @@ replace_and_remove_encode_cas()
               "remove durability");
 }
 
+// Each durable level must map onto its own proto level, `majority_and_persist_to_active` included —
+// it was the one level nothing asserted.
+//
+// This is the mapping's only guard, and no live case can stand in for it. The proto enum has no
+// NONE member and starts at MAJORITY = 0, so the three durable levels occupy 0, 1, 2 in declaration
+// order; a level shifted by one is still a value the gateway accepts, so the write succeeds and the
+// caller silently gets weaker or stronger guarantees than were asked for.
+void
+durability_levels_map_to_their_own_proto_levels()
+{
+  assert_true(pk::to_proto_durability(couchbase::durability_level::majority) ==
+                v1::DURABILITY_LEVEL_MAJORITY,
+              "majority");
+  assert_true(
+    pk::to_proto_durability(couchbase::durability_level::majority_and_persist_to_active) ==
+      v1::DURABILITY_LEVEL_MAJORITY_AND_PERSIST_TO_ACTIVE,
+    "majority_and_persist_to_active");
+  assert_true(pk::to_proto_durability(couchbase::durability_level::persist_to_majority) ==
+                v1::DURABILITY_LEVEL_PERSIST_TO_MAJORITY,
+              "persist_to_majority");
+}
+
 void
 durability_none_is_left_unset()
 {
@@ -489,6 +511,8 @@ tests() -> test_suite
       { "mutation_response_decodes_cas_and_token", mutation_response_decodes_cas_and_token },
       { "replace_and_remove_encode_cas", replace_and_remove_encode_cas },
       { "durability_none_is_left_unset", durability_none_is_left_unset },
+      { "durability_levels_map_to_their_own_proto_levels",
+        durability_levels_map_to_their_own_proto_levels },
       { "lifecycle_ops_encode_expected_fields", lifecycle_ops_encode_expected_fields },
       { "exists_and_lock_responses_decode", exists_and_lock_responses_decode },
       { "counter_encodes_and_decodes", counter_encodes_and_decodes },

--- a/test/cng/protostellar/live_kv.cxx
+++ b/test/cng/protostellar/live_kv.cxx
@@ -35,13 +35,17 @@
 #include "core/utils/binary.hxx"
 #include "core/utils/connection_string.hxx"
 
+#include <couchbase/durability_level.hxx>
 #include <couchbase/error_codes.hxx>
 
 #include <asio/executor_work_guard.hpp>
 #include <asio/io_context.hpp>
 
+#include <array>
+#include <cstddef>
 #include <cstdlib>
 #include <string>
+#include <utility>
 
 namespace couchbase::cng::test
 {
@@ -307,6 +311,106 @@ insert_and_replace_round_trip_against_live_gateway()
     "insert -> dup_insert -> replace -> missing_replace -> remove -> missing_remove completed");
 }
 
+// A durable mutation must be accepted by a real gateway at every level this transport can express.
+//
+// What this case cannot pin is which timeout budget the client resolved: a gateway answers a
+// durable write identically whichever budget was chosen, so that property is asserted against an
+// in-process server in component_timeouts.cxx instead. What only a live run can catch is a level
+// the gateway refuses or does not understand -- the converter test pins what the client sends, not
+// what the server accepts, and the two are different claims.
+//
+// Each level gets its own io_context and component so that a level which hangs or fails is
+// attributed to itself rather than to whichever one happens to run first.
+void
+durable_mutations_against_live_gateway()
+{
+  const auto connstr_opt = safe_getenv("TEST_CONNECTION_STRING");
+  if (!connstr_opt.has_value()) {
+    skip("TEST_CONNECTION_STRING is not set");
+  }
+  const auto parsed = parse_connection_string(connstr_opt.value());
+  if (!parsed.uses_protostellar()) {
+    skip("TEST_CONNECTION_STRING is not a couchbase2:// endpoint");
+  }
+  if (parsed.bootstrap_nodes.empty()) {
+    skip("no nodes in TEST_CONNECTION_STRING");
+  }
+
+  const auto& node = parsed.bootstrap_nodes.front();
+  const auto port = node.port > 0 ? node.port : parsed.default_port;
+  const std::string endpoint = node.address + ":" + std::to_string(port);
+
+  cluster_options options;
+  options.enable_tls = true;
+  options.tls_verify = tls_verify_mode::none;
+
+  cluster_credentials credentials;
+  credentials.username = env_or("TEST_CB2_USERNAME", "Administrator");
+  credentials.password = env_or("TEST_CB2_PASSWORD", "password");
+
+  const auto bucket = env_or("TEST_CB2_BUCKET", "default");
+  const auto id = document_id{ bucket, "_default", "_default", "cng-live-durable-key" };
+
+  const std::array<std::pair<couchbase::durability_level, const char*>, 3> levels{ {
+    { couchbase::durability_level::majority, "majority" },
+    { couchbase::durability_level::majority_and_persist_to_active,
+      "majority_and_persist_to_active" },
+    { couchbase::durability_level::persist_to_majority, "persist_to_majority" },
+  } };
+
+  std::string failure;
+  std::size_t accepted = 0;
+
+  for (const auto& [level, name] : levels) {
+    asio::io_context io;
+    auto work = asio::make_work_guard(io);
+    auto channel = ps::make_channel(endpoint, options, credentials);
+    component_config config;
+    config.channel = channel;
+    config.credentials = credentials;
+    config.timeouts.key_value = 20'000ms;
+    config.timeouts.key_value_durable = 20'000ms;
+    component comp{ io, config };
+
+    ops::upsert_request upsert;
+    upsert.id = id;
+    upsert.value = cu::to_binary(R"({"cng":true})");
+    upsert.durability_level = level;
+    comp.execute(std::move(upsert), [&, name = name](ops::upsert_response result) {
+      if (result.ctx.ec()) {
+        failure = std::string{ "durable upsert (" } + name + "): " + result.ctx.ec().message();
+      } else {
+        ++accepted;
+      }
+      work.reset();
+    });
+    io.run();
+
+    if (!failure.empty()) {
+      break;
+    }
+  }
+
+  {
+    asio::io_context io;
+    auto work = asio::make_work_guard(io);
+    auto channel = ps::make_channel(endpoint, options, credentials);
+    component_config config;
+    config.channel = channel;
+    config.credentials = credentials;
+    component comp{ io, config };
+    ops::remove_request cleanup;
+    cleanup.id = id;
+    comp.execute(std::move(cleanup), [&](ops::remove_response) {
+      work.reset();
+    });
+    io.run();
+  }
+
+  assert_true(failure.empty(), failure);
+  assert_eq(accepted, levels.size(), "every durability level is accepted by the gateway");
+}
+
 } // namespace
 
 auto
@@ -321,6 +425,10 @@ tests() -> test_suite
         test_env::cluster_only },
       { "insert_and_replace_round_trip_against_live_gateway",
         insert_and_replace_round_trip_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "durable_mutations_against_live_gateway",
+        durable_mutations_against_live_gateway,
         timeout::integration,
         test_env::cluster_only },
     },


### PR DESCRIPTION
Durable KV mutations were bounded by the standard key_value timeout (2.5s) rather than the dedicated kv_durable_timeout (10s), so a synchronous-durability write timed out on the read budget.

Add key_value_durable to component_timeouts and select it, through resolve_kv_timeout, for a request that asks for a durability level. The retry loop resolves the operation's deadline by the same rule rather than a copy of it: it narrows the request timeout on every attempt, so the component is always handed an engaged value and applying the rule only there would leave it unreachable. The cluster's timeouts are assigned per field, so a member left unpopulated is a visible omission rather than one covered by the struct's own default.

No lower bound is imposed on an explicit request timeout. The MCBP path raises a durable operation to a 1500ms floor, which it needs because it has no durable default at all; neither RFC 59 nor RFC 77 states a floor.

--- Stacked PR **24/30** in the CNG (`couchbase2://`) transport series. The change specific to this PR is its top commit; the commits beneath it belong to earlier PRs in the series. Depends on #1043 — merge the series bottom-up.
