### PR TITLE
CXXCBC-927: build the API reference without doxygen warnings

### DIFF
--- a/core/cluster.cxx
+++ b/core/cluster.cxx
@@ -962,10 +962,13 @@ public:
     }
     auto [hostname, port] = origin_.next_address();
     auto endpoint = hostname + ":" + port;
-    // parse_connection_string() rejects a couchbase2:// string carrying more than one host, so this
-    // is only reachable for an origin assembled programmatically (set_nodes(), or the
-    // hostname/port constructors). Kept as a guard rather than an assertion: using the first
-    // endpoint is well defined, and the log says which one was chosen.
+    // Several nodes reach here from an origin assembled programmatically (set_nodes(), or the
+    // hostname/port constructors), and from a connection string naming more than one host:
+    // parse_connection_string() records that as an error on the connection_string, but no caller
+    // reads that field, so the origin is built with every host regardless. Kept as a log rather
+    // than a rejection: one endpoint is as good as another here, and since the node list is
+    // shuffled unless preserve_bootstrap_nodes_order is set, the message is what says which one
+    // this process picked.
     if (origin_.get_nodes().size() > 1) {
       CB_LOG_INFO("[{}]: couchbase2 uses a single gateway endpoint (\"{}\"); the remaining {} "
                   "node(s) on this origin are ignored (the gateway fronts the cluster).",

--- a/couchbase/analytics_options.hxx
+++ b/couchbase/analytics_options.hxx
@@ -182,10 +182,11 @@ struct analytics_options : public common_options<analytics_options> {
    * mutations. If you want to include all the mutations up to the point of the query, use {@link
    * analytics_scan_consistency::request_plus}.
    *
-   * Note that you cannot use this method and {@link #consistent_with(const mutation_state&)} at the
-   * same time, since they are mutually exclusive. As a rule of thumb, if you only care to be
-   * consistent with the mutation you just wrote on the same thread/app, use
-   * {@link #consistent_with(const mutation_state&)}. If you need "global" scan consistency, use
+   * Note that you cannot use this method and {@link #consistent_with consistent_with(const
+   * mutation_state&)} at the same time, since they are mutually exclusive. As a rule of thumb, if
+   * you only care to be consistent with the mutation you just wrote on the same thread/app, use
+   * {@link #consistent_with consistent_with(const mutation_state&)}. If you need "global" scan
+   * consistency, use
    * {@link analytics_scan_consistency::request_plus} on this method.
    *
    * @param scan_consistency the index scan consistency to be used for this query
@@ -208,12 +209,12 @@ struct analytics_options : public common_options<analytics_options> {
    * and if you want your N1QL query to include those you need to pass the mutation tokens into a
    * {@link mutation_state}.
    *
-   * Note that you cannot use this method and {@link #scan_consistency(analytics_scan_consistency)}
-   * at the same time, since they are mutually exclusive. As a rule of thumb, if you only care to be
-   * consistent with the mutation you just wrote on the same thread/app, use this method. If you
-   * need "global" scan consistency, use
-   * {@link analytics_scan_consistency#request_plus} on {@link
-   * #scan_consistency(analytics_scan_consistency)}.
+   * Note that you cannot use this method and {@link #scan_consistency
+   * scan_consistency(analytics_scan_consistency)} at the same time, since they are mutually
+   * exclusive. As a rule of thumb, if you only care to be consistent with the mutation you just
+   * wrote on the same thread/app, use this method. If you need "global" scan consistency, use
+   * {@link analytics_scan_consistency#request_plus} on {@link #scan_consistency
+   * scan_consistency(analytics_scan_consistency)}.
    *
    * @param state the mutation state containing the mutation tokens.
    * @return this options builder for chaining purposes.

--- a/couchbase/boolean_query.hxx
+++ b/couchbase/boolean_query.hxx
@@ -47,8 +47,8 @@ namespace couchbase
  * In the example below the following rules enforced by the boolean query:
  * * retrieved documents MUST match `"hostel room"` in their `reviews.content` field AND have `true`
  * in `free_breakfast` field.
- * * also the documents SHOULD have EITHER `reviews.ratings.Overall > 4` OR `reviews.ratings.Service
- * > 5`.
+ * * also the documents SHOULD have EITHER `reviews.ratings.Overall > 4` OR
+ * `reviews.ratings.Service > 5`.
  * * and finally, exclude documents with `city` `"Padfield"` or `"Gilingham"`.
  *
  * @snippet{trimleft} test_unit_search.cxx search-boolean

--- a/couchbase/bucket.hxx
+++ b/couchbase/bucket.hxx
@@ -90,8 +90,13 @@ public:
    * @param options custom options to change the default behavior.
    * @param handler the handler that implements @ref ping_handler.
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which opens no per-bucket
+   * sessions to probe and reports @ref errc::common::feature_not_available instead.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   void ping(const ping_options& options, ping_handler&& handler) const;
 
@@ -104,8 +109,13 @@ public:
    * @param options custom options to change the default behavior.
    * @return future object that carries result of the operation.
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which opens no per-bucket
+   * sessions to probe and reports @ref errc::common::feature_not_available instead.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   [[nodiscard]] auto ping(const ping_options& options = {}) const
     -> std::future<std::pair<error, ping_result>>;

--- a/couchbase/cluster.hxx
+++ b/couchbase/cluster.hxx
@@ -69,8 +69,16 @@ public:
    * over this options).
    * @param handler the handler
    *
+   * @note A connection string with the @c couchbase2:// scheme selects the @ref couchbase2
+   * "couchbase2" transport, which routes every operation through a Cloud Native Gateway (CNG). It
+   * requires a library built with that support and restricts how the connection string may be
+   * written; see
+   * @ref couchbase2.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   static void connect(const std::string& connection_string,
                       const cluster_options& options,
@@ -85,8 +93,16 @@ public:
    *
    * @return future object that carries cluster object and operation status
    *
+   * @note A connection string with the @c couchbase2:// scheme selects the @ref couchbase2
+   * "couchbase2" transport, which routes every operation through a Cloud Native Gateway (CNG). It
+   * requires a library built with that support and restricts how the connection string may be
+   * written; see
+   * @ref couchbase2.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   [[nodiscard]] static auto connect(const std::string& connection_string,
                                     const cluster_options& options)
@@ -406,8 +422,13 @@ public:
    * @param options custom options to change the default behavior.
    * @param handler the handler that implements @ref ping_handler.
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which has no per-node service
+   * endpoints to probe and reports @ref errc::common::feature_not_available instead.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   void ping(const ping_options& options, ping_handler&& handler) const;
 
@@ -420,8 +441,13 @@ public:
    * @param options custom options to change the default behavior.
    * @return future object that carries result of the operation.
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which has no per-node service
+   * endpoints to probe and reports @ref errc::common::feature_not_available instead.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   [[nodiscard]] auto ping(const ping_options& options = {}) const
     -> std::future<std::pair<error, ping_result>>;
@@ -439,8 +465,14 @@ public:
    * @param options custom options to change the default behavior.
    * @param handler the handler that implements @ref diagnostics_handler.
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which keeps no per-node
+   * connection state to report on and returns @ref errc::common::feature_not_available rather than
+   * an empty report.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   void diagnostics(const diagnostics_options& options, diagnostics_handler&& handler) const;
 
@@ -457,8 +489,14 @@ public:
    * @param options custom options to change the default behavior.
    * @return future object that carries result of the operation.
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which keeps no per-node
+   * connection state to report on and returns @ref errc::common::feature_not_available rather than
+   * an empty report.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   [[nodiscard]] auto diagnostics(const diagnostics_options& options = {}) const
     -> std::future<std::pair<error, diagnostics_result>>;

--- a/couchbase/collection.hxx
+++ b/couchbase/collection.hxx
@@ -340,8 +340,13 @@ public:
    * @exception errc::common::ambiguous_timeout
    * @exception errc::common::unambiguous_timeout
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which reports
+   * @ref errc::common::feature_not_available for replica reads.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   void get_any_replica(std::string document_id,
                        const get_any_replica_options& options,
@@ -368,8 +373,13 @@ public:
    * @exception errc::common::ambiguous_timeout
    * @exception errc::common::unambiguous_timeout
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which reports
+   * @ref errc::common::feature_not_available for replica reads.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   [[nodiscard]] auto get_any_replica(std::string document_id,
                                      const get_any_replica_options& options = {}) const
@@ -392,8 +402,13 @@ public:
    * @exception errc::common::ambiguous_timeout
    * @exception errc::common::unambiguous_timeout
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which reports
+   * @ref errc::common::feature_not_available for replica reads.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   void get_all_replicas(std::string document_id,
                         const get_all_replicas_options& options,
@@ -423,8 +438,13 @@ public:
    * @exception errc::common::ambiguous_timeout
    * @exception errc::common::unambiguous_timeout
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which reports
+   * @ref errc::common::feature_not_available for replica reads.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   [[nodiscard]] auto get_all_replicas(std::string document_id,
                                       const get_all_replicas_options& options = {}) const
@@ -792,8 +812,13 @@ public:
    * @exception errc::common::ambiguous_timeout
    * @exception errc::common::unambiguous_timeout
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which reports
+   * @ref errc::common::feature_not_available for subdocument mutations.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   void mutate_in(std::string document_id,
                  const mutate_in_specs& specs,
@@ -817,8 +842,13 @@ public:
    * @exception errc::common::ambiguous_timeout
    * @exception errc::common::unambiguous_timeout
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which reports
+   * @ref errc::common::feature_not_available for subdocument mutations.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   [[nodiscard]] auto mutate_in(std::string document_id,
                                const mutate_in_specs& specs,
@@ -838,8 +868,13 @@ public:
    * @exception errc::common::ambiguous_timeout
    * @exception errc::common::unambiguous_timeout
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which reports
+   * @ref errc::common::feature_not_available for subdocument lookups.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   void lookup_in(std::string document_id,
                  const lookup_in_specs& specs,
@@ -859,8 +894,13 @@ public:
    * @exception errc::common::ambiguous_timeout
    * @exception errc::common::unambiguous_timeout
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which reports
+   * @ref errc::common::feature_not_available for subdocument lookups.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   [[nodiscard]] auto lookup_in(std::string document_id,
                                const lookup_in_specs& specs,
@@ -885,8 +925,13 @@ public:
    * @exception errc::common::ambiguous_timeout
    * @exception errc::common::unambiguous_timeout
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which reports
+   * @ref errc::common::feature_not_available for replica lookups.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   void lookup_in_all_replicas(std::string document_id,
                               const lookup_in_specs& specs,
@@ -911,8 +956,13 @@ public:
    * @exception errc::common::ambiguous_timeout
    * @exception errc::common::unambiguous_timeout
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which reports
+   * @ref errc::common::feature_not_available for replica lookups.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   [[nodiscard]] auto lookup_in_all_replicas(std::string document_id,
                                             const lookup_in_specs& specs,
@@ -933,8 +983,13 @@ public:
    * @exception errc::common::ambiguous_timeout
    * @exception errc::common::unambiguous_timeout
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which reports
+   * @ref errc::common::feature_not_available for replica lookups.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   void lookup_in_any_replica(std::string document_id,
                              const lookup_in_specs& specs,
@@ -955,8 +1010,13 @@ public:
    * @exception errc::common::ambiguous_timeout
    * @exception errc::common::unambiguous_timeout
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, which reports
+   * @ref errc::common::feature_not_available for replica lookups.
+   *
    * @since 1.0.0
    * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   [[nodiscard]] auto lookup_in_any_replica(std::string document_id,
                                            const lookup_in_specs& specs,
@@ -1085,8 +1145,15 @@ public:
    * system may have to scan a lot of documents to find the matching documents. For low latency
    * range queries, it is recommended that you use SQL++ with the necessary indexes.
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, and not refused up front: the
+   * scan needs the bucket configuration and the per-node connections that transport does not open,
+   * so it fails on that path rather than reporting
+   * @ref errc::common::feature_not_available.
+   *
    * @since 1.0.0
    * @volatile
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   void scan(const scan_type& scan_type, const scan_options& options, scan_handler&& handler) const;
 
@@ -1102,8 +1169,15 @@ public:
    * system may have to scan a lot of documents to find the matching documents. For low latency
    * range queries, it is recommended that you use SQL++ with the necessary indexes.
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, and not refused up front: the
+   * scan needs the bucket configuration and the per-node connections that transport does not open,
+   * so it fails on that path rather than reporting
+   * @ref errc::common::feature_not_available.
+   *
    * @since 1.0.0
    * @volatile
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   [[nodiscard]] auto scan(const scan_type& scan_type, const scan_options& options = {}) const
     -> std::future<std::pair<error, scan_result>>;

--- a/couchbase/common_durability_options.hxx
+++ b/couchbase/common_durability_options.hxx
@@ -79,9 +79,23 @@ public:
    * {@link durability_level::none}, since it is not allowed to use both mechanisms at the same
    * time.
    *
+   * @note Not served over the @ref couchbase2 "couchbase2" transport, and not refused before the
+   * mutation is applied: observing persistence and replication needs per-node connections that
+   * transport does not open, so the mutation is sent to the gateway and applied and only the
+   * polling that follows fails. The document is already written when the error arrives, and that
+   * error comes from the failed poll rather than being
+   * @ref errc::common::feature_not_available. Level-based durability, set by
+   * @c durability(durability_level), is served normally and is the durability to use over that
+   * transport.
+   *
    * @param persist_to_nodes the durability persistence requirement.
    * @param replicate_to_nodes the durability replication requirement.
    * @return this options builder for chaining purposes.
+   *
+   * @since 1.0.0
+   * @committed
+   * @cng_since{1.4.0}
+   * @cng_uncommitted
    */
   auto durability(persist_to persist_to_nodes, replicate_to replicate_to_nodes) -> derived_class&
   {

--- a/couchbase/common_durability_options.hxx
+++ b/couchbase/common_durability_options.hxx
@@ -53,8 +53,8 @@ public:
   /**
    * Allows to customize the enhanced durability requirements for this operation.
    *
-   * @note if a {@link #durability(persist_to, replicate_to)} has been set beforehand it will be set
-   * back to {@link persist_to::none} and
+   * @note if a {@link #durability durability(persist_to, replicate_to)} has been set beforehand it
+   * will be set back to {@link persist_to::none} and
    * {@link replicate_to::none}, since it is not allowed to use both mechanisms at the same
    * time.</p>
    *
@@ -75,7 +75,8 @@ public:
   /**
    * Allows to customize the poll-based durability requirements for this operation.
    *
-   * @note if a {@link #durability(durability_level)} has been set beforehand it will be set back to
+   * @note if a {@link #durability durability(durability_level)} has been set beforehand it will be
+   * set back to
    * {@link durability_level::none}, since it is not allowed to use both mechanisms at the same
    * time.
    *

--- a/couchbase/decrement_options.hxx
+++ b/couchbase/decrement_options.hxx
@@ -68,7 +68,7 @@ struct decrement_options : public common_durability_options<decrement_options> {
    * Sets the expiry for the document. By default the document will never expire.
    *
    * The duration must be less than 50 years. For expiry further in the future, use
-   * {@link #expiry(std::chrono::system_clock::time_point)}.
+   * {@link #expiry expiry(std::chrono::system_clock::time_point)}.
    *
    * @param duration the duration after which the document will expire (zero duration means never
    * expire).

--- a/couchbase/get_replica_result.hxx
+++ b/couchbase/get_replica_result.hxx
@@ -53,6 +53,7 @@ public:
    * @param cas
    * @param is_replica true if the document originates from replica node
    * @param value raw document contents along with flags describing its structure
+   * @param crypto_manager manager handed to the transcoder to decrypt encrypted fields
    *
    * @since 1.0.0
    * @committed

--- a/couchbase/get_result.hxx
+++ b/couchbase/get_result.hxx
@@ -56,6 +56,7 @@ public:
    * @param cas
    * @param value raw document contents along with flags describing its structure
    * @param expiry_time optional point in time when the document will expire
+   * @param crypto_manager manager handed to the transcoder to decrypt encrypted fields
    *
    * @since 1.0.0
    * @committed

--- a/couchbase/increment_options.hxx
+++ b/couchbase/increment_options.hxx
@@ -69,7 +69,7 @@ struct increment_options : public common_durability_options<increment_options> {
    * Sets the expiry for the document. By default the document will never expire.
    *
    * The duration must be less than 50 years. For expiry further in the future, use
-   * {@link #expiry(std::chrono::system_clock::time_point)}.
+   * {@link #expiry expiry(std::chrono::system_clock::time_point)}.
    *
    * @param duration the duration after which the document will expire (zero duration means never
    * expire).

--- a/couchbase/insert_options.hxx
+++ b/couchbase/insert_options.hxx
@@ -70,7 +70,7 @@ struct insert_options : public common_durability_options<insert_options> {
    * Sets the expiry for the document. By default the document will never expire.
    *
    * The duration must be less than 50 years. For expiry further in the future, use
-   * {@link #expiry(std::chrono::system_clock::time_point)}.
+   * {@link #expiry expiry(std::chrono::system_clock::time_point)}.
    *
    * @param duration the duration after which the document will expire (zero duration means never
    * expire).

--- a/couchbase/mutate_in_options.hxx
+++ b/couchbase/mutate_in_options.hxx
@@ -80,8 +80,8 @@ struct mutate_in_options : public common_durability_options<mutate_in_options> {
    *
    * If true, and the document exists, its expiry will not be modified. Otherwise the document's
    * expiry is determined by
-   * {@link #expiry(std::chrono::seconds)} or {@link
-   * #expiry(std::chrono::system_clock::time_point)}.
+   * {@link #expiry expiry(std::chrono::seconds)} or {@link #expiry
+   * expiry(std::chrono::system_clock::time_point)}.
    *
    * Requires Couchbase Server 7.0 or later.
    *
@@ -101,7 +101,7 @@ struct mutate_in_options : public common_durability_options<mutate_in_options> {
    * Sets the expiry for the document. By default the document will never expire.
    *
    * The duration must be less than 50 years. For expiry further in the future, use
-   * {@link #expiry(std::chrono::system_clock::time_point)}.
+   * {@link #expiry expiry(std::chrono::system_clock::time_point)}.
    *
    * @param duration the duration after which the document will expire (zero duration means never
    * expire).

--- a/couchbase/network_options.hxx
+++ b/couchbase/network_options.hxx
@@ -38,7 +38,7 @@ public:
   /**
    * Selects network to use.
    *
-   * @param name network name as it is exposed in the configuration.
+   * @param network_name network name as it is exposed in the configuration.
    * @return this object for chaining purposes.
    *
    * @see

--- a/couchbase/query_options.hxx
+++ b/couchbase/query_options.hxx
@@ -137,8 +137,9 @@ struct query_options : public common_options<query_options> {
    *
    * If this method is set to true, the server will send metrics back to the client which are
    * available through the
-   * {@link query_meta_data#metrics()} section. As opposed to {@link #profile(query_profile)},
-   * returning metrics is rather cheap and can also be enabled in production if needed.
+   * {@link query_meta_data#metrics()} section. As opposed to {@link #profile
+   * profile(query_profile)}, returning metrics is rather cheap and can also be enabled in
+   * production if needed.
    *
    * @param metrics set to true if the server should return simple query metrics.
    * @return this options builder for chaining purposes.
@@ -385,10 +386,11 @@ struct query_options : public common_options<query_options> {
    * mutations. If you want to include all the mutations up to the point of the query, use {@link
    * query_scan_consistency::request_plus}.
    *
-   * Note that you cannot use this method and {@link #consistent_with(const mutation_state&)} at the
-   * same time, since they are mutually exclusive. As a rule of thumb, if you only care to be
-   * consistent with the mutation you just wrote on the same thread/app, use
-   * {@link #consistent_with(const mutation_state&)}. If you need "global" scan consistency, use
+   * Note that you cannot use this method and {@link #consistent_with consistent_with(const
+   * mutation_state&)} at the same time, since they are mutually exclusive. As a rule of thumb, if
+   * you only care to be consistent with the mutation you just wrote on the same thread/app, use
+   * {@link #consistent_with consistent_with(const mutation_state&)}. If you need "global" scan
+   * consistency, use
    * {@link query_scan_consistency::request_plus} on this method.
    *
    * @param scan_consistency the index scan consistency to be used for this query
@@ -411,12 +413,12 @@ struct query_options : public common_options<query_options> {
    * and if you want your N1QL query to include those you need to pass the mutation tokens into a
    * {@link mutation_state}.
    *
-   * Note that you cannot use this method and {@link #scan_consistency(query_scan_consistency)} at
-   * the same time, since they are mutually exclusive. As a rule of thumb, if you only care to be
-   * consistent with the mutation you just wrote on the same thread/app, use this method. If you
-   * need "global" scan consistency, use
-   * {@link query_scan_consistency#request_plus} on {@link
-   * #scan_consistency(query_scan_consistency)}.
+   * Note that you cannot use this method and {@link #scan_consistency
+   * scan_consistency(query_scan_consistency)} at the same time, since they are mutually exclusive.
+   * As a rule of thumb, if you only care to be consistent with the mutation you just wrote on the
+   * same thread/app, use this method. If you need "global" scan consistency, use
+   * {@link query_scan_consistency#request_plus} on {@link #scan_consistency
+   * scan_consistency(query_scan_consistency)}.
    *
    * @param state the mutation state containing the mutation tokens.
    * @return this options builder for chaining purposes.

--- a/couchbase/replace_options.hxx
+++ b/couchbase/replace_options.hxx
@@ -73,8 +73,8 @@ struct replace_options : public common_durability_options<replace_options> {
    *
    * If true, and the document exists, its expiry will not be modified. Otherwise the document's
    * expiry is determined by
-   * {@link #expiry(std::chrono::seconds)} or {@link
-   * #expiry(std::chrono::system_clock::time_point)}.
+   * {@link #expiry expiry(std::chrono::seconds)} or {@link #expiry
+   * expiry(std::chrono::system_clock::time_point)}.
    *
    * Requires Couchbase Server 7.0 or later.
    *
@@ -94,7 +94,7 @@ struct replace_options : public common_durability_options<replace_options> {
    * Sets the expiry for the document. By default the document will never expire.
    *
    * The duration must be less than 50 years. For expiry further in the future, use
-   * {@link #expiry(std::chrono::system_clock::time_point)}.
+   * {@link #expiry expiry(std::chrono::system_clock::time_point)}.
    *
    * @param duration the duration after which the document will expire (zero duration means never
    * expire).

--- a/couchbase/scan_result_item.hxx
+++ b/couchbase/scan_result_item.hxx
@@ -62,6 +62,7 @@ public:
    * @param cas
    * @param value raw document contents along with flags describing its structure
    * @param expiry_time optional point in time when the document will expire
+   * @param crypto_manager manager handed to the transcoder to decrypt encrypted fields
    *
    * @since 1.0.0
    * @internal

--- a/couchbase/search_options.hxx
+++ b/couchbase/search_options.hxx
@@ -135,10 +135,10 @@ struct search_options : public common_options<search_options> {
    * data it has in the index right away. This is fast, but might not include the most recent
    * mutations.
    *
-   * Note that you cannot use this method and {@link #consistent_with(const mutation_state&)} at the
-   * same time, since they are mutually exclusive. As a rule of thumb, if you only care to be
-   * consistent with the mutation you just wrote on the same thread/app, use
-   * {@link #consistent_with(const mutation_state&)}.
+   * Note that you cannot use this method and {@link #consistent_with consistent_with(const
+   * mutation_state&)} at the same time, since they are mutually exclusive. As a rule of thumb, if
+   * you only care to be consistent with the mutation you just wrote on the same thread/app, use
+   * {@link #consistent_with consistent_with(const mutation_state&)}.
    *
    * @param scan_consistency the index scan consistency to be used for this query
    * @return this options builder for chaining purposes.
@@ -160,9 +160,10 @@ struct search_options : public common_options<search_options> {
    * and if you want your N1QL query to include those you need to pass the mutation tokens into a
    * {@link mutation_state}.
    *
-   * Note that you cannot use this method and {@link #scan_consistency(search_scan_consistency)} at
-   * the same time, since they are mutually exclusive. As a rule of thumb, if you only care to be
-   * consistent with the mutation you just wrote on the same thread/app, use this method.
+   * Note that you cannot use this method and {@link #scan_consistency
+   * scan_consistency(search_scan_consistency)} at the same time, since they are mutually exclusive.
+   * As a rule of thumb, if you only care to be consistent with the mutation you just wrote on the
+   * same thread/app, use this method.
    *
    * @param state the mutation state containing the mutation tokens.
    * @return this options builder for chaining purposes.

--- a/couchbase/upsert_options.hxx
+++ b/couchbase/upsert_options.hxx
@@ -72,8 +72,8 @@ struct upsert_options : public common_durability_options<upsert_options> {
    *
    * If true, and the document exists, its expiry will not be modified. Otherwise the document's
    * expiry is determined by
-   * {@link #expiry(std::chrono::seconds)} or {@link
-   * #expiry(std::chrono::system_clock::time_point)}.
+   * {@link #expiry expiry(std::chrono::seconds)} or {@link #expiry
+   * expiry(std::chrono::system_clock::time_point)}.
    *
    * Requires Couchbase Server 7.0 or later.
    *
@@ -93,7 +93,7 @@ struct upsert_options : public common_durability_options<upsert_options> {
    * Sets the expiry for the document. By default the document will never expire.
    *
    * The duration must be less than 50 years. For expiry further in the future, use
-   * {@link #expiry(std::chrono::system_clock::time_point)}.
+   * {@link #expiry expiry(std::chrono::system_clock::time_point)}.
    *
    * @param duration the duration after which the document will expire (zero duration means never
    * expire).

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -405,7 +405,7 @@ AUTOLINK_SUPPORT       = YES
 # diagrams that involve STL classes more complete and accurate.
 # The default value is: NO.
 
-BUILTIN_STL_SUPPORT    = NO
+BUILTIN_STL_SUPPORT    = YES
 
 # If you use Microsoft's C++/CLI language, you should set this option to YES to
 # enable parsing support.
@@ -2825,15 +2825,6 @@ DOT_GRAPH_MAX_NODES    = 100
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 MAX_DOT_GRAPH_DEPTH    = 0
-
-# Set the DOT_MULTI_TARGETS tag to YES to allow dot to generate multiple output
-# files in one run (i.e. multiple -o and -T options on the command line). This
-# makes dot run faster, but since only newer versions of dot (>1.8.10) support
-# this, this feature is disabled by default.
-# The default value is: NO.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-DOT_MULTI_TARGETS      = NO
 
 # If the GENERATE_LEGEND tag is set to YES doxygen will generate a legend page
 # explaining the meaning of the various boxes and arrows in the dot generated

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -292,7 +292,13 @@ TAB_SIZE               = 4
 ALIASES                = "committed=\xrefitem stability_committed \"Committed\" \"Committed Interfaces\" Generally available API and should be preferred in production" \
                          "uncommitted=\xrefitem stability_uncommitted \"Uncommitted\" \"Uncommitted Interfaces\" Might be changed in the future, and eventually promoted to committed" \
                          "volatile=\xrefitem stability_volatile \"Volatile\" \"Volatile Interfaces\" Should not be used in production" \
-                         "internal=\xrefitem stability_internal \"Internal\" \"Internal Interfaces\" Internal interface"
+                         "internal=\xrefitem stability_internal \"Internal\" \"Internal Interfaces\" Internal interface" \
+                         "cng_since{1}=@since \1 -- Cloud Native Gateway (CNG, \
+                         couchbase2://) support" \
+                         "cng_uncommitted=\xrefitem stability_uncommitted \"Uncommitted\" \
+                         \"Uncommitted Interfaces\" Cloud Native Gateway (CNG, \
+                         couchbase2://) support is uncommitted and may change in a future \
+                         release, independently of the stability of the API it applies to"
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
@@ -955,6 +961,7 @@ WARN_LOGFILE           =
 INPUT                  = ${DOXYGEN_INPUT_DIR} \
                          ${PROJECT_SOURCE_DIR}/docs/mainpage.hxx \
                          ${PROJECT_SOURCE_DIR}/docs/stability.hxx \
+                         ${PROJECT_SOURCE_DIR}/docs/couchbase2.hxx \
                          ${PROJECT_SOURCE_DIR}/docs/cli.hxx \
                          ${PROJECT_SOURCE_DIR}/docs/cbc.md \
                          ${PROJECT_SOURCE_DIR}/docs/cbc-get.md \

--- a/docs/cbc-config.md
+++ b/docs/cbc-config.md
@@ -1,4 +1,4 @@
-# cbc-config - Fetch Cluster Configuration
+# cbc-config - Fetch Cluster Configuration {#cbc-config}
 
 ### NAME
 
@@ -15,6 +15,7 @@ This tool retrieves configuration of the cluster in JSON format.
 
 ### OPTIONS
 
+<dl>
 <dt>`-h,--help`</dt><dd>Print this help message and exit</dd>
 <dt>`--pretty-json`</dt><dd>Try to pretty-print as JSON value (prints AS-IS if the document is not a JSON).</dd>
 <dt>`--level=LEVEL`</dt><dd>Level of the config. Allowed values are: `bucket`, `cluster`. (`--bucket-name` is required for `bucket`).</dd>

--- a/docs/cbc-keygen.md
+++ b/docs/cbc-keygen.md
@@ -24,6 +24,7 @@ You can also set the number of vbuckets with the `--number-of-vbuckets` switch.
 
 ### OPTIONS
 
+<dl>
 <dt>`-h,--help`</dt><dd>Print this help message and exit</dd>
 <dt>`--number-of-keys=INTEGER`</dt><dd>How many keys to generate. [default: `1`]</dd>
 <dt>`--fixed-length=INTEGER`</dt><dd>The length of the key to generate. [default: `6`]</dd>

--- a/docs/cbc.md
+++ b/docs/cbc.md
@@ -52,7 +52,6 @@ Perform Analytics query. See [cbc-analytics](#cbc-analytics) for more informatio
 <dd>
 Run simple workload generator. See [cbc-pillowfight](#cbc-pillowfight) for more information.
 </dd>
-</dl>
 
 <dt>keygen</dt>
 <dd>
@@ -63,6 +62,7 @@ Generate batches of keys with specific properties. See [cbc-keygen](#cbc-keygen)
 <dd>
 Retrieve cluster configuration. See [cbc-config](#cbc-config) for more information.
 </dd>
+</dl>
 
 ### OPTIONS
 

--- a/docs/cli.hxx
+++ b/docs/cli.hxx
@@ -19,7 +19,7 @@
 
 /**
  * @page cli Command Line Tools
- * @brief Indexes of the API grouped by stability.
+ * @brief The command line tools shipped with the library.
  *
  * @subpage cbc
  *

--- a/docs/couchbase2.hxx
+++ b/docs/couchbase2.hxx
@@ -1,0 +1,105 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+/**
+ * @page couchbase2 The couchbase2:// transport
+ * @brief Connecting through a Cloud Native Gateway instead of directly to cluster nodes.
+ *
+ * A connection string with the @c couchbase2:// scheme routes every operation over gRPC to a single
+ * Cloud Native Gateway (CNG) endpoint, rather than opening MCBP and HTTP connections to each node
+ * of a cluster. The gateway performs the routing the library would otherwise do itself.
+ *
+ * The public API is the same one used for @c couchbase:// and @c couchbases://. No type or method
+ * is specific to this transport; what changes is which operations a cluster can serve, and how a
+ * connection string is written.
+ *
+ * @warning The transport as a whole carries the stability level of this page. Individual API
+ * entities keep their own stability, which this page does not lower: @ref couchbase::collection#get
+ * is @ref stability_committed "committed" whether it runs over @c couchbase:// or @c couchbase2://.
+ * What is uncommitted is the behaviour of running it over this transport at all.
+ *
+ * ### Enabling it
+ *
+ * Support is a compile-time option and is @b off by default. A library built without
+ * @c COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2 refuses a @c couchbase2:// connection string, reporting
+ * @ref couchbase::errc::common::feature_not_available from @ref couchbase::cluster#connect rather
+ * than attempting a handshake the gateway cannot answer.
+ *
+ * ### Writing the connection string
+ *
+ * The scheme implies TLS: a @c couchbase2:// connection is always encrypted, and the default port
+ * is 18098. Neither is inferred from the scheme name, so an endpoint published on another port must
+ * say so explicitly, and a private certificate authority must be trusted as it would be for
+ * @c couchbases://.
+ *
+ * Two further rules apply to @c couchbase2:// that do not apply to the other schemes:
+ *
+ * * Exactly one host. The gateway fronts the whole cluster, so there is no node list to rotate
+ *   through. A string naming several hosts still connects, to a single one of them: the bootstrap
+ *   list is shuffled unless @c preserve_bootstrap_nodes_order is set, so which one is not
+ *   predictable from the order they were written in. The log records the endpoint chosen and that
+ *   the rest were ignored.
+ * * No bootstrap-mode suffix on the host, since the gateway uses neither MCBP nor HTTP config
+ *   bootstrap. A suffix is ignored.
+ *
+ * ### Operations the library refuses
+ *
+ * These report @ref couchbase::errc::common::feature_not_available without reaching the gateway,
+ * because the transport has no way to carry them:
+ *
+ * * @ref couchbase::cluster#ping, @ref couchbase::bucket#ping and
+ *   @ref couchbase::cluster#diagnostics -- there are no per-node or per-bucket sessions to probe.
+ * * @ref couchbase::collection#get_all_replicas, @ref couchbase::collection#get_any_replica,
+ *   @ref couchbase::collection#lookup_in_all_replicas and
+ *   @ref couchbase::collection#lookup_in_any_replica.
+ * * Subdocument operations against the active node, @ref couchbase::collection#lookup_in and
+ *   @ref couchbase::collection#mutate_in.
+ * * Requests carrying an option or a value the transport has no equivalent for, across query,
+ *   analytics, search, views and management -- a memcached bucket, for instance. The refusal
+ *   depends on what the request carries rather than on the operation, so the same call may be
+ *   served or refused according to how it was built.
+ *
+ * ### Operations that fail without being refused
+ *
+ * Two things are not served either, but do not report
+ * @ref couchbase::errc::common::feature_not_available and are not turned away before work begins.
+ * Both need the bucket configuration and the per-node connections this transport does not open, so
+ * they fail on that path instead, and the error describes that failure rather than the missing
+ * feature.
+ *
+ * The first is @ref couchbase::collection#scan.
+ *
+ * The second is poll-based durability, and it is the one to know about, because the mutation is
+ * already applied by the time it fails.
+ *
+ * It is requested by passing @ref couchbase::persist_to and @ref couchbase::replicate_to to
+ * @ref couchbase::common_durability_options. The mutation is sent to the gateway and applied, and
+ * only the polling that follows fails, so the document is already written when the error arrives
+ * and the durability it asked for has not been established.
+ *
+ * Level-based durability, requested with a @ref couchbase::durability_level, is served normally and
+ * is the durability to use over this transport.
+ *
+ * Anything not listed above is sent to the gateway, which decides whether it can serve it. An
+ * operation the gateway does not implement is reported in the gateway's own terms, so the set of
+ * working operations depends on the gateway version as well as on this library.
+ *
+ * @cng_since{1.4.0}
+ * @cng_uncommitted
+ */


### PR DESCRIPTION
[CXXCBC-927](https://couchbasecloud.atlassian.net/browse/CXXCBC-927)

Stacked on #1065, so this PR shows that commit too until it merges. Only the second commit —
`CXXCBC-927` — belongs to this change.

The `doxygen` target completed successfully but emitted 89 warnings. Because they were always there,
a warning introduced by a new change was indistinguishable from the standing noise. They were not
cosmetic either: each corresponded to documentation that rendered wrongly.

After this change the target emits none.

## What was wrong

| n | cause | fix |
| --- | --- | --- |
| 26 | `{@link #f(args)}` never resolved | doxygen cannot match an argument list against a declaration using a trailing return type (`auto f(x) -> T&`), which is how every options-builder setter is declared. Rewritten as `{@link #f f(args)}` |
| 42 | malformed definition lists in three `cbc` manual pages | two never opened `<dl>`; `cbc.md` closed it before its last two entries, orphaning the `keygen` and `config` entries |
| 2 | `@subpage cbc-config` unresolvable | `cbc-config.md` was the only page missing its `{#cbc-config}` label |
| 4 | undocumented `crypto_manager` on three result constructors; `@param name` against an argument called `network_name` | documented and renamed |
| 1 | `</blockquote>` without a match | a wrapped line began `> 5`, which markdown reads as a blockquote |
| 1 | obsolete `DOT_MULTI_TARGETS` | removed |
| 1 | `std::hash<couchbase::node_id>` unparseable | `BUILTIN_STL_SUPPORT = YES` |

The first row is the one worth remembering: the failure is a property of the declaration style, not of
the individual links, so any future `{@link #f(args)}` in this codebase is dead on arrival. It was
isolated rather than guessed — in a minimal reproduction a plain-return-type control resolved with an
argument list, while every trailing-return-type form failed, with `#`, qualified, and `@ref` spellings
alike. The replacement keeps the full signature as the visible text, so overloads such as
`expiry(std::chrono::seconds)` and `expiry(std::chrono::system_clock::time_point)` remain
distinguishable in the rendered text.

## Verification

The zero is demonstrated rather than asserted. A canary `@ref this_symbol_does_not_exist_xyz` was
injected into a public header; the same check that reports zero then reported exactly one warning, and
removing the canary returned it to zero. Without that control, "no matches" would have been
indistinguishable from a broken check.

`BUILTIN_STL_SUPPORT = YES` was checked for side effects: it adds exactly one page, the `std::hash`
specialization it was enabled for, and no STL container pages. Signatures still render with their STL
types intact.

`clang-format` reflowed some of the rewritten links across lines. Doxygen still resolves them and the
rendered text is unaffected, which was confirmed on the generated pages rather than assumed — several
links in these files were already wrapped before this change. The library compiles.

## Not done here

Warnings are not turned into errors. Doxygen's warning set varies between versions, and the reference
is not built in CI, so `WARN_AS_ERROR` would fail the docs build for contributors running a different
doxygen rather than catching regressions in a pinned environment. It is worth revisiting if the
reference is ever built in CI.


[CXXCBC-927]: https://couchbasecloud.atlassian.net/browse/CXXCBC-927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ