### PR TITLE
CXXCBC-905: compress KV values over couchbase2

### DIFF
--- a/cmake/Protostellar.cmake
+++ b/cmake/Protostellar.cmake
@@ -242,4 +242,5 @@ set(couchbase_cxx_protostellar_TRANSPORT_FILES
     ${PROJECT_SOURCE_DIR}/core/protostellar/dispatcher.cxx
     ${PROJECT_SOURCE_DIR}/core/protostellar/credentials.cxx
     ${PROJECT_SOURCE_DIR}/core/protostellar/error_utils.cxx
+    ${PROJECT_SOURCE_DIR}/core/protostellar/kv_converter.cxx
     ${PROJECT_SOURCE_DIR}/core/protostellar/component.cxx)

--- a/core/cluster.cxx
+++ b/core/cluster.cxx
@@ -1010,8 +1010,10 @@ public:
       const std::scoped_lock lock(protostellar_mutex_);
       protostellar_ = std::make_shared<protostellar::component>(
         ctx_,
-        protostellar::component_config{
-          std::move(channel), origin_.credentials(), make_component_timeouts(options) });
+        protostellar::component_config{ std::move(channel),
+                                        origin_.credentials(),
+                                        make_component_timeouts(options),
+                                        make_compression_settings(options) });
     }
     CB_LOG_INFO(R"(open couchbase2 cluster, id: "{}", endpoint: "{}")", id_, endpoint);
     return handler({});

--- a/core/cluster_options.hxx
+++ b/core/cluster_options.hxx
@@ -28,6 +28,8 @@
 #include "timeout_defaults.hxx"
 #include "tls_verify_mode.hxx"
 
+#include "core/protostellar/compression_settings.hxx"
+
 #include <couchbase/metrics/meter.hxx>
 #include <couchbase/retry_strategy.hxx>
 #include <couchbase/tracing/request_tracer.hxx>
@@ -72,6 +74,8 @@ public:
   bool enable_unordered_execution{ true };
   bool enable_clustermap_notification{ true };
   bool enable_compression{ true };
+  std::size_t compression_min_size{ 32 };
+  double compression_min_ratio{ 0.83 };
   bool enable_tracing{ true };
   bool enable_metrics{ true };
   bool enable_orphan_reporting{ true };
@@ -121,5 +125,15 @@ public:
   // per request from the operation timeout, so the value here is not used for it.
   row_streamer_options streaming{};
 };
+
+[[nodiscard]] inline auto
+make_compression_settings(const cluster_options& options) -> protostellar::kv::compression_settings
+{
+  protostellar::kv::compression_settings compression{};
+  compression.enabled = options.enable_compression;
+  compression.min_size = options.compression_min_size;
+  compression.min_ratio = options.compression_min_ratio;
+  return compression;
+}
 
 } // namespace couchbase::core

--- a/core/impl/public_cluster.cxx
+++ b/core/impl/public_cluster.cxx
@@ -177,6 +177,8 @@ options_to_origin(const std::string& connection_string, cluster_options::built o
   user_options.server_group = opts.network.server_group;
 
   user_options.enable_compression = opts.compression.enabled;
+  user_options.compression_min_size = opts.compression.min_size;
+  user_options.compression_min_ratio = opts.compression.min_ratio;
 
   user_options.enable_metrics = opts.metrics.enabled;
   if (opts.metrics.enabled) {

--- a/core/protostellar/component.cxx
+++ b/core/protostellar/component.cxx
@@ -193,6 +193,7 @@ component::component(asio::io_context& io, component_config config)
              search_admin_v1::SearchAdminService::NewStub(config.channel) }) }
   , authorization_{ authorization_header(config.credentials) }
   , timeouts_{ config.timeouts }
+  , compression_{ config.compression }
   // Initialised last (see the declaration order in the header), so the channel can be moved in.
   , dispatcher_{ io, std::move(config.channel) }
 {
@@ -209,7 +210,7 @@ component::execute(const operations::get_request& request,
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
   }
-  auto proto = std::make_shared<v1::GetRequest>(kv::encode(request));
+  auto proto = std::make_shared<v1::GetRequest>(kv::encode(request, compression_));
   const auto id = request.id;
   const auto retry_attempts = request.retries.retry_attempts();
   const auto retry_reasons = request.retries.retry_reasons();
@@ -229,8 +230,8 @@ component::execute(const operations::get_request& request,
       grpc::Status status, v1::GetResponse resp) mutable {
       (void)proto; // kept only to keep the request alive for the call
       // A get reads and nothing more, so a deadline here is unambiguous: the document cannot have
-      // changed. kv::decode owns the compressed-content rule (it reports feature_not_available
-      // rather than handing back an empty value with a success status).
+      // changed. kv::decode owns the compressed-content rule (it reports the decode failure rather
+      // than handing back an empty value with a success status).
       auto ctx =
         make_error_context(status, id, operation_kind::read_only, retry_attempts, retry_reasons);
       handler(kv::decode(resp, std::move(ctx)));
@@ -242,7 +243,7 @@ component::execute(const operations::get_projected_request& request,
                    utils::movable_function<void(operations::get_projected_response)>&& handler)
   -> pending_call
 {
-  auto proto = std::make_shared<v1::GetRequest>(kv::encode(request));
+  auto proto = std::make_shared<v1::GetRequest>(kv::encode(request, compression_));
   const auto id = request.id;
   const auto retry_attempts = request.retries.retry_attempts();
   const auto retry_reasons = request.retries.retry_reasons();
@@ -266,10 +267,6 @@ component::execute(const operations::get_projected_request& request,
       (void)proto; // kept only to keep the request alive for the call
       auto ctx =
         make_error_context(status, id, operation_kind::read_only, retry_attempts, retry_reasons);
-      if (status.ok() && resp.content_case() == v1::GetResponse::kContentCompressed) {
-        ctx = make_key_value_error_context(
-          errc::common::feature_not_available, id, retry_attempts, retry_reasons);
-      }
       handler(kv::decode(resp, std::move(ctx), request));
     });
 }
@@ -283,7 +280,7 @@ component::execute(const operations::upsert_request& request,
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
   }
-  auto proto = std::make_shared<v1::UpsertRequest>(kv::encode(request));
+  auto proto = std::make_shared<v1::UpsertRequest>(kv::encode(request, compression_));
   const auto id = request.id;
   const auto retry_attempts = request.retries.retry_attempts();
   const auto retry_reasons = request.retries.retry_reasons();
@@ -316,7 +313,7 @@ component::execute(const operations::insert_request& request,
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
   }
-  auto proto = std::make_shared<v1::InsertRequest>(kv::encode(request));
+  auto proto = std::make_shared<v1::InsertRequest>(kv::encode(request, compression_));
   const auto id = request.id;
   const auto retry_attempts = request.retries.retry_attempts();
   const auto retry_reasons = request.retries.retry_reasons();
@@ -349,7 +346,7 @@ component::execute(const operations::replace_request& request,
   if (timeout <= std::chrono::milliseconds::zero()) {
     return fail_expired(io_, request, handler);
   }
-  auto proto = std::make_shared<v1::ReplaceRequest>(kv::encode(request));
+  auto proto = std::make_shared<v1::ReplaceRequest>(kv::encode(request, compression_));
   const auto id = request.id;
   const auto retry_attempts = request.retries.retry_attempts();
   const auto retry_reasons = request.retries.retry_reasons();
@@ -477,7 +474,7 @@ component::execute(const operations::get_and_lock_request& request,
                    utils::movable_function<void(operations::get_and_lock_response)>&& handler)
   -> pending_call
 {
-  auto proto = std::make_shared<v1::GetAndLockRequest>(kv::encode(request));
+  auto proto = std::make_shared<v1::GetAndLockRequest>(kv::encode(request, compression_));
   const auto id = request.id;
   const auto retry_attempts = request.retries.retry_attempts();
   const auto retry_reasons = request.retries.retry_reasons();
@@ -502,10 +499,6 @@ component::execute(const operations::get_and_lock_request& request,
       (void)proto; // kept only to keep the request alive for the call
       auto ctx =
         make_error_context(status, id, operation_kind::mutating, retry_attempts, retry_reasons);
-      if (status.ok() && resp.content_case() == v1::GetAndLockResponse::kContentCompressed) {
-        ctx = make_key_value_error_context(
-          errc::common::feature_not_available, id, retry_attempts, retry_reasons);
-      }
       handler(kv::decode(resp, std::move(ctx)));
     });
 }
@@ -548,7 +541,7 @@ component::execute(const operations::get_and_touch_request& request,
                    utils::movable_function<void(operations::get_and_touch_response)>&& handler)
   -> pending_call
 {
-  auto proto = std::make_shared<v1::GetAndTouchRequest>(kv::encode(request));
+  auto proto = std::make_shared<v1::GetAndTouchRequest>(kv::encode(request, compression_));
   const auto id = request.id;
   const auto retry_attempts = request.retries.retry_attempts();
   const auto retry_reasons = request.retries.retry_reasons();
@@ -573,10 +566,6 @@ component::execute(const operations::get_and_touch_request& request,
       (void)proto; // kept only to keep the request alive for the call
       auto ctx =
         make_error_context(status, id, operation_kind::mutating, retry_attempts, retry_reasons);
-      if (status.ok() && resp.content_case() == v1::GetAndTouchResponse::kContentCompressed) {
-        ctx = make_key_value_error_context(
-          errc::common::feature_not_available, id, retry_attempts, retry_reasons);
-      }
       handler(kv::decode(resp, std::move(ctx)));
     });
 }

--- a/core/protostellar/component.hxx
+++ b/core/protostellar/component.hxx
@@ -75,6 +75,7 @@
 #include "core/operations/management/search_index_get_all.hxx"
 #include "core/operations/management/search_index_get_documents_count.hxx"
 #include "core/operations/management/search_index_upsert.hxx"
+#include "core/protostellar/compression_settings.hxx"
 #include "core/protostellar/dispatcher.hxx"
 #include "core/timeout_defaults.hxx"
 #include "core/utils/movable_function.hxx"
@@ -111,6 +112,7 @@ struct component_config {
   std::shared_ptr<grpc::Channel> channel{};
   cluster_credentials credentials{};
   component_timeouts timeouts{};
+  kv::compression_settings compression{};
 };
 
 // The core KV request types the component can execute over couchbase2. cluster_impl routes only
@@ -374,6 +376,7 @@ private:
   std::unique_ptr<stubs> stubs_;
   std::string authorization_;
   component_timeouts timeouts_;
+  kv::compression_settings compression_;
   // Declared last, so it is destroyed first: ~dispatcher() cancels and drains the calls issued
   // through the stubs above, which must therefore still be alive while it runs.
   dispatcher dispatcher_;

--- a/core/protostellar/compression_settings.hxx
+++ b/core/protostellar/compression_settings.hxx
@@ -1,0 +1,33 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <cstddef>
+
+namespace couchbase::core::protostellar::kv
+{
+
+// The user's compression knobs. Defaults mirror the classic SDK (enabled; snappy applied only when
+// the value is at least min_size and shrinks below min_ratio).
+struct compression_settings {
+  bool enabled{ true };
+  std::size_t min_size{ 32 };
+  double min_ratio{ 0.83 };
+};
+
+} // namespace couchbase::core::protostellar::kv

--- a/core/protostellar/dispatcher.cxx
+++ b/core/protostellar/dispatcher.cxx
@@ -30,9 +30,8 @@ default_channel_arguments() -> grpc::ChannelArguments
   args.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS, 30'000);
   args.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, 5'000);
   args.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
-  // RFC 77 (Bootstrapping -> Maximum Message Size): couchbase2 clients must raise the receive
-  // limit to 25 MiB; gRPC's 4 MB default is too small for the largest values Couchbase serves.
-  args.SetMaxReceiveMessageSize(25 * 1024 * 1024);
+  // gRPC's 4 MB default is too small for the largest values Couchbase serves.
+  args.SetMaxReceiveMessageSize(static_cast<int>(max_receive_message_size));
   return args;
 }
 

--- a/core/protostellar/dispatcher.hxx
+++ b/core/protostellar/dispatcher.hxx
@@ -28,6 +28,7 @@
 #include <algorithm>
 #include <chrono>
 #include <condition_variable>
+#include <cstddef>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -38,6 +39,11 @@
 
 namespace couchbase::core::protostellar
 {
+
+// RFC 77 (Bootstrapping -> Maximum Message Size): couchbase2 clients raise the receive limit to
+// 25 MiB, so nothing the transport hands to a converter can legitimately exceed it -- including a
+// value a compressed payload claims to inflate to.
+constexpr std::size_t max_receive_message_size{ std::size_t{ 25 } * 1024 * 1024 };
 
 // Registry of in-flight gRPC calls so the transport can cancel and drain them at shutdown. Without
 // it, teardown could destroy the io_context (and channel) while a gRPC callback is still pending on

--- a/core/protostellar/kv_converter.cxx
+++ b/core/protostellar/kv_converter.cxx
@@ -1,0 +1,70 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// snappy compression for the couchbase2 KV converter, kept out of kv_converter.hxx so the header
+// (included by white-box tests) does not leak a dependency on <snappy.h> / the snappy library.
+
+#include "core/protostellar/kv_converter.hxx"
+
+#include "core/protostellar/dispatcher.hxx"
+
+#include <snappy.h>
+
+#include <cstddef>
+
+namespace couchbase::core::protostellar::kv
+{
+auto
+maybe_compress(const std::vector<std::byte>& value, const compression_settings& compression)
+  -> std::optional<std::string>
+{
+  if (!compression.enabled || value.size() < compression.min_size) {
+    return std::nullopt;
+  }
+  const auto raw = utils::to_string(value);
+  std::string compressed;
+  snappy::Compress(raw.data(), raw.size(), &compressed);
+  // Only worth sending compressed when it shrinks to at most min_ratio of the original; a value
+  // landing exactly on the ratio is sent compressed, as it is in the other SDKs.
+  if (static_cast<double>(compressed.size()) <=
+      static_cast<double>(raw.size()) * compression.min_ratio) {
+    return compressed;
+  }
+  return std::nullopt;
+}
+
+auto
+snappy_uncompress(const std::string& compressed) -> std::optional<std::string>
+{
+  // snappy::Uncompress resizes its output to the length declared in the frame header before it
+  // validates the body, so a few bytes can ask for a multi-gigabyte allocation. Read the declared
+  // length first and refuse anything the transport could not have carried: the resulting
+  // std::bad_alloc would be thrown inside a gRPC completion and take the process with it.
+  std::size_t length{};
+  if (!snappy::GetUncompressedLength(compressed.data(), compressed.size(), &length)) {
+    return std::nullopt;
+  }
+  if (length > max_receive_message_size) {
+    return std::nullopt;
+  }
+  std::string uncompressed;
+  if (snappy::Uncompress(compressed.data(), compressed.size(), &uncompressed)) {
+    return uncompressed;
+  }
+  return std::nullopt;
+}
+} // namespace couchbase::core::protostellar::kv

--- a/core/protostellar/kv_converter.hxx
+++ b/core/protostellar/kv_converter.hxx
@@ -24,6 +24,7 @@
 
 #include "core/document_id.hxx"
 #include "core/error_context/key_value.hxx"
+#include "core/logger/logger.hxx"
 #include "core/operations/document_append.hxx"
 #include "core/operations/document_decrement.hxx"
 #include "core/operations/document_exists.hxx"
@@ -39,6 +40,7 @@
 #include "core/operations/document_touch.hxx"
 #include "core/operations/document_unlock.hxx"
 #include "core/operations/document_upsert.hxx"
+#include "core/protostellar/compression_settings.hxx"
 #include "core/utils/binary.hxx"
 
 #include <couchbase/cas.hxx>
@@ -139,11 +141,9 @@ to_core_token(const v1::MutationToken& token) -> couchbase::mutation_token
 }
 
 // Every response that carries a document body puts it in a content oneof, and the generated
-// accessor for the inactive arm returns the empty-string singleton. Reading content_uncompressed()
-// while the compressed arm is active would therefore produce an empty value with a valid CAS and
-// no error -- indistinguishable from an empty document. Compression negotiation lands in
-// CXXCBC-905; until then every body-bearing decoder refuses the compressed arm instead of losing
-// the value, which is the same fail-closed rule the request side applies.
+// accessor for the inactive arm returns the empty-string singleton. The active arm therefore has to
+// be tested before reading either one, or a compressed payload decodes to an empty value with a
+// valid CAS -- indistinguishable from an empty document.
 template<typename Proto>
 [[nodiscard]] auto
 content_is_compressed(const Proto& proto) -> bool
@@ -151,13 +151,77 @@ content_is_compressed(const Proto& proto) -> bool
   return proto.content_case() == Proto::kContentCompressed;
 }
 
+// ── Compression (RFC 77) ───────────────────────────────────────────────────────
+
+// snappy lives in kv_converter.cxx (compiled into the client library) so <snappy.h> stays out of
+// this header, which white-box tests include — they then need neither snappy's headers nor its
+// symbols. maybe_compress returns the compressed bytes when compression is enabled and the value
+// clears the size/ratio threshold, else std::nullopt ("store uncompressed"); snappy_uncompress
+// returns std::nullopt on malformed input and on a frame declaring more than the transport's
+// maximum message size, which no legitimate value can exceed.
+[[nodiscard]] auto
+maybe_compress(const std::vector<std::byte>& value, const compression_settings& compression)
+  -> std::optional<std::string>;
+[[nodiscard]] auto
+snappy_uncompress(const std::string& compressed) -> std::optional<std::string>;
+
+// Signals the gateway that it may return snappy-compressed content (RFC 77: send
+// COMPRESSION_ENABLED_OPTIONAL when enabled; leave the field unset when the user disabled
+// compression; never COMPRESSION_ENABLED_ALWAYS).
+template<typename Proto>
+inline void
+set_read_compression(Proto& proto, const compression_settings& compression)
+{
+  if (compression.enabled) {
+    proto.set_compression(v1::COMPRESSION_ENABLED_OPTIONAL);
+  }
+}
+
+// Fills a write request's content oneof, snappy-compressing when maybe_compress deems it
+// worthwhile.
+template<typename Proto>
+inline void
+set_write_content(Proto& proto,
+                  const std::vector<std::byte>& value,
+                  const compression_settings& compression)
+{
+  if (auto compressed = maybe_compress(value, compression)) {
+    proto.set_content_compressed(std::move(*compressed));
+  } else {
+    proto.set_content_uncompressed(utils::to_string(value));
+  }
+}
+
+// Reads a response's content oneof, snappy-decoding a compressed payload. Returns nullopt when the
+// compressed arm does not decode: handing back empty bytes instead would produce a value that no
+// caller can distinguish from an empty document, which is the same silent data-loss trap that made
+// the unguarded oneof read wrong before compression landed. A gateway emitting an undecodable
+// snappy frame is a server-side fault, so the callers surface it as internal_server_failure rather
+// than inventing a value.
+template<typename Proto>
+inline auto
+decode_content(const Proto& proto) -> std::optional<std::vector<std::byte>>
+{
+  if (content_is_compressed(proto)) {
+    if (auto uncompressed = snappy_uncompress(proto.content_compressed())) {
+      return utils::to_binary(*uncompressed);
+    }
+    CB_LOG_DEBUG("failed to decompress snappy payload in response (compressed_size={})",
+                 proto.content_compressed().size());
+    return std::nullopt;
+  }
+  return utils::to_binary(proto.content_uncompressed());
+}
+
 // ── Get ───────────────────────────────────────────────────────────────────────
 
 inline auto
-encode(const operations::get_request& request) -> v1::GetRequest
+encode(const operations::get_request& request, const compression_settings& compression)
+  -> v1::GetRequest
 {
   v1::GetRequest proto;
   set_location(proto, request.id);
+  set_read_compression(proto, compression);
   return proto;
 }
 
@@ -166,21 +230,24 @@ decode(const v1::GetResponse& proto, key_value_error_context ctx) -> operations:
 {
   operations::get_response response;
   response.ctx = std::move(ctx);
-  if (content_is_compressed(proto)) {
-    response.ctx.override_ec(errc::common::feature_not_available);
+  auto value = decode_content(proto);
+  if (!value) {
+    response.ctx.override_ec(errc::common::internal_server_failure);
     return response;
   }
-  response.value = utils::to_binary(proto.content_uncompressed());
+  response.value = std::move(*value);
   response.cas = couchbase::cas{ proto.cas() };
   response.flags = proto.content_flags();
   return response;
 }
 
 inline auto
-encode(const operations::get_projected_request& request) -> v1::GetRequest
+encode(const operations::get_projected_request& request, const compression_settings& compression)
+  -> v1::GetRequest
 {
   v1::GetRequest proto;
   set_location(proto, request.id);
+  set_read_compression(proto, compression);
   for (const auto& path : request.projections) {
     proto.add_project(path);
   }
@@ -194,11 +261,12 @@ decode(const v1::GetResponse& proto,
 {
   operations::get_projected_response response;
   response.ctx = std::move(ctx);
-  if (content_is_compressed(proto)) {
-    response.ctx.override_ec(errc::common::feature_not_available);
+  auto value = decode_content(proto);
+  if (!value) {
+    response.ctx.override_ec(errc::common::internal_server_failure);
     return response;
   }
-  response.value = utils::to_binary(proto.content_uncompressed());
+  response.value = std::move(*value);
   response.cas = couchbase::cas{ proto.cas() };
   response.flags = proto.content_flags();
   if (proto.has_expiry()) {
@@ -223,11 +291,12 @@ decode_mutation(const Proto& proto, key_value_error_context ctx) -> Response
 }
 
 inline auto
-encode(const operations::upsert_request& request) -> v1::UpsertRequest
+encode(const operations::upsert_request& request, const compression_settings& compression)
+  -> v1::UpsertRequest
 {
   v1::UpsertRequest proto;
   set_location(proto, request.id);
-  proto.set_content_uncompressed(utils::to_string(request.value));
+  set_write_content(proto, request.value, compression);
   proto.set_content_flags(request.flags);
   // preserve_expiry is expressed by omitting the oneof, NOT through the proto's
   // preserve_expiry_on_existing flag. The gateway rejects that flag outright whenever the oneof is
@@ -242,11 +311,12 @@ encode(const operations::upsert_request& request) -> v1::UpsertRequest
 }
 
 inline auto
-encode(const operations::insert_request& request) -> v1::InsertRequest
+encode(const operations::insert_request& request, const compression_settings& compression)
+  -> v1::InsertRequest
 {
   v1::InsertRequest proto;
   set_location(proto, request.id);
-  proto.set_content_uncompressed(utils::to_string(request.value));
+  set_write_content(proto, request.value, compression);
   proto.set_content_flags(request.flags);
   // insert has no preserve_expiry: a document that does not exist yet has no expiry to preserve.
   set_expiry(proto, request.expiry);
@@ -257,11 +327,12 @@ encode(const operations::insert_request& request) -> v1::InsertRequest
 }
 
 inline auto
-encode(const operations::replace_request& request) -> v1::ReplaceRequest
+encode(const operations::replace_request& request, const compression_settings& compression)
+  -> v1::ReplaceRequest
 {
   v1::ReplaceRequest proto;
   set_location(proto, request.id);
-  proto.set_content_uncompressed(utils::to_string(request.value));
+  set_write_content(proto, request.value, compression);
   proto.set_content_flags(request.flags);
   if (request.cas.value() != 0) {
     proto.set_cas(request.cas.value());
@@ -351,11 +422,13 @@ decode(const v1::ExistsResponse& proto, key_value_error_context ctx) -> operatio
 }
 
 inline auto
-encode(const operations::get_and_lock_request& request) -> v1::GetAndLockRequest
+encode(const operations::get_and_lock_request& request, const compression_settings& compression)
+  -> v1::GetAndLockRequest
 {
   v1::GetAndLockRequest proto;
   set_location(proto, request.id);
   proto.set_lock_time_secs(request.lock_time);
+  set_read_compression(proto, compression);
   return proto;
 }
 
@@ -365,11 +438,12 @@ decode(const v1::GetAndLockResponse& proto, key_value_error_context ctx)
 {
   operations::get_and_lock_response response;
   response.ctx = std::move(ctx);
-  if (content_is_compressed(proto)) {
-    response.ctx.override_ec(errc::common::feature_not_available);
+  auto value = decode_content(proto);
+  if (!value) {
+    response.ctx.override_ec(errc::common::internal_server_failure);
     return response;
   }
-  response.value = utils::to_binary(proto.content_uncompressed());
+  response.value = std::move(*value);
   response.cas = couchbase::cas{ proto.cas() };
   response.flags = proto.content_flags();
   return response;
@@ -394,11 +468,13 @@ decode(const v1::UnlockResponse& /* proto */, key_value_error_context ctx)
 }
 
 inline auto
-encode(const operations::get_and_touch_request& request) -> v1::GetAndTouchRequest
+encode(const operations::get_and_touch_request& request, const compression_settings& compression)
+  -> v1::GetAndTouchRequest
 {
   v1::GetAndTouchRequest proto;
   set_location(proto, request.id);
   set_expiry(proto, request.expiry);
+  set_read_compression(proto, compression);
   return proto;
 }
 
@@ -408,11 +484,12 @@ decode(const v1::GetAndTouchResponse& proto, key_value_error_context ctx)
 {
   operations::get_and_touch_response response;
   response.ctx = std::move(ctx);
-  if (content_is_compressed(proto)) {
-    response.ctx.override_ec(errc::common::feature_not_available);
+  auto value = decode_content(proto);
+  if (!value) {
+    response.ctx.override_ec(errc::common::internal_server_failure);
     return response;
   }
-  response.value = utils::to_binary(proto.content_uncompressed());
+  response.value = std::move(*value);
   response.cas = couchbase::cas{ proto.cas() };
   response.flags = proto.content_flags();
   return response;

--- a/test/cng/CMakeLists.txt
+++ b/test/cng/CMakeLists.txt
@@ -119,8 +119,9 @@ if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 AND TARGET couchbase_cxx_protostellar)
   add_cng_test(protostellar/kv_converter LINK_CLIENT LIBS couchbase_cxx_protostellar)
 
   # Protostellar KV component (CXXCBC-891).
-  add_cng_test(protostellar/component LINK_CLIENT LIBS couchbase_cxx_protostellar)
-  add_cng_test(protostellar/component_kv_operations LINK_CLIENT LIBS couchbase_cxx_protostellar)
+  add_cng_test(protostellar/component LINK_CLIENT LIBS couchbase_cxx_protostellar snappy)
+  add_cng_test(protostellar/component_kv_operations LINK_CLIENT LIBS couchbase_cxx_protostellar
+               snappy)
   add_cng_test(protostellar/live_kv_operations LINK_CLIENT LIBS couchbase_cxx_protostellar)
 
   # KV transport-level retry, including the overall time budget (CXXCBC-896).

--- a/test/cng/protostellar/component.cxx
+++ b/test/cng/protostellar/component.cxx
@@ -40,7 +40,8 @@
 
 #include <grpcpp/server_builder.h>
 
-#include <atomic>
+#include <snappy.h>
+
 #include <chrono>
 #include <cstdint>
 #include <limits>
@@ -74,11 +75,18 @@ public:
     for (int i = 0; i < request->project_size(); ++i) {
       last_project.push_back(request->project(i));
     }
+    last_get_compression.reset();
+    if (request->has_compression()) {
+      last_get_compression = request->compression();
+    }
     if (request->key() == "missing") {
       return { grpc::StatusCode::NOT_FOUND, "no such document" };
     }
     if (request->key() == "compressed") {
-      response->set_content_compressed("dummy_compressed_data");
+      std::string compressed;
+      static const std::string src{ "hello_snappy_decompressed_value" };
+      snappy::Compress(src.data(), src.size(), &compressed);
+      response->set_content_compressed(compressed);
       response->set_cas(0x2222ULL);
       return grpc::Status::OK;
     }
@@ -95,6 +103,12 @@ public:
     record_auth(context);
     if (request->key() == "fail") {
       return { grpc::StatusCode::UNAVAILABLE, "node unavailable" };
+    }
+    last_upsert_content_case = request->content_case();
+    if (request->has_content_compressed()) {
+      last_upsert_compressed_payload = request->content_compressed();
+    } else if (request->has_content_uncompressed()) {
+      last_upsert_uncompressed_payload = request->content_uncompressed();
     }
     response->set_cas(0x3333ULL);
     auto* token = response->mutable_mutation_token();
@@ -157,7 +171,11 @@ public:
   }
 
   std::vector<std::string> last_project{};
+  std::optional<v1::CompressionEnabled> last_get_compression{};
   std::string last_auth_header{};
+  v1::UpsertRequest::ContentCase last_upsert_content_case{ v1::UpsertRequest::CONTENT_NOT_SET };
+  std::string last_upsert_compressed_payload{};
+  std::string last_upsert_uncompressed_payload{};
 
   // Test knobs. `reply_delay` makes every handler sleep before answering, so a client-side deadline
   // can fire while the call is genuinely in flight. `calls_received` counts the requests that
@@ -229,7 +247,7 @@ get_round_trips_on_the_io_thread()
   in_process_server server;
   asio::io_context io;
   auto work = asio::make_work_guard(io);
-  component comp{ io, component_config{ server.channel(), cluster_credentials{}, { 5000ms } } };
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, { 5000ms }, {} } };
 
   ops::get_request request;
   request.id = make_id("k1");
@@ -255,7 +273,7 @@ get_maps_not_found_into_the_error_context()
   in_process_server server;
   asio::io_context io;
   auto work = asio::make_work_guard(io);
-  component comp{ io, component_config{ server.channel(), cluster_credentials{}, { 5000ms } } };
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, { 5000ms }, {} } };
 
   ops::get_request request;
   request.id = make_id("missing");
@@ -277,7 +295,7 @@ upsert_returns_cas_and_mutation_token()
   in_process_server server;
   asio::io_context io;
   auto work = asio::make_work_guard(io);
-  component comp{ io, component_config{ server.channel(), cluster_credentials{}, { 5000ms } } };
+  component comp{ io, component_config{ server.channel(), cluster_credentials{}, { 5000ms }, {} } };
 
   ops::upsert_request request;
   request.id = make_id("k1");
@@ -297,7 +315,7 @@ upsert_returns_cas_and_mutation_token()
 }
 
 void
-get_handles_compressed_content_with_feature_not_available()
+get_decompresses_compressed_content()
 {
   in_process_server server;
   asio::io_context io;
@@ -314,8 +332,44 @@ get_handles_compressed_content_with_feature_not_available()
   });
   io.run();
 
-  assert_true(outcome.ctx.ec() == couchbase::errc::common::feature_not_available,
-              "compressed content surfaces feature_not_available");
+  assert_false(static_cast<bool>(outcome.ctx.ec()), "get compressed succeeded");
+  assert_eq(cu::to_string(outcome.value),
+            std::string{ "hello_snappy_decompressed_value" },
+            "value decompressed via snappy");
+}
+
+void
+upsert_compresses_large_payload_when_enabled()
+{
+  in_process_server server;
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  component comp{
+    io, component_config{ server.channel(), cluster_credentials{}, { 5000ms }, { true } }
+  };
+
+  const std::string large_body(1024, 'z');
+  ops::upsert_request request;
+  request.id = make_id("k1");
+  request.value = cu::to_binary(large_body);
+
+  ops::upsert_response outcome;
+  comp.execute(std::move(request), [&](ops::upsert_response response) {
+    outcome = std::move(response);
+    work.reset();
+  });
+  io.run();
+
+  assert_false(static_cast<bool>(outcome.ctx.ec()), "upsert large body succeeded");
+  assert_true(server.service().last_upsert_content_case == v1::UpsertRequest::kContentCompressed,
+              "large payload sent as content_compressed over gRPC");
+
+  std::string decompressed;
+  const bool ok = snappy::Uncompress(server.service().last_upsert_compressed_payload.data(),
+                                     server.service().last_upsert_compressed_payload.size(),
+                                     &decompressed);
+  assert_true(ok, "server received valid snappy compressed payload");
+  assert_eq(decompressed, large_body, "decompressed payload matches original 1024-byte input");
 }
 
 void
@@ -712,6 +766,40 @@ get_projected_encodes_projections_and_decodes_response()
   assert_eq(server.service().last_project[1], "bar.baz", "second projection path matches");
 }
 
+// A projected read reaches the gateway's ordinary Get handler, which decides on compression from
+// the request's own field. Both halves are asserted on one call: what left the client, and what it
+// made of the compressed answer that opting in invites.
+void
+get_projected_negotiates_and_decodes_compression()
+{
+  in_process_server server;
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  component comp{
+    io, component_config{ server.channel(), cluster_credentials{}, { 5000ms }, { true } }
+  };
+
+  ops::get_projected_request request;
+  request.id = make_id("compressed");
+  request.projections = { "foo" };
+
+  ops::get_projected_response outcome;
+  comp.execute(std::move(request), [&](ops::get_projected_response response) {
+    outcome = std::move(response);
+    work.reset();
+  });
+  io.run();
+
+  assert_true(server.service().last_get_compression.has_value(),
+              "a projected read opts in to compression");
+  assert_true(server.service().last_get_compression.value() == v1::COMPRESSION_ENABLED_OPTIONAL,
+              "it opts in as OPTIONAL, never ALWAYS");
+  assert_false(static_cast<bool>(outcome.ctx.ec()), "get_projected compressed succeeded");
+  assert_eq(cu::to_string(outcome.value),
+            std::string{ "hello_snappy_decompressed_value" },
+            "projected value decompressed via snappy");
+}
+
 } // namespace
 
 auto
@@ -721,14 +809,20 @@ tests() -> test_suite
     "protostellar_component",
     {
       { "get_round_trips_on_the_io_thread", get_round_trips_on_the_io_thread, timeout::network },
+      { "get_projected_negotiates_and_decodes_compression",
+        get_projected_negotiates_and_decodes_compression,
+        timeout::network },
       { "get_projected_encodes_projections_and_decodes_response",
         get_projected_encodes_projections_and_decodes_response,
         timeout::network },
       { "get_maps_not_found_into_the_error_context",
         get_maps_not_found_into_the_error_context,
         timeout::network },
-      { "get_handles_compressed_content_with_feature_not_available",
-        get_handles_compressed_content_with_feature_not_available,
+      { "get_decompresses_compressed_content",
+        get_decompresses_compressed_content,
+        timeout::network },
+      { "upsert_compresses_large_payload_when_enabled",
+        upsert_compresses_large_payload_when_enabled,
         timeout::network },
       { "upsert_returns_cas_and_mutation_token",
         upsert_returns_cas_and_mutation_token,

--- a/test/cng/protostellar/component_kv_operations.cxx
+++ b/test/cng/protostellar/component_kv_operations.cxx
@@ -54,6 +54,8 @@
 #include <google/rpc/error_details.pb.h>
 #include <google/rpc/status.pb.h>
 
+#include <snappy.h>
+
 #include <asio/executor_work_guard.hpp>
 #include <asio/io_context.hpp>
 
@@ -124,6 +126,19 @@ constexpr const char* key_missing_bucket = "missing-bucket";
 constexpr const char* key_missing_scope = "missing-scope";
 constexpr const char* key_missing_collection = "missing-collection";
 
+// What the compressed arm carries. It has to be a real snappy frame: an undecodable one is a
+// server fault and takes the internal_server_failure path, which would not tell us whether
+// decompression works.
+const std::string compressed_plaintext{ "hello_snappy_decompressed_value" };
+
+[[nodiscard]] auto
+snappy_frame() -> std::string
+{
+  std::string compressed;
+  snappy::Compress(compressed_plaintext.data(), compressed_plaintext.size(), &compressed);
+  return compressed;
+}
+
 // Records what each request carried so a case can assert the encoding directly, rather than infer
 // it from a response this same double produced.
 struct recorded_request {
@@ -184,7 +199,7 @@ public:
       return status;
     }
     if (request->key() == std::string{ key_compressed }) {
-      response->set_content_compressed("dummy_compressed_data");
+      response->set_content_compressed(snappy_frame());
       response->set_cas(0xa003ULL);
       return grpc::Status::OK;
     }
@@ -216,7 +231,7 @@ public:
       return status;
     }
     if (request->key() == std::string{ key_compressed }) {
-      response->set_content_compressed("dummy_compressed_data");
+      response->set_content_compressed(snappy_frame());
       response->set_cas(0xa004ULL);
       return grpc::Status::OK;
     }
@@ -609,7 +624,7 @@ get_and_lock_maps_a_locked_document_into_document_locked()
 }
 
 void
-get_and_lock_refuses_compressed_content()
+get_and_lock_decompresses_compressed_content()
 {
   in_process_server server;
   ops::get_and_lock_request request;
@@ -618,12 +633,11 @@ get_and_lock_refuses_compressed_content()
 
   const auto outcome = run(server, std::move(request));
 
-  // The guard has to be keyed on GetAndLockResponse. Copied from get's and left keyed on
-  // GetResponse it would still compile, and compressed content would be handed back as if it were
-  // the document body -- which is why this is checked through a real round trip.
-  assert_true(outcome.ctx.ec() == couchbase::errc::common::feature_not_available,
-              "compressed content is refused rather than returned as the value");
-  assert_true(outcome.value.empty(), "and no body is handed back");
+  // The value has to come back intact: handing back the raw snappy frame, or an empty body, are
+  // the two ways this goes wrong quietly.
+  assert_false(static_cast<bool>(outcome.ctx.ec()),
+               "get_and_lock with compressed content succeeded");
+  assert_eq(cu::to_string(outcome.value), compressed_plaintext, "the body is decompressed");
 }
 
 // --- unlock -------------------------------------------------------------------------------------
@@ -690,7 +704,7 @@ get_and_touch_encodes_the_expiry_and_returns_the_value()
 }
 
 void
-get_and_touch_refuses_compressed_content()
+get_and_touch_decompresses_compressed_content()
 {
   in_process_server server;
   ops::get_and_touch_request request;
@@ -699,9 +713,9 @@ get_and_touch_refuses_compressed_content()
 
   const auto outcome = run(server, std::move(request));
 
-  assert_true(outcome.ctx.ec() == couchbase::errc::common::feature_not_available,
-              "compressed content is refused rather than returned as the value");
-  assert_true(outcome.value.empty(), "and no body is handed back");
+  assert_false(static_cast<bool>(outcome.ctx.ec()),
+               "get_and_touch with compressed content succeeded");
+  assert_eq(cu::to_string(outcome.value), compressed_plaintext, "the body is decompressed");
 }
 
 // --- increment / decrement ----------------------------------------------------------------------
@@ -1436,8 +1450,8 @@ tests() -> test_suite
       { "get_and_lock_maps_a_locked_document_into_document_locked",
         get_and_lock_maps_a_locked_document_into_document_locked,
         timeout::network },
-      { "get_and_lock_refuses_compressed_content",
-        get_and_lock_refuses_compressed_content,
+      { "get_and_lock_decompresses_compressed_content",
+        get_and_lock_decompresses_compressed_content,
         timeout::network },
       { "unlock_sends_the_cas_and_completes",
         unlock_sends_the_cas_and_completes,
@@ -1449,8 +1463,8 @@ tests() -> test_suite
       { "get_and_touch_encodes_the_expiry_and_returns_the_value",
         get_and_touch_encodes_the_expiry_and_returns_the_value,
         timeout::network },
-      { "get_and_touch_refuses_compressed_content",
-        get_and_touch_refuses_compressed_content,
+      { "get_and_touch_decompresses_compressed_content",
+        get_and_touch_decompresses_compressed_content,
         timeout::network },
       { "increment_encodes_the_delta_and_initial_and_returns_the_counter",
         increment_encodes_the_delta_and_initial_and_returns_the_counter,

--- a/test/cng/protostellar/kv_converter.cxx
+++ b/test/cng/protostellar/kv_converter.cxx
@@ -19,14 +19,18 @@
 
 #include "framework/test_runner.hxx"
 
+#include "core/cluster_options.hxx"
+#include "core/protostellar/dispatcher.hxx"
 #include "core/protostellar/kv_converter.hxx"
 #include "core/utils/binary.hxx"
 
 #include <couchbase/error_codes.hxx>
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <optional>
 #include <string>
 
 namespace couchbase::cng::test
@@ -51,7 +55,7 @@ get_request_encodes_location()
 {
   ops::get_request request;
   request.id = document_id{ "travel-sample", "inventory", "airline", "airline_10" };
-  const auto proto = pk::encode(request);
+  const auto proto = pk::encode(request, pk::compression_settings{});
   assert_eq(proto.bucket_name(), std::string{ "travel-sample" }, "bucket");
   assert_eq(proto.scope_name(), std::string{ "inventory" }, "scope");
   assert_eq(proto.collection_name(), std::string{ "airline" }, "collection");
@@ -70,24 +74,6 @@ get_response_decodes_value_cas_flags()
   assert_eq(cu::to_string(response.value), std::string{ "{\"type\":\"airline\"}" }, "value");
   assert_eq(response.cas.value(), 0x1234'5678'9abc'def0ULL, "cas");
   assert_eq(response.flags, static_cast<std::uint32_t>(0x0200'0006), "flags");
-}
-
-// GetResponse.content is a oneof, and the accessor for the inactive arm returns the empty-string
-// singleton. Reading content_uncompressed() while the compressed arm is active would yield an empty
-// value with a valid CAS and no error, which no caller can tell apart from an empty document. Until
-// snappy negotiation lands (CXXCBC-905) the decoder has to fail closed.
-void
-get_response_refuses_compressed_content()
-{
-  v1::GetResponse proto;
-  proto.set_content_compressed("not-really-snappy");
-  proto.set_cas(0x1234ULL);
-  proto.set_content_flags(0x0200'0006U);
-
-  const auto response = pk::decode(proto, key_value_error_context{});
-  assert_true(response.ctx.ec() == errc::common::feature_not_available,
-              "the compressed arm is refused rather than decoded as an empty value");
-  assert_true(response.value.empty(), "no partial value is handed back");
 }
 
 // The three branches of set_expiry, plus the exact cutoff. Every expectation below is behaviour
@@ -143,19 +129,19 @@ expiry_encodes_every_branch_explicitly()
     upsert.id = test_id();
     upsert.value = cu::to_binary("v");
     upsert.expiry = expected.expiry;
-    assert_expiry(pk::encode(upsert), expected, "upsert " + label);
+    assert_expiry(pk::encode(upsert, pk::compression_settings{}), expected, "upsert " + label);
 
     ops::insert_request insert;
     insert.id = test_id();
     insert.value = cu::to_binary("v");
     insert.expiry = expected.expiry;
-    assert_expiry(pk::encode(insert), expected, "insert " + label);
+    assert_expiry(pk::encode(insert, pk::compression_settings{}), expected, "insert " + label);
 
     ops::replace_request replace;
     replace.id = test_id();
     replace.value = cu::to_binary("v");
     replace.expiry = expected.expiry;
-    assert_expiry(pk::encode(replace), expected, "replace " + label);
+    assert_expiry(pk::encode(replace, pk::compression_settings{}), expected, "replace " + label);
   }
 }
 
@@ -212,7 +198,8 @@ expiry_encodes_every_branch_for_get_and_touch_and_the_counters()
     ops::get_and_touch_request get_and_touch;
     get_and_touch.id = test_id();
     get_and_touch.expiry = expected.expiry;
-    assert_expiry(pk::encode(get_and_touch), expected, "get_and_touch " + label);
+    assert_expiry(
+      pk::encode(get_and_touch, pk::compression_settings{}), expected, "get_and_touch " + label);
 
     ops::increment_request increment;
     increment.id = test_id();
@@ -236,7 +223,7 @@ preserve_expiry_omits_the_expiry_oneof()
   upsert.value = cu::to_binary("v");
   upsert.expiry = 300U;
   upsert.preserve_expiry = true;
-  const auto upsert_proto = pk::encode(upsert);
+  const auto upsert_proto = pk::encode(upsert, pk::compression_settings{});
   assert_true(upsert_proto.expiry_case() == v1::UpsertRequest::EXPIRY_NOT_SET,
               "upsert expresses preserve by omitting the expiry oneof");
 
@@ -247,14 +234,15 @@ preserve_expiry_omits_the_expiry_oneof()
   replace.value = cu::to_binary("v");
   replace.expiry = 300U;
   replace.preserve_expiry = true;
-  assert_true(pk::encode(replace).expiry_case() == v1::ReplaceRequest::EXPIRY_NOT_SET,
+  assert_true(pk::encode(replace, pk::compression_settings{}).expiry_case() ==
+                v1::ReplaceRequest::EXPIRY_NOT_SET,
               "replace expresses preserve by omitting the expiry oneof");
 
   // ...and with the flag off, a default replace must clear the TTL rather than inherit it.
   ops::replace_request plain;
   plain.id = test_id();
   plain.value = cu::to_binary("v");
-  const auto plain_proto = pk::encode(plain);
+  const auto plain_proto = pk::encode(plain, pk::compression_settings{});
   assert_true(plain_proto.expiry_case() == v1::ReplaceRequest::kExpirySecs,
               "a default replace sends an explicit expiry");
   assert_eq(plain_proto.expiry_secs(), static_cast<std::uint32_t>(0), "...and it is zero");
@@ -280,7 +268,7 @@ upsert_never_emits_a_gateway_rejected_expiry_shape()
       request.value = cu::to_binary("v");
       request.expiry = expected.expiry;
       request.preserve_expiry = preserve;
-      const auto proto = pk::encode(request);
+      const auto proto = pk::encode(request, pk::compression_settings{});
 
       const std::string label = std::string{ "preserve=" } + (preserve ? "true" : "false") +
                                 " expiry=" + std::to_string(expected.expiry);
@@ -322,7 +310,7 @@ upsert_request_encodes_all_fields()
   request.expiry = 300U;
   request.durability_level = couchbase::durability_level::majority;
 
-  const auto proto = pk::encode(request);
+  const auto proto = pk::encode(request, pk::compression_settings{});
   assert_eq(proto.content_uncompressed(), std::string{ "document-body" }, "content");
   assert_eq(proto.content_flags(), static_cast<std::uint32_t>(6), "flags");
   assert_true(proto.expiry_case() == v1::UpsertRequest::kExpirySecs, "expiry uses seconds");
@@ -358,7 +346,7 @@ replace_and_remove_encode_cas()
   replace.id = test_id();
   replace.value = cu::to_binary("v");
   replace.cas = couchbase::cas{ 0x99ULL };
-  const auto replace_proto = pk::encode(replace);
+  const auto replace_proto = pk::encode(replace, pk::compression_settings{});
   assert_true(replace_proto.has_cas(), "replace carries cas");
   assert_eq(replace_proto.cas(), 0x99ULL, "replace cas value");
 
@@ -405,7 +393,7 @@ durability_none_is_left_unset()
   insert.id = test_id();
   insert.value = cu::to_binary("v");
   insert.durability_level = couchbase::durability_level::none;
-  const auto proto = pk::encode(insert);
+  const auto proto = pk::encode(insert, pk::compression_settings{});
   assert_false(proto.has_durability_level(), "insert leaves durability unset for none");
 }
 
@@ -423,7 +411,9 @@ lifecycle_ops_encode_expected_fields()
   ops::get_and_lock_request lock;
   lock.id = document_id{ "b", "s", "c", "k" };
   lock.lock_time = 30U;
-  assert_eq(pk::encode(lock).lock_time_secs(), static_cast<std::uint32_t>(30), "lock time");
+  assert_eq(pk::encode(lock, pk::compression_settings{}).lock_time_secs(),
+            static_cast<std::uint32_t>(30),
+            "lock time");
 
   ops::unlock_request unlock;
   unlock.id = document_id{ "b", "s", "c", "k" };
@@ -487,6 +477,233 @@ append_encodes_content_and_cas()
   assert_eq(proto.cas(), 0x55ULL, "append cas value");
 }
 
+// Every read that can carry a document body opts in, get_projected included: the gateway serves
+// projections from the same Get handler as a full read, so a projected read that stayed silent
+// would be the one path unable to accept a compressed body. gocb, the Java SDK and the .NET SDK all
+// put the projection paths and the compression mode on the same request.
+void
+read_compression_opt_in_follows_settings()
+{
+  ops::get_request get;
+  get.id = test_id();
+  ops::get_projected_request projected;
+  projected.id = test_id();
+  projected.projections = { "foo" };
+  ops::get_and_lock_request lock;
+  lock.id = test_id();
+  ops::get_and_touch_request touch;
+  touch.id = test_id();
+
+  const auto opted_in = [](const auto& proto, const std::string& label) {
+    assert_true(proto.has_compression(), label + ": enabled -> compression field present");
+    assert_true(proto.compression() == v1::COMPRESSION_ENABLED_OPTIONAL,
+                label + ": enabled -> OPTIONAL, never ALWAYS");
+  };
+  const pk::compression_settings enabled{ true };
+  opted_in(pk::encode(get, enabled), "get");
+  opted_in(pk::encode(projected, enabled), "get_projected");
+  opted_in(pk::encode(lock, enabled), "get_and_lock");
+  opted_in(pk::encode(touch, enabled), "get_and_touch");
+
+  const pk::compression_settings disabled{ false };
+  assert_false(pk::encode(get, disabled).has_compression(), "get: disabled -> field unset");
+  assert_false(pk::encode(projected, disabled).has_compression(),
+               "get_projected: disabled -> field unset");
+  assert_false(pk::encode(lock, disabled).has_compression(),
+               "get_and_lock: disabled -> field unset");
+  assert_false(pk::encode(touch, disabled).has_compression(),
+               "get_and_touch: disabled -> field unset");
+}
+
+// The gateway may answer any opted-in read with the compressed arm, so every read decoder has to
+// inflate it. A path that read content_uncompressed directly would hand back the empty-string
+// singleton with a success status.
+void
+every_read_path_decodes_compressed_content()
+{
+  const std::string plain(256, 'x');
+  const auto frame = pk::maybe_compress(cu::to_binary(plain), pk::compression_settings{});
+  assert_true(frame.has_value(), "the fixture value is compressible");
+
+  v1::GetResponse get_proto;
+  get_proto.set_content_compressed(*frame);
+  assert_eq(cu::to_string(pk::decode(get_proto, key_value_error_context{}).value), plain, "get");
+
+  ops::get_projected_request projected;
+  projected.id = test_id();
+  assert_eq(cu::to_string(pk::decode(get_proto, key_value_error_context{}, projected).value),
+            plain,
+            "get_projected");
+
+  v1::GetAndLockResponse lock_proto;
+  lock_proto.set_content_compressed(*frame);
+  assert_eq(
+    cu::to_string(pk::decode(lock_proto, key_value_error_context{}).value), plain, "get_and_lock");
+
+  v1::GetAndTouchResponse touch_proto;
+  touch_proto.set_content_compressed(*frame);
+  assert_eq(cu::to_string(pk::decode(touch_proto, key_value_error_context{}).value),
+            plain,
+            "get_and_touch");
+}
+
+void
+compression_round_trips_large_values()
+{
+  const std::string big(1024, 'a'); // well over min_size and highly compressible
+  ops::upsert_request request;
+  request.id = document_id{ "b", "s", "c", "k" };
+  request.value = cu::to_binary(big);
+
+  const auto compressed = pk::encode(request, pk::compression_settings{ true });
+  assert_true(compressed.content_case() == v1::UpsertRequest::kContentCompressed,
+              "large compressible value is snappy-compressed");
+
+  // A compressed response must snappy-decode back to the original (never empty-as-success).
+  v1::GetResponse response;
+  response.set_content_compressed(compressed.content_compressed());
+  const auto decoded = pk::decode(response, key_value_error_context{});
+  assert_eq(cu::to_string(decoded.value), big, "content_compressed decodes to the original value");
+
+  const auto raw = pk::encode(request, pk::compression_settings{ false });
+  assert_true(raw.content_case() == v1::UpsertRequest::kContentUncompressed,
+              "compression disabled sends raw content");
+}
+
+// A gateway emitting an undecodable snappy frame must not surface as an empty document -- an empty
+// value with a valid CAS is indistinguishable from a real empty one, which is the same silent
+// data-loss trap the unguarded content oneof had before compression landed. decode_content returns
+// nullopt and the decoder reports the server-side fault instead of inventing a value.
+void
+malformed_compressed_content_fails_closed()
+{
+  v1::GetResponse proto;
+  proto.set_content_compressed(std::string(64, '\xff')); // not a snappy frame
+  proto.set_cas(0x1234ULL);
+  proto.set_content_flags(0x0200'0006U);
+
+  const auto response = pk::decode(proto, key_value_error_context{});
+  assert_true(response.ctx.ec() == errc::common::internal_server_failure,
+              "undecodable compressed content is reported rather than silently emptied");
+  assert_true(response.value.empty(), "no invented value is handed back");
+
+  ops::get_projected_request projected;
+  projected.id = test_id();
+  const auto projected_response = pk::decode(proto, key_value_error_context{}, projected);
+  assert_true(projected_response.ctx.ec() == errc::common::internal_server_failure,
+              "a projected read reports it too");
+  assert_true(projected_response.value.empty(), "no invented projected value is handed back");
+}
+
+// snappy sizes its output buffer from the length declared in the frame header before it validates
+// the body, so an inflated length is an allocation request. Nothing larger than the transport's
+// maximum message size can have been carried here, and a std::bad_alloc raised inside a gRPC
+// completion would take the process down rather than fail the operation.
+void
+an_oversized_declared_length_is_refused()
+{
+  std::optional<std::string> frame;
+  {
+    const std::string oversized(couchbase::core::protostellar::max_receive_message_size + 1, 'a');
+    frame = pk::maybe_compress(cu::to_binary(oversized), pk::compression_settings{});
+  }
+  assert_true(frame.has_value(), "the fixture compresses");
+  assert_false(pk::snappy_uncompress(*frame).has_value(),
+               "a frame declaring more than the transport can carry is refused, not inflated");
+
+  v1::GetResponse proto;
+  proto.set_content_compressed(*frame);
+  const auto response = pk::decode(proto, key_value_error_context{});
+  assert_true(response.ctx.ec() == errc::common::internal_server_failure,
+              "the refusal surfaces as an error rather than an empty value");
+}
+
+void
+the_min_size_threshold_admits_a_value_of_exactly_min_size()
+{
+  const pk::compression_settings settings{};
+  const auto compresses = [&settings](std::size_t size) {
+    ops::upsert_request request;
+    request.id = test_id();
+    request.value = cu::to_binary(std::string(size, 'a'));
+    return pk::encode(request, settings).content_case() == v1::UpsertRequest::kContentCompressed;
+  };
+  assert_false(compresses(settings.min_size - 1), "one byte below min_size is sent raw");
+  assert_true(compresses(settings.min_size), "a value of exactly min_size is compressed");
+}
+
+// min_ratio is the largest compressed/original ratio still worth sending, so a value landing
+// exactly on it is compressed. The threshold is derived from the fixture's own compressed size over
+// a power-of-two original, which makes both the division and the comparison exact in binary
+// floating point -- an approximate ratio would not tell the inclusive bound from the exclusive one.
+void
+the_min_ratio_threshold_is_inclusive()
+{
+  const std::string original(1024, 'a');
+  const auto value = cu::to_binary(original);
+  const auto measured = pk::maybe_compress(value, pk::compression_settings{ true, 32, 1.0 });
+  assert_true(measured.has_value(), "the fixture compresses at ratio 1.0");
+  const auto exact_ratio = static_cast<double>(measured->size()) / static_cast<double>(1024);
+
+  assert_true(
+    pk::maybe_compress(value, pk::compression_settings{ true, 32, exact_ratio }).has_value(),
+    "a value landing exactly on min_ratio is compressed");
+  const auto below = static_cast<double>(measured->size() - 1) / static_cast<double>(1024);
+  assert_false(pk::maybe_compress(value, pk::compression_settings{ true, 32, below }).has_value(),
+               "a value that misses min_ratio is sent raw");
+}
+
+// A value can clear min_size and still be worth sending raw. Without the ratio check every
+// incompressible payload would go out larger than it arrived.
+void
+an_incompressible_value_is_sent_uncompressed()
+{
+  // A fixed linear congruential sequence rather than <random>: the bytes have to be the same on
+  // every platform for the ratio the assertion depends on to be the same.
+  std::uint32_t state{ 20260806U };
+  std::string noise;
+  noise.reserve(4096);
+  while (noise.size() < 4096) {
+    state = (state * 1103515245U) + 12345U;
+    noise.push_back(static_cast<char>((state >> 16U) & 0xFFU));
+  }
+
+  ops::upsert_request request;
+  request.id = test_id();
+  request.value = cu::to_binary(noise);
+  const auto proto = pk::encode(request, pk::compression_settings{});
+  assert_true(proto.content_case() == v1::UpsertRequest::kContentUncompressed,
+              "a value snappy cannot shrink past min_ratio is sent raw");
+}
+
+void
+cluster_options_maps_compression_settings()
+{
+  couchbase::core::cluster_options options;
+  options.enable_compression = false;
+  options.compression_min_size = 128;
+  options.compression_min_ratio = 0.5;
+
+  const auto settings = couchbase::core::make_compression_settings(options);
+  assert_false(settings.enabled, "enable_compression mapped");
+  assert_eq(settings.min_size, std::size_t{ 128 }, "min_size mapped");
+  assert_eq(settings.min_ratio, 0.5, "min_ratio mapped");
+}
+
+void
+custom_compression_thresholds_are_honoured()
+{
+  const std::string text(256, 'a');
+  ops::upsert_request request;
+  request.id = test_id();
+  request.value = cu::to_binary(text);
+
+  const pk::compression_settings custom{ true, 512, 0.83 };
+  const auto proto = pk::encode(request, custom);
+  assert_true(proto.content_case() == v1::UpsertRequest::kContentUncompressed,
+              "payload below custom min_size is sent uncompressed");
+}
+
 } // namespace
 
 auto
@@ -497,7 +714,6 @@ tests() -> test_suite
     {
       { "get_request_encodes_location", get_request_encodes_location },
       { "get_response_decodes_value_cas_flags", get_response_decodes_value_cas_flags },
-      { "get_response_refuses_compressed_content", get_response_refuses_compressed_content },
       { "expiry_encodes_every_branch_explicitly", expiry_encodes_every_branch_explicitly },
       { "expiry_encodes_every_branch_for_get_and_touch_and_the_counters",
         expiry_encodes_every_branch_for_get_and_touch_and_the_counters },
@@ -517,6 +733,18 @@ tests() -> test_suite
       { "exists_and_lock_responses_decode", exists_and_lock_responses_decode },
       { "counter_encodes_and_decodes", counter_encodes_and_decodes },
       { "append_encodes_content_and_cas", append_encodes_content_and_cas },
+      { "read_compression_opt_in_follows_settings", read_compression_opt_in_follows_settings },
+      { "every_read_path_decodes_compressed_content", every_read_path_decodes_compressed_content },
+      { "compression_round_trips_large_values", compression_round_trips_large_values },
+      { "the_min_size_threshold_admits_a_value_of_exactly_min_size",
+        the_min_size_threshold_admits_a_value_of_exactly_min_size },
+      { "the_min_ratio_threshold_is_inclusive", the_min_ratio_threshold_is_inclusive },
+      { "an_incompressible_value_is_sent_uncompressed",
+        an_incompressible_value_is_sent_uncompressed },
+      { "malformed_compressed_content_fails_closed", malformed_compressed_content_fails_closed },
+      { "an_oversized_declared_length_is_refused", an_oversized_declared_length_is_refused },
+      { "cluster_options_maps_compression_settings", cluster_options_maps_compression_settings },
+      { "custom_compression_thresholds_are_honoured", custom_compression_thresholds_are_honoured },
     },
   };
 }

--- a/test/cng/protostellar/live_kv.cxx
+++ b/test/cng/protostellar/live_kv.cxx
@@ -411,6 +411,113 @@ durable_mutations_against_live_gateway()
   assert_eq(accepted, levels.size(), "every durability level is accepted by the gateway");
 }
 
+// A value the client compressed has to survive the gateway: it arrives in the compressed arm of the
+// request oneof, is translated into an MCBP write carrying the snappy datatype, and reads back
+// byte-identical. The converter tests pin what the client puts on the wire and the in-process
+// server pins what it makes of a reply; neither can say whether the frame the client produces is
+// one a real gateway accepts. Truncating that frame is what this case fails on.
+//
+// The projected read is the second half: it reaches the gateway's ordinary Get handler, so it
+// negotiates compression like any other read and has to complete rather than be refused.
+void
+compressed_values_round_trip_against_live_gateway()
+{
+  const auto connstr_opt = safe_getenv("TEST_CONNECTION_STRING");
+  if (!connstr_opt.has_value()) {
+    skip("TEST_CONNECTION_STRING is not set");
+  }
+  const auto parsed = parse_connection_string(connstr_opt.value());
+  if (!parsed.uses_protostellar()) {
+    skip("TEST_CONNECTION_STRING is not a couchbase2:// endpoint");
+  }
+  if (parsed.bootstrap_nodes.empty()) {
+    skip("no nodes in TEST_CONNECTION_STRING");
+  }
+
+  const auto& node = parsed.bootstrap_nodes.front();
+  const auto port = node.port > 0 ? node.port : parsed.default_port;
+  const std::string endpoint = node.address + ":" + std::to_string(port);
+
+  cluster_options options;
+  options.enable_tls = true;
+  options.tls_verify = tls_verify_mode::none;
+
+  cluster_credentials credentials;
+  credentials.username = env_or("TEST_CB2_USERNAME", "Administrator");
+  credentials.password = env_or("TEST_CB2_PASSWORD", "password");
+
+  const auto bucket = env_or("TEST_CB2_BUCKET", "default");
+  const auto id = document_id{ bucket, "_default", "_default", "cng-live-compressed-key" };
+  const std::string body =
+    R"({"marker":"cng-compressed","padding":")" + std::string(4096, 'a') + R"("})";
+
+  // The document is well past min_size and mostly a single repeated byte, so the client's own
+  // threshold has to choose the compressed arm -- otherwise this case would silently degrade into
+  // an ordinary uncompressed round trip and assert nothing about compression.
+  assert_true(pk::maybe_compress(cu::to_binary(body), pk::compression_settings{}).has_value(),
+              "the fixture document is one the client compresses");
+
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  auto channel = ps::make_channel(endpoint, options, credentials);
+  component_config config;
+  config.channel = channel;
+  config.credentials = credentials;
+  config.timeouts.key_value = 20'000ms;
+  component comp{ io, config };
+
+  std::string failure;
+  bool completed{ false };
+
+  ops::upsert_request upsert;
+  upsert.id = id;
+  upsert.value = cu::to_binary(body);
+  comp.execute(std::move(upsert), [&](ops::upsert_response stored) {
+    if (stored.ctx.ec()) {
+      failure = "compressed upsert: " + stored.ctx.ec().message();
+      work.reset();
+      return;
+    }
+    ops::get_request get;
+    get.id = id;
+    comp.execute(std::move(get), [&](ops::get_response fetched) {
+      if (fetched.ctx.ec()) {
+        failure = "get of a compressed document: " + fetched.ctx.ec().message();
+        work.reset();
+        return;
+      }
+      if (cu::to_string(fetched.value) != body) {
+        failure = "get of a compressed document returned " + std::to_string(fetched.value.size()) +
+                  " bytes, expected " + std::to_string(body.size());
+        work.reset();
+        return;
+      }
+      ops::get_projected_request projected;
+      projected.id = id;
+      projected.projections = { "marker" };
+      comp.execute(std::move(projected), [&](ops::get_projected_response fields) {
+        if (fields.ctx.ec()) {
+          failure = "projected read of a compressed document: " + fields.ctx.ec().message();
+        } else if (cu::to_string(fields.value).find("cng-compressed") == std::string::npos) {
+          failure = "projected read returned " + cu::to_string(fields.value);
+        } else {
+          completed = true;
+        }
+        ops::remove_request cleanup;
+        cleanup.id = id;
+        comp.execute(std::move(cleanup), [&](ops::remove_response) {
+          work.reset();
+        });
+      });
+    });
+  });
+
+  io.run();
+
+  assert_true(failure.empty(), failure);
+  assert_true(completed, "compressed upsert -> get -> projected get completed");
+}
+
 } // namespace
 
 auto
@@ -429,6 +536,10 @@ tests() -> test_suite
         test_env::cluster_only },
       { "durable_mutations_against_live_gateway",
         durable_mutations_against_live_gateway,
+        timeout::integration,
+        test_env::cluster_only },
+      { "compressed_values_round_trip_against_live_gateway",
+        compressed_values_round_trip_against_live_gateway,
         timeout::integration,
         test_env::cluster_only },
     },


### PR DESCRIPTION
The couchbase2 KV path neither requested nor produced snappy-compressed content and read only the
uncompressed field, so a compressed response would have decoded to an empty value (silent data
loss) and large values were always sent raw. RFC 77 makes compression default-on, matching the
Java/Go/.NET SDKs.

Thread the cluster compression settings into the converter: send COMPRESSION_ENABLED_OPTIONAL on
every read that can carry a document body unless the user disabled compression, snappy-compress
Upsert/Insert/Replace when the value is at least min_size and shrinks to at most min_ratio of its
original, and snappy-decode a content_compressed response. COMPRESSION_ENABLED_ALWAYS is never
sent.

A payload that does not decode, or that declares more than the transport's maximum message size,
fails the operation rather than yielding a value. Empty bytes with a valid CAS are
indistinguishable from an empty document, and sizing an allocation from an unvalidated length
header is a denial of service the process cannot survive.

---
Stacked PR **25/30** in the CNG (`couchbase2://`) transport series. The change specific to this PR is its top commit; the commits beneath it belong to earlier PRs in the series. Depends on #1046 — merge the series bottom-up.
