### PR TITLE
CXXCBC-917: compile the Protostellar stubs with the project's sanitizer flags

### DIFF
--- a/cmake/Protostellar.cmake
+++ b/cmake/Protostellar.cmake
@@ -155,6 +155,24 @@ set_target_properties(
              COMPILE_WARNING_AS_ERROR OFF
              CXX_CLANG_TIDY ""
              CXX_INCLUDE_WHAT_YOU_USE "")
+# The generated stubs MUST be compiled with the same sanitizer flags as everything that includes the
+# generated headers, because protobuf changes the LAYOUT of every message under ThreadSanitizer:
+# port_def.inc defines PROTOBUF_TSAN from the compiler's thread_sanitizer feature test, and
+# PROTOBUF_TSAN_DECLARE_MEMBER -- which appears in every generated message's Impl_ -- then adds a
+# `::uint32_t _tsan_detect_race` member. So sizeof(UpsertResponse) is 40 without -fsanitize=thread
+# and 48 with it, and every setter additionally stores a race-detection byte past the smaller size.
+#
+# enable_sanitizers() attaches the flags PUBLIC to the client target, which propagates UP to the
+# tests but never DOWN into this library (the client links it PRIVATE). That left RpcMethodHandler
+# -- instantiated in the uninstrumented kv.grpc.pb.cc -- reserving a 40-byte `ResponseType rsp` on
+# its stack directly below the saved `param` reference, while the instrumented handler's set_cas()
+# wrote the race byte at offset 40, zeroing that pointer's low byte. RunHandler then read
+# param.request from an address 32 bytes off, got a null, and destroyed a null request: the
+# `unit (tsan)` SEGV in cng_component_test at method_handler.h:119 (CXXCBC-917).
+#
+# PROTOBUF_TSAN cannot be forced to a fixed value instead -- port_def.inc #errors if it is already
+# defined -- so matching the flags is the only supported remedy.
+enable_sanitizers(couchbase_cxx_protostellar)
 # NOTE (ABI visibility): couchbase_cxx_client links this library whenever
 # COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 is on (see the target_link_libraries guarded by that option
 # in the top-level CMakeLists.txt, alongside the transport sources appended below). So in a


### PR DESCRIPTION
Under ThreadSanitizer protobuf changes the layout of every generated message: `port_def.inc` derives `PROTOBUF_TSAN` from the compiler's `thread_sanitizer` feature test, and `PROTOBUF_TSAN_DECLARE_MEMBER` then adds a `::uint32_t _tsan_detect_race` member to each message's `Impl_`. `sizeof(UpsertResponse)` is 40 bytes without `-fsanitize=thread` and 48 with it, and every setter stores a race-detection byte past the smaller size.

`enable_sanitizers()` attaches the flags PUBLIC to the client library, so they reach the tests but not the generated stubs, which the client links PRIVATE. `RpcMethodHandler`, instantiated in the uninstrumented `kv.grpc.pb.cc`, reserved a 40-byte response on its stack directly below the saved `HandlerParameter` reference; the instrumented handler then wrote the race byte one word past it and zeroed that pointer's low byte. The request was read from the wrong address and destroyed as null, crashing `cng_component_test` on the tsan leg.

Compiling the stubs with the same sanitizer flags makes every translation unit agree on the layout. `PROTOBUF_TSAN` cannot be pinned to a fixed value instead, because `port_def.inc` errors if it is already defined. The call is a no-op when no sanitizer is enabled.

## The failure this fixes

`unit (tsan)` crashed in `cng_component_test` while every other leg passed:

```
ERROR: ThreadSanitizer: SEGV on unknown address 0x000000000008 (READ)
 #0 protobuf::internal::InternalMetadata::HasUnknownFieldsTag() metadata_lite.h:142
 #3 couchbase::kv::v1::UpsertRequest::~UpsertRequest() kv.pb.cc:7645
 #4 grpc::internal::RpcMethodHandler<...UpsertRequest...>::RunHandler() method_handler.h:119
 #5 grpc::Server::SyncRequest::ContinueRunAfterInterception() server_cc.cc:471
```

`method_handler.h:119` destroys the request inside `if (status.ok())`, so the state required to crash there — a null request with an OK status — is one gRPC never constructs. It was a misaligned read of a valid object.

Under gdb, with the constructor and line 119 both breakpointed in a run containing exactly one of each:

```
CTOR   obj=0x7f6dc27fd420        <- HandlerParameter constructed here
RUNHDL param=0x7f6dc27fd400      <- the saved copy at line 119; low byte 0x20 -> 0x00
at crash: param.request=(nil)  ->  ~UpsertRequest (this=0x0)
```

Bisecting across the statements of `RunHandler` puts the write inside the handler call, and the store itself is visible in the executable's `_internal_set_cas`: `movb $0x0,0x28(%rax)`, a one-byte store at object offset 40, preceded by `__tsan_write1`.

## How this was verified

The reproduction is a container running the leg with clang-20, libc++ and 4 CPUs, where the failure is deterministic.

- `cng_component_test`, full suite: **0 failures in 20 runs** (was 20/20 failing).
- Each of the six previously-crashing cases individually: **0/5** (was 5/5 each).
- The other CNG tests that stand up in-process servers, which had the same latent bug: `dispatcher`, `streaming`, `retry`, `query_streaming`, `component_timeouts`, `kv_retry`, `kv_converter`, `error_utils` — **0/3 each**.
- Non-sanitizer builds are unaffected: reconfiguring and building the ordinary gcc tree reports `ninja: no work to do`, so not one object is invalidated.

The mechanism was checked as well as the symptom, because a change that merely shifted memory would look identical: `RunHandler` now reserves 48 bytes at `rbp-0x40` instead of 40 at `rbp-0x38`, so the race byte lands at `rbp-0x18`, inside the response object, rather than on the saved pointer at `rbp-0x10`.

## Related, not addressed here

Two gRPC runtimes exist in one process on this leg: `cmake/GrpcProtobuf.cmake` skips system gRPC whenever `-stdlib=libc++` is set and builds it static in-tree, so the tsan leg alone links a static gRPC into both `libcouchbase_cxx_client.so` and the test executable. That is the hazard described in the ABI note in `cmake/Protostellar.cmake`. It is not the cause of this crash and the tests pass with it in place.

The same class of divergence also remains between the now-instrumented first-party code and the uninstrumented `libprotobuf`, for protobuf's own generated types. It is not exercised today — the only uses are by const reference — and closing it would mean building the fetched protobuf/gRPC with matching flags, at a significant build-time cost.

---
Stacked PR **09/30** in the CNG (`couchbase2://`) transport series. This branch contains a single commit on top of `main`. Everything below it has merged, so this is now the bottom of the open series and should merge first; #1032 and everything above it carry this commit as an ancestor and depend on it for a green tsan leg.
