### PR TITLE
CXXCBC-910: stream query/analytics rows incrementally with backpressure

### DIFF
--- a/core/impl/public_bucket.cxx
+++ b/core/impl/public_bucket.cxx
@@ -16,6 +16,7 @@
  */
 
 #include <couchbase/bucket.hxx>
+#include <couchbase/build_config.hxx>
 
 #include "core/cluster.hxx"
 #include "core/tracing/constants.hxx"

--- a/core/impl/public_cluster.cxx
+++ b/core/impl/public_cluster.cxx
@@ -15,6 +15,8 @@
  *   limitations under the License.
  */
 
+#include <couchbase/build_config.hxx>
+
 #include "core/cluster.hxx"
 
 #include "analytics.hxx"

--- a/core/protostellar/analytics_converter.hxx
+++ b/core/protostellar/analytics_converter.hxx
@@ -19,11 +19,12 @@
 
 // Translates the core analytics request/response to and from the couchbase.analytics.v1 protobuf
 // messages, mirroring query_converter. Rows arrive across streamed AnalyticsQueryResponse messages
-// and are buffered into analytics_response::rows; the terminal message carries the metadata.
+// and are buffered into analytics_response::rows when no callback is provided, or delivered
+// incrementally to row_callback when present; the terminal message carries the metadata.
 //
 // Features with no couchbase2 equivalent are reported by can_encode() so the component can surface
-// feature_not_available rather than silently dropping them: the `raw` passthrough map, the
-// streaming row_callback (only the buffered result path is wired), and scoped analytics.
+// feature_not_available rather than silently dropping them: the `raw` passthrough map and scoped
+// analytics.
 //
 // Scoped analytics is refused because the schema cannot express it, not merely because it is
 // unimplemented. AnalyticsQueryRequest at the pinned protostellar revision retired the field the
@@ -55,9 +56,8 @@ namespace v1 = ::couchbase::analytics::v1;
 [[nodiscard]] inline auto
 can_encode(const operations::analytics_request& request) -> bool
 {
-  return request.raw.empty() && !request.row_callback.has_value() &&
-         !request.bucket_name.has_value() && !request.scope_name.has_value() &&
-         !request.scope_qualifier.has_value();
+  return request.raw.empty() && !request.bucket_name.has_value() &&
+         !request.scope_name.has_value() && !request.scope_qualifier.has_value();
 }
 
 inline auto

--- a/core/protostellar/component.cxx
+++ b/core/protostellar/component.cxx
@@ -35,6 +35,7 @@
 #include "core/protostellar/search_converter.hxx"
 #include "core/protostellar/search_index_admin_converter.hxx"
 #include "core/protostellar/view_converter.hxx"
+#include "core/utils/json_stream_control.hxx"
 
 #include <couchbase/error_codes.hxx>
 
@@ -119,6 +120,37 @@ fail_expired(asio::io_context& io, const Request& request, Handler& handler) -> 
   });
   return {};
 }
+
+// Shared state for a streaming query/analytics/search/view response consumed row by row
+// (CXXCBC-910). `callback` is empty for the buffered path. `received_any` drives the CXXCBC-909
+// rule: once the gateway has sent anything the statement has begun executing, so a later error must
+// fail as request_canceled and never retry. It latches on arrival rather than on delivery to a
+// consumer, because a buffered request (no row_callback) is just as unsafe to replay -- a
+// `DELETE FROM ... WHERE ...` whose connection drops after the first result message would otherwise
+// map to a retryable error and apply the mutation twice. `stopped` latches when the consumer
+// returns stream_control::stop -- we keep reading to capture the terminal metadata (matching the
+// HTTP row_callback contract) but stop invoking it.
+struct row_stream_state {
+  std::function<utils::json::stream_control(std::string)> callback{};
+  bool stopped{ false };
+  bool received_any{ false };
+
+  // Feeds one row to the consumer. Returns true when the caller should buffer the row instead
+  // (no row_callback wired); in that case `row` is left untouched.
+  auto consume(std::string&& row) -> bool
+  {
+    received_any = true;
+    if (!callback) {
+      return true;
+    }
+    if (!stopped) {
+      if (callback(std::move(row)) == utils::json::stream_control::stop) {
+        stopped = true;
+      }
+    }
+    return false;
+  }
+};
 
 // Deliver a prepared response carrying ec without sending anything. Posted rather than invoked:
 // completions arrive on the io context, never inline out of execute(), which would re-enter the
@@ -763,9 +795,9 @@ component::execute(const operations::query_request& request,
     return fail_expired_ctx(io_, handler, stamped());
   }
 
-  // Features with no couchbase2 equivalent (raw passthrough, use_replica, streaming row_callback,
-  // node targeting, out-of-range tuning values): fail cleanly rather than silently dropping the
-  // caller's intent.
+  // Features with no couchbase2 equivalent (raw passthrough, use_replica, node targeting,
+  // out-of-range tuning values): fail cleanly rather than silently dropping the caller's intent.
+  // The streaming row_callback is wired below and is deliberately not among them.
   if (!query::can_encode(request)) {
     auto response = stamped();
     response.ctx.ec = errc::common::feature_not_available;
@@ -786,13 +818,18 @@ component::execute(const operations::query_request& request,
   const auto kind = request.readonly ? operation_kind::read_only : operation_kind::mutating;
   auto* stub = stubs_->query.get();
 
-  // Accumulated across streamed messages; shared between the row and completion callbacks.
+  // Accumulated across streamed messages; shared between the row and completion callbacks. With a
+  // row_callback wired, rows are delivered to the consumer as they arrive and `rows` stays empty.
   auto rows = std::make_shared<std::vector<std::string>>();
   auto meta = std::make_shared<operations::query_response::query_meta_data>();
   // Whether a MetaData message arrived at all, which is not the same as what it said. The gateway
   // leaves MetaData nil when its own result.MetaData() fails and still ends the stream OK, and an
   // absent status must not be classified as a failed one.
   auto meta_received = std::make_shared<bool>(false);
+  auto stream = std::make_shared<row_stream_state>();
+  if (request.row_callback) {
+    stream->callback = std::move(*request.row_callback);
+  }
 
   return dispatcher_.server_stream<query_v1::QueryResponse>(
     timeout,
@@ -803,9 +840,12 @@ component::execute(const operations::query_request& request,
       }
       stub->async()->Query(&ctx, proto.get(), reactor);
     },
-    [rows, meta, meta_received](query_v1::QueryResponse message) {
-      for (const auto& row : message.rows()) {
-        rows->push_back(row);
+    [rows, meta, meta_received, stream](query_v1::QueryResponse message) {
+      stream->received_any = true;
+      for (auto& row : *message.mutable_rows()) {
+        if (stream->consume(std::move(row))) {
+          rows->push_back(std::move(row));
+        }
       }
       if (message.has_meta_data()) {
         *meta_received = true;
@@ -817,6 +857,7 @@ component::execute(const operations::query_request& request,
      rows,
      meta,
      meta_received,
+     stream,
      proto,
      statement,
      client_context_id,
@@ -824,6 +865,10 @@ component::execute(const operations::query_request& request,
       (void)proto; // kept only to keep the request alive for the call
       operations::query_response response;
       response.ctx.ec = map_status(status, kind);
+      // CXXCBC-909: a mid-stream error after the gateway sent anything cannot be retried.
+      if (stream->received_any && retry_reason_for(response.ctx.ec).has_value()) {
+        response.ctx.ec = errc::common::request_canceled;
+      }
       response.ctx.statement = std::move(statement);
       response.ctx.client_context_id =
         meta->client_context_id.empty() ? std::move(client_context_id) : meta->client_context_id;
@@ -867,8 +912,8 @@ component::execute(const operations::analytics_request& request,
     return fail_expired_ctx(io_, handler, stamped());
   }
 
-  // Scoped analytics, raw passthrough, and the streaming row_callback have no couchbase2 mapping:
-  // fail cleanly rather than dropping the caller's intent.
+  // Scoped analytics and raw passthrough have no couchbase2 mapping: fail cleanly rather than
+  // dropping the caller's intent. The streaming row_callback is wired below and is not among them.
   if (!analytics::can_encode(request)) {
     auto response = stamped();
     response.ctx.ec = errc::common::feature_not_available;
@@ -894,6 +939,10 @@ component::execute(const operations::analytics_request& request,
   // gateway reported as running. Classifying without this would turn a stream that ended OK with no
   // metadata into an error.
   auto meta_received = std::make_shared<bool>(false);
+  auto stream = std::make_shared<row_stream_state>();
+  if (request.row_callback) {
+    stream->callback = std::move(*request.row_callback);
+  }
 
   return dispatcher_.server_stream<analytics_v1::AnalyticsQueryResponse>(
     timeout,
@@ -904,9 +953,12 @@ component::execute(const operations::analytics_request& request,
       }
       stub->async()->AnalyticsQuery(&ctx, proto.get(), reactor);
     },
-    [rows, meta, meta_received](analytics_v1::AnalyticsQueryResponse message) {
-      for (const auto& row : message.rows()) {
-        rows->push_back(row);
+    [rows, meta, meta_received, stream](analytics_v1::AnalyticsQueryResponse message) {
+      stream->received_any = true;
+      for (auto& row : *message.mutable_rows()) {
+        if (stream->consume(std::move(row))) {
+          rows->push_back(std::move(row));
+        }
       }
       if (message.has_meta_data()) {
         *meta_received = true;
@@ -918,6 +970,7 @@ component::execute(const operations::analytics_request& request,
      rows,
      meta,
      meta_received,
+     stream,
      proto,
      statement,
      client_context_id,
@@ -925,6 +978,10 @@ component::execute(const operations::analytics_request& request,
       (void)proto; // kept only to keep the request alive for the call
       operations::analytics_response response;
       response.ctx.ec = map_status(status, kind);
+      // CXXCBC-909: a mid-stream error after the gateway sent anything cannot be retried.
+      if (stream->received_any && retry_reason_for(response.ctx.ec).has_value()) {
+        response.ctx.ec = errc::common::request_canceled;
+      }
       response.ctx.statement = std::move(statement);
       response.ctx.client_context_id =
         meta->client_context_id.empty() ? std::move(client_context_id) : meta->client_context_id;

--- a/core/protostellar/component.hxx
+++ b/core/protostellar/component.hxx
@@ -240,8 +240,9 @@ public:
                utils::movable_function<void(operations::prepend_response)>&& handler)
     -> pending_call;
 
-  // N1QL query over the couchbase2 server-streaming transport. Rows are buffered into the response;
-  // the terminal message carries the metadata.
+  // N1QL query over the couchbase2 server-streaming transport. Rows are buffered into the response
+  // when no callback is provided, or delivered incrementally to row_callback when present; the
+  // terminal message carries the metadata.
   auto execute(const operations::query_request& request,
                utils::movable_function<void(operations::query_response)>&& handler) -> pending_call;
 

--- a/core/protostellar/dispatcher.hxx
+++ b/core/protostellar/dispatcher.hxx
@@ -29,6 +29,7 @@
 #include <chrono>
 #include <condition_variable>
 #include <cstddef>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -61,8 +62,21 @@ public:
   // even if a concurrent completion removes and releases the caller's own reference.
   void add(std::shared_ptr<grpc::ClientContext> context)
   {
+    auto* key = context.get();
     const std::scoped_lock lock{ mutex_ };
-    outstanding_.emplace(context.get(), std::move(context));
+    outstanding_.emplace(key, entry{ std::move(context), {}, {} });
+  }
+
+  // As above, for a call that cancellation alone does not drive to completion. `on_cancel` runs
+  // straight after TryCancel; `owner` keeps the call's own object alive for as long as it stays
+  // registered, so that hook cannot run against freed storage.
+  void add(std::shared_ptr<grpc::ClientContext> context,
+           std::function<void()> on_cancel,
+           std::shared_ptr<void> owner)
+  {
+    auto* key = context.get();
+    const std::scoped_lock lock{ mutex_ };
+    outstanding_.emplace(key, entry{ std::move(context), std::move(on_cancel), std::move(owner) });
   }
 
   void remove(grpc::ClientContext* context)
@@ -74,27 +88,33 @@ public:
     }
   }
 
-  // Cancel every in-flight call and block until all of their gRPC callbacks have run. Runs on the
-  // io_context thread at shutdown while gRPC's own threads deliver the cancellations, so there is
-  // no self-deadlock (the completions post back onto the io_context, which stays queued until the
-  // drain returns).
+  // Cancel every in-flight call and block until all of their gRPC callbacks have run. Runs on
+  // whichever thread destroys the dispatcher: the io_context thread, another thread while the io
+  // thread keeps running, or a thread that never runs the io_context at all. Nothing here may
+  // therefore depend on io_context work making progress. gRPC's own threads deliver the
+  // cancellations and the completions post back onto the io_context, where they stay queued until
+  // the drain returns, so blocking here cannot deadlock against them.
   void cancel_and_drain()
   {
-    // Snapshot owning shared_ptrs under the lock, then release it before calling TryCancel so no
-    // external gRPC call runs while mutex_ is held (a completion delivered on a gRPC thread takes
-    // that same lock in remove()). The snapshot keeps every context alive across the unlocked
-    // cancel, so a concurrent completion that removes and releases its own reference cannot leave a
-    // dangling pointer under TryCancel.
-    std::vector<std::shared_ptr<grpc::ClientContext>> pending;
+    // Snapshot the entries under the lock, then release it before calling TryCancel or any cancel
+    // hook so no external gRPC call runs while mutex_ is held (a completion delivered on a gRPC
+    // thread takes that same lock in remove(), and releasing a read hold can deliver OnDone
+    // inline). The snapshot keeps every context and owner alive across the unlocked cancel, so a
+    // concurrent completion that removes and releases its own reference cannot leave a dangling
+    // pointer here.
+    std::vector<entry> pending;
     {
       const std::scoped_lock lock{ mutex_ };
       pending.reserve(outstanding_.size());
-      for (const auto& [ptr, context] : outstanding_) {
-        pending.push_back(context);
+      for (const auto& [ptr, item] : outstanding_) {
+        pending.push_back(item);
       }
     }
-    for (const auto& context : pending) {
-      context->TryCancel();
+    for (const auto& item : pending) {
+      item.context->TryCancel();
+      if (item.on_cancel) {
+        item.on_cancel();
+      }
     }
     std::unique_lock lock{ mutex_ };
     idle_.wait(lock, [this] {
@@ -103,9 +123,21 @@ public:
   }
 
 private:
+  struct entry {
+    std::shared_ptr<grpc::ClientContext> context;
+    // Run straight after TryCancel for calls that cancellation alone does not finish. A streaming
+    // call registers one that releases its read hold: gRPC defers OnDone while a hold is active,
+    // and the hold is otherwise released only from an io_context continuation -- which cannot run
+    // when the drain is itself blocking the io thread. Empty for unary calls, which take no holds.
+    std::function<void()> on_cancel;
+    // Keeps a self-owning call object (the streaming reactor) alive for as long as it is
+    // registered, so on_cancel cannot run against freed storage.
+    std::shared_ptr<void> owner;
+  };
+
   std::mutex mutex_{};
   std::condition_variable idle_{};
-  std::unordered_map<grpc::ClientContext*, std::shared_ptr<grpc::ClientContext>> outstanding_{};
+  std::unordered_map<grpc::ClientContext*, entry> outstanding_{};
 };
 
 // Handle to an in-flight unary call. cancel() maps to gRPC's client-side TryCancel; the call still
@@ -161,12 +193,17 @@ default_channel_arguments() -> grpc::ChannelArguments;
 make_insecure_channel(const std::string& endpoint) -> std::shared_ptr<grpc::Channel>;
 
 // Reads a gRPC server stream via the callback API and hands each message, plus the terminal
-// status, to the io_context. Self-owning: ownership passes to the completion posted from OnDone, so
-// the reactor is destroyed whether that task runs or is discarded with the io_context.
-// Assumes a single-threaded io_context (the SDK contract), so the FIFO post order guarantees
-// every row is delivered before the completion runs.
+// status, to the io_context. Assumes a single-threaded io_context (the SDK contract), so the FIFO
+// post order guarantees every row is delivered before the completion runs.
+//
+// Held by shared_ptr, with every posted continuation carrying a strong reference. That covers both
+// endings: the last reference is dropped either by the io_context running the completion or by the
+// io_context being destroyed with the completion still queued. It also lets the read hold below be
+// released from another thread without racing the reactor's own destruction.
 template<typename Response>
-class streaming_reactor final : public grpc::ClientReadReactor<Response>
+class streaming_reactor final
+  : public grpc::ClientReadReactor<Response>
+  , public std::enable_shared_from_this<streaming_reactor<Response>>
 {
 public:
   streaming_reactor(asio::io_context& io,
@@ -184,20 +221,90 @@ public:
 
   void begin()
   {
+    // Because backpressure re-issues StartRead from the io_context (outside the reaction, see
+    // OnReadDone), a hold keeps the call alive between a completed read and the next StartRead --
+    // otherwise gRPC could finalize the call (fire OnDone, free the reader) while a queued read
+    // task still holds a pointer to it, and the stray StartRead would hit a destroyed call. This is
+    // gRPC's documented requirement for issuing an operation from outside a reaction, not a local
+    // precaution: see the AddHold contract in grpcpp/impl/codegen/client_callback.h.
+    //
+    // The hold is released in OnReadDone once a read comes back not-ok, or by release_hold() when
+    // the call is cancelled while no read is outstanding. That second caller is not the read loop's
+    // owner and cannot know whether a read task is still queued, so the hold alone does not close
+    // the window -- release_hold() and the queued StartRead are ordered against each other instead.
+    //
+    // This runs under the same lock, because server_stream() registers the cancel hook before the
+    // invoker binds the reactor to a call: a drain in that window would otherwise reach RemoveHold
+    // with no reader bound and no hold taken. Under the lock the two orders are both well defined
+    // -- either the hold is taken and the drain releases it, or the drain gets there first and no
+    // hold is taken at all. The call is still started in that second case, so it runs to OnDone and
+    // releases the drain rather than stranding it.
+    const std::scoped_lock lock{ mutex_ };
+    if (!hold_released_) {
+      this->AddHold();
+      hold_taken_ = true;
+    }
     this->StartRead(&current_);
     this->StartCall();
+  }
+
+  // Releases begin()'s hold, at most once however many times this is called -- RemoveHold has to
+  // balance AddHold exactly, and two callers race for it: OnReadDone when reads stop, and
+  // cancel_and_drain() through the hook registered in server_stream().
+  //
+  // The drain needs that hook because a hold defers OnDone. Between a completed read and the next
+  // StartRead no read is outstanding for TryCancel to fail, so nothing would drive the call to
+  // completion, and the drain -- which may be running on the io_context thread itself -- would wait
+  // for an OnDone that cannot fire until a continuation that cannot run has run.
+  //
+  // The lock orders this release against the queued StartRead in OnReadDone; it is not there to
+  // make the flag thread-safe. Removing the last hold destroys the reader synchronously, inside
+  // RemoveHold, so the two must not overlap: whichever side acquires the lock first, the other sees
+  // a decision already made rather than a reader mid-destruction. Releasing while a read is
+  // outstanding is harmless -- the outstanding read keeps gRPC's own count above zero, so it
+  // finalizes only once that read completes.
+  void release_hold()
+  {
+    const std::scoped_lock lock{ mutex_ };
+    if (!hold_released_) {
+      hold_released_ = true;
+      // Nothing to balance if begin() has not run yet: the reactor is reachable from the tracker
+      // before the invoker binds it to a call, and RemoveHold on an unbound reactor dereferences a
+      // reader that does not exist. Setting the flag is enough -- begin() reads it and skips the
+      // hold.
+      if (hold_taken_) {
+        this->RemoveHold();
+      }
+    }
   }
 
   void OnReadDone(bool ok) override
   {
     if (!ok) {
-      return; // stream finished; OnDone follows
+      release_hold(); // no more reads; let the call finalize and OnDone fire
+      return;
     }
     auto message = std::make_shared<Response>(std::move(current_));
-    asio::post(io_, [this, message]() {
-      on_row_(std::move(*message));
+    // Backpressure: issue the next read from *inside* the io_context continuation, only after the
+    // consumer has processed this row. On a single-threaded io_context that caps the amount gRPC
+    // reads ahead of a slow consumer at one message, instead of draining the whole stream into the
+    // asio post queue. current_ is moved-from here but no read is outstanding until StartRead runs.
+    // The continuation holds a strong reference so it cannot outlive its own reactor.
+    //
+    // The consumer runs before the lock is taken, deliberately: it is caller code, and holding the
+    // reactor's lock across it would let a slow or blocking consumer stall a concurrent drain.
+    asio::post(io_, [self = this->shared_from_this(), message]() {
+      self->on_row_(std::move(*message));
+      const std::scoped_lock lock{ self->mutex_ };
+      if (self->hold_released_) {
+        // The hold is gone, so gRPC may already have destroyed the reader -- it does so inside
+        // RemoveHold -- and a StartRead would dispatch through it. Nothing is lost by stopping
+        // here: the hold was released either because reads had finished or because the call was
+        // cancelled, and either way it is already on its way to OnDone.
+        return;
+      }
+      self->StartRead(&self->current_);
     });
-    this->StartRead(&current_);
   }
 
   void OnDone(const grpc::Status& status) override
@@ -214,20 +321,25 @@ public:
     // Copy the status into the closure -- it is a reference parameter, so the posted task must own
     // its own copy rather than capture a reference that dangles once OnDone returns.
     //
-    // Ownership of the reactor moves into the task rather than being released by its body: a task
-    // that ran `delete this` would never delete anything when the task is destroyed without being
-    // run, which is exactly what happens when the io_context is torn down with this completion
-    // still queued. Holding it in a unique_ptr covers both endings -- run, or destroyed unrun.
-    asio::post(io_,
-               [self = std::unique_ptr<streaming_reactor>(this), status_copy = status]() mutable {
-                 // Moved rather than copied: the task owns this status and does not touch it again,
-                 // and grpc::Status carries two std::strings.
-                 self->on_done_(std::move(status_copy));
-               });
+    // The strong reference is what destroys the reactor: dropped when this task runs, or when the
+    // task is destroyed unrun because the io_context went away first. A shared_ptr rather than the
+    // unique_ptr this held before backpressure, because the cancel hook needs a weak reference to
+    // the same object.
+    asio::post(io_, [self = this->shared_from_this(), status_copy = status]() mutable {
+      // Moved rather than copied: the task owns this status and does not touch it again, and
+      // grpc::Status carries two std::strings.
+      self->on_done_(std::move(status_copy));
+    });
     tracker->remove(context);
   }
 
 private:
+  // Guards the hold flags and, with them, the ordering between releasing the hold and issuing a
+  // read -- both the next read in OnReadDone and the first one in begin(). Uncontended in steady
+  // state: only the io_context thread takes it, and the cancel hook once at teardown.
+  std::mutex mutex_{};
+  bool hold_taken_{ false };
+  bool hold_released_{ false };
   asio::io_context& io_;
   std::shared_ptr<call_tracker> tracker_;
   Response current_{};
@@ -328,28 +440,33 @@ public:
   {
     auto context = std::make_shared<grpc::ClientContext>();
     context->set_deadline(call_deadline(timeout));
-    // Register before launch so shutdown can cancel it; the reactor deregisters in OnDone.
-    tracker_->add(context);
-    // Owned by gRPC for the duration of the call; deletes itself in OnDone.
-    auto* reactor = new streaming_reactor<Response>(
+    // gRPC only borrows the reactor for the duration of the call; ownership stays with this
+    // shared_ptr and the continuations the reactor posts.
+    auto reactor = std::make_shared<streaming_reactor<Response>>(
       io_, tracker_, context, std::move(on_row), std::move(on_done));
-    // If the invoker fails to bind the reactor to a call, OnDone never fires, so deregister and
-    // delete the reactor here rather than leak it and block cancel_and_drain() forever at shutdown.
-    //
-    // Only when the invoker itself threw, though. Once it returns, gRPC holds this pointer and will
-    // call OnDone on it, so deleting it because the later begin() threw -- StartRead and StartCall
-    // allocate, so bad_alloc is the realistic path -- would hand gRPC freed storage. Leaving it for
-    // OnDone to release instead risks leaking a reactor whose call never started, which is the
-    // better of the two failures.
-    auto bound = false;
+    // Register before launch so shutdown can cancel it; the reactor deregisters in OnDone. The hook
+    // releases the reactor's read hold, without which a cancelled-but-parked stream never reaches
+    // OnDone and the drain blocks forever; the reactor doubles as the owner so the hook always has
+    // a live object to call.
+    tracker_->add(
+      context,
+      [weak = std::weak_ptr<streaming_reactor<Response>>{ reactor }]() {
+        if (const auto locked = weak.lock()) {
+          locked->release_hold();
+        }
+      },
+      reactor);
+    // If the invoker fails to bind the reactor to a call, OnDone never fires, so deregister here
+    // rather than block cancel_and_drain() forever at shutdown. Dropping the tracker's reference
+    // leaves this scope holding the last one, so the reactor is destroyed as the exception unwinds.
+    bool bound{ false };
     try {
-      std::forward<Invoker>(invoker)(*context, reactor);
+      std::forward<Invoker>(invoker)(*context, reactor.get());
       bound = true;
       reactor->begin();
     } catch (...) {
-      tracker_->remove(context.get());
       if (!bound) {
-        delete reactor;
+        tracker_->remove(context.get());
       }
       throw;
     }

--- a/core/protostellar/query_converter.hxx
+++ b/core/protostellar/query_converter.hxx
@@ -19,13 +19,14 @@
 
 // Translates the core N1QL query request/response to and from the couchbase.query.v1 protobuf
 // messages. Rows arrive across streamed QueryResponse messages and are buffered into
-// query_response::rows; the terminal message carries the metadata. Deliberately does not reuse the
+// query_response::rows when no callback is provided, or delivered incrementally to row_callback
+// when present; the terminal message carries the metadata. Deliberately does not reuse the
 // MCBP-bound encode_to/make_response (those build an HTTP body + parse a JSON reply).
 //
 // Query features with no couchbase2 equivalent are reported by can_encode() so the component can
 // surface feature_not_available rather than silently dropping them: the `raw` passthrough map,
-// use_replica, the streaming row_callback (only the buffered result path is wired), node targeting
-// via send_to_node, and tuning values too large for the proto's uint32 fields.
+// use_replica, node targeting via send_to_node, and tuning values too large for the proto's
+// uint32 fields.
 
 #include "core/json_string.hxx"
 #include "core/operations/document_query.hxx"
@@ -59,9 +60,9 @@ fits_uint32(const std::optional<std::uint64_t>& value) -> bool
 can_encode(const operations::query_request& request) -> bool
 {
   return request.raw.empty() && !request.use_replica.value_or(false) &&
-         !request.row_callback.has_value() && !request.send_to_node.has_value() &&
-         fits_uint32(request.max_parallelism) && fits_uint32(request.pipeline_batch) &&
-         fits_uint32(request.pipeline_cap) && fits_uint32(request.scan_cap);
+         !request.send_to_node.has_value() && fits_uint32(request.max_parallelism) &&
+         fits_uint32(request.pipeline_batch) && fits_uint32(request.pipeline_cap) &&
+         fits_uint32(request.scan_cap);
 }
 
 // Split the SDK query_context ("default:`bucket`.`scope`") into the proto's bucket_name/scope_name.

--- a/test/cng/CMakeLists.txt
+++ b/test/cng/CMakeLists.txt
@@ -188,4 +188,7 @@ if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 AND TARGET couchbase_cxx_protostellar)
   add_cng_test(protostellar/component_timeouts LINK_CLIENT LIBS couchbase_cxx_protostellar)
   # Ping / diagnostics feature_not_available over couchbase2 (CXXCBC-907).
   add_cng_test(protostellar/ping_diagnostics LINK_CLIENT LIBS couchbase_cxx_protostellar)
+
+  # Streaming backpressure & cancel (CXXCBC-910).
+  add_cng_test(protostellar/query_streaming LINK_CLIENT LIBS couchbase_cxx_protostellar)
 endif()

--- a/test/cng/protostellar/analytics_converter.cxx
+++ b/test/cng/protostellar/analytics_converter.cxx
@@ -122,6 +122,12 @@ can_encode_rejects_unsupported_features()
   ops::analytics_request with_raw = base;
   with_raw.raw.emplace("timeout", couchbase::core::json_string{ "\"1s\"" });
   assert_false(pa::can_encode(with_raw), "raw passthrough is not supported");
+
+  ops::analytics_request with_row_callback = base;
+  with_row_callback.row_callback = [](std::string) {
+    return couchbase::core::utils::json::stream_control::next_row;
+  };
+  assert_true(pa::can_encode(with_row_callback), "the analytics streaming row callback is wired");
 }
 
 // Every way of naming a scope has to be refused, not just the one the original test covered. The

--- a/test/cng/protostellar/query_converter.cxx
+++ b/test/cng/protostellar/query_converter.cxx
@@ -340,11 +340,13 @@ can_encode_rejects_unsupported_features()
   without_replica.use_replica = false;
   assert_true(pq::can_encode(without_replica), "use_replica=false is not a rejection");
 
+  // Wired as of CXXCBC-910: rows are handed to the callback as they arrive rather than buffered,
+  // so this is no longer a reason to refuse the request.
   ops::query_request with_row_callback = base;
   with_row_callback.row_callback = [](std::string) {
     return couchbase::core::utils::json::stream_control::next_row;
   };
-  assert_false(pq::can_encode(with_row_callback), "the streaming row callback is not wired");
+  assert_true(pq::can_encode(with_row_callback), "the streaming row callback is wired");
 
   // There is no proto field for node targeting and the gateway routes on its own, so honouring
   // the request is impossible; couchbase-jvm-clients raises the same refusal.

--- a/test/cng/protostellar/query_streaming.cxx
+++ b/test/cng/protostellar/query_streaming.cxx
@@ -1,0 +1,510 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Streaming row_callback wiring for query over couchbase2 (CXXCBC-910 / -0025). Drives the
+// component against an in-process QueryService: rows delivered incrementally via row_callback,
+// stream_control::stop draining to the terminal metadata, and a mid-stream error surfacing as
+// request_canceled once rows have reached the consumer. Env-agnostic (in-process server).
+
+#include "framework/test_runner.hxx"
+
+#include "core/cluster_credentials.hxx"
+#include "core/operations/document_analytics.hxx"
+#include "core/operations/document_query.hxx"
+#include "core/protostellar/component.hxx"
+#include "core/protostellar/query_proto.hxx"
+#include "core/utils/json_stream_control.hxx"
+
+#include <couchbase/analytics/v1/analytics.grpc.pb.h>
+#include <couchbase/error_codes.hxx>
+
+#include <asio/executor_work_guard.hpp>
+#include <asio/io_context.hpp>
+
+#include <grpcpp/server_builder.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace v1 = ::couchbase::query::v1;
+namespace ops = ::couchbase::core::operations;
+using ::couchbase::core::cluster_credentials;
+using ::couchbase::core::protostellar::component;
+using ::couchbase::core::protostellar::component_config;
+using ::couchbase::core::utils::json::stream_control;
+using namespace std::chrono_literals;
+
+// Branches on the statement so a single service covers every case: "ok" streams two batches plus a
+// metadata tail; "error" streams one row then fails with a retryable status (UNAVAILABLE).
+class test_query_service final : public v1::QueryService::Service
+{
+public:
+  // Counts what actually reached the server, which is how a case distinguishes "rejected before
+  // dispatch" from "dispatched and then failed" -- the response alone cannot tell them apart.
+  std::atomic<int> calls_received{ 0 };
+
+  auto Query(grpc::ServerContext* /* context */,
+             const v1::QueryRequest* request,
+             grpc::ServerWriter<v1::QueryResponse>* writer) -> grpc::Status override
+  {
+    calls_received.fetch_add(1);
+    {
+      v1::QueryResponse batch;
+      batch.add_rows("{\"row\":1}");
+      batch.add_rows("{\"row\":2}");
+      writer->Write(batch);
+    }
+    if (request->statement() == "error") {
+      return { grpc::StatusCode::UNAVAILABLE, "gateway went away mid-stream" };
+    }
+    if (request->statement() == "invalid_argument") {
+      return { grpc::StatusCode::INVALID_ARGUMENT, "invalid argument mid-stream" };
+    }
+    {
+      v1::QueryResponse batch;
+      batch.add_rows("{\"row\":3}");
+      writer->Write(batch);
+    }
+    {
+      v1::QueryResponse tail;
+      auto* meta = tail.mutable_meta_data();
+      meta->set_request_id("req-1");
+      meta->set_client_context_id("ctx-1");
+      meta->set_status(v1::QueryResponse_MetaData_Status_STATUS_SUCCESS);
+      writer->Write(tail);
+    }
+    return grpc::Status::OK;
+  }
+};
+
+class in_process_query_server
+{
+public:
+  in_process_query_server()
+  {
+    grpc::ServerBuilder builder;
+    builder.RegisterService(&service_);
+    server_ = builder.BuildAndStart();
+  }
+  in_process_query_server(const in_process_query_server&) = delete;
+  in_process_query_server(in_process_query_server&&) = delete;
+  auto operator=(const in_process_query_server&) -> in_process_query_server& = delete;
+  auto operator=(in_process_query_server&&) -> in_process_query_server& = delete;
+  ~in_process_query_server()
+  {
+    server_->Shutdown(std::chrono::system_clock::now());
+  }
+  [[nodiscard]] auto channel() -> std::shared_ptr<grpc::Channel>
+  {
+    return server_->InProcessChannel(grpc::ChannelArguments{});
+  }
+  [[nodiscard]] auto service() -> test_query_service&
+  {
+    return service_;
+  }
+
+private:
+  test_query_service service_;
+  std::unique_ptr<grpc::Server> server_;
+};
+
+auto
+make_component(asio::io_context& io, in_process_query_server& server) -> component
+{
+  return component{ io,
+                    component_config{ server.channel(),
+                                      cluster_credentials{},
+                                      { 5000ms, 5000ms, 5000ms, 5000ms, 5000ms, 5000ms, 5000ms },
+                                      { false } } };
+}
+
+void
+row_callback_delivers_rows_incrementally()
+{
+  in_process_query_server server;
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  auto comp = make_component(io, server);
+
+  std::vector<std::string> delivered;
+  ops::query_request request;
+  request.statement = "ok";
+  request.row_callback = [&delivered](std::string row) {
+    delivered.push_back(std::move(row));
+    return stream_control::next_row;
+  };
+
+  ops::query_response outcome;
+  comp.execute(std::move(request), [&](ops::query_response response) {
+    outcome = std::move(response);
+    work.reset();
+  });
+  io.run();
+
+  assert_false(static_cast<bool>(outcome.ctx.ec), "query succeeded");
+  assert_eq(delivered.size(), std::size_t{ 3 }, "every row reached the callback");
+  assert_eq(delivered.at(0), std::string{ "{\"row\":1}" }, "row order preserved");
+  assert_eq(delivered.at(2), std::string{ "{\"row\":3}" }, "last row delivered");
+  assert_true(outcome.rows.empty(), "rows are not also buffered into the response");
+  assert_eq(outcome.meta.client_context_id, std::string{ "ctx-1" }, "terminal metadata captured");
+}
+
+void
+row_callback_stop_drains_to_metadata()
+{
+  in_process_query_server server;
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  auto comp = make_component(io, server);
+
+  std::vector<std::string> delivered;
+  ops::query_request request;
+  request.statement = "ok";
+  request.row_callback = [&delivered](std::string row) {
+    delivered.push_back(std::move(row));
+    return stream_control::stop; // stop after the very first row
+  };
+
+  ops::query_response outcome;
+  comp.execute(std::move(request), [&](ops::query_response response) {
+    outcome = std::move(response);
+    work.reset();
+  });
+  io.run();
+
+  assert_false(static_cast<bool>(outcome.ctx.ec), "stream still completes cleanly");
+  assert_eq(delivered.size(), std::size_t{ 1 }, "no rows delivered after stop");
+  assert_eq(outcome.meta.client_context_id,
+            std::string{ "ctx-1" },
+            "terminal metadata still captured after stop");
+}
+
+void
+mid_stream_error_after_delivery_maps_to_request_canceled()
+{
+  in_process_query_server server;
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  auto comp = make_component(io, server);
+
+  std::vector<std::string> delivered;
+  ops::query_request request;
+  request.statement = "error";
+  request.row_callback = [&delivered](std::string row) {
+    delivered.push_back(std::move(row));
+    return stream_control::next_row;
+  };
+
+  ops::query_response outcome;
+  comp.execute(std::move(request), [&](ops::query_response response) {
+    outcome = std::move(response);
+    work.reset();
+  });
+  io.run();
+
+  assert_false(delivered.empty(), "rows reached the consumer before the error");
+  assert_true(outcome.ctx.ec == couchbase::errc::common::request_canceled,
+              "a retryable error after delivery becomes request_canceled");
+}
+
+// The same mid-stream failure without a row_callback. The buffered path has no consumer to deliver
+// to, but the gateway has still executed the statement, so replaying it is just as unsafe: a
+// `DELETE FROM ... WHERE ...` that streamed a result message before the connection dropped would be
+// applied twice by the retry loop. The rows the case never reads are the point -- they are what
+// proves the statement ran.
+void
+a_buffered_mid_stream_error_maps_to_request_canceled()
+{
+  in_process_query_server server;
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  auto comp = make_component(io, server);
+
+  ops::query_request request;
+  request.statement = "error";
+
+  ops::query_response outcome;
+  comp.execute(std::move(request), [&](ops::query_response response) {
+    outcome = std::move(response);
+    work.reset();
+  });
+  io.run();
+
+  assert_false(outcome.rows.empty(), "the gateway's row was buffered before the error");
+  assert_true(outcome.ctx.ec == couchbase::errc::common::request_canceled,
+              "a retryable error after the gateway sent rows becomes request_canceled");
+}
+
+void
+a_non_retryable_mid_stream_error_preserves_its_error_code()
+{
+  in_process_query_server server;
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  auto comp = make_component(io, server);
+
+  ops::query_request request;
+  request.statement = "invalid_argument";
+
+  ops::query_response outcome;
+  comp.execute(std::move(request), [&](ops::query_response response) {
+    outcome = std::move(response);
+    work.reset();
+  });
+  io.run();
+
+  assert_true(
+    outcome.ctx.ec == couchbase::errc::common::invalid_argument,
+    "a non-retryable error after delivery is preserved rather than remapped to request_canceled");
+}
+
+// The exhausted-budget guard on a non-KV path. The streaming services resolve a timeout exactly as
+// the KV overloads do, so a non-positive one would otherwise reach the dispatcher and become a
+// stream with no deadline -- one that cluster::close() then waits on. Asserting the server saw
+// nothing is what makes this a real check rather than a restatement of the error code.
+void
+an_exhausted_budget_is_rejected_before_dispatch()
+{
+  in_process_query_server server;
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  auto comp = make_component(io, server);
+
+  ops::query_request request;
+  request.statement = "SELECT 1";
+  request.timeout = 0ms;
+
+  std::optional<ops::query_response> outcome;
+  int completions = 0;
+  std::thread::id handler_thread;
+  comp.execute(std::move(request), [&](ops::query_response response) {
+    ++completions;
+    outcome = std::move(response);
+    handler_thread = std::this_thread::get_id();
+    work.reset();
+  });
+  io.run();
+
+  assert_true(outcome.has_value(), "the handler runs");
+  assert_eq(completions, 1, "the handler runs exactly once");
+  assert_true(outcome->ctx.ec == couchbase::errc::common::unambiguous_timeout,
+              "a query that was never sent definitively did not happen");
+  assert_eq(server.service().calls_received.load(), 0, "nothing reached the server");
+  assert_true(handler_thread == std::this_thread::get_id(),
+              "the rejection is delivered on the io thread like every other completion");
+}
+
+namespace analytics_v1 = ::couchbase::analytics::v1;
+
+class test_analytics_service final : public analytics_v1::AnalyticsService::Service
+{
+public:
+  std::atomic<int> calls_received{ 0 };
+
+  auto AnalyticsQuery(grpc::ServerContext* /* context */,
+                      const analytics_v1::AnalyticsQueryRequest* request,
+                      grpc::ServerWriter<analytics_v1::AnalyticsQueryResponse>* writer)
+    -> grpc::Status override
+  {
+    calls_received.fetch_add(1);
+    {
+      analytics_v1::AnalyticsQueryResponse batch;
+      batch.add_rows("{\"analytics_row\":1}");
+      batch.add_rows("{\"analytics_row\":2}");
+      writer->Write(batch);
+    }
+    if (request->statement() == "error") {
+      return { grpc::StatusCode::UNAVAILABLE, "gateway went away mid-stream" };
+    }
+    if (request->statement() == "invalid_argument") {
+      return { grpc::StatusCode::INVALID_ARGUMENT, "invalid argument mid-stream" };
+    }
+    {
+      analytics_v1::AnalyticsQueryResponse tail;
+      auto* meta = tail.mutable_meta_data();
+      meta->set_client_context_id("analytics-ctx-1");
+      meta->set_status("success");
+      writer->Write(tail);
+    }
+    return grpc::Status::OK;
+  }
+};
+
+class in_process_analytics_server
+{
+public:
+  in_process_analytics_server()
+  {
+    grpc::ServerBuilder builder;
+    builder.RegisterService(&service_);
+    server_ = builder.BuildAndStart();
+  }
+  in_process_analytics_server(const in_process_analytics_server&) = delete;
+  in_process_analytics_server(in_process_analytics_server&&) = delete;
+  auto operator=(const in_process_analytics_server&) -> in_process_analytics_server& = delete;
+  auto operator=(in_process_analytics_server&&) -> in_process_analytics_server& = delete;
+  ~in_process_analytics_server()
+  {
+    server_->Shutdown();
+  }
+  [[nodiscard]] auto channel() -> std::shared_ptr<grpc::Channel>
+  {
+    return server_->InProcessChannel(grpc::ChannelArguments{});
+  }
+
+private:
+  test_analytics_service service_;
+  std::unique_ptr<grpc::Server> server_;
+};
+
+void
+analytics_streaming_incremental_delivery_and_stop()
+{
+  in_process_analytics_server server;
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  component comp{ io,
+                  component_config{ server.channel(),
+                                    cluster_credentials{},
+                                    { 5000ms, 5000ms, 5000ms, 5000ms, 5000ms, 5000ms, 5000ms },
+                                    { false } } };
+
+  std::vector<std::string> delivered;
+  ops::analytics_request request;
+  request.statement = "SELECT 1";
+  request.row_callback = [&delivered](std::string row) {
+    delivered.push_back(std::move(row));
+    return stream_control::stop; // stop after 1st row
+  };
+
+  ops::analytics_response outcome;
+  comp.execute(std::move(request), [&](ops::analytics_response response) {
+    outcome = std::move(response);
+    work.reset();
+  });
+  io.run();
+
+  assert_false(static_cast<bool>(outcome.ctx.ec), "analytics query succeeded");
+  assert_eq(delivered.size(), std::size_t{ 1 }, "delivery stopped after 1st row");
+  assert_eq(delivered.at(0), std::string{ "{\"analytics_row\":1}" }, "1st row delivered");
+  assert_eq(outcome.meta.client_context_id,
+            std::string{ "analytics-ctx-1" },
+            "terminal metadata captured after stop");
+}
+
+void
+analytics_mid_stream_error_maps_to_request_canceled()
+{
+  in_process_analytics_server server;
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  component comp{ io,
+                  component_config{ server.channel(),
+                                    cluster_credentials{},
+                                    { 5000ms, 5000ms, 5000ms, 5000ms, 5000ms, 5000ms, 5000ms },
+                                    { false } } };
+
+  ops::analytics_request request;
+  request.statement = "error";
+
+  ops::analytics_response outcome;
+  comp.execute(std::move(request), [&](ops::analytics_response response) {
+    outcome = std::move(response);
+    work.reset();
+  });
+  io.run();
+
+  assert_true(outcome.ctx.ec == couchbase::errc::common::request_canceled,
+              "a retryable analytics error after the gateway sent rows becomes request_canceled");
+}
+
+void
+analytics_non_retryable_mid_stream_error_preserves_its_error_code()
+{
+  in_process_analytics_server server;
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  component comp{ io,
+                  component_config{ server.channel(),
+                                    cluster_credentials{},
+                                    { 5000ms, 5000ms, 5000ms, 5000ms, 5000ms, 5000ms, 5000ms },
+                                    { false } } };
+
+  ops::analytics_request request;
+  request.statement = "invalid_argument";
+
+  ops::analytics_response outcome;
+  comp.execute(std::move(request), [&](ops::analytics_response response) {
+    outcome = std::move(response);
+    work.reset();
+  });
+  io.run();
+
+  assert_true(outcome.ctx.ec == couchbase::errc::common::invalid_argument,
+              "a non-retryable analytics error after delivery is preserved rather than remapped to "
+              "request_canceled");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_query_streaming",
+    {
+      { "an_exhausted_budget_is_rejected_before_dispatch",
+        an_exhausted_budget_is_rejected_before_dispatch,
+        timeout::network },
+      { "row_callback_delivers_rows_incrementally",
+        row_callback_delivers_rows_incrementally,
+        timeout::network },
+      { "row_callback_stop_drains_to_metadata",
+        row_callback_stop_drains_to_metadata,
+        timeout::network },
+      { "a_buffered_mid_stream_error_maps_to_request_canceled",
+        a_buffered_mid_stream_error_maps_to_request_canceled,
+        timeout::network },
+      { "mid_stream_error_after_delivery_maps_to_request_canceled",
+        mid_stream_error_after_delivery_maps_to_request_canceled,
+        timeout::network },
+      { "a_non_retryable_mid_stream_error_preserves_its_error_code",
+        a_non_retryable_mid_stream_error_preserves_its_error_code,
+        timeout::network },
+      { "analytics_streaming_incremental_delivery_and_stop",
+        analytics_streaming_incremental_delivery_and_stop,
+        timeout::network },
+      { "analytics_mid_stream_error_maps_to_request_canceled",
+        analytics_mid_stream_error_maps_to_request_canceled,
+        timeout::network },
+      { "analytics_non_retryable_mid_stream_error_preserves_its_error_code",
+        analytics_non_retryable_mid_stream_error_preserves_its_error_code,
+        timeout::network },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test

--- a/test/cng/protostellar/streaming.cxx
+++ b/test/cng/protostellar/streaming.cxx
@@ -40,6 +40,8 @@
 #include <atomic>
 #include <chrono>
 #include <cstddef>
+#include <functional>
+#include <future>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -68,6 +70,9 @@ struct service_plan {
   bool send_metadata{ false };          // trailing metadata-only message, as N1QL sends
   bool park_until_cancelled{ false };   // hold the stream open so the client's deadline/cancel wins
   grpc::Status terminal{ grpc::Status::OK };
+  // Signalled after the first message is written, so a case can wait for the stream to be
+  // parked between reads rather than guessing with a sleep.
+  std::function<void()> on_first_write{};
 };
 
 // This tree is C++17, so designated initialisers are out. Named factories rather than positional
@@ -130,6 +135,9 @@ public:
       batch.add_rows("{\"row\":" + std::to_string(i) + "}");
       if (!writer->Write(batch)) {
         return { grpc::StatusCode::CANCELLED, "client went away" };
+      }
+      if (i == 1 && plan_.on_first_write) {
+        plan_.on_first_write();
       }
     }
     if (plan_.send_metadata) {
@@ -695,6 +703,111 @@ streams_launched_from_many_threads_all_complete()
             "every stream launched concurrently completes exactly once");
 }
 
+// A stream parked between reads -- gRPC has delivered a message and is waiting for the io_context
+// to issue the next StartRead -- is the steady state of the backpressure design, and the one state
+// TryCancel alone cannot finish: no read is outstanding to fail, and the read hold defers OnDone.
+// Without a cancel hook that releases that hold, ~dispatcher() waits for an OnDone that cannot
+// fire, so this case fails by timing out rather than by assertion.
+void
+destructor_drains_a_parked_stream()
+{
+  std::promise<void> first_write_promise;
+  auto first_write_future = first_write_promise.get_future();
+
+  auto plan = streams_rows(3);
+  plan.on_first_write = [&first_write_promise]() {
+    first_write_promise.set_value();
+  };
+  in_process_query_server server{ std::move(plan) };
+  const auto channel = server.channel();
+  stream_fixture fixture{ channel };
+  const auto probe = std::make_shared<int>(0);
+
+  {
+    asio::io_context io;
+    dispatcher disp{ io, channel };
+    disp.server_stream<v1::QueryResponse>(
+      timeout::network,
+      fixture.invoker(),
+      [](v1::QueryResponse) {
+      },
+      [probe](grpc::Status) {
+      });
+    // Wait deterministically for gRPC to deliver the first write from the server and park. The
+    // io_context is never run, so nothing issues the next StartRead.
+    const auto write_status = first_write_future.wait_for(10s);
+    assert_true(write_status == std::future_status::ready,
+                "server delivered its first batch to the stream");
+    std::this_thread::sleep_for(10ms);
+  }
+
+  assert_eq(
+    probe.use_count(), long{ 1 }, "the parked reactor is released once the drain completes");
+}
+
+// Releasing the read hold is what permits gRPC to destroy the reader, and it destroys it
+// synchronously inside RemoveHold. The drain returns only after OnDone, which gRPC delivers after
+// that destruction -- so once ~dispatcher() has returned, a queued continuation that still issues
+// StartRead dispatches through a destroyed reader. This parks a continuation between its row and
+// its next read, drains, and only then lets it resume, which is the interleaving
+// streams_launched_from_many_threads_all_complete reaches by chance and this case reaches every
+// run.
+//
+// The consumer runs outside the reactor's lock, which this case also pins: parking inside on_row
+// must not block the drain, so a guard that held the lock across the consumer callback would hang
+// here rather than fail.
+void
+a_row_in_flight_when_the_drain_releases_the_hold_does_not_resume_the_read()
+{
+  std::promise<void> row_delivered_promise;
+  auto row_delivered = row_delivered_promise.get_future();
+  std::promise<void> resume_promise;
+  auto resume = resume_promise.get_future();
+
+  auto plan = streams_rows(1);
+  plan.park_until_cancelled = true;
+  in_process_query_server server{ std::move(plan) };
+  const auto channel = server.channel();
+  stream_fixture fixture{ channel };
+
+  asio::io_context io;
+  auto work = asio::make_work_guard(io);
+  std::thread io_thread{ [&io]() {
+    io.run();
+  } };
+
+  auto rows = 0;
+  auto completions = 0;
+
+  {
+    dispatcher disp{ io, channel };
+    disp.server_stream<v1::QueryResponse>(
+      timeout::network,
+      fixture.invoker(),
+      [&](v1::QueryResponse) {
+        if (++rows == 1) {
+          row_delivered_promise.set_value();
+          // Bounded rather than indefinite: a regression that never releases this parks the io
+          // thread, and a case that fails is worth more than one that hangs.
+          resume.wait_for(park_giveup);
+        }
+      },
+      [&completions](grpc::Status) {
+        ++completions;
+      });
+    const auto delivered = row_delivered.wait_for(park_giveup);
+    assert_true(delivered == std::future_status::ready, "the first row reached the consumer");
+    // ~dispatcher() cancels and drains here, with the continuation still parked before its read.
+  }
+  resume_promise.set_value();
+
+  work.reset();
+  io_thread.join();
+
+  assert_eq(rows, 1, "the row delivered before the drain is not lost");
+  assert_eq(completions, 1, "the stream completes exactly once after the parked read is abandoned");
+}
+
 } // namespace
 
 auto
@@ -728,6 +841,10 @@ tests() -> test_suite
         timeout::network },
       { "an_invoker_that_throws_leaves_nothing_registered",
         an_invoker_that_throws_leaves_nothing_registered,
+        timeout::network },
+      { "destructor_drains_a_parked_stream", destructor_drains_a_parked_stream, timeout::network },
+      { "a_row_in_flight_when_the_drain_releases_the_hold_does_not_resume_the_read",
+        a_row_in_flight_when_the_drain_releases_the_hold_does_not_resume_the_read,
         timeout::network },
       { "concurrent_streams_are_all_drained_by_the_destructor",
         concurrent_streams_are_all_drained_by_the_destructor,


### PR DESCRIPTION
Query and analytics rows were fully buffered into the response before the
handler ran, so a large result set materialized entirely in memory and the
streaming row_callback reported feature_not_available.

Read the gRPC server stream at the consumer's pace: the streaming reactor now
issues the next StartRead from inside the io_context continuation rather than
eagerly on the gRPC thread, capping read-ahead at one message per slow
consumer. Reads are therefore issued from outside the reaction, which gRPC
permits only while the call is held, so the reactor holds it for as long as its
read loop is live. Releasing that hold is ordered against the queued read under
the reactor's own lock, because the last hold going away destroys the reader
synchronously: a read issued after cancellation released the hold would
otherwise dispatch through a destroyed object. Query/analytics execute now feed
each row to the row_callback as it arrives; stream_control::stop stops delivery
but keeps reading to capture the terminal metadata, matching the HTTP contract.

A retryable error that arrives after the gateway has sent anything is mapped
to request_canceled so the op is never silently retried (CXXCBC-909). The latch
is on arrival rather than on delivery to a row_callback: a buffered request
whose statement has already executed is equally unsafe to replay.

---
Stacked PR **1/2** in the CNG (`couchbase2://`) transport series. The change specific to this PR is its top commit; the commits beneath it belong to earlier PRs in the series.