### PR TITLE
CXXCBC-926: document Cloud Native Gateway support on the public API

### DIFF
--- a/core/cluster.cxx
+++ b/core/cluster.cxx
@@ -962,10 +962,13 @@ public:
     }
     auto [hostname, port] = origin_.next_address();
     auto endpoint = hostname + ":" + port;
-    // parse_connection_string() rejects a couchbase2:// string carrying more than one host, so this
-    // is only reachable for an origin assembled programmatically (set_nodes(), or the
-    // hostname/port constructors). Kept as a guard rather than an assertion: using the first
-    // endpoint is well defined, and the log says which one was chosen.
+    // Several nodes reach here from an origin assembled programmatically (set_nodes(), or the
+    // hostname/port constructors), and from a connection string naming more than one host:
+    // parse_connection_string() records that as an error on the connection_string, but no caller
+    // reads that field, so the origin is built with every host regardless. Kept as a log rather
+    // than a rejection: one endpoint is as good as another here, and since the node list is
+    // shuffled unless preserve_bootstrap_nodes_order is set, the message is what says which one
+    // this process picked.
     if (origin_.get_nodes().size() > 1) {
       CB_LOG_INFO("[{}]: couchbase2 uses a single gateway endpoint (\"{}\"); the remaining {} "
                   "node(s) on this origin are ignored (the gateway fronts the cluster).",

--- a/couchbase/bucket.hxx
+++ b/couchbase/bucket.hxx
@@ -90,8 +90,13 @@ public:
    * @param options custom options to change the default behavior.
    * @param handler the handler that implements @ref ping_handler.
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which opens no per-bucket
+   * sessions to probe and reports @ref errc::common::feature_not_available instead.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   void ping(const ping_options& options, ping_handler&& handler) const;
 
@@ -104,8 +109,13 @@ public:
    * @param options custom options to change the default behavior.
    * @return future object that carries result of the operation.
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which opens no per-bucket
+   * sessions to probe and reports @ref errc::common::feature_not_available instead.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   [[nodiscard]] auto ping(const ping_options& options = {}) const
     -> std::future<std::pair<error, ping_result>>;

--- a/couchbase/cluster.hxx
+++ b/couchbase/cluster.hxx
@@ -69,8 +69,16 @@ public:
    * over this options).
    * @param handler the handler
    *
+   * @note A connection string with the @c couchbase2:// scheme selects the @ref couchbase2
+   * "couchbase2" transport, which routes every operation through a Cloud Native Gateway (CNG). It
+   * requires a library built with that support and restricts how the connection string may be
+   * written; see
+   * @ref couchbase2.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   static void connect(const std::string& connection_string,
                       const cluster_options& options,
@@ -85,8 +93,16 @@ public:
    *
    * @return future object that carries cluster object and operation status
    *
+   * @note A connection string with the @c couchbase2:// scheme selects the @ref couchbase2
+   * "couchbase2" transport, which routes every operation through a Cloud Native Gateway (CNG). It
+   * requires a library built with that support and restricts how the connection string may be
+   * written; see
+   * @ref couchbase2.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   [[nodiscard]] static auto connect(const std::string& connection_string,
                                     const cluster_options& options)
@@ -406,8 +422,13 @@ public:
    * @param options custom options to change the default behavior.
    * @param handler the handler that implements @ref ping_handler.
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which has no per-node service
+   * endpoints to probe and reports @ref errc::common::feature_not_available instead.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   void ping(const ping_options& options, ping_handler&& handler) const;
 
@@ -420,8 +441,13 @@ public:
    * @param options custom options to change the default behavior.
    * @return future object that carries result of the operation.
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which has no per-node service
+   * endpoints to probe and reports @ref errc::common::feature_not_available instead.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   [[nodiscard]] auto ping(const ping_options& options = {}) const
     -> std::future<std::pair<error, ping_result>>;
@@ -439,8 +465,14 @@ public:
    * @param options custom options to change the default behavior.
    * @param handler the handler that implements @ref diagnostics_handler.
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which keeps no per-node
+   * connection state to report on and returns @ref errc::common::feature_not_available rather than
+   * an empty report.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   void diagnostics(const diagnostics_options& options, diagnostics_handler&& handler) const;
 
@@ -457,8 +489,14 @@ public:
    * @param options custom options to change the default behavior.
    * @return future object that carries result of the operation.
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which keeps no per-node
+   * connection state to report on and returns @ref errc::common::feature_not_available rather than
+   * an empty report.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   [[nodiscard]] auto diagnostics(const diagnostics_options& options = {}) const
     -> std::future<std::pair<error, diagnostics_result>>;

--- a/couchbase/collection.hxx
+++ b/couchbase/collection.hxx
@@ -340,8 +340,13 @@ public:
    * @exception errc::common::ambiguous_timeout
    * @exception errc::common::unambiguous_timeout
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which reports
+   * @ref errc::common::feature_not_available for replica reads.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   void get_any_replica(std::string document_id,
                        const get_any_replica_options& options,
@@ -368,8 +373,13 @@ public:
    * @exception errc::common::ambiguous_timeout
    * @exception errc::common::unambiguous_timeout
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which reports
+   * @ref errc::common::feature_not_available for replica reads.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   [[nodiscard]] auto get_any_replica(std::string document_id,
                                      const get_any_replica_options& options = {}) const
@@ -392,8 +402,13 @@ public:
    * @exception errc::common::ambiguous_timeout
    * @exception errc::common::unambiguous_timeout
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which reports
+   * @ref errc::common::feature_not_available for replica reads.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   void get_all_replicas(std::string document_id,
                         const get_all_replicas_options& options,
@@ -423,8 +438,13 @@ public:
    * @exception errc::common::ambiguous_timeout
    * @exception errc::common::unambiguous_timeout
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which reports
+   * @ref errc::common::feature_not_available for replica reads.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   [[nodiscard]] auto get_all_replicas(std::string document_id,
                                       const get_all_replicas_options& options = {}) const
@@ -792,8 +812,13 @@ public:
    * @exception errc::common::ambiguous_timeout
    * @exception errc::common::unambiguous_timeout
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which reports
+   * @ref errc::common::feature_not_available for subdocument mutations.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   void mutate_in(std::string document_id,
                  const mutate_in_specs& specs,
@@ -817,8 +842,13 @@ public:
    * @exception errc::common::ambiguous_timeout
    * @exception errc::common::unambiguous_timeout
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which reports
+   * @ref errc::common::feature_not_available for subdocument mutations.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   [[nodiscard]] auto mutate_in(std::string document_id,
                                const mutate_in_specs& specs,
@@ -838,8 +868,13 @@ public:
    * @exception errc::common::ambiguous_timeout
    * @exception errc::common::unambiguous_timeout
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which reports
+   * @ref errc::common::feature_not_available for subdocument lookups.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   void lookup_in(std::string document_id,
                  const lookup_in_specs& specs,
@@ -859,8 +894,13 @@ public:
    * @exception errc::common::ambiguous_timeout
    * @exception errc::common::unambiguous_timeout
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which reports
+   * @ref errc::common::feature_not_available for subdocument lookups.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   [[nodiscard]] auto lookup_in(std::string document_id,
                                const lookup_in_specs& specs,
@@ -885,8 +925,13 @@ public:
    * @exception errc::common::ambiguous_timeout
    * @exception errc::common::unambiguous_timeout
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which reports
+   * @ref errc::common::feature_not_available for replica lookups.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   void lookup_in_all_replicas(std::string document_id,
                               const lookup_in_specs& specs,
@@ -911,8 +956,13 @@ public:
    * @exception errc::common::ambiguous_timeout
    * @exception errc::common::unambiguous_timeout
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which reports
+   * @ref errc::common::feature_not_available for replica lookups.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   [[nodiscard]] auto lookup_in_all_replicas(std::string document_id,
                                             const lookup_in_specs& specs,
@@ -933,8 +983,13 @@ public:
    * @exception errc::common::ambiguous_timeout
    * @exception errc::common::unambiguous_timeout
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which reports
+   * @ref errc::common::feature_not_available for replica lookups.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   void lookup_in_any_replica(std::string document_id,
                              const lookup_in_specs& specs,
@@ -955,8 +1010,13 @@ public:
    * @exception errc::common::ambiguous_timeout
    * @exception errc::common::unambiguous_timeout
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which reports
+   * @ref errc::common::feature_not_available for replica lookups.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   [[nodiscard]] auto lookup_in_any_replica(std::string document_id,
                                            const lookup_in_specs& specs,
@@ -1085,8 +1145,15 @@ public:
    * system may have to scan a lot of documents to find the matching documents. For low latency
    * range queries, it is recommended that you use SQL++ with the necessary indexes.
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, and not refused up front: the
+   * scan needs the bucket configuration and the per-node connections that transport does not open,
+   * so it fails on that path rather than reporting
+   * @ref errc::common::feature_not_available.
+   *
    * @since 1.0.0
    * @volatile
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   void scan(const scan_type& scan_type, const scan_options& options, scan_handler&& handler) const;
 
@@ -1102,8 +1169,15 @@ public:
    * system may have to scan a lot of documents to find the matching documents. For low latency
    * range queries, it is recommended that you use SQL++ with the necessary indexes.
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, and not refused up front: the
+   * scan needs the bucket configuration and the per-node connections that transport does not open,
+   * so it fails on that path rather than reporting
+   * @ref errc::common::feature_not_available.
+   *
    * @since 1.0.0
    * @volatile
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   [[nodiscard]] auto scan(const scan_type& scan_type, const scan_options& options = {}) const
     -> std::future<std::pair<error, scan_result>>;

--- a/couchbase/common_durability_options.hxx
+++ b/couchbase/common_durability_options.hxx
@@ -79,9 +79,23 @@ public:
    * {@link durability_level::none}, since it is not allowed to use both mechanisms at the same
    * time.
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, and not refused before the
+   * mutation is applied: observing persistence and replication needs per-node connections that
+   * transport does not open, so the mutation is sent to the gateway and applied and only the
+   * polling that follows fails. The document is already written when the error arrives, and that
+   * error comes from the failed poll rather than being
+   * @ref errc::common::feature_not_available. Level-based durability, set by
+   * @c durability(durability_level), is served normally and is the durability to use over that
+   * transport.
+   *
    * @param persist_to_nodes the durability persistence requirement.
    * @param replicate_to_nodes the durability replication requirement.
    * @return this options builder for chaining purposes.
+   *
+   * @since 1.0.0
+   * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   auto durability(persist_to persist_to_nodes, replicate_to replicate_to_nodes) -> derived_class&
   {

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -292,7 +292,13 @@ TAB_SIZE               = 4
 ALIASES                = "committed=\xrefitem stability_committed \"Committed\" \"Committed Interfaces\" Generally available API and should be preferred in production" \
                          "uncommitted=\xrefitem stability_uncommitted \"Uncommitted\" \"Uncommitted Interfaces\" Might be changed in the future, and eventually promoted to committed" \
                          "volatile=\xrefitem stability_volatile \"Volatile\" \"Volatile Interfaces\" Should not be used in production" \
-                         "internal=\xrefitem stability_internal \"Internal\" \"Internal Interfaces\" Internal interface"
+                         "internal=\xrefitem stability_internal \"Internal\" \"Internal Interfaces\" Internal interface" \
+                         "cng_since{1}=@since \1 -- Cloud Native Gateway (CNG, \
+                         couchbase2://) support" \
+                         "cng_uncommitted=\xrefitem stability_uncommitted \"Uncommitted\" \
+                         \"Uncommitted Interfaces\" Cloud Native Gateway (CNG, \
+                         couchbase2://) support is uncommitted and may change in a future \
+                         release, independently of the stability of the API it applies to"
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
@@ -955,6 +961,7 @@ WARN_LOGFILE           =
 INPUT                  = ${DOXYGEN_INPUT_DIR} \
                          ${PROJECT_SOURCE_DIR}/docs/mainpage.hxx \
                          ${PROJECT_SOURCE_DIR}/docs/stability.hxx \
+                         ${PROJECT_SOURCE_DIR}/docs/couchbase2.hxx \
                          ${PROJECT_SOURCE_DIR}/docs/cli.hxx \
                          ${PROJECT_SOURCE_DIR}/docs/cbc.md \
                          ${PROJECT_SOURCE_DIR}/docs/cbc-get.md \

--- a/docs/couchbase2.hxx
+++ b/docs/couchbase2.hxx
@@ -1,0 +1,105 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+/**
+ * @page couchbase2 The couchbase2:// transport
+ * @brief Connecting through a Cloud Native Gateway instead of directly to cluster nodes.
+ *
+ * A connection string with the @c couchbase2:// scheme routes every operation over gRPC to a single
+ * Cloud Native Gateway (CNG) endpoint, rather than opening MCBP and HTTP connections to each node
+ * of a cluster. The gateway performs the routing the library would otherwise do itself.
+ *
+ * The public API is the same one used for @c couchbase:// and @c couchbases://. No type or method
+ * is specific to this transport; what changes is which operations a cluster can serve, and how a
+ * connection string is written.
+ *
+ * @warning The transport as a whole carries the stability level of this page. Individual API
+ * entities keep their own stability, which this page does not lower: @ref couchbase::collection#get
+ * is @ref stability_committed "committed" whether it runs over @c couchbase:// or @c couchbase2://.
+ * What is uncommitted is the behaviour of running it over this transport at all.
+ *
+ * ### Enabling it
+ *
+ * Support is a compile-time option and is @b off by default. A library built without
+ * @c COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 refuses a @c couchbase2:// connection string, reporting
+ * @ref couchbase::errc::common::feature_not_available from @ref couchbase::cluster#connect rather
+ * than attempting a handshake the gateway cannot answer.
+ *
+ * ### Writing the connection string
+ *
+ * The scheme implies TLS: a @c couchbase2:// connection is always encrypted, and the default port
+ * is 18098. Neither is inferred from the scheme name, so an endpoint published on another port must
+ * say so explicitly, and a private certificate authority must be trusted as it would be for
+ * @c couchbases://.
+ *
+ * Two further rules apply to @c couchbase2:// that do not apply to the other schemes:
+ *
+ * * Exactly one host. The gateway fronts the whole cluster, so there is no node list to rotate
+ *   through. A string naming several hosts still connects, to a single one of them: the bootstrap
+ *   list is shuffled unless @c preserve_bootstrap_nodes_order is set, so which one is not
+ *   predictable from the order they were written in. The log records the endpoint chosen and that
+ *   the rest were ignored.
+ * * No bootstrap-mode suffix on the host, since the gateway uses neither MCBP nor HTTP config
+ *   bootstrap. A suffix is ignored.
+ *
+ * ### Operations the library refuses
+ *
+ * These report @ref couchbase::errc::common::feature_not_available without reaching the gateway,
+ * because the transport has no way to carry them:
+ *
+ * * @ref couchbase::cluster#ping, @ref couchbase::bucket#ping and
+ *   @ref couchbase::cluster#diagnostics -- there are no per-node or per-bucket sessions to probe.
+ * * @ref couchbase::collection#get_all_replicas, @ref couchbase::collection#get_any_replica,
+ *   @ref couchbase::collection#lookup_in_all_replicas and
+ *   @ref couchbase::collection#lookup_in_any_replica.
+ * * Subdocument operations against the active node, @ref couchbase::collection#lookup_in and
+ *   @ref couchbase::collection#mutate_in.
+ * * Requests carrying an option or a value the transport has no equivalent for, across query,
+ *   analytics, search, views and management -- a memcached bucket, for instance. The refusal
+ *   depends on what the request carries rather than on the operation, so the same call may be
+ *   served or refused according to how it was built.
+ *
+ * ### Operations that fail without being refused
+ *
+ * Two things are not served either, but do not report
+ * @ref couchbase::errc::common::feature_not_available and are not turned away before work begins.
+ * Both need the bucket configuration and the per-node connections this transport does not open, so
+ * they fail on that path instead, and the error describes that failure rather than the missing
+ * feature.
+ *
+ * The first is @ref couchbase::collection#scan.
+ *
+ * The second is poll-based durability, and it is the one to know about, because the mutation is
+ * already applied by the time it fails.
+ *
+ * It is requested by passing @ref couchbase::persist_to and @ref couchbase::replicate_to to
+ * @ref couchbase::common_durability_options. The mutation is sent to the gateway and applied, and
+ * only the polling that follows fails, so the document is already written when the error arrives
+ * and the durability it asked for has not been established.
+ *
+ * Level-based durability, requested with a @ref couchbase::durability_level, is served normally and
+ * is the durability to use over this transport.
+ *
+ * Anything not listed above is sent to the gateway, which decides whether it can serve it. An
+ * operation the gateway does not implement is reported in the gateway's own terms, so the set of
+ * working operations depends on the gateway version as well as on this library.
+ *
+ * @cng_since{1.4.0}
+ * @cng_uncommitted
+ */


### PR DESCRIPTION
[CXXCBC-926](https://couchbasecloud.atlassian.net/browse/CXXCBC-926)

The Cloud Native Gateway work added no public type and no public method, so nothing in the public
headers recorded that it happened. `cluster::connect()` accepts a `couchbase2://` connection string,
and a cluster reached that way refuses several operations it serves over `couchbase://`, but a caller
found that out by receiving `feature_not_available` at runtime.

A new `@page couchbase2` describes the transport: how the scheme differs from the others, that
support is a compile-time option which is off by default, and which operations the library refuses
without reaching the gateway. Both `connect()` overloads and each refused operation carry a note
pointing at it. Nothing changes at runtime — this is documentation only.

## Why two stability pairs, and why aliases

The annotated entities are all `@since 1.0.0` and `@committed`. Gateway support arrived in 1.4.0 and
is not committed. Marking `get_all_replicas()` `@uncommitted` would be false: the method is unchanged
and remains committed; what is uncommitted is the behaviour of running it over this transport.

A bare second `@since 1.4.0` / `@uncommitted` pair says that, but reads as a contradiction against the
first pair. Two Doxygen aliases carry the distinction in their own rendered text instead:

```
@since 1.0.0
@committed
@cng_since{1.4.0}
@cng_uncommitted
```

renders as

> **Since** 1.0.0 — **Committed**: Generally available API and should be preferred in production
> **Since** 1.4.0 – Cloud Native Gateway (CNG, couchbase2://) support
> **Uncommitted**: Cloud Native Gateway (CNG, couchbase2://) support is uncommitted and may change in
> a future release, independently of the stability of the API it applies to

## Where the notes went

Refused over `couchbase2://`, each note naming the error reported:

- `cluster::ping()`, `bucket::ping()`, `cluster::diagnostics()`
- `collection::get_all_replicas()`, `get_any_replica()`, `lookup_in_all_replicas()`,
  `lookup_in_any_replica()`
- poll-based durability

Poll-based durability is annotated on `common_durability_options::durability(persist_to, replicate_to)`
— the single point a caller opts into it — rather than on the nine mutations that inherit it. A note
on `upsert()` would be false unless a requirement had been set. That overload was also missing the
`@since`/`@committed` pair its sibling carries; it has been added.

Operations that merely succeed over the gateway are covered collectively by the page rather than
individually, since which of them work depends on the gateway version as much as on this library.

## Verification

The API reference was built and inspected, not just compiled:

- No new doxygen warnings; every `@ref` added resolves. An early draft referenced the two
  `durability()` overloads by signature and did not resolve — doxygen cannot match an argument list
  against a trailing-return-type declaration — so those became code text.
- The rendered output was checked on the generated pages rather than assumed. A first attempt wrote
  `@ref couchbase2 transport`, which rendered as "the **The couchbase2:// transport** transport"
  because the page title is the link text; all 17 sites now pass explicit link text.
- Searching the public headers and the generated documentation pages for the internal project name
  returns nothing; the prose uses Cloud Native Gateway, CNG and `couchbase2://` only.
- `clang-format` clean, and the library compiles.

## A comment that contradicted its code

Writing the page surfaced a false statement in `core/cluster.cxx`. The comment on the single-endpoint
guard in `open_protostellar()` stated that `parse_connection_string()` rejects a `couchbase2://`
string carrying more than one host, and therefore that the guard could only fire for an origin
assembled programmatically.

It cannot reject it. The parser writes an error onto the `connection_string`, but
`connection_string::error` has no reader outside the parser itself and the test suite, so `origin` is
constructed with every host and such a connection string reaches the guard exactly like a
programmatic origin does. A reader trusting the comment would have been entitled to turn the guard
into an assertion. It is corrected here, and the guard is unchanged.

The same finding also corrected the page: an early draft stated that the two `couchbase2://`
connection-string rules are reported as `invalid_argument`. They are not — a string naming several
hosts connects to the first and logs that the rest were ignored, which is what the page now says.

That the parser's validation never reaches a caller is a pre-existing defect, not specific to the
gateway, and is not fixed here — only the comment and the documentation are made to match what the
code actually does.


[CXXCBC-926]: https://couchbasecloud.atlassian.net/browse/CXXCBC-926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ