### PR TITLE
CXXCBC-924: release the cluster reference before signalling close completion

### DIFF
--- a/core/impl/public_cluster.cxx
+++ b/core/impl/public_cluster.cxx
@@ -601,6 +601,13 @@ public:
     // Spawn new thread to avoid joining IO thread from the same thread
     std::thread([self = shared_from_this(), handler = std::move(handler)]() mutable {
       self->do_close();
+      // Drop the reference before signalling completion, not after. handler() is what releases
+      // the caller's wait, so anything this thread still owns afterwards outlives that wait. When
+      // this is the last reference, releasing it later means ~cluster_impl -- which starts another
+      // thread and joins the IO thread -- runs unsynchronised with the caller, and a caller that
+      // returns from main() leaves those threads running while static destructors tear down the
+      // gRPC and abseil singletons underneath them.
+      self.reset();
       handler();
     }).detach();
   }


### PR DESCRIPTION
cluster_impl::close() runs on a detached thread that captures a shared_ptr to
the cluster and invokes the caller's handler while still holding it. The handler
is what releases the caller's wait, so the reference outlives that wait: when it
is the last one, ~cluster_impl runs afterwards, and it starts another thread and
joins the IO thread. A caller that returns from main() once its wait completes
therefore leaves those threads running into exit(), where static destructors are
tearing down the gRPC and abseil singletons they use.

The failure this produces is a SIGSEGV inside libabsl during
__run_exit_handlers, with the test's own assertions already passed. It is
reproducible on the connect path, where a failed open closes the half-built
cluster through the same function.

Drop the reference before calling the handler, so the destructor and the IO
thread join both complete while the caller is still waiting. Nothing the library
owns then outlives the caller's completion.
