### PR TITLE
CXXCBC-919: keep the CNG tests clear of gRPC's callback-queue teardown race

### DIFF
--- a/test/cng/CMakeLists.txt
+++ b/test/cng/CMakeLists.txt
@@ -102,6 +102,9 @@ if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 AND TARGET couchbase_cxx_protostellar)
   # server implements.
   add_cng_test(protostellar/dispatcher LINK_CLIENT LIBS couchbase_cxx_protostellar)
 
+  # Regression test for the gRPC callback-queue teardown race (CXXCBC-919).
+  add_cng_test(protostellar/callback_queue_churn LINK_CLIENT LIBS couchbase_cxx_protostellar)
+
   # TLS/auth credentials (CXXCBC-890).
   add_cng_test(protostellar/credentials LINK_CLIENT LIBS couchbase_cxx_protostellar)
 

--- a/test/cng/protostellar/callback_queue_churn.cxx
+++ b/test/cng/protostellar/callback_queue_churn.cxx
@@ -1,0 +1,167 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Regression test for CXXCBC-919: repeatedly creating and destroying an in-process server, channel
+// and dispatcher must not abort the process.
+//
+// Each cycle drops the last reference to gRPC's process-global callback completion queue, which
+// makes gRPC shut it down, join its "nexting" threads and delete it. Doing that hundreds of times
+// in one process races the nexting threads still polling the queue and aborts with
+//
+//     ref_counted.h:183]  assertion failed: prior > 0
+//
+// See callback_queue_keepalive.hxx for the mechanism and why pinning the queue avoids it.
+//
+// Environment knobs, for investigating the underlying gRPC race rather than testing our side of it:
+//
+// Both are read through safe_getenv, so an empty value counts as unset rather than as "set".
+//
+//   CNG_CALLBACK_QUEUE_CYCLES=<n>     cycles per run (default below)
+//   CNG_CALLBACK_QUEUE_NO_KEEPALIVE=1 skip the keepalive, i.e. reproduce the abort. Measured at
+//                                     7 aborts in 40 runs at 200 cycles against gRPC 1.48.4;
+//                                     0 in 40 with the keepalive.
+//
+// This case is deliberately cheap -- 200 cycles is about 80 ms -- so it can act as a canary without
+// slowing the suite.
+
+#include "framework/test_runner.hxx"
+
+#include "callback_queue_keepalive.hxx"
+
+#include "core/protostellar/dispatcher.hxx"
+
+#include <couchbase/kv/v1/kv.grpc.pb.h>
+
+#include <asio/executor_work_guard.hpp>
+#include <asio/io_context.hpp>
+
+#include <grpcpp/server_builder.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace couchbase::cng::test
+{
+namespace
+{
+namespace kv = ::couchbase::kv::v1;
+using ::couchbase::core::protostellar::dispatcher;
+using namespace std::chrono_literals;
+
+constexpr int default_cycles{ 200 };
+
+class echo_service final : public kv::KvService::Service
+{
+public:
+  auto Get(grpc::ServerContext* /* context */,
+           const kv::GetRequest* request,
+           kv::GetResponse* response) -> grpc::Status override
+  {
+    response->set_content_uncompressed("value:" + request->key());
+    response->set_cas(0xdead'beefULL);
+    return grpc::Status::OK;
+  }
+};
+
+// One create/use/destroy cycle. The server is destroyed too, not just the channel: the server holds
+// its own reference to the callback queue, so keeping it alive would pin the count above zero and
+// the teardown under test would never run.
+void
+one_cycle()
+{
+  echo_service service;
+  grpc::ServerBuilder builder;
+  builder.RegisterService(&service);
+  auto server = builder.BuildAndStart();
+  auto channel = server->InProcessChannel(grpc::ChannelArguments{});
+
+  {
+    asio::io_context io;
+    dispatcher disp{ io, channel };
+    auto stub = kv::KvService::NewStub(channel);
+    auto request = std::make_shared<kv::GetRequest>();
+    request->set_key("k");
+
+    auto guard = asio::make_work_guard(io);
+    disp.unary<kv::GetResponse>(
+      1000ms,
+      [stub = stub.get(), request](grpc::ClientContext& context,
+                                   kv::GetResponse& response,
+                                   std::function<void(grpc::Status)> callback) {
+        stub->async()->Get(&context, request.get(), &response, std::move(callback));
+      },
+      [&guard](grpc::Status /* status */, kv::GetResponse /* response */) mutable {
+        guard.reset();
+      });
+    io.run();
+  }
+
+  channel.reset();
+  server->Shutdown(std::chrono::system_clock::now());
+  server->Wait();
+}
+
+[[nodiscard]] auto
+cycles_from_environment() -> int
+{
+  const auto raw = safe_getenv("CNG_CALLBACK_QUEUE_CYCLES");
+  if (!raw.has_value()) {
+    return default_cycles;
+  }
+  const auto parsed = std::strtol(raw->c_str(), nullptr, 10);
+  return (parsed > 0) ? static_cast<int>(parsed) : default_cycles;
+}
+
+void
+cycling_servers_does_not_abort_the_process()
+{
+  if (!safe_getenv("CNG_CALLBACK_QUEUE_NO_KEEPALIVE").has_value()) {
+    pin_callback_queue();
+  }
+
+  const auto cycles = cycles_from_environment();
+  int completed{ 0 };
+  for (int i = 0; i < cycles; ++i) {
+    one_cycle();
+    ++completed;
+  }
+
+  // Surviving the loop *is* the property under test: the abort this pins down kills the process
+  // outright, so there is no failure mode to observe other than reaching the end.
+  assert_eq(completed, cycles, "every teardown cycle completed without aborting the process");
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "protostellar_callback_queue_churn",
+    {
+      { "cycling_servers_does_not_abort_the_process",
+        cycling_servers_does_not_abort_the_process,
+        timeout::network },
+    },
+  };
+}
+
+} // namespace couchbase::cng::test

--- a/test/cng/protostellar/callback_queue_keepalive.hxx
+++ b/test/cng/protostellar/callback_queue_keepalive.hxx
@@ -1,0 +1,139 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// Pins gRPC's process-global callback completion queue for the lifetime of a test binary
+// (CXXCBC-919).
+//
+// gRPC serves the callback API from a completion queue chosen per channel in
+// `Channel::CallbackCQ()` (src/cpp/client/channel_cc.cc):
+//
+//     if (grpc_iomgr_run_in_background()) {
+//       callback_cq = new grpc::CompletionQueue(...GRPC_CQ_CALLBACK...);  // per channel
+//     } else {
+//       callback_cq = CompletionQueue::CallbackAlternativeCQ();           // process-global
+//     }
+//
+// On POSIX that predicate is `grpc_event_engine_run_in_background()`, which is false for the
+// iomgr-backed EventEngine that distribution builds of gRPC use, so the second branch is taken.
+// That queue is reference counted: a channel takes a reference on its first callback-API call and
+// drops it when destroyed, and when the count reaches zero gRPC shuts the queue down, joins its
+// "nexting" threads and deletes it (src/cpp/common/completion_queue_cc.cc). Driving that teardown
+// races the nexting threads still polling the queue and aborts the process:
+//
+//     ref_counted.h:183]  assertion failed: prior > 0
+//
+// A test that stands up an in-process server per case destroys the last channel between cases and
+// so runs that teardown repeatedly. Holding one of these objects keeps the count above zero for the
+// whole binary, so the teardown happens once at exit rather than between every case.
+//
+// This does not fix the underlying race, which is gRPC's; it keeps it out of the blast radius of
+// tests that are about our own transport. The production exposure — an application that opens and
+// closes clusters in a loop cycles the same queue — is tracked in CXXCBC-919.
+
+#pragma once
+
+#include "core/protostellar/dispatcher.hxx"
+
+#include <couchbase/kv/v1/kv.grpc.pb.h>
+
+#include <asio/executor_work_guard.hpp>
+#include <asio/io_context.hpp>
+
+#include <grpcpp/server_builder.h>
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <utility>
+
+namespace couchbase::cng::test
+{
+
+// Minimal service so the keepalive channel has something to call. The reference on the callback
+// queue is taken lazily, on a channel's first callback-API call, so constructing a channel is not
+// enough -- one real call has to complete.
+class keepalive_service final : public ::couchbase::kv::v1::KvService::Service
+{
+public:
+  auto Get(grpc::ServerContext* /* context */,
+           const ::couchbase::kv::v1::GetRequest* /* request */,
+           ::couchbase::kv::v1::GetResponse* response) -> grpc::Status override
+  {
+    response->set_cas(1);
+    return grpc::Status::OK;
+  }
+};
+
+class callback_queue_keepalive
+{
+public:
+  callback_queue_keepalive()
+  {
+    grpc::ServerBuilder builder;
+    builder.RegisterService(&service_);
+    server_ = builder.BuildAndStart();
+    channel_ = server_->InProcessChannel(grpc::ChannelArguments{});
+
+    asio::io_context io;
+    ::couchbase::core::protostellar::dispatcher dispatcher{ io, channel_ };
+    auto stub = ::couchbase::kv::v1::KvService::NewStub(channel_);
+    auto request = std::make_shared<::couchbase::kv::v1::GetRequest>();
+    request->set_key("callback-queue-keepalive");
+
+    auto guard = asio::make_work_guard(io);
+    dispatcher.unary<::couchbase::kv::v1::GetResponse>(
+      std::chrono::seconds{ 5 },
+      [stub = stub.get(), request](grpc::ClientContext& context,
+                                   ::couchbase::kv::v1::GetResponse& response,
+                                   std::function<void(grpc::Status)> callback) {
+        stub->async()->Get(&context, request.get(), &response, std::move(callback));
+      },
+      [&guard](grpc::Status /* status */, ::couchbase::kv::v1::GetResponse /* response */) mutable {
+        guard.reset();
+      });
+    io.run();
+  }
+
+  ~callback_queue_keepalive()
+  {
+    channel_.reset();
+    if (server_) {
+      server_->Shutdown(std::chrono::system_clock::now());
+      server_->Wait();
+    }
+  }
+
+  callback_queue_keepalive(const callback_queue_keepalive&) = delete;
+  callback_queue_keepalive(callback_queue_keepalive&&) = delete;
+  auto operator=(const callback_queue_keepalive&) -> callback_queue_keepalive& = delete;
+  auto operator=(callback_queue_keepalive&&) -> callback_queue_keepalive& = delete;
+
+private:
+  keepalive_service service_{};
+  std::unique_ptr<grpc::Server> server_{};
+  std::shared_ptr<grpc::Channel> channel_{};
+};
+
+// Call once from any test case that stands up in-process servers. The first call pins the queue;
+// the object lives until the process exits.
+inline void
+pin_callback_queue()
+{
+  static const callback_queue_keepalive keepalive{};
+}
+
+} // namespace couchbase::cng::test

--- a/test/cng/protostellar/component.cxx
+++ b/test/cng/protostellar/component.cxx
@@ -22,6 +22,8 @@
 
 #include "framework/test_runner.hxx"
 
+#include "callback_queue_keepalive.hxx"
+
 #include "core/cluster_credentials.hxx"
 #include "core/document_id.hxx"
 #include "core/error_context/key_value.hxx"
@@ -177,6 +179,11 @@ class in_process_server
 public:
   in_process_server()
   {
+    // Pin gRPC's process-global callback completion queue for the lifetime of this binary.
+    // Without it, destroying the last channel between cases drives a teardown that races
+    // gRPC's own polling threads and aborts the process (CXXCBC-919).
+    pin_callback_queue();
+
     grpc::ServerBuilder builder;
     builder.RegisterService(&service_);
     server_ = builder.BuildAndStart();

--- a/test/cng/protostellar/dispatcher.cxx
+++ b/test/cng/protostellar/dispatcher.cxx
@@ -23,6 +23,8 @@
 
 #include "framework/test_runner.hxx"
 
+#include "callback_queue_keepalive.hxx"
+
 #include "core/protostellar/dispatcher.hxx"
 
 #include <couchbase/kv/v1/kv.grpc.pb.h>
@@ -85,6 +87,11 @@ public:
   explicit in_process_server(std::chrono::milliseconds delay)
     : service_{ delay }
   {
+    // Pin gRPC's process-global callback completion queue for the lifetime of this binary.
+    // Without it, destroying the last channel between cases drives a teardown that races
+    // gRPC's own polling threads and aborts the process (CXXCBC-919).
+    pin_callback_queue();
+
     grpc::ServerBuilder builder;
     builder.RegisterService(&service_);
     server_ = builder.BuildAndStart();


### PR DESCRIPTION
`cng_dispatcher_test` aborts intermittently with `assertion failed: prior > 0` from gRPC's `ref_counted.h`. The faulting thread is one of gRPC's own and no frame of ours appears in the backtrace: it is a double-unref of a `grpc_completion_queue` from inside `grpc_completion_queue_next`.

The queue is gRPC's process-global callback queue. `Channel::CallbackCQ()` serves the callback API from a per-channel queue when `grpc_iomgr_run_in_background()` is true and from that global one otherwise, and on POSIX the predicate is false for the iomgr-backed EventEngine distribution builds use. The global queue is reference counted: a channel takes a reference on its first callback-API call and drops it when destroyed, and at zero gRPC shuts the queue down, joins its polling threads and deletes it. Tests that stand up an in-process server per case destroy the last channel between cases, so they run that teardown repeatedly and race it.

Hold one channel for the lifetime of each affected test binary, which keeps the count above zero so the teardown runs once at exit instead of between every case.

## Where it came from

CI, on the `cng` job of PR #1033 (https://github.com/couchbase/couchbase-cxx-client/actions/runs/30929498773/job/92068255608):

```
6/12 Test #733: cng_dispatcher_test ... Subprocess aborted***Exception:  0.66 sec
E0804 17:05:47.205653939  8846 ref_counted.h:183]  assertion failed: prior > 0
```

The backtrace, from a local core dump:

```
#4/#5 grpc_core::RefCount::Unref (this=0x…e750)   ref_counted.h:183   -> abort
#6    grpc_cq_internal_unref (cq=0x…e750)         completion_queue.cc:619
#7    cq_next (cq=0x…e750)                        completion_queue.cc:1084
#8/#9 <lambda>                                   completion_queue_cc.cc:76/100
#10-11 grpc_core::Thread ("nexting_thread")       thd_posix.cc
```

It is **not** specific to #1033: that commit does not touch the dispatcher at all, and `core/protostellar/dispatcher.{cxx,hxx}` and `test/cng/protostellar/dispatcher.cxx` are all already on `main`. It reproduces on `main`.

## How the fix was measured

The failure is rare when driven by the real suite — 0 in 3100 runs of `cng_dispatcher_test` on `main`, which cycles the teardown only about four times per process. The new `callback_queue_churn` case does several hundred cycles in one process instead, which raises the rate enough to A/B against:

| | aborts |
|---|---|
| cycling servers, no keepalive | **7 / 40** |
| cycling servers, with keepalive | **0 / 40** |

`P(0/40 | p = 7/40) ≈ 0.045%`. Across all rounds: 12/62 without, 0/52 with. The shipped test reproduces the same way — `CNG_CALLBACK_QUEUE_NO_KEEPALIVE=1` aborted 2 of 30 runs, the default 0 of 30 — so the negative control is preserved in the test itself rather than only in a throwaway branch.

Measured against system gRPC 1.48.4; CI hit it with 1.51.1.

## What this does not do

It does not fix the underlying race, which is inside gRPC's own global-queue teardown. It keeps that race out of the blast radius of tests whose subject is our transport.

The production exposure is unchanged and is recorded in CXXCBC-919: an application that opens and closes clusters in a loop cycles the same global queue. Two things could close it properly — a gRPC version or EventEngine configuration where `grpc_iomgr_run_in_background()` is true, so the safe per-channel queue is used, or an upstream fix to the teardown ordering. Pinning a process-global gRPC resource for the lifetime of the client library would also work but costs 2–16 permanently-live polling threads, which is a design decision rather than a bug fix.
