### PR TITLE
CXXCBC-102: do not stop a streaming session whose response already completed

### DIFF
--- a/core/io/http_streaming_response.cxx
+++ b/core/io/http_streaming_response.cxx
@@ -65,10 +65,24 @@ public:
         return;
       }
       closed_ = true;
+      // Only stop the session when the response was abandoned mid-body: such a connection is left
+      // at an arbitrary offset and cannot be reused. A response that was already fully received
+      // (reading_complete_) leaves the connection at a message boundary, and http_session has
+      // already handed it back to the keep-alive pool via its stream-end handler
+      // (http_session_manager::check_in) — stopping it here would evict a live pooled connection
+      // and make the *next* unrelated request on it fail with request_canceled.
+      //
+      // The response can be complete before a single read_some: a small body (notably an error
+      // response, whose preamble carries the error and which a consumer therefore cancels rather
+      // than drains) arrives whole in the initial parse, so reading_complete_ is set at
+      // construction while session_ is still held.
+      //
       // Hand the session out to be stopped below, then drop our reference. Written as two
       // statements rather than std::exchange because cppcheck's flow analysis mis-models the
       // std::exchange return value and wrongly reports the `if (to_stop)` guard as always-false.
-      to_stop = session_;
+      if (!reading_complete_) {
+        to_stop = session_;
+      }
       session_ = nullptr;
       final_ec_ = ec;
       // close() is only reached on error/cancel (a clean end sets reading_complete_ instead), so

--- a/test/test_integration_query.cxx
+++ b/test/test_integration_query.cxx
@@ -1120,3 +1120,61 @@ TEST_CASE("integration: streaming query matches buffered query", "[integration]"
 
   cluster.close().get();
 }
+
+TEST_CASE("integration: a rejected streaming query does not evict the pooled connection",
+          "[integration]")
+{
+  test::utils::integration_test_guard integration;
+  if (!integration.cluster_version().supports_query()) {
+    SKIP("cluster does not support query");
+  }
+
+  // A query the service rejects outright answers with a small body that arrives complete in a
+  // single read, so http_session has already handed the connection back to the keep-alive pool (via
+  // its stream-end handler) by the time the streaming layer reports the preamble error and tears
+  // the stream down. That teardown must not stop the session: it no longer belongs to the stream.
+  //
+  // Regression: it did, which raced a stop() against the next request that checked the very same
+  // pooled connection out, failing a perfectly well-formed request with request_canceled. Because
+  // it is a race the repeat below matters -- the defect reproduced on roughly three runs in four,
+  // so a single round would let it through about a quarter of the time.
+  const std::string error_query =
+    "SELECT * FROM `nonexistent_bucket_that_does_not_exist_xyz` LIMIT 1";
+  constexpr int rounds{ 5 };
+
+  for (int round = 0; round < rounds; ++round) {
+    // A fresh connection per round, so each round races against a pool holding exactly the
+    // connection the rejected stream released.
+    auto cluster = integration.public_cluster();
+    {
+      auto [err, result] = cluster.query_stream(error_query).get();
+      // The rejection surfaces either at dispatch or as the stream's terminal; drain in the latter
+      // case so the stream reaches its terminal either way. Assert that it was in fact rejected:
+      // a run where the statement unexpectedly succeeded would exercise none of the teardown this
+      // test guards, and must be a visible failure rather than a silent pass.
+      bool rejected = static_cast<bool>(err.ec());
+      if (!rejected) {
+        while (true) {
+          auto [row_err, row] = result.next().get();
+          if (row_err.ec()) {
+            rejected = true;
+            break;
+          }
+          if (!row.has_value()) {
+            break;
+          }
+        }
+      }
+      REQUIRE(rejected);
+    }
+
+    // The next request is the one that checks out the released connection, and it must succeed.
+    auto [err, result] = cluster.query(R"(SELECT "ok" AS v)", couchbase::query_options{}).get();
+    REQUIRE_SUCCESS(err.ec());
+    auto rows = result.rows_as<couchbase::codec::tao_json_serializer, tao::json::value>();
+    REQUIRE(rows.size() == 1);
+    REQUIRE(rows[0].at("v").get_string() == "ok");
+
+    cluster.close().get();
+  }
+}


### PR DESCRIPTION
**Stack 1/3.** Base `main`. Followed by the error-context fix, then the examples.

### What changes

`http_streaming_response_body::close()` unconditionally stopped the underlying HTTP session. When the response had already been received in full, `http_session` has already handed that session back to the keep-alive pool from its stream-end handler, so stopping it evicted a live pooled connection and raced the next request that checked the same connection out, failing it with `request_canceled`.

`close()` now stops the session only when the body was abandoned mid-response, where the connection is left at an arbitrary offset and is unusable.

Reached whenever a stream is cancelled rather than drained after a small, complete response — a rejected query being the usual case, since its preamble carries the error and there is nothing to drain.

### Test

`integration: a rejected streaming query does not evict the pooled connection`.

The defect is a race, so the test repeats the sequence; a single round misses it a meaningful fraction of the time. Verified to fail without the fix and pass with it.

### Verification

Against a 6-node 8.0.1 cluster (kv/n1ql/index/fts/cbas): `test_integration_query`, `test_unit_query_stream`, `test_unit_http_streaming_response`, `test_unit_row_streamer` pass. `bin/check-clang-format` clean against `main`.

Not covered: a unit-level guard. Observing `session->stop()` needs a mock `http_session` that does not exist, so the integration test is the only guard.
