### PR TITLE
CXXCBC-907: report ping/diagnostics as feature_not_available over couchbase2

### DIFF
--- a/core/cluster.cxx
+++ b/core/cluster.cxx
@@ -3099,4 +3099,15 @@ cluster::find_bucket_by_name(const std::string& name) const -> std::shared_ptr<b
   return impl_->find_bucket_by_name(name);
 }
 
+auto
+cluster::is_protostellar() const -> bool
+{
+#ifdef COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2
+  if (impl_) {
+    return impl_->is_protostellar();
+  }
+#endif
+  return false;
+}
+
 } // namespace couchbase::core

--- a/core/cluster.hxx
+++ b/core/cluster.hxx
@@ -367,6 +367,7 @@ public:
   [[nodiscard]] auto cluster_label_listener() const
     -> const std::shared_ptr<cluster_label_listener>&;
   [[nodiscard]] auto find_bucket_by_name(const std::string& name) const -> std::shared_ptr<bucket>;
+  [[nodiscard]] auto is_protostellar() const -> bool;
 
 private:
   std::shared_ptr<cluster_impl> impl_;

--- a/core/impl/public_bucket.cxx
+++ b/core/impl/public_bucket.cxx
@@ -71,6 +71,15 @@ public:
   {
     auto obs_rec = create_observability_recorder(
       core::tracing::operation::ping, std::nullopt, options.parent_span);
+#ifdef COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2
+    if (core_.is_protostellar()) {
+      // couchbase2 has no per-bucket sessions to probe; mirror cluster::ping and the other SDKs.
+      obs_rec->finish(errc::common::feature_not_available);
+      return handler(error{ errc::common::feature_not_available,
+                            "ping is not supported over the couchbase2 protocol" },
+                     {});
+    }
+#endif
     return core_.ping(
       options.report_id,
       name_,

--- a/core/impl/public_cluster.cxx
+++ b/core/impl/public_cluster.cxx
@@ -398,6 +398,17 @@ public:
   {
     auto obs_rec = create_observability_recorder(
       core::tracing::operation::ping, std::nullopt, options.parent_span);
+#ifdef COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2
+    if (core_.is_protostellar()) {
+      // couchbase2 is a thin gRPC client with no per-service sessions to actively probe, and RFC 77
+      // defines no ping semantics for it. Mirror Java/Go/.NET, which surface ping as
+      // feature_not_available on this protocol, rather than returning a misleading empty report.
+      obs_rec->finish(errc::common::feature_not_available);
+      return handler(error{ errc::common::feature_not_available,
+                            "ping is not supported over the couchbase2 protocol" },
+                     {});
+    }
+#endif
     return core_.ping(
       options.report_id,
       {},
@@ -413,6 +424,16 @@ public:
   {
     auto obs_rec = create_observability_recorder(
       core::tracing::operation::diagnostics, std::nullopt, options.parent_span);
+#ifdef COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2
+    if (core_.is_protostellar()) {
+      // No per-service sessions exist to report on over couchbase2, and the RFC 77 Diagnostics
+      // section is empty. Mirror Java/Go/.NET (feature_not_available) instead of an empty report.
+      obs_rec->finish(errc::common::feature_not_available);
+      return handler(error{ errc::common::feature_not_available,
+                            "diagnostics is not supported over the couchbase2 protocol" },
+                     {});
+    }
+#endif
     return core_.diagnostics(
       options.report_id,
       [obs_rec = std::move(obs_rec), handler = std::move(handler)](const auto& resp) mutable {

--- a/test/cng/CMakeLists.txt
+++ b/test/cng/CMakeLists.txt
@@ -186,4 +186,6 @@ if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 AND TARGET couchbase_cxx_protostellar)
 
   # KV durable-timeout resolution (CXXCBC-904).
   add_cng_test(protostellar/component_timeouts LINK_CLIENT LIBS couchbase_cxx_protostellar)
+  # Ping / diagnostics feature_not_available over couchbase2 (CXXCBC-907).
+  add_cng_test(protostellar/ping_diagnostics LINK_CLIENT LIBS couchbase_cxx_protostellar)
 endif()

--- a/test/cng/protostellar/ping_diagnostics.cxx
+++ b/test/cng/protostellar/ping_diagnostics.cxx
@@ -1,0 +1,82 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// ping()/diagnostics() over couchbase2 (CXXCBC-907). couchbase2 is a thin gRPC client with no
+// per-service sessions to probe, and RFC 77 defines no ping/diagnostics semantics for it, so both
+// return feature_not_available at the public layer (mirroring Java/Go/.NET) rather than an empty,
+// misleading success report. The error is returned before any I/O, so this is env-agnostic: a lazy
+// connect to an unroutable endpoint is enough (no gateway required).
+
+#include "framework/test_runner.hxx"
+
+#include <couchbase/cluster.hxx>
+
+#include <string>
+#include <utility>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+void
+ping_and_diagnostics_are_feature_not_available_over_couchbase2()
+{
+  couchbase::cluster_options options{ "Administrator", "password" };
+  // couchbase2:// is TLS; skip verification so the lazy connect does not depend on a real cert.
+  options.security().tls_verify(couchbase::tls_verify_mode::none);
+
+  // Port 1 has no listener, but the couchbase2 open is lazy (the channel dials on first use), so
+  // connect succeeds without a gateway and ping/diagnostics short-circuit before any I/O.
+  auto [connect_err, cluster] =
+    couchbase::cluster::connect("couchbase2://127.0.0.1:1", options).get();
+  assert_false(connect_err.ec().operator bool(), "connect(couchbase2://) succeeds (lazy)");
+
+  auto [ping_err, ping] = cluster.ping().get();
+  static_cast<void>(ping); // only the error code matters: the op is rejected before a report exists
+  assert_true(ping_err.ec() == couchbase::errc::common::feature_not_available,
+              "cluster.ping() over couchbase2 is feature_not_available");
+
+  auto [diag_err, diag] = cluster.diagnostics().get();
+  static_cast<void>(diag);
+  assert_true(diag_err.ec() == couchbase::errc::common::feature_not_available,
+              "cluster.diagnostics() over couchbase2 is feature_not_available");
+
+  auto [bucket_ping_err, bucket_ping] = cluster.bucket("default").ping().get();
+  static_cast<void>(bucket_ping);
+  assert_true(bucket_ping_err.ec() == couchbase::errc::common::feature_not_available,
+              "bucket.ping() over couchbase2 is feature_not_available");
+
+  cluster.close().get();
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_ping_diagnostics",
+    {
+      { "ping_and_diagnostics_are_feature_not_available_over_couchbase2",
+        ping_and_diagnostics_are_feature_not_available_over_couchbase2,
+        timeout::integration,
+        test_env::agnostic },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test


### PR DESCRIPTION
Over couchbase2, ping() and diagnostics() read absent MCBP structures and
returned an empty but successful report, which misleadingly implies a healthy
cluster with no endpoints.

Return feature_not_available instead, matching Java, Go, and .NET -- all three
surface ping and diagnostics as unavailable on this protocol, none synthesizes
a report, and the RFC 77 diagnostics section is empty. The thin gRPC client has
no per-service sessions to probe. The guard sits at the public layer
(cluster and bucket), where the handler carries an error, keyed on
is_protostellar(), and returns before any I/O. wait_until_ready remains the
supported readiness check (it polls the gRPC channel connectivity state).