### PR TITLE
CXXCBC-915: advertise couchbase2 capabilities from the FIT performer

### DIFF
--- a/tools/fit_performer/CMakeLists.txt
+++ b/tools/fit_performer/CMakeLists.txt
@@ -139,6 +139,11 @@ target_include_directories(
           ${CMAKE_SOURCE_DIR}/core)
 target_include_directories(fit_performer SYSTEM PRIVATE ${PROTO_SRC_DIR})
 
+# The generated couchbase/build_config.hxx records which optional components this build actually
+# compiled -- performerCapsFetch reads it so the performer only claims capabilities that are really
+# present. The client library does not export this directory, so it is added here explicitly.
+target_include_directories(fit_performer PRIVATE ${PROJECT_BINARY_DIR}/generated)
+
 target_link_libraries(
   fit_performer
   PRIVATE ${couchbase_cxx_client_DEFAULT_LIBRARY}

--- a/tools/fit_performer/src/service.cxx
+++ b/tools/fit_performer/src/service.cxx
@@ -32,6 +32,8 @@
 #include "performer.pb.h"
 #include "transactions.commands.pb.h"
 
+#include <couchbase/build_config.hxx>
+
 #include <core/meta/features.hxx>
 #include <core/meta/version.hxx>
 #include <core/transactions/attempt_context_impl.hxx>
@@ -1587,6 +1589,21 @@ TxnService::performerCapsFetch(grpc::ServerContext* /*context*/,
   response->add_sdk_implementation_caps(protocol::sdk::Caps::SDK_VECTOR_SEARCH_BASE64);
   response->add_sdk_implementation_caps(protocol::sdk::Caps::SDK_ZONE_AWARE_READ_FROM_REPLICA);
   response->add_sdk_implementation_caps(protocol::sdk::Caps::SUPPORTS_AUTHENTICATOR);
+#ifdef COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2
+  // Only a build that actually compiled the couchbase2 transport may claim
+  // these. The driver decides whether a run is couchbase2 from its own
+  // connection string, not from PROTOSTELLAR, so that one is self-description
+  // rather than a gate. SDK_COUCHBASE2_OBSERVABILITY is read: without it the
+  // driver disables the RFC 77 observability tests for a performer connected
+  // over couchbase2, which would silently skip what CXXCBC-902 implemented.
+  //
+  // Deliberately no transaction capability here: the transport has no subdoc
+  // operations and nothing for transactions.v1, while the transaction
+  // implementation stages through subdoc with xattrs, so transaction workloads
+  // cannot run over couchbase2 yet.
+  response->add_sdk_implementation_caps(protocol::sdk::Caps::PROTOSTELLAR);
+  response->add_sdk_implementation_caps(protocol::sdk::Caps::SDK_COUCHBASE2_OBSERVABILITY);
+#endif
 #ifdef COUCHBASE_CXX_CLIENT_SUPPORTS_APP_TELEMETRY
   response->add_sdk_implementation_caps(protocol::sdk::Caps::SDK_APP_TELEMETRY);
 #endif


### PR DESCRIPTION
The FIT driver can already drive this performer over couchbase2://, but the
performer never says that it can. The connection path needs nothing: it passes
the driver-supplied connection string through untouched, prepending couchbase://
only when the address carries no scheme at all, and the driver supplies the
scheme from its own configuration.

What was missing is self-description. performerCapsFetch now returns
PROTOSTELLAR and SDK_COUCHBASE2_OBSERVABILITY, guarded so that only a build
which actually compiled the transport claims them. The second is load-bearing:
the driver reads it, and without it disables the RFC 77 observability tests for
a performer connected over couchbase2 -- silently skipping what CXXCBC-902
implemented. PROTOSTELLAR is not read by the driver today, which decides whether
a run is couchbase2 from its own connection string, so advertising it is
self-description that lets the driver gate on it later.

No transaction capability is claimed. The transport implements no subdoc
operations and nothing for transactions.v1, while the transaction implementation
stages documents through subdoc with xattrs, so transaction workloads cannot run
over couchbase2 yet.