### PR TITLE
build: propagate sanitizer compile flags to fetched gRPC/protobuf targets

### DIFF
--- a/cmake/GrpcProtobuf.cmake
+++ b/cmake/GrpcProtobuf.cmake
@@ -120,6 +120,38 @@ else()
 
   FetchContent_MakeAvailable(grpc)
 
+  # Compile all fetched gRPC, Protobuf, Abseil, upb, re2 targets with the project's sanitizer
+  # flags so that all translation units agree on struct layouts, member definitions, and TSan
+  # instrumentation (mirroring commit be6fb44f9 / CXXCBC-917 for couchbase_cxx_protostellar).
+  if(LIST_OF_SANITIZERS AND NOT "${LIST_OF_SANITIZERS}" STREQUAL "")
+    function(couchbase_get_targets_recursively out_var dir)
+      get_property(_targets DIRECTORY "${dir}" PROPERTY BUILDSYSTEM_TARGETS)
+      get_property(_subdirs DIRECTORY "${dir}" PROPERTY SUBDIRECTORIES)
+      foreach(_subdir IN LISTS _subdirs)
+        couchbase_get_targets_recursively(_sub_targets "${_subdir}")
+        list(APPEND _targets ${_sub_targets})
+      endforeach()
+      set(${out_var} "${_targets}" PARENT_SCOPE)
+    endfunction()
+
+    couchbase_get_targets_recursively(_fetched_targets "${grpc_SOURCE_DIR}")
+    foreach(_fetched_target IN LISTS _fetched_targets)
+      get_target_property(_target_type ${_fetched_target} TYPE)
+      if(_target_type STREQUAL "STATIC_LIBRARY"
+         OR _target_type STREQUAL "SHARED_LIBRARY"
+         OR _target_type STREQUAL "OBJECT_LIBRARY"
+         OR _target_type STREQUAL "EXECUTABLE")
+        target_compile_options(${_fetched_target} PRIVATE -fsanitize=${LIST_OF_SANITIZERS})
+        target_link_options(${_fetched_target} PRIVATE -fsanitize=${LIST_OF_SANITIZERS})
+        if("thread" IN_LIST SANITIZERS
+           AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+           AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "14.0.0")
+          target_compile_options(${_fetched_target} PRIVATE -Wno-error=tsan)
+        endif()
+      endif()
+    endforeach()
+  endif()
+
   # Abseil-cpp bundled with gRPC v1.65.5 has a bug in its randen HWAES compile
   # options on Apple ARM64: CMake's option deduplication strips the second
   # -Xarch_x86_64 prefix, leaving -msse4.1 unscoped, which causes a hard error

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -1,78 +1,79 @@
-function(enable_sanitizers project_name)
+# Evaluated at file scope when Sanitizers.cmake is included by top-level CMakeLists.txt.
+# Setting options and computing LIST_OF_SANITIZERS globally (rather than scoped inside
+# enable_sanitizers()) ensures LIST_OF_SANITIZERS and SANITIZERS are available to
+# ThirdPartyDependencies.cmake and FetchContent hooks when configuring bundled dependencies.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+  option(ENABLE_COVERAGE "Enable coverage reporting for gcc/clang" FALSE)
 
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
-    option(ENABLE_COVERAGE "Enable coverage reporting for gcc/clang" FALSE)
+  set(SANITIZERS "")
 
-    if(ENABLE_COVERAGE)
-      target_compile_options(${project_name} INTERFACE --coverage -O0 -g)
-      target_link_libraries(${project_name} INTERFACE --coverage)
-    endif()
-
-    set(SANITIZERS "")
-
-    option(ENABLE_SANITIZER_ADDRESS "Enable address sanitizer" FALSE)
-    if(ENABLE_SANITIZER_ADDRESS)
-      list(APPEND SANITIZERS "address")
-    endif()
-
-    option(ENABLE_SANITIZER_LEAK "Enable leak sanitizer" FALSE)
-    if(ENABLE_SANITIZER_LEAK)
-      list(APPEND SANITIZERS "leak")
-    endif()
-
-    option(ENABLE_SANITIZER_UNDEFINED_BEHAVIOUR "Enable undefined behaviour sanitizer" FALSE)
-    if(ENABLE_SANITIZER_UNDEFINED_BEHAVIOUR)
-      list(APPEND SANITIZERS "undefined")
-    endif()
-
-    option(ENABLE_SANITIZER_THREAD "Enable thread sanitizer" FALSE)
-    if(ENABLE_SANITIZER_THREAD)
-      if("address" IN_LIST SANITIZERS OR "leak" IN_LIST SANITIZERS)
-        message(WARNING "Thread sanitizer does not work with Address and Leak sanitizer enabled")
-      else()
-        list(APPEND SANITIZERS "thread")
-        # Propagate the suppression file path so that test targets can set TSAN_OPTIONS.
-        set(COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS
-            "${PROJECT_SOURCE_DIR}/.tsan_suppressions"
-            CACHE FILEPATH "Path to TSan suppressions file")
-      endif()
-    endif()
-
-    option(ENABLE_SANITIZER_MEMORY "Enable memory sanitizer" FALSE)
-    if(ENABLE_SANITIZER_MEMORY AND CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
-      if("address" IN_LIST SANITIZERS
-         OR "thread" IN_LIST SANITIZERS
-         OR "leak" IN_LIST SANITIZERS)
-        message(WARNING "Memory sanitizer does not work with Address, Thread and Leak sanitizer enabled")
-      else()
-        list(APPEND SANITIZERS "memory")
-      endif()
-    endif()
-
-    list(
-      JOIN
-      SANITIZERS
-      ","
-      LIST_OF_SANITIZERS)
-
+  option(ENABLE_SANITIZER_ADDRESS "Enable address sanitizer" FALSE)
+  if(ENABLE_SANITIZER_ADDRESS)
+    list(APPEND SANITIZERS "address")
   endif()
 
-  if(LIST_OF_SANITIZERS)
-    if(NOT
-       "${LIST_OF_SANITIZERS}"
-       STREQUAL
-       "")
-      target_compile_options(${project_name} PUBLIC -fsanitize=${LIST_OF_SANITIZERS})
-      if("thread" IN_LIST SANITIZERS AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "14.0.0")
-        # GCC 14+ emits -Wtsan compile-time warnings for std::atomic_thread_fence (e.g. in Asio headers).
-        # Under -Werror, this breaks compilation. -Wno-error=tsan prevents compile errors while keeping
-        # runtime TSan instrumentation (-fsanitize=thread) fully active to catch actual data races.
-        target_compile_options(${project_name} PUBLIC -Wno-error=tsan)
-      endif()
-      target_link_libraries(${project_name} PUBLIC -fsanitize=${LIST_OF_SANITIZERS})
-      target_compile_definitions(${project_name} PUBLIC COUCHBASE_CXX_CLIENT_BUILD_SANITIZED=1)
-      message(STATUS "Enabled sanitizers: ${LIST_OF_SANITIZERS}")
+  option(ENABLE_SANITIZER_LEAK "Enable leak sanitizer" FALSE)
+  if(ENABLE_SANITIZER_LEAK)
+    list(APPEND SANITIZERS "leak")
+  endif()
+
+  option(ENABLE_SANITIZER_UNDEFINED_BEHAVIOUR "Enable undefined behaviour sanitizer" FALSE)
+  if(ENABLE_SANITIZER_UNDEFINED_BEHAVIOUR)
+    list(APPEND SANITIZERS "undefined")
+  endif()
+
+  option(ENABLE_SANITIZER_THREAD "Enable thread sanitizer" FALSE)
+  if(ENABLE_SANITIZER_THREAD)
+    if("address" IN_LIST SANITIZERS OR "leak" IN_LIST SANITIZERS)
+      message(WARNING "Thread sanitizer does not work with Address and Leak sanitizer enabled")
+    else()
+      list(APPEND SANITIZERS "thread")
+      # Propagate the suppression file path so that test targets can set TSAN_OPTIONS.
+      set(COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS
+          "${PROJECT_SOURCE_DIR}/.tsan_suppressions"
+          CACHE FILEPATH "Path to TSan suppressions file")
     endif()
+  endif()
+
+  option(ENABLE_SANITIZER_MEMORY "Enable memory sanitizer" FALSE)
+  if(ENABLE_SANITIZER_MEMORY AND CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+    if("address" IN_LIST SANITIZERS
+       OR "thread" IN_LIST SANITIZERS
+       OR "leak" IN_LIST SANITIZERS)
+      message(WARNING "Memory sanitizer does not work with Address, Thread and Leak sanitizer enabled")
+    else()
+      list(APPEND SANITIZERS "memory")
+    endif()
+  endif()
+
+  list(
+    JOIN
+    SANITIZERS
+    ","
+    LIST_OF_SANITIZERS)
+
+endif()
+
+function(enable_sanitizers project_name)
+
+  if(ENABLE_COVERAGE)
+    target_compile_options(${project_name} INTERFACE --coverage -O0 -g)
+    target_link_libraries(${project_name} INTERFACE --coverage)
+  endif()
+
+  if(LIST_OF_SANITIZERS AND NOT "${LIST_OF_SANITIZERS}" STREQUAL "")
+    target_compile_options(${project_name} PUBLIC -fsanitize=${LIST_OF_SANITIZERS})
+    if("thread" IN_LIST SANITIZERS
+       AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+       AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "14.0.0")
+      # GCC 14+ emits -Wtsan compile-time warnings for std::atomic_thread_fence (e.g. in Asio headers).
+      # Under -Werror, this breaks compilation. -Wno-error=tsan prevents compile errors while keeping
+      # runtime TSan instrumentation (-fsanitize=thread) fully active to catch actual data races.
+      target_compile_options(${project_name} PUBLIC -Wno-error=tsan)
+    endif()
+    target_link_libraries(${project_name} PUBLIC -fsanitize=${LIST_OF_SANITIZERS})
+    target_compile_definitions(${project_name} PUBLIC COUCHBASE_CXX_CLIENT_BUILD_SANITIZED=1)
+    message(STATUS "Enabled sanitizers: ${LIST_OF_SANITIZERS}")
   endif()
 
 endfunction()


### PR DESCRIPTION
### Summary
When gRPC and Protobuf are fetched via `FetchContent`, their CMake targets are created without the project's sanitizer flags (`-fsanitize=thread`). This causes a mixed-instrumentation ABI mismatch between uninstrumented third-party library translation units (such as `libprotobuf`'s `arena.cc`) and instrumented project translation units.

Under TSan with `libc++`, Abseil Layout expects 16-byte alignment when `alignof(std::atomic<void*>) == 16`, whereas uninstrumented `libprotobuf` declares `kSentryArenaChunk` with default 8-byte alignment. When an instrumented test translation unit accesses `kSentryArenaChunk`, `absl::container_internal::LayoutImpl::Pointer` asserts `reinterpret_cast<uintptr_t>(p) % alignment == 0` and aborts.

### Fix
1. Evaluated sanitizer options and variable definitions (`LIST_OF_SANITIZERS`) at file scope in `cmake/Sanitizers.cmake` so they are available globally when `ThirdPartyDependencies.cmake` is included.
2. Recursively collected all targets under `grpc_SOURCE_DIR` and propagated `-fsanitize=${LIST_OF_SANITIZERS}` at compile and link time to all static, shared, object, and executable targets immediately after `FetchContent_MakeAvailable(grpc)`.

This ensures all translation units across gRPC, Protobuf, Abseil, the client library, and the test suite agree on struct layouts, alignment, and TSan instrumentation (mirroring `CXXCBC-917` / commit `be6fb44f90477acd0e113e175e243675c0efb129` for `couchbase_cxx_protostellar`).