### PR TITLE
CXXCBC-485: report an error context for streaming query and analytics failures

### DIFF
--- a/core/analytics_stream.cxx
+++ b/core/analytics_stream.cxx
@@ -54,6 +54,28 @@ normalize_stream_error(std::error_code ec) -> std::error_code
 }
 } // namespace
 
+namespace
+{
+// Lift the service-reported diagnostics out of a parsed preamble/trailer. Called for both sections,
+// so whichever one carried the failure is what the error context ends up describing.
+auto
+extract_error_details(const operations::analytics_response::analytics_meta_data& meta,
+                      std::string raw) -> stream_error_details
+{
+  stream_error_details details{};
+  details.client_context_id = meta.client_context_id;
+  // Retained whether or not the section reports an error: it becomes error_context::http_body,
+  // which the buffered path fills for every response, and even an error-free envelope names the
+  // request the service logged.
+  details.raw = std::move(raw);
+  if (!meta.errors.empty()) {
+    details.first_error_code = meta.errors.front().code;
+    details.first_error_message = meta.errors.front().message;
+  }
+  return details;
+}
+} // namespace
+
 class analytics_stream_impl : public std::enable_shared_from_this<analytics_stream_impl>
 {
 public:
@@ -73,11 +95,18 @@ public:
       try {
         meta = operations::parse_analytics_meta(utils::json::parse(preamble));
       } catch (const std::exception&) {
+        {
+          // Keep the unparseable preamble: it is the only diagnostic there is for a malformed
+          // response, and the buffered path reports the raw body in the same situation.
+          const std::scoped_lock lock{ self->mutex_ };
+          self->error_details_.raw = std::move(preamble);
+        }
         return on_ready(errc::common::parsing_failure);
       }
       {
         const std::scoped_lock lock{ self->mutex_ };
         self->signature_ = meta.signature;
+        self->error_details_ = extract_error_details(meta, std::move(preamble));
       }
       // An upfront error is rare for the streaming path (status/errors usually arrive in the
       // trailer). The preamble status is typically "running", so only surface an early error when
@@ -130,9 +159,14 @@ public:
           auto meta = operations::parse_analytics_meta(utils::json::parse(raw_meta.value()));
           terminal_ec = operations::map_analytics_error(meta);
           const std::scoped_lock lock{ self->mutex_ };
+          // The trailer is where a request that failed part-way reports itself, so its diagnostics
+          // supersede the preamble's for the terminal error.
+          self->error_details_ = extract_error_details(meta, std::move(raw_meta.value()));
           self->meta_data_ = std::move(meta);
         } catch (const std::exception&) {
           terminal_ec = errc::common::parsing_failure;
+          const std::scoped_lock lock{ self->mutex_ };
+          self->error_details_.raw = std::move(raw_meta.value());
         }
       }
       {
@@ -157,6 +191,12 @@ public:
     return meta_data_;
   }
 
+  [[nodiscard]] auto error_details() const -> stream_error_details
+  {
+    const std::scoped_lock lock{ mutex_ };
+    return error_details_;
+  }
+
   void cancel()
   {
     streamer_.cancel();
@@ -167,6 +207,7 @@ private:
   mutable std::mutex mutex_{};
   std::optional<std::string> signature_{};
   std::optional<operations::analytics_response::analytics_meta_data> meta_data_{};
+  stream_error_details error_details_{};
   // Terminal-sticky state (guarded by mutex_): once next_row reports the terminal, it is remembered
   // so every later pull re-delivers it instead of parking on the drained channel.
   bool terminal_reached_{ false };
@@ -197,6 +238,12 @@ auto
 analytics_stream::signature() const -> std::optional<std::string>
 {
   return impl_->signature();
+}
+
+auto
+analytics_stream::error_details() const -> stream_error_details
+{
+  return impl_->error_details();
 }
 
 auto

--- a/core/analytics_stream.hxx
+++ b/core/analytics_stream.hxx
@@ -19,6 +19,7 @@
 
 #include "core/operations/document_analytics.hxx"
 #include "row_streamer.hxx"
+#include "stream_error_details.hxx"
 #include "utils/movable_function.hxx"
 
 #include <memory>
@@ -62,6 +63,13 @@ public:
    * the response carried an upfront error (or the preamble failed to parse).
    */
   void start(utils::movable_function<void(std::error_code early_error)>&& on_ready);
+
+  /**
+   * Service-reported diagnostics from the most recently parsed JSON section — the preamble after
+   * start(), the trailer once the terminal has been reached. The dispatch layer stamps these into
+   * the error context so a streaming failure reports the same detail as a buffered one.
+   */
+  [[nodiscard]] auto error_details() const -> stream_error_details;
 
   /**
    * Retrieves the next row. A populated row is delivered with a falsy error_code. An empty row

--- a/core/analytics_stream_component.cxx
+++ b/core/analytics_stream_component.cxx
@@ -110,13 +110,28 @@ public:
 
     http_request http_req{ service_type::analytics, "POST" };
     http_req.path = "/query/service";
+
+    // Everything about the request that an error context reports, known before dispatch. The
+    // response-side fields (HTTP status, the service's first error, the endpoint) are filled in as
+    // they become available, so a failure at any stage carries as much detail as the buffered path.
+    // Held behind a shared_ptr, not by value: it carries the encoded request body in
+    // `parameters`, and both the dispatch callback and the synchronous dispatch-failure branch
+    // below need it, so sharing avoids deep-copying that body on every streaming request.
+    auto base_ctx = std::make_shared<error_context::analytics>();
+    base_ctx->client_context_id = client_context_id;
+    base_ctx->statement = request.statement;
+    base_ctx->method = http_req.method;
+    base_ctx->path = http_req.path;
+
     try {
       http_req.body = build_streaming_analytics_body(request, client_context_id, timeout);
     } catch (const std::exception&) {
       // A caller-supplied raw/parameter value that is not valid JSON fails encoding; surface it as
       // invalid_argument rather than letting the exception escape the public API.
-      return handler({}, errc::common::invalid_argument);
+      base_ctx->ec = errc::common::invalid_argument;
+      return handler({}, std::move(*base_ctx));
     }
+    base_ctx->parameters = http_req.body;
     http_req.timeout = timeout;
     http_req.client_context_id = client_context_id;
     http_req.is_read_only = request.readonly;
@@ -140,11 +155,23 @@ public:
     const bool read_only = request.readonly;
     auto op = http_.do_http_request(
       http_req,
-      [self = shared_from_this(), callback_state, timeout, read_only](http_response resp,
-                                                                      dispatch_error err) mutable {
+      [self = shared_from_this(), callback_state, timeout, read_only, base_ctx](
+        http_response resp, dispatch_error err) mutable {
         if (auto ec = to_error_code(err)) {
-          self->invoke(callback_state, {}, ec);
+          base_ctx->ec = ec;
+          self->invoke(callback_state, {}, std::move(*base_ctx));
           return;
+        }
+        // The response is in hand, so the context can now name the endpoint and HTTP status.
+        base_ctx->http_status = resp.status_code();
+        const auto dispatch_info = resp.dispatch_info();
+        base_ctx->hostname = dispatch_info.hostname;
+        base_ctx->port = dispatch_info.port;
+        if (!dispatch_info.remote_address.empty()) {
+          base_ctx->last_dispatched_to = dispatch_info.remote_address;
+        }
+        if (!dispatch_info.local_address.empty()) {
+          base_ctx->last_dispatched_from = dispatch_info.local_address;
         }
         // Use the cluster's streaming tuning, but bound the server between reads with this
         // request's timeout: if it stalls mid-body the stream times out rather than hanging next()
@@ -153,20 +180,30 @@ public:
         options.idle_timeout = timeout;
         options.is_read_only = read_only;
         auto stream = std::make_shared<analytics_stream>(self->io_, resp.body(), options);
-        stream->start([self, callback_state, stream](std::error_code early_error) mutable {
-          if (early_error) {
-            // No consumer will ever take ownership of this stream, so tear the underlying body
-            // (socket + timers) down explicitly rather than leaking it until the last handle drops.
-            stream->cancel();
-            self->invoke(callback_state, {}, early_error);
-            return;
-          }
-          self->invoke(callback_state, std::move(*stream), {});
-        });
+        stream->start(
+          [self, callback_state, stream, base_ctx](std::error_code early_error) mutable {
+            if (early_error) {
+              // The preamble is what carried the failure, so stamp its diagnostics before tearing
+              // the stream down.
+              base_ctx->ec = early_error;
+              apply_error_details(*base_ctx, stream->error_details());
+              // No consumer will ever take ownership of this stream, so tear the underlying body
+              // (socket + timers) down explicitly rather than leaking it until the last handle
+              // drops.
+              stream->cancel();
+              self->invoke(callback_state, {}, std::move(*base_ctx));
+              return;
+            }
+            // Hand the base context to the consumer alongside the stream: a terminal error reached
+            // later is stamped onto it, so a mid-stream failure reports the same detail as this
+            // one.
+            self->invoke(callback_state, std::move(*stream), std::move(*base_ctx));
+          });
       });
 
     if (!op.has_value()) {
-      invoke(callback_state, {}, to_error_code(op.error()));
+      base_ctx->ec = to_error_code(op.error());
+      invoke(callback_state, {}, std::move(*base_ctx));
     }
   }
 
@@ -184,7 +221,7 @@ private:
 
   void invoke(const std::shared_ptr<callback_state_type>& state,
               analytics_stream stream,
-              std::error_code ec)
+              error_context::analytics ctx)
   {
     analytics_stream_component::handler_type handler;
     {
@@ -196,7 +233,7 @@ private:
       handler = std::move(state->handler);
     }
     if (handler) {
-      handler(std::move(stream), ec);
+      handler(std::move(stream), std::move(ctx));
     }
   }
 

--- a/core/analytics_stream_component.hxx
+++ b/core/analytics_stream_component.hxx
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "analytics_stream.hxx"
+#include "error_context/analytics.hxx"
 #include "operations/document_analytics.hxx"
 #include "utils/movable_function.hxx"
 
@@ -44,7 +45,14 @@ class http_component;
 class analytics_stream_component
 {
 public:
-  using handler_type = utils::movable_function<void(analytics_stream, std::error_code)>;
+  // The context carries the error code (error_context::analytics::ec) alongside the diagnostics the
+  // buffered path reports — statement, parameters, the service's first error, HTTP status and body,
+  // and where the request was dispatched — so a streaming failure is as diagnosable as a buffered
+  // one. It is delivered on both outcomes: when the stream fails to start it describes that
+  // failure, and when it starts it describes the request and its dispatch, for the consumer to
+  // report a terminal error against later. Only `ec` differs between the two: falsy means the
+  // stream started.
+  using handler_type = utils::movable_function<void(analytics_stream, error_context::analytics)>;
 
   analytics_stream_component(asio::io_context& io,
                              http_component http,

--- a/core/cluster.cxx
+++ b/core/cluster.cxx
@@ -1738,19 +1738,35 @@ cluster::execute(operations::query_request request,
 }
 
 void
-cluster::query_stream(
-  operations::query_request request,
-  utils::movable_function<void(couchbase::core::query_stream, std::error_code)>&& handler) const
+cluster::query_stream(operations::query_request request,
+                      utils::movable_function<void(couchbase::core::query_stream,
+                                                   error_context::query)>&& handler) const
 {
   // Mirror operations::query_request::encode_to: use_replica is only honored when the cluster
-  // advertises read-from-replica support, otherwise the request is rejected up front.
+  // advertises read-from-replica support, otherwise the request is rejected up front. Rejected here
+  // means nothing was dispatched, so the context can only describe the request itself.
   if (request.use_replica.has_value()) {
+    auto reject = [&request](std::error_code ec) {
+      error_context::query ctx{};
+      ctx.ec = ec;
+      ctx.statement = request.statement;
+      // Generate an id when the caller supplied none, the way every dispatched path does, so even
+      // a request rejected before dispatch has a context that can be correlated with the logs.
+      // Not value_or(): its argument is evaluated whether or not the optional is engaged, which
+      // would generate and format a UUID only to discard it whenever the caller supplied an id.
+      ctx.client_context_id = request.client_context_id.has_value()
+                                ? *request.client_context_id
+                                : uuid::to_string(uuid::random());
+      ctx.method = "POST";
+      ctx.path = "/query/service";
+      return ctx;
+    };
     auto [ec, manager] = impl_->http_session_manager();
     if (ec) {
-      return handler({}, ec);
+      return handler({}, reject(ec));
     }
     if (!manager->configuration_capabilities().supports_read_from_replica()) {
-      return handler({}, errc::common::feature_not_available);
+      return handler({}, reject(errc::common::feature_not_available));
     }
   }
 
@@ -1766,7 +1782,8 @@ cluster::query_stream(
 void
 cluster::analytics_query_stream(
   operations::analytics_request request,
-  utils::movable_function<void(couchbase::core::analytics_stream, std::error_code)>&& handler) const
+  utils::movable_function<void(couchbase::core::analytics_stream, error_context::analytics)>&&
+    handler) const
 {
   auto cluster_opts = impl_->origin().second.options();
   auto default_timeout = cluster_opts.default_timeout_for(service_type::analytics);

--- a/core/cluster.hxx
+++ b/core/cluster.hxx
@@ -20,6 +20,8 @@
 #include "deprecation_utils.hxx"
 #include "diagnostics.hxx"
 #include "error.hxx"
+#include "error_context/analytics.hxx"
+#include "error_context/query.hxx"
 #include "operations_fwd.hxx"
 #include "origin.hxx"
 #include "topology/configuration.hxx"
@@ -130,7 +132,7 @@ public:
    * pulled lazily from the handle, so the full response body is never buffered.
    */
   void query_stream(o::query_request request,
-                    mf<void(query_stream, std::error_code)>&& handler) const;
+                    mf<void(query_stream, error_context::query)>&& handler) const;
 
   /**
    * Dispatches an analytics query as a streaming request, resolving the handler with an
@@ -139,7 +141,7 @@ public:
    * buffered.
    */
   void analytics_query_stream(o::analytics_request request,
-                              mf<void(analytics_stream, std::error_code)>&& handler) const;
+                              mf<void(analytics_stream, error_context::analytics)>&& handler) const;
   void execute(o::remove_request request, mf<void(o::remove_response)>&& handler) const;
   void execute(o::replace_request request, mf<void(o::replace_response)>&& handler) const;
   void execute(o::search_request request, mf<void(o::search_response)>&& handler) const;

--- a/core/free_form_http_request.cxx
+++ b/core/free_form_http_request.cxx
@@ -67,7 +67,18 @@ public:
 
   [[nodiscard]] auto endpoint() const -> std::string
   {
-    return {};
+    if (cached_body_ || fault_enabled_) {
+      return {};
+    }
+    return streaming_resp_.dispatch_info().remote_address;
+  }
+
+  [[nodiscard]] auto dispatch_info() const -> io::http_dispatch_info
+  {
+    if (cached_body_ || fault_enabled_) {
+      return {};
+    }
+    return streaming_resp_.dispatch_info();
   }
 
   [[nodiscard]] auto status_code() const -> std::uint32_t
@@ -194,6 +205,11 @@ auto
 http_response::endpoint() const -> std::string
 {
   return impl_->endpoint();
+}
+auto
+http_response::dispatch_info() const -> io::http_dispatch_info
+{
+  return impl_->dispatch_info();
 }
 auto
 http_response::status_code() const -> std::uint32_t

--- a/core/free_form_http_request.hxx
+++ b/core/free_form_http_request.hxx
@@ -18,6 +18,7 @@
 #include <couchbase/build_config.hxx>
 
 #include "core/impl/bootstrap_error.hxx"
+#include "core/io/http_streaming_response.hxx"
 #include "service_type.hxx"
 #include "utils/movable_function.hxx"
 
@@ -119,6 +120,9 @@ public:
   explicit http_response(io::http_streaming_response resp);
 
   [[nodiscard]] auto endpoint() const -> std::string;
+  // Where this response was dispatched. Empty for the in-memory/fault test bodies, which have no
+  // session behind them.
+  [[nodiscard]] auto dispatch_info() const -> io::http_dispatch_info;
   [[nodiscard]] auto status_code() const -> std::uint32_t;
   [[nodiscard]] auto content_length() const -> std::size_t;
 

--- a/core/impl/analytics.cxx
+++ b/core/impl/analytics.cxx
@@ -22,6 +22,7 @@
 #include "core/cluster.hxx"
 #include "core/operations/document_analytics.hxx"
 #include "core/utils/binary.hxx"
+#include "error.hxx"
 #include "internal_analytics_stream_result.hxx"
 #include "observability_recorder.hxx"
 
@@ -162,15 +163,17 @@ dispatch_analytics_stream(const core::cluster& core,
 {
   core.analytics_query_stream(
     std::move(request),
-    [obs_rec = std::move(obs_rec), handler = std::move(handler)](core::analytics_stream stream,
-                                                                 std::error_code ec) mutable {
-      if (ec) {
-        obs_rec->finish(ec);
-        return handler(couchbase::error{ ec, "failed to start the streaming analytics query" }, {});
+    [obs_rec = std::move(obs_rec), handler = std::move(handler)](
+      core::analytics_stream stream, core::error_context::analytics ctx) mutable {
+      if (ctx.ec) {
+        obs_rec->finish(ctx.ec);
+        return handler(make_error(ctx), {});
       }
-      // Transfer the recorder to the handle; it finishes the operation at the stream terminal.
-      auto internal =
-        std::make_shared<internal_analytics_stream_result>(std::move(stream), std::move(obs_rec));
+      // Transfer the recorder to the handle; it finishes the operation at the stream terminal. The
+      // context travels with it so a terminal error is reported with the same statement/endpoint
+      // detail as a failure to start, plus whatever the trailer said.
+      auto internal = std::make_shared<internal_analytics_stream_result>(
+        std::move(stream), std::move(obs_rec), std::move(ctx));
       handler({}, analytics_stream_result{ std::move(internal) });
     });
 }

--- a/core/impl/internal_analytics_stream_result.hxx
+++ b/core/impl/internal_analytics_stream_result.hxx
@@ -23,8 +23,10 @@
 
 #include "core/analytics_stream.hxx"
 
+#include "core/error_context/analytics.hxx"
 #include <atomic>
 #include <future>
+
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -44,7 +46,8 @@ class internal_analytics_stream_result
 {
 public:
   internal_analytics_stream_result(core::analytics_stream stream,
-                                   std::unique_ptr<core::impl::observability_recorder> obs_rec);
+                                   std::unique_ptr<core::impl::observability_recorder> obs_rec,
+                                   core::error_context::analytics ctx);
   // Non-copyable and non-movable: holds a std::mutex and is only ever owned via shared_ptr.
   internal_analytics_stream_result(const internal_analytics_stream_result&) = delete;
   internal_analytics_stream_result(internal_analytics_stream_result&&) = delete;
@@ -79,6 +82,11 @@ private:
   void resolve_meta_data(std::error_code ec);
 
   core::analytics_stream stream_;
+
+  // The request's error context as of a successfully started stream (statement, parameters, HTTP
+  // status, endpoint). A terminal error is reported against a copy of this with the trailer's
+  // diagnostics stamped on, so a mid-stream failure is as diagnosable as one that failed to start.
+  core::error_context::analytics ctx_;
 
   // Observability recorder for the whole streaming operation. Its operation span already parents
   // the request; finish() is called exactly once from resolve_meta_data() (the single terminal

--- a/core/impl/internal_query_stream_result.hxx
+++ b/core/impl/internal_query_stream_result.hxx
@@ -23,8 +23,10 @@
 
 #include "core/query_stream.hxx"
 
+#include "core/error_context/query.hxx"
 #include <atomic>
 #include <future>
+
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -44,7 +46,8 @@ class internal_query_stream_result
 {
 public:
   internal_query_stream_result(core::query_stream stream,
-                               std::unique_ptr<core::impl::observability_recorder> obs_rec);
+                               std::unique_ptr<core::impl::observability_recorder> obs_rec,
+                               core::error_context::query ctx);
   // Non-copyable and non-movable: holds a std::mutex and is only ever owned via shared_ptr.
   internal_query_stream_result(const internal_query_stream_result&) = delete;
   internal_query_stream_result(internal_query_stream_result&&) = delete;
@@ -78,6 +81,11 @@ private:
   void resolve_meta_data(std::error_code ec);
 
   core::query_stream stream_;
+
+  // The request's error context as of a successfully started stream (statement, parameters, HTTP
+  // status, endpoint). A terminal error is reported against a copy of this with the trailer's
+  // diagnostics stamped on, so a mid-stream failure is as diagnosable as one that failed to start.
+  core::error_context::query ctx_;
 
   // Observability recorder for the whole streaming operation. Its operation span already parents
   // the request; finish() is called exactly once from resolve_meta_data() (the single terminal

--- a/core/impl/public_analytics_stream_result.cxx
+++ b/core/impl/public_analytics_stream_result.cxx
@@ -26,6 +26,7 @@
 #include "core/utils/binary.hxx"
 
 #include "analytics.hxx"
+#include "error.hxx"
 #include "internal_analytics_stream_result.hxx"
 #include "observability_recorder.hxx"
 
@@ -86,8 +87,10 @@ build_analytics_meta_data(core::operations::analytics_response::analytics_meta_d
 
 internal_analytics_stream_result::internal_analytics_stream_result(
   core::analytics_stream stream,
-  std::unique_ptr<core::impl::observability_recorder> obs_rec)
+  std::unique_ptr<core::impl::observability_recorder> obs_rec,
+  core::error_context::analytics ctx)
   : stream_{ std::move(stream) }
+  , ctx_{ std::move(ctx) }
   , obs_rec_{ std::move(obs_rec) }
 {
 }
@@ -122,7 +125,16 @@ internal_analytics_stream_result::resolve_meta_data(std::error_code ec)
 {
   std::pair<error, analytics_meta_data> value;
   if (ec) {
-    value.first = error(ec, "analytics stream ended with an error");
+    // Report the terminal against the request's context with whatever the response said stamped on,
+    // so a mid-stream failure carries the same detail (statement, service error, endpoint) as one
+    // that never started. A cancellation leaves the service error code and message unset, because
+    // the service never reported one, but the envelope parsed so far is still reported as the body:
+    // it names the request id the service logs are keyed by, and the buffered path likewise reports
+    // whatever body it received.
+    auto ctx = ctx_;
+    ctx.ec = ec;
+    core::apply_error_details(ctx, stream_.error_details());
+    value.first = core::impl::make_error(ctx);
   }
   auto core_meta = stream_.meta_data();
   if (core_meta) {
@@ -201,7 +213,17 @@ internal_analytics_stream_result::next(analytics_row_handler&& handler)
     // thread before terminal_reached_ becomes visible.
     self->resolve_meta_data(ec);
     if (ec) {
-      return handler(error(ec, "analytics stream ended with an error"), {});
+      // Deliver the contextual error resolve_meta_data() has just published rather than building a
+      // bare one here. This is the first and usually only observation of a mid-stream terminal, so
+      // it has to carry the same diagnostics as every later next() (served by the terminal_reached_
+      // guard above) and as meta_data(); constructing a fresh error here would report the one case
+      // this class exists to describe with an empty context.
+      error terminal_error;
+      {
+        const std::scoped_lock lk{ self->meta_mutex_ };
+        terminal_error = self->terminal_value_.first;
+      }
+      return handler(std::move(terminal_error), {});
     }
     return handler({}, {});
   });

--- a/core/impl/public_query_stream_result.cxx
+++ b/core/impl/public_query_stream_result.cxx
@@ -25,6 +25,7 @@
 #include "core/operations/document_query.hxx"
 #include "core/utils/binary.hxx"
 
+#include "error.hxx"
 #include "internal_query_stream_result.hxx"
 #include "observability_recorder.hxx"
 #include "query.hxx"
@@ -96,8 +97,10 @@ build_query_meta_data(core::operations::query_response::query_meta_data meta) ->
 
 internal_query_stream_result::internal_query_stream_result(
   core::query_stream stream,
-  std::unique_ptr<core::impl::observability_recorder> obs_rec)
+  std::unique_ptr<core::impl::observability_recorder> obs_rec,
+  core::error_context::query ctx)
   : stream_{ std::move(stream) }
+  , ctx_{ std::move(ctx) }
   , obs_rec_{ std::move(obs_rec) }
 {
 }
@@ -132,7 +135,16 @@ internal_query_stream_result::resolve_meta_data(std::error_code ec)
 {
   std::pair<error, query_meta_data> value;
   if (ec) {
-    value.first = error(ec, "query stream ended with an error");
+    // Report the terminal against the request's context with whatever the response said stamped on,
+    // so a mid-stream failure carries the same detail (statement, service error, endpoint) as one
+    // that never started. A cancellation leaves the service error code and message unset, because
+    // the service never reported one, but the envelope parsed so far is still reported as the body:
+    // it names the request id the service logs are keyed by, and the buffered path likewise reports
+    // whatever body it received.
+    auto ctx = ctx_;
+    ctx.ec = ec;
+    core::apply_error_details(ctx, stream_.error_details());
+    value.first = core::impl::make_error(ctx);
   }
   auto core_meta = stream_.meta_data();
   if (core_meta) {
@@ -211,7 +223,17 @@ internal_query_stream_result::next(query_row_handler&& handler)
     // thread before terminal_reached_ becomes visible.
     self->resolve_meta_data(ec);
     if (ec) {
-      return handler(error(ec, "query stream ended with an error"), {});
+      // Deliver the contextual error resolve_meta_data() has just published rather than building a
+      // bare one here. This is the first and usually only observation of a mid-stream terminal, so
+      // it has to carry the same diagnostics as every later next() (served by the terminal_reached_
+      // guard above) and as meta_data(); constructing a fresh error here would report the one case
+      // this class exists to describe with an empty context.
+      error terminal_error;
+      {
+        const std::scoped_lock lk{ self->meta_mutex_ };
+        terminal_error = self->terminal_value_.first;
+      }
+      return handler(std::move(terminal_error), {});
     }
     return handler({}, {});
   });

--- a/core/impl/query.cxx
+++ b/core/impl/query.cxx
@@ -223,45 +223,51 @@ dispatch_query_stream(const core::cluster& core,
     // buffered path and replay the already-parsed result through a buffered query_stream — no JSON
     // re-serialization or re-parsing — so callers observe identical semantics to the adhoc path.
     auto& io = core.io_context();
-    core.execute(
-      std::move(request),
-      [&io, obs_rec = std::move(obs_rec), handler = std::move(handler)](
-        operations::query_response resp) mutable {
-        if (resp.ctx.ec) {
-          // Terminal reached before a handle exists: record the operation metric/span here.
-          obs_rec->finish(resp.ctx.ec);
-          return handler(make_error(resp.ctx), {});
-        }
-        auto stream =
-          std::make_shared<core::query_stream>(io, std::move(resp.rows), std::move(resp.meta));
-        stream->start([obs_rec = std::move(obs_rec), handler = std::move(handler), stream](
-                        std::error_code early_error) mutable {
-          if (early_error) {
-            obs_rec->finish(early_error);
-            return handler(couchbase::error{ early_error, "failed to start the streaming query" },
-                           {});
-          }
-          // Transfer the recorder to the handle; it finishes the operation at the stream terminal.
-          auto internal =
-            std::make_shared<internal_query_stream_result>(std::move(*stream), std::move(obs_rec));
-          handler({}, query_stream_result{ std::move(internal) });
-        });
-      });
+    core.execute(std::move(request),
+                 [&io, obs_rec = std::move(obs_rec), handler = std::move(handler)](
+                   operations::query_response resp) mutable {
+                   if (resp.ctx.ec) {
+                     // Terminal reached before a handle exists: record the operation metric/span
+                     // here.
+                     obs_rec->finish(resp.ctx.ec);
+                     return handler(make_error(resp.ctx), {});
+                   }
+                   auto stream = std::make_shared<core::query_stream>(
+                     io, std::move(resp.rows), std::move(resp.meta));
+                   stream->start([obs_rec = std::move(obs_rec),
+                                  handler = std::move(handler),
+                                  stream,
+                                  ctx = std::move(resp.ctx)](std::error_code early_error) mutable {
+                     if (early_error) {
+                       obs_rec->finish(early_error);
+                       ctx.ec = early_error;
+                       return handler(make_error(ctx), {});
+                     }
+                     // Transfer the recorder to the handle; it finishes the operation at the stream
+                     // terminal. The buffered request's context travels with it, so a terminal
+                     // error is reported with the same detail the buffered path would have given.
+                     auto internal = std::make_shared<internal_query_stream_result>(
+                       std::move(*stream), std::move(obs_rec), std::move(ctx));
+                     handler({}, query_stream_result{ std::move(internal) });
+                   });
+                 });
     return;
   }
 
-  core.query_stream(
-    std::move(request),
-    [obs_rec = std::move(obs_rec), handler = std::move(handler)](core::query_stream stream,
-                                                                 std::error_code ec) mutable {
-      if (ec) {
-        obs_rec->finish(ec);
-        return handler(couchbase::error{ ec, "failed to start the streaming query" }, {});
-      }
-      auto internal =
-        std::make_shared<internal_query_stream_result>(std::move(stream), std::move(obs_rec));
-      handler({}, query_stream_result{ std::move(internal) });
-    });
+  core.query_stream(std::move(request),
+                    [obs_rec = std::move(obs_rec), handler = std::move(handler)](
+                      core::query_stream stream, core::error_context::query ctx) mutable {
+                      if (ctx.ec) {
+                        obs_rec->finish(ctx.ec);
+                        return handler(make_error(ctx), {});
+                      }
+                      // The context travels with the handle: a terminal error reached later is
+                      // reported with the same statement/endpoint detail as a failure to start,
+                      // plus whatever the trailer said.
+                      auto internal = std::make_shared<internal_query_stream_result>(
+                        std::move(stream), std::move(obs_rec), std::move(ctx));
+                      handler({}, query_stream_result{ std::move(internal) });
+                    });
 }
 
 auto

--- a/core/io/http_streaming_response.cxx
+++ b/core/io/http_streaming_response.cxx
@@ -231,11 +231,13 @@ public:
   http_streaming_response_impl(std::uint32_t status_code,
                                std::string status_message,
                                std::map<std::string, std::string> headers,
-                               http_streaming_response_body body)
+                               http_streaming_response_body body,
+                               http_dispatch_info dispatch_info)
     : status_code_{ status_code }
     , status_message_{ std::move(status_message) }
     , headers_{ std::move(headers) }
     , body_{ std::move(body) }
+    , dispatch_info_{ std::move(dispatch_info) }
   {
   }
 
@@ -267,23 +269,42 @@ public:
     return false;
   }
 
+  [[nodiscard]] auto dispatch_info() const -> const http_dispatch_info&
+  {
+    return dispatch_info_;
+  }
+
 private:
   std::uint32_t status_code_;
   std::string status_message_;
   std::map<std::string, std::string> headers_;
   http_streaming_response_body body_;
+  http_dispatch_info dispatch_info_;
 };
 
 http_streaming_response::http_streaming_response(
   asio::io_context& io,
   const couchbase::core::io::http_streaming_parser& parser,
   std::shared_ptr<http_session> session)
-  : impl_{ std::make_shared<http_streaming_response_impl>(
-      parser.status_code,
-      parser.status_message,
-      parser.headers,
-      http_streaming_response_body{ io, std::move(session), parser.body_chunk, parser.complete }) }
+  : impl_{ nullptr }
 {
+  http_dispatch_info dispatch_info{};
+  if (session) {
+    // Taken from the session's http_context, the same source io::http_command stamps onto a
+    // buffered response, so both paths report the identical endpoint. The port is already a
+    // std::uint16_t there; http_session::port() is that same value rendered as a string for
+    // resolving and for the Host header, so parsing it back would only reintroduce a conversion.
+    dispatch_info.hostname = session->http_context().hostname;
+    dispatch_info.port = session->http_context().port;
+    dispatch_info.remote_address = session->remote_address();
+    dispatch_info.local_address = session->local_address();
+  }
+  impl_ = std::make_shared<http_streaming_response_impl>(
+    parser.status_code,
+    parser.status_message,
+    parser.headers,
+    http_streaming_response_body{ io, std::move(session), parser.body_chunk, parser.complete },
+    std::move(dispatch_info));
 }
 
 auto
@@ -314,5 +335,11 @@ auto
 http_streaming_response::must_close_connection() const -> bool
 {
   return impl_->must_close_connection();
+}
+
+auto
+http_streaming_response::dispatch_info() const -> const http_dispatch_info&
+{
+  return impl_->dispatch_info();
 }
 } // namespace couchbase::core::io

--- a/core/io/http_streaming_response.hxx
+++ b/core/io/http_streaming_response.hxx
@@ -59,6 +59,16 @@ private:
 
 class http_streaming_response_impl;
 
+// Where a streaming response was dispatched, captured at construction rather than held as a session
+// reference: an error context is built after the stream has been torn down, by which point the
+// session may already be back in the keep-alive pool or gone.
+struct http_dispatch_info {
+  std::string hostname{};
+  std::uint16_t port{};
+  std::string remote_address{};
+  std::string local_address{};
+};
+
 class http_streaming_response
 {
 public:
@@ -72,6 +82,7 @@ public:
   [[nodiscard]] auto headers() const -> const std::map<std::string, std::string>&;
   [[nodiscard]] auto body() -> http_streaming_response_body&;
   [[nodiscard]] auto must_close_connection() const -> bool;
+  [[nodiscard]] auto dispatch_info() const -> const http_dispatch_info&;
 
 private:
   std::shared_ptr<http_streaming_response_impl> impl_;

--- a/core/query_stream.cxx
+++ b/core/query_stream.cxx
@@ -81,8 +81,31 @@ public:
   [[nodiscard]] virtual auto signature() const -> std::optional<std::string> = 0;
   [[nodiscard]] virtual auto meta_data() const
     -> std::optional<operations::query_response::query_meta_data> = 0;
+  [[nodiscard]] virtual auto error_details() const -> stream_error_details = 0;
   virtual void cancel() = 0;
 };
+
+namespace
+{
+// Lift the service-reported diagnostics out of a parsed preamble/trailer. Called for both sections,
+// so whichever one carried the failure is what the error context ends up describing.
+auto
+extract_error_details(const operations::query_response::query_meta_data& meta, std::string raw)
+  -> stream_error_details
+{
+  stream_error_details details{};
+  details.client_context_id = meta.client_context_id;
+  // Retained whether or not the section reports an error: it becomes error_context::http_body,
+  // which the buffered path fills for every response, and even an error-free envelope names the
+  // request the service logged.
+  details.raw = std::move(raw);
+  if (meta.errors && !meta.errors->empty()) {
+    details.first_error_code = meta.errors->front().code;
+    details.first_error_message = meta.errors->front().message;
+  }
+  return details;
+}
+} // namespace
 
 namespace
 {
@@ -109,11 +132,18 @@ public:
       try {
         meta = operations::parse_query_meta(utils::json::parse(preamble));
       } catch (const std::exception&) {
+        {
+          // Keep the unparseable preamble: it is the only diagnostic there is for a malformed
+          // response, and the buffered path reports the raw body in the same situation.
+          const std::scoped_lock lock{ self->mutex_ };
+          self->error_details_.raw = std::move(preamble);
+        }
         return on_ready(errc::common::parsing_failure);
       }
       {
         const std::scoped_lock lock{ self->mutex_ };
         self->signature_ = meta.signature;
+        self->error_details_ = extract_error_details(meta, std::move(preamble));
       }
       // An upfront error is rare for the streaming path (status/errors usually arrive in the
       // trailer). Mirror the analytics preamble check and gate on error entries rather than status:
@@ -169,9 +199,14 @@ public:
           auto meta = operations::parse_query_meta(utils::json::parse(raw_meta.value()));
           terminal_ec = operations::map_query_error(meta);
           const std::scoped_lock lock{ self->mutex_ };
+          // The trailer is where a request that failed part-way reports itself, so its diagnostics
+          // supersede the preamble's for the terminal error.
+          self->error_details_ = extract_error_details(meta, std::move(raw_meta.value()));
           self->meta_data_ = std::move(meta);
         } catch (const std::exception&) {
           terminal_ec = errc::common::parsing_failure;
+          const std::scoped_lock lock{ self->mutex_ };
+          self->error_details_.raw = std::move(raw_meta.value());
         }
       }
       {
@@ -196,6 +231,12 @@ public:
     return meta_data_;
   }
 
+  [[nodiscard]] auto error_details() const -> stream_error_details override
+  {
+    const std::scoped_lock lock{ mutex_ };
+    return error_details_;
+  }
+
   void cancel() override
   {
     streamer_.cancel();
@@ -206,6 +247,7 @@ private:
   mutable std::mutex mutex_{};
   std::optional<std::string> signature_{};
   std::optional<operations::query_response::query_meta_data> meta_data_{};
+  stream_error_details error_details_{};
   // Terminal-sticky state (guarded by mutex_): once next_row reports the terminal, it is remembered
   // so every later pull re-delivers it instead of parking on the drained channel.
   bool terminal_reached_{ false };
@@ -267,6 +309,13 @@ public:
     return meta_;
   }
 
+  [[nodiscard]] auto error_details() const -> stream_error_details override
+  {
+    // The response was parsed by the buffered path, so there is no raw JSON left to report; the
+    // service's error itself still is.
+    return extract_error_details(meta_, {});
+  }
+
   void cancel() override
   {
     cancelled_ = true;
@@ -301,6 +350,12 @@ void
 query_stream::start(utils::movable_function<void(std::error_code)>&& on_ready)
 {
   impl_->start(std::move(on_ready));
+}
+
+auto
+query_stream::error_details() const -> stream_error_details
+{
+  return impl_->error_details();
 }
 
 void

--- a/core/query_stream.hxx
+++ b/core/query_stream.hxx
@@ -19,6 +19,7 @@
 
 #include "core/operations/document_query.hxx"
 #include "row_streamer.hxx"
+#include "stream_error_details.hxx"
 #include "utils/movable_function.hxx"
 
 #include <memory>
@@ -69,6 +70,13 @@ public:
    * the response carried an upfront error (or the preamble failed to parse).
    */
   void start(utils::movable_function<void(std::error_code early_error)>&& on_ready);
+
+  /**
+   * Service-reported diagnostics from the most recently parsed JSON section — the preamble after
+   * start(), the trailer once the terminal has been reached. The dispatch layer stamps these into
+   * the error context so a streaming failure reports the same detail as a buffered one.
+   */
+  [[nodiscard]] auto error_details() const -> stream_error_details;
 
   /**
    * Retrieves the next row. A populated row is delivered with a falsy error_code. An empty row

--- a/core/query_stream_component.cxx
+++ b/core/query_stream_component.cxx
@@ -112,13 +112,28 @@ public:
 
     http_request http_req{ service_type::query, "POST" };
     http_req.path = "/query/service";
+
+    // Everything about the request that an error context reports, known before dispatch. The
+    // response-side fields (HTTP status, the service's first error, the endpoint) are filled in as
+    // they become available, so a failure at any stage carries as much detail as the buffered path.
+    // Held behind a shared_ptr, not by value: it carries the encoded request body in
+    // `parameters`, and both the dispatch callback and the synchronous dispatch-failure branch
+    // below need it, so sharing avoids deep-copying that body on every streaming request.
+    auto base_ctx = std::make_shared<error_context::query>();
+    base_ctx->client_context_id = client_context_id;
+    base_ctx->statement = request.statement;
+    base_ctx->method = http_req.method;
+    base_ctx->path = http_req.path;
+
     try {
       http_req.body = build_streaming_query_body(request, client_context_id, timeout);
     } catch (const std::exception&) {
       // A caller-supplied raw/parameter value that is not valid JSON fails encoding; surface it as
       // invalid_argument rather than letting the exception escape the public API.
-      return handler({}, errc::common::invalid_argument);
+      base_ctx->ec = errc::common::invalid_argument;
+      return handler({}, std::move(*base_ctx));
     }
+    base_ctx->parameters = http_req.body;
     http_req.timeout = timeout;
     http_req.client_context_id = client_context_id;
     http_req.is_read_only = request.readonly;
@@ -139,11 +154,23 @@ public:
     const bool read_only = request.readonly;
     auto op = http_.do_http_request(
       http_req,
-      [self = shared_from_this(), callback_state, timeout, read_only](http_response resp,
-                                                                      dispatch_error err) mutable {
+      [self = shared_from_this(), callback_state, timeout, read_only, base_ctx](
+        http_response resp, dispatch_error err) mutable {
         if (auto ec = to_error_code(err)) {
-          self->invoke(callback_state, {}, ec);
+          base_ctx->ec = ec;
+          self->invoke(callback_state, {}, std::move(*base_ctx));
           return;
+        }
+        // The response is in hand, so the context can now name the endpoint and HTTP status.
+        base_ctx->http_status = resp.status_code();
+        const auto dispatch_info = resp.dispatch_info();
+        base_ctx->hostname = dispatch_info.hostname;
+        base_ctx->port = dispatch_info.port;
+        if (!dispatch_info.remote_address.empty()) {
+          base_ctx->last_dispatched_to = dispatch_info.remote_address;
+        }
+        if (!dispatch_info.local_address.empty()) {
+          base_ctx->last_dispatched_from = dispatch_info.local_address;
         }
         // Use the cluster's streaming tuning, but bound the server between reads with this
         // request's timeout: if it stalls mid-body the stream times out rather than hanging next()
@@ -152,20 +179,30 @@ public:
         options.idle_timeout = timeout;
         options.is_read_only = read_only;
         auto stream = std::make_shared<query_stream>(self->io_, resp.body(), options);
-        stream->start([self, callback_state, stream](std::error_code early_error) mutable {
-          if (early_error) {
-            // No consumer will ever take ownership of this stream, so tear the underlying body
-            // (socket + timers) down explicitly rather than leaking it until the last handle drops.
-            stream->cancel();
-            self->invoke(callback_state, {}, early_error);
-            return;
-          }
-          self->invoke(callback_state, std::move(*stream), {});
-        });
+        stream->start(
+          [self, callback_state, stream, base_ctx](std::error_code early_error) mutable {
+            if (early_error) {
+              // The preamble is what carried the failure, so stamp its diagnostics before tearing
+              // the stream down.
+              base_ctx->ec = early_error;
+              apply_error_details(*base_ctx, stream->error_details());
+              // No consumer will ever take ownership of this stream, so tear the underlying body
+              // (socket + timers) down explicitly rather than leaking it until the last handle
+              // drops.
+              stream->cancel();
+              self->invoke(callback_state, {}, std::move(*base_ctx));
+              return;
+            }
+            // Hand the base context to the consumer alongside the stream: a terminal error reached
+            // later is stamped onto it, so a mid-stream failure reports the same detail as this
+            // one.
+            self->invoke(callback_state, std::move(*stream), std::move(*base_ctx));
+          });
       });
 
     if (!op.has_value()) {
-      invoke(callback_state, {}, to_error_code(op.error()));
+      base_ctx->ec = to_error_code(op.error());
+      invoke(callback_state, {}, std::move(*base_ctx));
     }
   }
 
@@ -183,7 +220,7 @@ private:
 
   void invoke(const std::shared_ptr<callback_state_type>& state,
               query_stream stream,
-              std::error_code ec)
+              error_context::query ctx)
   {
     query_stream_component::handler_type handler;
     {
@@ -195,7 +232,7 @@ private:
       handler = std::move(state->handler);
     }
     if (handler) {
-      handler(std::move(stream), ec);
+      handler(std::move(stream), std::move(ctx));
     }
   }
 

--- a/core/query_stream_component.hxx
+++ b/core/query_stream_component.hxx
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "error_context/query.hxx"
 #include "operations/document_query.hxx"
 #include "query_stream.hxx"
 #include "utils/movable_function.hxx"
@@ -46,7 +47,14 @@ class http_component;
 class query_stream_component
 {
 public:
-  using handler_type = utils::movable_function<void(query_stream, std::error_code)>;
+  // The context carries the error code (error_context::query::ec) alongside the diagnostics the
+  // buffered path reports — statement, parameters, the service's first error, HTTP status and body,
+  // and where the request was dispatched — so a streaming failure is as diagnosable as a buffered
+  // one. It is delivered on both outcomes: when the stream fails to start it describes that
+  // failure, and when it starts it describes the request and its dispatch, for the consumer to
+  // report a terminal error against later. Only `ec` differs between the two: falsy means the
+  // stream started.
+  using handler_type = utils::movable_function<void(query_stream, error_context::query)>;
 
   query_stream_component(asio::io_context& io,
                          http_component http,

--- a/core/stream_error_details.hxx
+++ b/core/stream_error_details.hxx
@@ -1,0 +1,69 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace couchbase::core
+{
+/**
+ * Service-reported diagnostics lifted out of a streaming response, so a streaming failure can be
+ * reported with the same context the buffered path provides.
+ *
+ * A stream parses two JSON sections that can carry errors: the preamble (everything before the row
+ * array, which is where a rejected request reports itself) and the trailer (which is where a
+ * request that failed part-way through reports itself). Whichever section produced the latest
+ * diagnostics is what these fields describe; `raw` is the JSON text they came from, and stands in
+ * for the buffered path's whole-body capture.
+ */
+struct stream_error_details {
+  std::uint64_t first_error_code{};
+  std::string first_error_message{};
+  std::string client_context_id{};
+  std::string raw{};
+};
+
+/**
+ * Stamps stream diagnostics onto a query/analytics error context. Templated on the context because
+ * the two services carry structurally identical contexts under different types.
+ *
+ * Each field is only written when the stream actually reported it, so these diagnostics augment the
+ * context rather than erasing it. That matters for the prepared-statement path, which reaches the
+ * streaming handle by replaying an already-buffered response: its context arrives fully populated
+ * (http_command captures the response body for every request), and there is no raw JSON left for
+ * the replay to report, so an unconditional write would clear the body it already had.
+ *
+ * client_context_id is deliberately left alone: the context already holds the id the request was
+ * sent with, which is the one to correlate against server logs, and the echoed value can differ.
+ */
+template<typename Context>
+void
+apply_error_details(Context& ctx, const stream_error_details& details)
+{
+  if (details.first_error_code != 0) {
+    ctx.first_error_code = details.first_error_code;
+  }
+  if (!details.first_error_message.empty()) {
+    ctx.first_error_message = details.first_error_message;
+  }
+  if (!details.raw.empty()) {
+    ctx.http_body = details.raw;
+  }
+}
+} // namespace couchbase::core

--- a/test/test_integration_analytics.cxx
+++ b/test/test_integration_analytics.cxx
@@ -35,6 +35,8 @@
 #include "core/operations/management/collection_create.hxx"
 #include "core/operations/management/collections.hxx"
 
+#include <tao/json/from_string.hpp>
+
 TEST_CASE("integration: analytics query", "[integration]")
 {
   test::utils::integration_test_guard integration;
@@ -1152,4 +1154,55 @@ TEST_CASE("integration: analytics management identifier encoding", "[integration
     }
     REQUIRE_SUCCESS(drop_dataverse(dataverse));
   }
+}
+
+TEST_CASE("integration: streaming analytics reports the same error context as buffered analytics",
+          "[integration]")
+{
+  test::utils::integration_test_guard integration;
+
+  if (integration.ctx.deployment == test::utils::deployment_type::elixir) {
+    SKIP("elixir deployment does not support analytics");
+  }
+  if (!integration.has_analytics_service()) {
+    SKIP("cluster does not have analytics service");
+  }
+
+  auto cluster = integration.public_cluster();
+
+  // Regression: a streaming failure used to arrive with an empty error context, losing the
+  // service's own error code and message exactly when they were needed. Compare against the
+  // buffered path.
+  const std::string error_statement = "SELECT * FROM `nonexistent_dataset_xyz`";
+
+  auto [buffered_err, buffered] =
+    cluster.analytics_query(error_statement, couchbase::analytics_options{}).get();
+  REQUIRE(buffered_err.ec());
+  const auto buffered_ctx = tao::json::from_string(buffered_err.ctx().to_json());
+  const auto expected_error_code = buffered_ctx.at("first_error_code").as<std::uint64_t>();
+  REQUIRE(expected_error_code != 0);
+
+  auto [err, result] = cluster.analytics_query_stream(error_statement).get();
+  auto streaming_err = err;
+  if (!streaming_err.ec()) {
+    while (true) {
+      auto [row_err, row] = result.next().get();
+      if (row_err.ec()) {
+        streaming_err = row_err;
+        break;
+      }
+      if (!row.has_value()) {
+        break;
+      }
+    }
+  }
+  REQUIRE(streaming_err.ec());
+
+  const auto streaming_ctx = tao::json::from_string(streaming_err.ctx().to_json());
+  REQUIRE(streaming_ctx.at("first_error_code").as<std::uint64_t>() == expected_error_code);
+  REQUIRE(streaming_ctx.at("statement").as<std::string>() == error_statement);
+  REQUIRE_FALSE(streaming_ctx.at("hostname").as<std::string>().empty());
+  REQUIRE_FALSE(streaming_ctx.at("http_body").as<std::string>().empty());
+
+  cluster.close().get();
 }

--- a/test/test_integration_query.cxx
+++ b/test/test_integration_query.cxx
@@ -1178,3 +1178,128 @@ TEST_CASE("integration: a rejected streaming query does not evict the pooled con
     cluster.close().get();
   }
 }
+
+TEST_CASE("integration: streaming query reports the same error context as buffered query",
+          "[integration]")
+{
+  test::utils::integration_test_guard integration;
+  if (!integration.cluster_version().supports_query()) {
+    SKIP("cluster does not support query");
+  }
+  auto cluster = integration.public_cluster();
+
+  // Regression: a streaming failure used to arrive with an empty error context, so everything the
+  // buffered path reports -- the service's own error code and message, the statement, the endpoint
+  // -- was lost precisely when it was needed. Compare the two paths on the same rejected statement.
+  const std::string error_query =
+    "SELECT * FROM `nonexistent_bucket_that_does_not_exist_xyz` LIMIT 1";
+
+  auto [buffered_err, buffered] = cluster.query(error_query, couchbase::query_options{}).get();
+  REQUIRE(buffered_err.ec());
+  const auto buffered_ctx = tao::json::from_string(buffered_err.ctx().to_json());
+  const auto expected_error_code = buffered_ctx.at("first_error_code").as<std::uint64_t>();
+  REQUIRE(expected_error_code != 0);
+
+  auto [err, result] = cluster.query_stream(error_query).get();
+  // The rejection surfaces either at dispatch or as the stream's terminal; take whichever fired.
+  auto streaming_err = err;
+  if (!streaming_err.ec()) {
+    while (true) {
+      auto [row_err, row] = result.next().get();
+      if (row_err.ec()) {
+        streaming_err = row_err;
+        break;
+      }
+      if (!row.has_value()) {
+        break;
+      }
+    }
+  }
+  REQUIRE(streaming_err.ec());
+
+  const auto streaming_ctx = tao::json::from_string(streaming_err.ctx().to_json());
+  REQUIRE(streaming_ctx.at("first_error_code").as<std::uint64_t>() == expected_error_code);
+  REQUIRE(streaming_ctx.at("first_error_message").as<std::string>() ==
+          buffered_ctx.at("first_error_message").as<std::string>());
+  REQUIRE(streaming_ctx.at("statement").as<std::string>() == error_query);
+  REQUIRE_FALSE(streaming_ctx.at("client_context_id").as<std::string>().empty());
+  REQUIRE_FALSE(streaming_ctx.at("hostname").as<std::string>().empty());
+  REQUIRE_FALSE(streaming_ctx.at("http_body").as<std::string>().empty());
+  REQUIRE(streaming_ctx.find("parameters") != nullptr);
+
+  cluster.close().get();
+}
+
+TEST_CASE("integration: a streaming query terminal error carries the request context",
+          "[integration]")
+{
+  test::utils::integration_test_guard integration;
+  if (!integration.cluster_version().supports_query()) {
+    SKIP("cluster does not support query");
+  }
+  auto cluster = integration.public_cluster();
+
+  // A terminal reached after the stream started must also be reported against the request's context
+  // rather than as a bare error code. cancel() is the deterministic way to reach one.
+  // 15000 is deliberate: the query service rejects a larger ARRAY_RANGE with error 5010 ("Out of
+  // range evaluating ARRAY_RANGE()") on the older servers in the CI matrix. Any row count above one
+  // works here -- the test cancels after the first row.
+  const std::string statement = "SELECT n FROM ARRAY_RANGE(0, 15000) AS n";
+  auto [err, result] = cluster.query_stream(statement).get();
+  REQUIRE_SUCCESS(err.ec());
+  REQUIRE(result.next().get().second.has_value());
+  result.cancel();
+
+  auto [terminal_err, row] = result.next().get();
+  REQUIRE(terminal_err.ec() == couchbase::errc::common::request_canceled);
+  const auto ctx = tao::json::from_string(terminal_err.ctx().to_json());
+  REQUIRE(ctx.at("statement").as<std::string>() == statement);
+  REQUIRE_FALSE(ctx.at("hostname").as<std::string>().empty());
+  REQUIRE(ctx.at("http_status").as<std::uint32_t>() == 200);
+  // Serialized only when non-zero, so its presence is what proves the endpoint was captured.
+  REQUIRE(ctx.find("port") != nullptr);
+
+  // A cancellation has no service-reported error, so the error code and message stay unset (both
+  // are omitted from the JSON when empty). The response envelope parsed before the cancel is still
+  // reported as the body: it names the request the service knows, and the buffered path likewise
+  // reports the body it received.
+  REQUIRE(ctx.find("first_error_code") == nullptr);
+  REQUIRE(ctx.find("first_error_message") == nullptr);
+  const auto body = tao::json::from_string(ctx.at("http_body").as<std::string>());
+  REQUIRE_FALSE(body.at("requestID").as<std::string>().empty());
+  REQUIRE(body.find("errors") == nullptr);
+
+  cluster.close().get();
+}
+
+TEST_CASE("integration: a streaming prepared statement keeps the buffered response diagnostics",
+          "[integration]")
+{
+  test::utils::integration_test_guard integration;
+  if (!integration.cluster_version().supports_query()) {
+    SKIP("cluster does not support query");
+  }
+  auto cluster = integration.public_cluster();
+
+  // A prepared statement (adhoc=false) is not streamed live: it runs buffered and its
+  // already-parsed response is replayed through the streaming handle, so the handle starts life
+  // with the fully populated context the buffered path built -- including the response body
+  // http_command captures for every request. The replay itself has no raw JSON left to report, so
+  // stamping the stream's diagnostics onto that context must not overwrite what is already there.
+  auto [err, result] =
+    cluster.query_stream(R"(SELECT "prepared" AS v)", couchbase::query_options{}.adhoc(false))
+      .get();
+  REQUIRE_SUCCESS(err.ec());
+  REQUIRE(result.next().get().second.has_value());
+
+  // cancel() reaches a terminal deterministically, which is where the context is stamped.
+  result.cancel();
+  auto [terminal_err, row] = result.next().get();
+  REQUIRE(terminal_err.ec() == couchbase::errc::common::request_canceled);
+
+  const auto ctx = tao::json::from_string(terminal_err.ctx().to_json());
+  REQUIRE(ctx.at("statement").as<std::string>() == R"(SELECT "prepared" AS v)");
+  REQUIRE_FALSE(ctx.at("http_body").as<std::string>().empty());
+
+  cluster.close().get();
+}

--- a/test/test_unit_analytics_stream.cxx
+++ b/test/test_unit_analytics_stream.cxx
@@ -21,6 +21,8 @@
 // drive the state machine over in-memory bodies (no server, no analytics service required).
 
 #include "core/analytics_stream.hxx"
+#include "core/impl/internal_analytics_stream_result.hxx"
+#include "core/impl/observability_recorder.hxx"
 #include "core/operations/document_analytics.hxx"
 #include "test_helper_streaming.hxx"
 
@@ -28,8 +30,11 @@
 
 #include <asio/io_context.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <tao/json/from_string.hpp>
 
+#include <cstdint>
 #include <functional>
+#include <memory>
 #include <optional>
 #include <string>
 #include <system_error>
@@ -272,4 +277,60 @@ TEST_CASE("unit: analytics_stream reports no signature when absent", "[unit]")
 
   REQUIRE(resolved);
   REQUIRE_FALSE(stream.signature().has_value());
+}
+
+TEST_CASE("unit: a mid-stream analytics terminal error is reported with the request context",
+          "[unit]")
+{
+  // Counterpart of the query case in test_unit_query_stream.cxx: rows followed by a trailing error,
+  // so the terminal arrives from the stream and reaches the first observing next().
+  asio::io_context io;
+  const std::string doc = R"({"requestID":"r-ctx","results":[{"a":1}],)"
+                          R"("status":"fatal","errors":[{"code":24000,"msg":"boom"}]})";
+  auto body = test::utils::make_cached_response_body(io, doc);
+  couchbase::core::analytics_stream stream{ io, std::move(body) };
+
+  std::error_code start_ec{ make_error_code(std::errc::operation_in_progress) };
+  stream.start([&start_ec](std::error_code ec) {
+    start_ec = ec;
+  });
+  io.run();
+  REQUIRE_FALSE(start_ec); // the error is in the trailer, so starting succeeds
+
+  couchbase::core::error_context::analytics ctx{};
+  ctx.statement = "SELECT a FROM x";
+  ctx.client_context_id = "cid-1";
+  ctx.method = "POST";
+  ctx.path = "/analytics/service";
+  ctx.hostname = "node.example";
+  ctx.port = 8095;
+  auto internal = std::make_shared<couchbase::internal_analytics_stream_result>(
+    std::move(stream), nullptr, std::move(ctx));
+
+  io.restart();
+  int rows = 0;
+  std::optional<couchbase::error> terminal;
+  std::function<void()> pump = [&]() {
+    internal->next([&](couchbase::error err, std::optional<couchbase::analytics_row> row) {
+      if (!row.has_value()) {
+        terminal = std::move(err);
+        return;
+      }
+      ++rows;
+      pump();
+    });
+  };
+  pump();
+  io.run();
+
+  REQUIRE(rows == 1);
+  REQUIRE(terminal.has_value());
+  REQUIRE(terminal->ec());
+  const auto reported = tao::json::from_string(terminal->ctx().to_json());
+  REQUIRE(reported.at("statement").as<std::string>() == "SELECT a FROM x");
+  REQUIRE(reported.at("client_context_id").as<std::string>() == "cid-1");
+  REQUIRE(reported.at("hostname").as<std::string>() == "node.example");
+  REQUIRE(reported.at("port").as<std::uint16_t>() == 8095);
+  REQUIRE(reported.at("first_error_code").as<std::uint64_t>() == 24000);
+  REQUIRE(reported.at("first_error_message").as<std::string>() == "boom");
 }

--- a/test/test_unit_query_stream.cxx
+++ b/test/test_unit_query_stream.cxx
@@ -16,6 +16,8 @@
  */
 
 #include "core/cluster.hxx"
+#include "core/impl/internal_query_stream_result.hxx"
+#include "core/impl/observability_recorder.hxx"
 #include "core/query_stream.hxx"
 #include "test_helper_streaming.hxx"
 
@@ -23,8 +25,11 @@
 
 #include <asio/io_context.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <tao/json/from_string.hpp>
 
+#include <cstdint>
 #include <functional>
+#include <memory>
 #include <optional>
 #include <string>
 #include <system_error>
@@ -98,11 +103,13 @@ TEST_CASE("unit: query_stream surfaces a trailing query error after rows", "[uni
 
 TEST_CASE("unit: cluster exposes a core query_stream entry point", "[unit]")
 {
-  // Compile-only: the symbol exists with the expected signature.
-  using fn =
-    void (couchbase::core::cluster::*)(couchbase::core::operations::query_request,
-                                       couchbase::core::utils::movable_function<void(
-                                         couchbase::core::query_stream, std::error_code)>&&) const;
+  // Compile-only: the symbol exists with the expected signature. The handler receives an error
+  // context rather than a bare error_code, so a streaming failure carries the same diagnostics
+  // (statement, service error, endpoint) the buffered path reports.
+  using fn = void (couchbase::core::cluster::*)(
+    couchbase::core::operations::query_request,
+    couchbase::core::utils::movable_function<void(couchbase::core::query_stream,
+                                                  couchbase::core::error_context::query)>&&) const;
   constexpr fn p = &couchbase::core::cluster::query_stream;
   STATIC_REQUIRE(p != nullptr); // compile-time contract: the overload resolves to exactly `fn`
 }
@@ -349,4 +356,63 @@ TEST_CASE("unit: query_stream reports no signature when absent", "[unit]")
 
   REQUIRE(resolved);
   REQUIRE_FALSE(stream.signature().has_value()); // no signature key in the response
+}
+
+TEST_CASE("unit: a mid-stream query terminal error is reported with the request context", "[unit]")
+{
+  // Rows followed by a trailing error, so the terminal arrives from the stream itself. That is the
+  // path which hands the failure to the caller's first observing next(), and it is the only one
+  // that exercises it: cancel() publishes the terminal before next() runs, so a cancelled stream is
+  // served by the idempotent re-delivery guard instead.
+  asio::io_context io;
+  const std::string doc = R"({"requestID":"r-ctx","results":[{"a":1}],)"
+                          R"("status":"fatal","errors":[{"code":5000,"msg":"boom"}]})";
+  auto body = test::utils::make_cached_response_body(io, doc);
+  couchbase::core::query_stream stream{ io, std::move(body) };
+
+  std::error_code start_ec{ make_error_code(std::errc::operation_in_progress) };
+  stream.start([&start_ec](std::error_code ec) {
+    start_ec = ec;
+  });
+  io.run();
+  REQUIRE_FALSE(start_ec); // the error is in the trailer, so starting succeeds
+
+  couchbase::core::error_context::query ctx{};
+  ctx.statement = "SELECT a FROM x";
+  ctx.client_context_id = "cid-1";
+  ctx.method = "POST";
+  ctx.path = "/query/service";
+  ctx.hostname = "node.example";
+  ctx.port = 8093;
+  auto internal = std::make_shared<couchbase::internal_query_stream_result>(
+    std::move(stream), nullptr, std::move(ctx));
+
+  io.restart();
+  int rows = 0;
+  std::optional<couchbase::error> terminal;
+  std::function<void()> pump = [&]() {
+    internal->next([&](couchbase::error err, std::optional<couchbase::query_row> row) {
+      if (!row.has_value()) {
+        terminal = std::move(err);
+        return;
+      }
+      ++rows;
+      pump();
+    });
+  };
+  pump();
+  io.run();
+
+  REQUIRE(rows == 1);
+  REQUIRE(terminal.has_value());
+  REQUIRE(terminal->ec());
+  // The request-side fields come from the context the handle was built with, and the service-side
+  // ones from the trailer. A bare error built at the delivery site would carry neither.
+  const auto reported = tao::json::from_string(terminal->ctx().to_json());
+  REQUIRE(reported.at("statement").as<std::string>() == "SELECT a FROM x");
+  REQUIRE(reported.at("client_context_id").as<std::string>() == "cid-1");
+  REQUIRE(reported.at("hostname").as<std::string>() == "node.example");
+  REQUIRE(reported.at("port").as<std::uint16_t>() == 8093);
+  REQUIRE(reported.at("first_error_code").as<std::uint64_t>() == 5000);
+  REQUIRE(reported.at("first_error_message").as<std::string>() == "boom");
 }


### PR DESCRIPTION
**Stack 1 of 2.** Followed by #1052. Rebased on `main` after #1053 merged; this PR now contains only its own commit.

### What changes

Streaming failures, at dispatch and at the stream terminal alike, were reported as a bare error code in a generic message: `couchbase::error::ctx()` was empty, where the buffered path supplies the service's error code and message, the statement and encoded parameters, the HTTP status and body, and the node that answered.

- `query_stream_component` / `analytics_stream_component` build an `error_context` from the request before dispatch and fill in response-side fields as they arrive.
- `query_stream` / `analytics_stream` expose `error_details()` — the service-reported diagnostics parsed out of the preamble and, once reached, the trailer.
- The context travels with the result handle, so `internal_*_stream_result` reports a mid-stream terminal against it. A cancellation has no service-reported error, so its context describes only the request.
- Stream diagnostics augment the context rather than replace it: only fields the stream actually reported are stamped. The prepared-statement path needs that, because it reaches the streaming handle by replaying an already-buffered response and so starts out with a fully populated context the replay has nothing to add to.
- `io::http_streaming_response` captures the session's host, port and local/remote addresses at construction, exposed via `http_response::dispatch_info()`; the streaming layer previously reported no endpoint at all.
- Both core-internal streaming handler signatures (cluster entry points and components) carry `error_context::query` / `error_context::analytics` instead of `std::error_code`.

The public API is unchanged.

### Tests

- `integration: streaming query reports the same error context as buffered query`
- `integration: streaming analytics reports the same error context as buffered analytics`
- `integration: a streaming query terminal error carries the request context`
- `integration: a streaming prepared statement keeps the buffered response diagnostics` — verified to fail if the stamping is made unconditional

### Verification

Against a 6-node 8.0.1 cluster (kv/n1ql/index/fts/cbas): `test_integration_query`, `test_integration_analytics`, and the streaming unit suites pass. `bin/check-clang-format` clean against the parent commit.
