### PR TITLE
CXXCBC-929: report Cloud Native Gateway support in the build info

### DIFF
--- a/core/meta/version.cxx
+++ b/core/meta/version.cxx
@@ -96,6 +96,16 @@ sdk_build_info() -> std::map<std::string, std::string>
     "false"
 #endif
     ;
+  // Whether this build can serve couchbase2:// connection strings, i.e. whether it was compiled
+  // with Cloud Native Gateway support. A build without it rejects the scheme at connect time, so
+  // the answer is worth reporting next to the other build-time switches.
+  info["couchbase2"] =
+#if defined(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2)
+    "true"
+#else
+    "false"
+#endif
+    ;
   info["post_linked_openssl"] = COUCHBASE_CXX_CLIENT_POST_LINKED_OPENSSL;
   info["static_openssl"] =
 #if defined(COUCHBASE_CXX_CLIENT_STATIC_OPENSSL)
@@ -194,7 +204,7 @@ sdk_build_info_json() -> std::string
         name == "version_build" || name == "mozilla_ca_bundle_size") {
       info[name] = std::stoi(value);
     } else if (name == "snapshot" || name == "static_stdlib" || name == "static_openssl" ||
-               name == "mozilla_ca_bundle_embedded") {
+               name == "couchbase2" || name == "mozilla_ca_bundle_embedded") {
       info[name] = value == "true";
     } else {
       info[name] = value;

--- a/test/test_unit_utils.cxx
+++ b/test/test_unit_utils.cxx
@@ -172,6 +172,33 @@ TEST_CASE("unit: user_agent string", "[unit]")
           couchbase::core::meta::user_agent_for_http("0xDEADBEEF", "0xCAFEBEBE", "hello\nworld"));
 }
 
+TEST_CASE("unit: build info reports whether couchbase2 is supported", "[unit]")
+{
+  const auto info = couchbase::core::meta::sdk_build_info();
+  const auto entry = info.find("couchbase2");
+  REQUIRE(entry != info.end());
+
+  // Asserted against the macro rather than against a fixed value, so the case holds in either
+  // configuration and still fails if the entry stops tracking how the library was built.
+#if defined(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2)
+  REQUIRE(entry->second == "true");
+#else
+  REQUIRE(entry->second == "false");
+#endif
+
+  // The JSON rendering keeps its own list of which keys are booleans, so the raw entry above says
+  // nothing about it: assert the rendered type as well as the value, or dropping the key from that
+  // list would silently turn it back into a string.
+  // Through a string_view: parse() also has a json_string overload, and std::string converts to
+  // both.
+  const auto build_info_json = couchbase::core::meta::sdk_build_info_json();
+  const auto rendered = couchbase::core::utils::json::parse(std::string_view{ build_info_json });
+  const auto* couchbase2 = rendered.find("couchbase2");
+  REQUIRE(couchbase2 != nullptr);
+  REQUIRE(couchbase2->is_boolean());
+  REQUIRE(couchbase2->get_boolean() == (entry->second == "true"));
+}
+
 TEST_CASE("unit: utils::movable_function should be false after moving value out", "[unit]")
 {
   auto ptr = std::make_unique<int>(42);

--- a/tools/version.cxx
+++ b/tools/version.cxx
@@ -45,7 +45,7 @@ public:
           info[name] = std::stoi(value);
         } else if (name == "snapshot" || name == "static_stdlib" || name == "static_openssl" ||
                    name == "static_target" || name == "static_boringssl" || name == "columnar" ||
-                   name == "mozilla_ca_bundle_embedded") {
+                   name == "couchbase2" || name == "mozilla_ca_bundle_embedded") {
           info[name] = value == "true";
         } else {
           info[name] = value;
@@ -65,6 +65,12 @@ public:
     fmt::print(stdout, "CMake: {}\n", info["cmake_version"]);
     fmt::print(stdout, "ASIO: {}\n", info["asio"]);
     fmt::print(stdout, "Snappy: {}\n", info["snappy"]);
+    // Printed whether or not it is available: "not supported" is the answer someone running this
+    // command is usually after, and omitting the line would leave them unable to tell it apart
+    // from an older build that never reported it.
+    fmt::print(stdout,
+               "Cloud Native Gateway (couchbase2://): {}\n",
+               info["couchbase2"] == "true" ? "supported" : "not supported");
 #ifdef COUCHBASE_CXX_CLIENT_BUILD_OPENTELEMETRY
     fmt::print(stdout, "OpenTelemetry: {}\n", info["opentelemetry"]);
 #endif


### PR DESCRIPTION
[CXXCBC-929](https://couchbasecloud.atlassian.net/browse/CXXCBC-929)

Cloud Native Gateway support is a compile-time option, `COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2`, and it
is off by default. Nothing reported whether a given binary carried it.

The failure mode is quiet. A library built without the option does not reject a `couchbase2://`
connection string as malformed — it accepts the string and then fails the connect with
`feature_not_available`. To someone holding a prebuilt package that reads as a gateway, credential or
configuration problem, when the cause is the build they are running.

`sdk_build_info()` already answers this class of question for every other build-time switch it carries
(`columnar`, `static_openssl`, `static_boringssl`, `static_target`, OpenTelemetry). This one was
simply missing.

## What it looks like

```
$ cbc version
Version: 1.4.0
...
Snappy: 1.2.2
Cloud Native Gateway (couchbase2://): supported
```

```
$ cbc version --json
  "columnar": false,
  "couchbase2": true,
```

The line is printed whether or not support is present. "not supported" is the answer someone running
this command is usually after, and omitting the line would leave it indistinguishable from an older
binary that never reported anything.

## Verification

Both arms are exercised, not just the one this development build happens to use:

- Built with the option **on** — `cbc version` prints `supported` and `cbc version --json` emits
  `"couchbase2": true`. Cross-checked against `CMakeCache.txt`, which has
  `COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2:BOOL=ON` and `COUCHBASE_CXX_CLIENT_COLUMNAR:BOOL=OFF`; the two
  adjacent keys report opposite values matching that configuration, so the entry is not hardcoded.
- Built with the option **off** — verified by compiling against a generated `build_config.hxx` with
  the macro undefined exactly as CMake emits it, which yields `false`.
- The JSON rendering is a boolean, not the string `"true"`. The key was added to the boolean list in
  both `sdk_build_info_json()` and `cbc`, since those two lists are maintained separately.

The unit test asserts the entry against the macro rather than a fixed value, so it holds in either
configuration and still fails if the entry stops tracking how the library was built. It was
mutation-checked: changing the expected value makes it fail with `"true" == "WRONG"`, and restoring it
makes it pass, so the assertion is live rather than vacuous.

## Note for the reviewer

`sdk_build_info_json()` and `cbc version --json` maintain separate lists of which keys are booleans,
and they already disagree: `columnar`, `static_target` and `static_boringssl` are booleans in the tool
and strings in the library rendering. The new key is added to both so it is consistent wherever it
appears. Reconciling the pre-existing divergence is deliberately left out of this change.


[CXXCBC-929]: https://couchbasecloud.atlassian.net/browse/CXXCBC-929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ