### PR TITLE
CXXCBC-925: deprecate the Columnar build mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,20 @@ if(NOT DEFINED COUCHBASE_CXX_CLIENT_MASTER_PROJECT)
   endif()
 endif()
 
-option(COUCHBASE_CXX_CLIENT_COLUMNAR "Build with Columnar additions" FALSE)
+option(COUCHBASE_CXX_CLIENT_COLUMNAR "Build with Columnar additions (deprecated)" FALSE)
 if(COUCHBASE_CXX_CLIENT_COLUMNAR)
-  message(STATUS "COUCHBASE_CXX_CLIENT_COLUMNAR=${COUCHBASE_CXX_CLIENT_COLUMNAR} building with Columnar additions.")
+  # WARNING rather than DEPRECATION: DEPRECATION is silent unless CMAKE_WARN_DEPRECATED is set and
+  # is fatal under CMAKE_ERROR_DEPRECATED, and this notice must always print and never fail a build.
+  # One flowing paragraph: message() re-wraps its argument and renders embedded newlines as blank
+  # lines, so hand-drawn layout reads worse than none.
+  message(
+    WARNING
+      "DEPRECATED: COUCHBASE_CXX_CLIENT_COLUMNAR=${COUCHBASE_CXX_CLIENT_COLUMNAR}. "
+      "The Columnar build mode is deprecated in 1.4.0 and will be removed in 1.5.0, together with "
+      "the code it guards: core/columnar and every COUCHBASE_CXX_CLIENT_COLUMNAR conditional "
+      "around it. This is a notice, not an error: the mode builds and behaves exactly as before for "
+      "the whole 1.4.x series. Builds that set the option must move off it before upgrading to "
+      "1.5.0. Translation units including couchbase/build_config.hxx repeat this as a diagnostic.")
 endif()
 
 project(

--- a/cmake/build_config.hxx.in
+++ b/cmake/build_config.hxx.in
@@ -27,3 +27,26 @@
 #cmakedefine COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2
 #cmakedefine COUCHBASE_CXX_CLIENT_CREATE_OPERATION_SPAN_IN_CORE
 #cmakedefine COUCHBASE_CXX_CLIENT_BUILD_OPENTELEMETRY
+
+#ifdef COUCHBASE_CXX_CLIENT_COLUMNAR
+/*
+ * The Columnar build mode is deprecated in 1.4.0 and removed in 1.5.0. The configure step prints
+ * the full notice; this repeats it in every translation unit including this header, so it survives
+ * a build log that scrolls past CMake's output.
+ *
+ * #pragma message is the only spelling no warnings-as-errors setting can turn fatal: GCC reports
+ * it as a note, which carries no warning flag to escalate, and MSVC emits it with no warning
+ * number for /WX to act on. Clang reports it under -W#pragma-messages, which plain -Werror leaves
+ * alone but -Werror=#pragma-messages promotes, so the mapping is pinned back to a warning across
+ * the pragma. #warning and #pragma GCC warning are errors under -Werror and must not be used.
+ */
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-W#pragma-messages"
+#endif
+#pragma message("COUCHBASE_CXX_CLIENT_COLUMNAR is deprecated in 1.4.0 and will be removed in "     \
+                "1.5.0; see the CMake configure output for details")
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+#endif


### PR DESCRIPTION
[CXXCBC-925](https://couchbasecloud.atlassian.net/browse/CXXCBC-925)

`COUCHBASE_CXX_CLIENT_COLUMNAR` gates a prototype build mode slated for removal in 1.5.0 by
CXXCBC-782, and nothing in the build said so. `option()` contributed a single `STATUS` line among
several hundred and the compiler was silent, so a downstream build that sets the flag would first
learn of the removal when configure failed on an option that no longer exists.

Configuring with the option on now emits a CMake warning naming the deprecating and removing
versions, and every translation unit that includes the generated `build_config.hxx` repeats it as a
compiler diagnostic. Nothing else changes: the notices are the whole change, and neither can fail a
build.

## Why these spellings

Both follow from the requirement that a deprecation notice must never break someone's build.

- `message(WARNING)` rather than `message(DEPRECATION)`. The latter is silent unless
  `CMAKE_WARN_DEPRECATED` is set, and a hard error under `CMAKE_ERROR_DEPRECATED`.
- `#pragma message` rather than `#warning` or `#pragma GCC warning`, both of which are errors under
  `-Werror`. GCC reports `#pragma message` as a note, which carries no warning flag to escalate;
  MSVC emits it with no warning number for `/WX` to act on; Clang files it under
  `-W#pragma-messages`, which plain `-Werror` leaves alone but `-Werror=#pragma-messages` promotes,
  so the mapping is pinned back to a warning across the pragma.

## Verification

Compiling a translation unit that includes the generated header, under the project's warning set
with `WARNINGS_AS_ERRORS=TRUE`:

| case | GCC | Clang |
| --- | --- | --- |
| option ON | `note:`, exit 0 | `warning:`, exit 0 |
| option ON, plus `-Werror=#pragma-messages` | n/a | `warning:`, exit 0 |
| option OFF | silent, exit 0 | silent, exit 0 |

CMake configure with the option on exits 0 under `-Wdev -Werror=dev` and prints the warning; with
the option off it prints nothing about the deprecation.

The Clang guard was negative-controlled rather than assumed: removing only the
`#pragma clang diagnostic warning "-W#pragma-messages"` line turns the same compilation into
`error: ... [-Werror,-W#pragma-messages]`, exit 1. With the line present the same command exits 0.

Two limits worth stating explicitly:

- **The MSVC path is not verified.** `#pragma message` carrying no warning number for `/WX` is
  documented behaviour, not something measured here. The `columnar` CI job is ubuntu-24.04 only, and
  the Windows legs build with the option off, so the pragma is inactive there — CI will not close
  this gap either.
- **On GCC the notice appears as `note:`, not `warning:`.** That is the cost of the only spelling
  `-Werror` cannot promote. Log scrapers keying on `warning:` will not match it on GCC.

The `columnar` CI job runs `bin/build-tests` with `CB_COLUMNAR=ON` and leaves `WARNINGS_AS_ERRORS`
at its default of `TRUE`, so it exercises the GCC-with-`-Werror` case above.


[CXXCBC-925]: https://couchbasecloud.atlassian.net/browse/CXXCBC-925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ