### PR TITLE
CXXCBC-931: stage the file curl installs, and stop a comment truncating the glob list

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,21 +35,37 @@ automatically by CMake (Asio, GSL, nlohmann/json, BoringSSL/OpenSSL).
 
 ```
 couchbase/                      Public API — headers (.hxx) only. No core/ types exposed here.
-core/                           Internal implementation (.hxx + .cxx).
+core/                           Internal implementation (.hxx + .cxx). Selected subdirectories:
   io/                           MCBP and HTTP session/IO layer (Asio-based).
   mcbp/                         MCBP protocol codec and queue.
+  protocol/                     MCBP wire types.
+  protostellar/                 couchbase2:// (gRPC) transport and generated stubs.
+  operations/ management/       Request/response types; management operations.
+  transactions/ columnar/       Distributed transactions; columnar/analytics.
+  topology/ sasl/ crypto/       Cluster map, authentication, TLS/crypto helpers.
+  tracing/ metrics/ logger/     Observability.
   impl/                         Misc internal helpers (DNS SRV, retry, etc.).
   error_context/                Error context structs per operation type.
+  utils/ platform/ meta/        Small shared utilities.
 core/cluster.cxx                cluster / cluster_impl (pimpl) — connection lifecycle.
 core/bucket.cxx                 bucket / bucket_impl — per-bucket KV routing.
 core/crud_component.cxx         New KV operations (get, upsert, replace, …).
 core/collections_component.cxx  CID resolution and dispatch.
 core/response_handler.hxx       Interface for handling MCBP responses.
 test/                           Integration + unit tests (Catch2).
+test/cng/                       couchbase2:// tests — hand-rolled harness in
+                                test/cng/framework/, NOT Catch2. See test/cng/README.md.
+tools/                          cbc CLI, fit_performer, system_metrics.
+cmake/                          Build and packaging: dependency resolution, the RPM spec,
+                                debian/ and APKBUILD templates, tarball_glob.txt. CI runs
+                                the configure half of it, none of the packaging half —
+                                see the packaging section below.
 examples/                       Usage samples.
+docs/                           Doxygen input and prose documentation.
 bin/                            Helper scripts (check-clang-format, check-clang-tidy, …).
 third_party/                    Bundled/fetched dependencies.
-.clang-format                   Formatting rules.
+.clang-format                   C++ formatting rules (ColumnLimit: 100).
+.cmake-format.yaml              CMake formatting rules (line_width: 120).
 .clang-tidy                     Lint rules.
 CPPLINT.cfg                     cpplint configuration.
 ```
@@ -128,11 +144,35 @@ Every new KV operation added to `crud_component` must have a corresponding test
 in `test/test_integration_crud_component.cxx`. Tests must not rely on fixed
 `sleep_for` delays; use mutation tokens or polling loops instead.
 
+### couchbase2:// (CNG) tests
+
+`test/cng/` is a second suite with its own conventions, and the commands above do
+not apply to it. It uses the hand-rolled harness in `test/cng/framework/` rather
+than Catch2, is gated by `COUCHBASE_CXX_CLIENT_BUILD_CNG_TESTS`, and runs under
+ctest with the `cng` label. Each case declares whether it needs a cluster;
+cluster-only cases skip (exit 77) when `TEST_CONNECTION_STRING` is unset.
+
+**`test/cng/README.md` is the reference, and its setup is not a Couchbase cluster
+in a container.** A `couchbase2://` endpoint is served by the Cloud Native
+Gateway, which is deployed by the Couchbase Autonomous Operator and therefore
+needs Kubernetes: k3d for a local cluster, then `cbdinocluster` with the `cao`
+deployer. Consult that document before assuming how these tests are run or
+proposing changes to them; several of its constraints are not guessable from the
+code, among them that the gateway is only deployed when the cluster definition
+carries `cao.gateway-version`, that release versions must be used because a
+version with a build number resolves to an image needing an organization token,
+that the operator reconciles service memory quotas away unless the
+`CouchbaseCluster` resource itself is patched, and that a local gateway needs
+`tls_verify=none` because its certificate cannot be chained.
+
 ## Common defects to flag in code review
 
 1. `#include <iostream>` / `#include <cstdio>` in non-test `.cxx` files.
 2. Duplicate `#include` in the same file.
-3. Any added line over 100 characters.
+3. A line over the limit **for its language**: 100 columns for C++ (`.clang-format`,
+   `ColumnLimit: 100`), 120 for CMake (`.cmake-format.yaml`, `line_width: 120`).
+   Applying the C++ limit to `.cmake`, `CMakeLists.txt` or `cmake/*.txt` produces
+   findings the project does not want. Count the columns before reporting one.
 4. Single-argument constructors without `explicit`.
 5. Accessing an object after `std::move` in the same scope.
 6. Magic numeric literals in production paths without a named constant.
@@ -143,3 +183,183 @@ in `test/test_integration_crud_component.cxx`. Tests must not rely on fixed
 11. Planning/notes files (`REFACTORING_PLAN.md`, AI-convention files like
     `GEMINI.md`) committed to the repo.
 12. `core/` types or Asio headers exposed in `couchbase/` public headers.
+13. A comment that contradicts the code beneath it — a stale comment is a false
+    specification, not a cosmetic issue. See the documentation lens below.
+14. A test that cannot fail. See the test lens below.
+
+## Reviewing the build and packaging code
+
+**Review CMake changes to the same standard as C++ changes.** A defect here costs
+more than one in a `.cxx`, because it can stop every build at once rather than one
+code path — as a failed `cmake/CPM.cmake` download does, taking out every job that
+configures.
+
+CI covers this code unevenly, and the split is what decides how much weight a
+finding carries:
+
+- **Exercised on every job**: everything the configure step runs — dependency
+  resolution in `cmake/ThirdPartyDependencies.cmake`, `cmake/GrpcProtobuf.cmake`,
+  `cmake/CPM.cmake`, compiler and warning options, and the whole target graph.
+  A mistake here is usually caught, and caught loudly.
+- **Not exercised anywhere**: the install and packaging half. No workflow sets
+  `COUCHBASE_CXX_CLIENT_INSTALL`, so no CI leg runs the `install()` rules,
+  `bundle_static_library`, the licence installs, or any package build, and none
+  uses the RPM spec, `cmake/debian/`, `cmake/APKBUILD.in` or
+  `cmake/tarball_glob.txt`. Green CI says nothing about any of it. Review is the
+  only gate before a release build, so weigh findings there accordingly.
+
+What has actually broken here, and is worth checking on any change:
+
+- **The source tarball is filtered by patterns, and a missing file is only found
+  at install time.** `cmake/tarball_glob.txt` decides what enters the tarball the
+  packages build from. Vendored dependencies install *before* this project does,
+  so one file a dependency's own `install()` reads and the tarball omits stops the
+  whole `%install`/`dh_auto_install` step, after the entire vendored stack has
+  compiled. When a dependency is added or bumped, check what its install rules
+  read from its source tree, not just what gets linked.
+- **The patterns are `find -wholename`, not shell globs.** `**/` still requires an
+  intervening path segment, so a `**/` pattern **cannot match a file at the root
+  of a tree**; write both the root and nested spellings. Suffixes are literal:
+  `*.cmake.in` does not match `zconf.h.cmakein`.
+- **That file is read by `xargs`, whose quote handling is disabled deliberately.**
+  The read passes `-d "\n"`; without it an apostrophe anywhere in the file —
+  including in a comment — aborts `xargs` and silently drops every pattern after
+  that line, while the pipeline still exits 0 and the tarball target reports
+  success. Apostrophes are therefore fine; removing the delimiter is not. Flag any
+  change that drops `-d` from those `xargs` invocations in `cmake/Packaging.cmake`,
+  or that adds a new pattern-file read without it.
+- **A backslash argument inside `add_custom_command` needs four backslashes**
+  (`"\\\\n"`): CMake collapses them once and the shell ninja runs the command in
+  collapses them again. Two backslashes silently arrive as a bare letter.
+- **Tri-state options must be matched with `STREQUAL` before any boolean test.**
+  `if(<var>)` is true for every string CMake does not read as false, so an
+  unrecognised or misspelt value takes the ON branch. See
+  `COUCHBASE_CXX_CLIENT_SYSTEM_GRPC` in `cmake/GrpcProtobuf.cmake`.
+- **Visibility on vendored libraries is not cosmetic.** Hiding gRPC's symbols in a
+  build that links both the shared client and a stub library gives the process two
+  gRPCs, two `ExecCtx` thread-locals, and a crash inside gRPC's own closure list.
+- **A licence notice must ship for every dependency compiled into an artefact**,
+  and only for those actually built: the installs in `cmake/Packaging.cmake` are
+  conditional on the option that built the code. A package that gains a vendored
+  dependency and not its notice is a licensing defect, not a nit.
+- **dpkg and rpm differ on co-owned files.** rpm reference-counts an identical
+  path owned by several subpackages; dpkg refuses it outright. Notices shared
+  between Debian binary packages need a per-package copy via `dh_install`
+  source/dest pairs.
+
+## Review the same diff from several angles
+
+This is a low-level C++ library: a single change is usually correct from one
+viewpoint and wrong from another, and a reviewer who reads it once, linearly,
+finds only the defects that viewpoint exposes. Pass over the diff several times,
+each time as a different specialist, and say which concern produced a finding.
+Not every lens applies to every change; skip the ones that do not, and spend the
+effort on those that do.
+
+**API and ABI steward.** Does a public header in `couchbase/` leak a `core/`
+type, Asio, BoringSSL or `tl::expected` beyond the intentional surface? Does new
+state belong in `*_impl` rather than the outer class? Does a signature, a virtual
+method, or a struct layout change break users who compiled against the previous
+release?
+
+**Concurrency and lifetime.** Every KV and network path is asynchronous. Who owns
+the object the completion handler touches, and can it die first? Is captured
+state still alive when the callback runs? Can the handler run twice, or never, on
+an error path? Is anything shared between an Asio thread and the caller without
+synchronisation? A `shared_ptr` captured into a handler that the same object owns
+is a cycle.
+
+**Memory.** Dangling `string_view`/`span` into a buffer that has been reused or
+freed; use after `std::move`; a reference captured by `&` in a lambda that
+outlives the frame; an index or size computed from an untrusted length.
+
+**Wire protocol.** Encoding and decoding are where silent corruption lives:
+endianness, truncation, a field written with the wrong width, a partial read
+treated as complete, an extras/key/value framing mistake. For protobuf, a
+non-optional proto3 scalar cannot distinguish "absent" from "default" — code that
+needs the distinction must track arrival explicitly.
+
+**Errors and observability.** Is the error context fully populated before the
+callback runs? Is a failure swallowed, or converted into a success? Is the
+idempotent/non-idempotent timeout distinction right? Is the dispatch span closed
+on every path, including the error ones? Silent fallbacks that hide a failure are
+worse than the failure.
+
+**Performance.** Allocations and copies on the hot path; a container chosen for
+convenience in a per-operation struct; a `shared_ptr` copied where a reference
+would do; work done under a lock that need not be.
+
+**Portability.** The project builds with GCC, Clang and MSVC, on Linux, macOS and
+Windows, x86-64 and aarch64. Warnings differ sharply between them, and a warning
+that only Clang emits still fails every macOS and Windows leg — a `class`/`struct`
+mismatch is the recurring example. Sanitizer builds are their own configuration:
+flags applied per target are an ODR hazard when a type's layout depends on them.
+
+**Security.** Certificate verification and TLS options; credentials or tokens
+reaching a log; buffer arithmetic on attacker-controlled lengths.
+
+**Documentation and prose.** Every English sentence attached to the change has to
+describe what the code does, at every level: the comment above a line, the
+docstring on a public method, the file's header comment, `docs/`, the commit
+message, and the pull request body. They drift independently and nothing compares
+them, so each is checked against the diff separately.
+
+A comment that contradicts the code beneath it is a defect of the same
+seriousness as a wrong condition: it is a specification, and the next person
+changes the code to match it. Re-read the check before accepting the sentence
+above it. The same applies to a comment that lists what something handles when the
+list has grown, and to a commit message or PR body that claims behaviour the diff
+does not implement — that text is what people read years later, and it is the
+only record that is never re-run.
+
+Comments carry the contract and the reason, not a narration of the code or of how
+the change came about. Prefer deleting a comment to keeping one that will drift.
+Readability is part of correctness here: a name that misdescribes what a variable
+holds, or a function that has quietly grown a second responsibility, costs every
+future reader and is worth raising.
+
+**Tests.** Tests specify correct behaviour; they do not record current
+behaviour, and they must not lock in a bug or an internal detail that is free to
+change.
+
+The litmus test for any test added alongside a fix: **could this test have caught
+the bug being fixed?** If not, it is not pulling its weight. The order that
+produces such a test is to decide what correct behaviour is, assert that, watch
+it **fail** against the current or missing code, and only then implement. A test
+that passes the moment it is written, with no change to the code, has demonstrated
+nothing — it should be deleted or rewritten, not kept for the count.
+
+So, when reviewing tests, ask what would have to break for this to fail, and
+flag it when the answer is "nothing":
+
+- an assertion on a value the code under test also produced
+- a skip predicate that can never be false, so a live case cannot fail
+- a check of an internal representation rather than the observable contract,
+  which fails on refactoring and passes on regression
+- a fixed `sleep_for` standing in for a condition
+- setup that leaves preconditions implicit, so the case passes for a reason
+  other than the one it names — state the preconditions and assert the
+  postconditions in full, including what must *not* have changed
+
+## What makes a review finding useful here
+
+- **Verify the premise before reporting.** Several findings in this repository
+  have been declined because the rule cited did not exist (a limit that is 120 and
+  not 100), because the file was never compiled, or because the claimed mechanism
+  did not occur when run. A finding that names a rule should name where the rule is
+  configured.
+- **State a concrete failure**: the input or configuration, and what goes wrong.
+  "This could be a problem" cannot be actioned or refuted. A finding that predicts
+  a specific behaviour is valuable even when it turns out to be wrong, because it
+  can be tested.
+- **Prefer the root cause to the instance.** If the same mistake appears at five
+  call sites, say so once and name the shared cause; five separate comments on one
+  cause read as five problems.
+- **Suppressed findings are still findings.** Anything placed in a collapsed
+  block is read and answered like the rest, so it is worth the same care.
+- **Do not repeat a declined finding without new evidence.** A finding answered
+  with a measurement is closed; raising it again unchanged costs a round and
+  produces the same answer.
+- **The change may already do what is asked.** Re-read the current diff before
+  reporting; a review of an earlier revision produces findings the code has
+  already addressed.

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1,4 +1,6 @@
-set(CPM_DOWNLOAD_VERSION 0.42.0)
+set(CPM_DOWNLOAD_VERSION 0.43.1)
+# Published by upstream in the get_cpm.cmake of the same release. Update both together.
+set(CPM_HASH_SUM "1c40fc102ce9625d7de7eb14f541cab30cc3138dca627f0b0ec40293ce6c2934")
 
 if(CPM_SOURCE_CACHE)
   set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
@@ -11,21 +13,133 @@ endif()
 # Expand relative path. This is important if the provided path contains a tilde (~)
 get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
 
-function(download_cpm)
-  message(STATUS "Downloading CPM.cmake to ${CPM_DOWNLOAD_LOCATION}")
-  file(DOWNLOAD https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
-       ${CPM_DOWNLOAD_LOCATION})
+set(CPM_DOWNLOAD_ATTEMPTS
+    5
+    CACHE STRING "How many times to try downloading CPM.cmake before giving up")
+set(CPM_DOWNLOAD_RETRY_DELAY
+    2
+    CACHE STRING "Seconds to wait after the first failed attempt; each further wait doubles")
+# Without a bound, a peer that accepts the connection and then stops sending leaves file(DOWNLOAD)
+# waiting indefinitely and the retry below never runs. INACTIVITY_TIMEOUT bounds a stall, TIMEOUT
+# the whole transfer; the file is small, so both can be short enough to retry rather than hang.
+set(CPM_DOWNLOAD_INACTIVITY_TIMEOUT
+    20
+    CACHE STRING "Seconds of no data before an attempt to download CPM.cmake is abandoned")
+set(CPM_DOWNLOAD_TIMEOUT
+    60
+    CACHE STRING "Seconds before an attempt to download CPM.cmake is abandoned outright")
+
+# A file at CPM_DOWNLOAD_LOCATION is not necessarily CPM: file(DOWNLOAD) reports transport errors
+# only, so an HTTP 5xx or a rate-limit page arrives as a successful download whose body is HTML.
+# Including that defines nothing, and every dependency then fails with "Unknown CMake command
+# cpmaddpackage", which names neither the download nor the file to delete before retrying.
+set(CPM_VALIDATE_SCRIPT "${CMAKE_BINARY_DIR}/cmake/cpm_validate_candidate.cmake")
+file(
+  WRITE "${CPM_VALIDATE_SCRIPT}"
+  "include(\"\${CPM_CANDIDATE}\")
+if(NOT COMMAND cpmaddpackage)
+  message(FATAL_ERROR \"\${CPM_CANDIDATE} does not define CPMAddPackage\")
+endif()
+")
+
+# Whether a candidate is CPM is decided by a separate CMake process that includes it and looks for
+# the command. Searching the text for a name would accept a truncated script or an error page that
+# merely mentions it, and finding out by including it here would abort this configure on a parse
+# error instead of moving on to the next attempt.
+function(cpm_file_is_usable path out_var)
+  set(${out_var} FALSE PARENT_SCOPE)
+  if(NOT EXISTS "${path}")
+    return()
+  endif()
+  execute_process(
+    COMMAND "${CMAKE_COMMAND}" "-DCPM_CANDIDATE=${path}" -P "${CPM_VALIDATE_SCRIPT}"
+    RESULT_VARIABLE _cpm_validate_result
+    OUTPUT_QUIET ERROR_QUIET)
+  if(_cpm_validate_result EQUAL 0)
+    set(${out_var} TRUE PARENT_SCOPE)
+  endif()
 endfunction()
 
-if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
+# Transient failures fetching this file break every job that configures, so retry rather than fail
+# the build on one bad response.
+#
+# CPM_SOURCE_CACHE is shared between build trees, so nothing here may write or delete the shared path
+# while another configure could be reading it. Each attempt downloads to a private path, and only a
+# candidate that validates is moved onto the shared one; file(RENAME) within a directory is atomic, so
+# a concurrent reader sees either the previous file or the complete new one, never a partial write.
+# The private path is derived from the binary directory, which is what distinguishes one configure
+# from another.
+function(download_cpm)
+  set(_url
+      "https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake")
+  string(MD5 _tag "${CMAKE_BINARY_DIR}")
+  set(_staged "${CPM_DOWNLOAD_LOCATION}.${_tag}.part")
+  message(STATUS "Downloading CPM.cmake v${CPM_DOWNLOAD_VERSION} to ${CPM_DOWNLOAD_LOCATION}")
+  foreach(_attempt RANGE 1 ${CPM_DOWNLOAD_ATTEMPTS})
+    # LOG captures the transfer log, which carries the status line. Without it every HTTP failure
+    # reports libcurl's "HTTP response code said error" and nothing distinguishes a rate limit from a
+    # missing release, which are the same message and completely different problems.
+    # What arrives here is executed, so it is checked before it can be: EXPECTED_HASH against the
+    # sum upstream publishes, and TLS_VERIFY because CMake only began verifying certificates by
+    # default in 3.31 and this project supports 3.19, so on most of the roots it builds on the
+    # connection would otherwise go unauthenticated.
+    #
+    # The hash applies to the download alone. A cached file is deliberately not checked against it:
+    # the source tarball ships a patched CPM (see the sed in cmake/Packaging.cmake), so an offline
+    # build from the tarball has a legitimate copy that will never match upstream's sum.
+    file(DOWNLOAD "${_url}" "${_staged}" STATUS _status LOG _log
+         EXPECTED_HASH SHA256=${CPM_HASH_SUM} TLS_VERIFY ON
+         INACTIVITY_TIMEOUT ${CPM_DOWNLOAD_INACTIVITY_TIMEOUT} TIMEOUT ${CPM_DOWNLOAD_TIMEOUT})
+    list(GET _status 0 _code)
+    if(_code EQUAL 0)
+      cpm_file_is_usable("${_staged}" _usable)
+      if(_usable)
+        file(RENAME "${_staged}" "${CPM_DOWNLOAD_LOCATION}")
+        return()
+      endif()
+      set(_reason "the downloaded file does not define CPMAddPackage")
+    else()
+      list(GET _status 1 _reason)
+      # The last status line wins: a redirect to the asset host means the log holds one per hop.
+      string(REGEX MATCHALL "HTTP/[0-9.]+ [0-9]+[^\n\r]*" _http_lines "${_log}")
+      if(_http_lines)
+        list(POP_BACK _http_lines _http_line)
+        string(STRIP "${_http_line}" _http_line)
+        set(_reason "${_reason} [${_http_line}]")
+      endif()
+    endif()
+    file(REMOVE "${_staged}")
+    if(_attempt LESS CPM_DOWNLOAD_ATTEMPTS)
+      # Back off rather than retrying at a fixed interval: the failures worth retrying are a host
+      # rate-limiting or shedding load, and a burst of evenly spaced attempts is what it is shedding.
+      math(EXPR _delay "${CPM_DOWNLOAD_RETRY_DELAY} * (1 << (${_attempt} - 1))")
+      message(STATUS "  attempt ${_attempt} of ${CPM_DOWNLOAD_ATTEMPTS} failed: ${_reason}; "
+                     "retrying in ${_delay}s")
+      execute_process(COMMAND "${CMAKE_COMMAND}" -E sleep ${_delay})
+    else()
+      message(STATUS "  attempt ${_attempt} of ${CPM_DOWNLOAD_ATTEMPTS} failed: ${_reason}; "
+                     "no attempts left")
+    endif()
+  endforeach()
+  message(
+    FATAL_ERROR
+      "Could not download CPM.cmake v${CPM_DOWNLOAD_VERSION} from ${_url} in ${CPM_DOWNLOAD_ATTEMPTS} attempts: "
+      "${_reason}. Set CPM_SOURCE_CACHE to a directory that already holds "
+      "cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake to build without network access.")
+endfunction()
+
+cpm_file_is_usable("${CPM_DOWNLOAD_LOCATION}" CPM_DOWNLOAD_USABLE)
+if(NOT CPM_DOWNLOAD_USABLE)
   download_cpm()
-else()
-  # resume download if it previously failed
-  file(READ ${CPM_DOWNLOAD_LOCATION} check)
-  if("${check}" STREQUAL "")
-    download_cpm()
-  endif()
-  unset(check)
 endif()
 
 include(${CPM_DOWNLOAD_LOCATION})
+
+# The file validated a moment ago in another process, so reaching this means it was replaced in
+# between. Report it rather than letting the first dependency fail with an unexplained missing
+# command, and do not delete it: the writer was another configure, whose file this run has no claim
+# on, and the check above rejects it on the next run anyway if it really is unusable.
+if(NOT COMMAND cpmaddpackage)
+  message(FATAL_ERROR "${CPM_DOWNLOAD_LOCATION} did not define CPMAddPackage; it was replaced while this "
+                      "configure was reading it. Re-run to validate and download it again.")
+endif()

--- a/cmake/Packaging.cmake
+++ b/cmake/Packaging.cmake
@@ -311,6 +311,30 @@ if(COUCHBASE_CXX_CLIENT_BUILD_STATIC)
           DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
   install(FILES ${couchbase_cxx_client_static_IMPORTED_LOCATION} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+  # This archive carries every vendored dependency, so its debug info dwarfs everything else the
+  # development package ships: 2.8 GB against the 126 MB of the same archive stripped. Most
+  # distributions strip static archives themselves -- EL through brp-strip-static-archive, Debian
+  # through dh_strip -- but Fedora no longer does, and there the development package went out at
+  # 332 MB where every other target ships 13 MB.
+  #
+  # Strip it here so what ships does not depend on which of those a distribution still runs. Only for
+  # a package build: a local install is where someone debugging into the vendored code wants the
+  # symbols, and stripping is a no-op on a distribution that has already done it.
+  if(COUCHBASE_CXX_CLIENT_PACKAGE_BUILD AND CMAKE_STRIP)
+    get_filename_component(_static_archive_name "${couchbase_cxx_client_static_IMPORTED_LOCATION}" NAME)
+    install(
+      CODE "
+      set(_archive \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/${_static_archive_name}\")
+      if(EXISTS \"\${_archive}\")
+        message(STATUS \"Stripping debug info from \${_archive}\")
+        execute_process(COMMAND \"${CMAKE_STRIP}\" --strip-debug \"\${_archive}\" RESULT_VARIABLE _strip_result)
+        if(NOT _strip_result EQUAL 0)
+          message(FATAL_ERROR \"Failed to strip \${_archive}: \${_strip_result}\")
+        endif()
+      endif()
+    ")
+  endif()
 endif()
 
 if(COUCHBASE_CXX_CLIENT_BUILD_SHARED)

--- a/cmake/Packaging.cmake
+++ b/cmake/Packaging.cmake
@@ -416,7 +416,12 @@ add_custom_command(
     "-DCOUCHBASE_CXX_CLIENT_SOURCE_DATE_EPOCH=${COUCHBASE_CXX_CLIENT_SOURCE_DATE_EPOCH}"
     "-DCOUCHBASE_CXX_CLIENT_BUILD_TIMESTAMP=${COUCHBASE_CXX_CLIENT_BUILD_TIMESTAMP}"
   COMMAND
-    ${XARGS} -a ${COUCHBASE_CXX_TARBALL_THIRD_PARTY_GLOB_FILE} -I {} find
+    # -d: one pattern per line, with quote processing off. Without it an apostrophe anywhere in the
+    # glob file -- a comment is enough -- aborts xargs, and since its status is hidden by the pipe
+    # below, every pattern after that line is dropped from a tarball that still reports success.
+    # The argument has to reach xargs as backslash-n, which takes four backslashes here: CMake
+    # collapses them to two, and the shell that ninja runs the command in collapses those to one.
+    ${XARGS} -d "\\\\n" -a ${COUCHBASE_CXX_TARBALL_THIRD_PARTY_GLOB_FILE} -I {} find
     "${COUCHBASE_CXX_CLIENT_TARBALL_NAME}/tmp/cache" -wholename "${COUCHBASE_CXX_CLIENT_TARBALL_NAME}/tmp/cache/{}"
     -type f
     | grep -v
@@ -459,7 +464,8 @@ add_custom_command(
     | LC_ALL=C sort -u >
     "${COUCHBASE_CXX_CLIENT_TARBALL_NAME}/tmp/third_party_manifest.txt"
   COMMAND ${CMAKE_COMMAND} -E make_directory "${COUCHBASE_CXX_CLIENT_TARBALL_NAME}/tmp/filtered_cache"
-  COMMAND ${XARGS} -a "${COUCHBASE_CXX_CLIENT_TARBALL_NAME}/tmp/third_party_manifest.txt" -I {} ${CP} --parents
+  COMMAND ${XARGS} -d "\\\\n" -a "${COUCHBASE_CXX_CLIENT_TARBALL_NAME}/tmp/third_party_manifest.txt" -I {} ${CP}
+          --parents
           {} "${COUCHBASE_CXX_CLIENT_TARBALL_NAME}/tmp/filtered_cache"
   COMMAND
     ${CMAKE_COMMAND} -E rename

--- a/cmake/tarball_glob.txt
+++ b/cmake/tarball_glob.txt
@@ -143,6 +143,9 @@ curl/*/curl/**/*.inc
 curl/*/curl/*.rc
 curl/*/curl/**/*.rc
 curl/*/curl/**/*.cmake
+# Read by the install rules of curl from its source tree, so a tarball without it fails the install
+# step of every package build even though nothing links it.
+curl/*/curl/scripts/mk-ca-bundle.pl
 protostellar/*/protostellar/**/*.proto
 api_common_protos/*/api_common_protos/google/rpc/*.proto
 api_common_protos/*/api_common_protos/LICENSE*

--- a/core/utils/movable_function.hxx
+++ b/core/utils/movable_function.hxx
@@ -247,10 +247,18 @@ class movable_function<R(Args...)>
   // constructing a std::decay_t<F> from the forwarded argument, so a callable that cannot be
   // constructed there (e.g. a non-movable functor passed as an rvalue) is removed from overload
   // resolution rather than producing a hard error inside emplace().
+  //
+  // std::conjunction, not &&: the terms have to be instantiated one at a time, stopping at the
+  // first that is false. Asking whether this type is copy constructible -- which anything holding
+  // it in a std::any does -- instantiates this constraint with F = const movable_function&, and the
+  // constructibility term then asks for the trait that is already being computed. && evaluates
+  // lazily but instantiates every operand regardless, so the self-exclusion has to gate the others
+  // rather than merely precede them.
   template<typename F>
-  using enable_if_callable = std::enable_if_t<!std::is_same_v<std::decay_t<F>, movable_function> &&
-                                              std::is_constructible_v<std::decay_t<F>, F> &&
-                                              std::is_invocable_r_v<R, std::decay_t<F>&, Args...>>;
+  using enable_if_callable = std::enable_if_t<
+    std::conjunction_v<std::negation<std::is_same<std::decay_t<F>, movable_function>>,
+                       std::is_constructible<std::decay_t<F>, F>,
+                       std::is_invocable_r<R, std::decay_t<F>&, Args...>>>;
 
 public:
   movable_function() noexcept = default;

--- a/test/test_unit_movable_function.cxx
+++ b/test/test_unit_movable_function.cxx
@@ -19,12 +19,14 @@
 
 #include "core/utils/movable_function.hxx"
 
+#include <any>
 #include <array>
 #include <cstddef>
 #include <functional>
 #include <memory>
 #include <new>
 #include <stdexcept>
+#include <type_traits>
 #include <utility>
 
 namespace
@@ -573,3 +575,42 @@ TEST_CASE("unit: assigning a throwing-to-construct callable preserves the curren
   REQUIRE(static_cast<bool>(f));
   REQUIRE(f() == 7);
 }
+
+namespace
+{
+using callback = couchbase::core::utils::movable_function<void(int)>;
+
+struct matching_callable {
+  void operator()(int) const
+  {
+  }
+};
+
+struct wrong_signature {
+  void operator()(int, int) const
+  {
+  }
+};
+
+// Asking whether movable_function is copy constructible must answer, not recurse.
+//
+// The constructor constraint is instantiated with F = const movable_function&, and its
+// constructibility term then asks for the very trait being computed. std::conjunction stops at the
+// self-exclusion before that term is instantiated; joining the terms with && does not, because &&
+// instantiates every operand whatever the first one answers. std::any asks exactly this question
+// about anything it is handed, which is how the recursion was reached from
+// core/io/mcbp_command.hxx.
+//
+// These are static assertions because the defect is a compile error, not a wrong answer: where it
+// bites, this translation unit does not build. Only a toolchain whose std::is_constructible is a
+// class template rather than a compiler builtin reaches it -- gcc 8 does, gcc 9 and later do not --
+// so on a modern compiler these hold either way and pin the constraint's meaning instead.
+static_assert(!std::is_copy_constructible_v<callback>);
+static_assert(!std::is_constructible_v<std::any, callback>);
+static_assert(std::is_move_constructible_v<callback>);
+
+// The constraint still admits and rejects what it did before.
+static_assert(std::is_constructible_v<callback, matching_callable>);
+static_assert(!std::is_constructible_v<callback, wrong_signature>);
+static_assert(!std::is_constructible_v<callback, int>);
+} // namespace


### PR DESCRIPTION
Follow-up to #1068, in six files across five commits, each self-contained so that a rebase merge lands them independently:

| commit | files | subject |
| --- | --- | --- |
| 1 | `cmake/tarball_glob.txt`, `cmake/Packaging.cmake` | the install failure and the truncated pattern list |
| 2 | `cmake/CPM.cmake` | the CPM bootstrap |
| 3 | `core/utils/movable_function.hxx`, `test/test_unit_movable_function.cxx` | the gcc 8 compile error |
| 4 | `cmake/Packaging.cmake` | the size of the shipped static archive |
| 5 | `.github/copilot-instructions.md` | what reviewers need to know about this code |

## 1. No package can be built

curl's install rules read `scripts/mk-ca-bundle.pl` from its source tree. No pattern in `cmake/tarball_glob.txt` matches `.pl`, so the file is not staged into the source tarball every package is built from, and the install step fails for both formats:

```
CMake Error at _deps/curl-build/cmake_install.cmake:75 (file):
  file INSTALL cannot find
  ".../third_party_cache/curl/<hash>/curl/scripts/mk-ca-bundle.pl"
```

Every vendored dependency installs before this project does, so this stops `%install` / `dh_auto_install` before any of our own install rules run — including all the licence notices #1068 added. It only happens in a build from the tarball, and `COUCHBASE_CXX_CLIENT_INSTALL` is never set in CI, so no CI leg can catch it.

Rather than fix one file and rebuild blind, every source path referenced by the generated install scripts was enumerated and checked: **one missing out of 343, across 73 `cmake_install.cmake` files**. This is the only one.

## 2. A comment in the glob file silently deletes the rest of it

The glob file is read with `xargs -a … -I {}`, and xargs treats quotes as special. An apostrophe anywhere in it — **a comment is enough** — aborts it with "unmatched single quote" and drops **every remaining line**. The step pipes xargs into `grep -v … | sort -u`, so the pipeline still exits 0 and the tarball target reports success.

Adding the pattern above with a comment reading "curl's install rules …" silently removed the `protostellar` and `api_common_protos` patterns that follow it, producing a tarball that cannot build couchbase2 at all. Nothing in the build said so; only counting archive entries did.

`xargs -d "\n"` turns quote processing off, applied both to the glob file and to the generated file list copied from it. That argument must reach xargs as backslash-n, which takes four backslashes in CMake: `-d \n` arrives as `-d n` and silently splits the list on the letter *n*.

## 3. A failed CPM.cmake download breaks every job that configures

Unrelated to packaging, and the reason CI on main is currently red across `build`, `cppcheck`, `build (asan)` and the test workflows:

```
CMake Error at cmake/ThirdPartyDependencies.cmake:28 (cpmaddpackage):
  Unknown CMake command "cpmaddpackage".
```

`cmake/CPM.cmake` fetched CPM with `file(DOWNLOAD)` and neither checked the result nor validated the body. `file(DOWNLOAD)` reports transport errors only, so an HTTP error page or a rate-limit response is a successful download whose body is HTML; including it defines nothing, and the build then failed at the first dependency with a message naming neither the download nor the file to delete before retrying. One bad response from the release host took out every job that configures, and the bad file persisted to poison the next configure.

The download is now retried, and whether a candidate is CPM is decided by a separate CMake process that includes it and looks for the command — a text search would accept a truncated script that merely mentions the name, and including it directly would abort the configure on a parse error instead of moving to the next attempt. A cached copy is checked the same way instead of only for emptiness. CPM moves to 0.43.1 at the same time.

Each attempt is bounded and reported, all as cache variables: `CPM_DOWNLOAD_ATTEMPTS` (5), `CPM_DOWNLOAD_RETRY_DELAY` (2 seconds, doubling after each failure), `CPM_DOWNLOAD_INACTIVITY_TIMEOUT` (20 seconds, bounding a stalled transfer) and `CPM_DOWNLOAD_TIMEOUT` (60 seconds, bounding the whole attempt). Without a timeout a peer that accepts the connection and then stops sending leaves the download waiting indefinitely and the retry never runs.

Every HTTP failure reaches CMake as `"HTTP response code said error"`, so a rate limit and a missing release read identically. The status line is taken from the transfer log and reported with the attempt number and the wait before the next one:

```
--   attempt 1 of 5 failed: "HTTP response code said error" [HTTP/1.0 429 Too Many Requests]; retrying in 2s
```

`CPM_SOURCE_CACHE` is shared between build trees, so each attempt downloads to a path of its own and only a candidate that validates is moved onto the shared one, where the rename is atomic. Writing straight to the shared path exposed partial contents to a concurrent configure, and removing that path on failure could discard a file another configure had just completed.

Verified: an HTML error page in the cache is rejected and re-downloaded; a truncated script containing the token is rejected and re-downloaded; an unreachable release retries and then fails naming the reason, leaving nothing behind; two configures with different binary directories run concurrently against one shared cache, both succeed, and one file remains; a server returning 429 and one returning 404 are reported differently where both were previously the same sentence; and against a peer that accepts the connection and then sends nothing, the code without these bounds hangs until killed while the code with them fails cleanly in seconds.

## 4. movable_function's constraint asks about itself on gcc 8

Not a packaging defect, but it is what stops the `rocky+epel-8` root, so it is fixed here.

`std::any` constrains its converting constructor on `is_copy_constructible<T>`. Asking that about `movable_function` instantiates its converting-constructor constraint with `F = const movable_function&`, whose constructibility term then asks for the trait already being computed:

```
error: incomplete type 'std::is_constructible<couchbase::core::utils::movable_function<...>,
  const couchbase::core::utils::movable_function<...>&>' used in nested name specifier
```

The self-exclusion `!is_same_v<decay_t<F>, movable_function>` was already the first term of the constraint, and that is the trap: `&&` short-circuits *evaluation*, not *instantiation*, so every operand is instantiated whatever the first one answers. `std::conjunction` instantiates its arguments one at a time and stops at the first false, so the exclusion gates the rest instead of merely preceding them.

Only a toolchain whose `std::is_constructible` is a class template rather than a compiler builtin reaches the recursion, which is why this is confined to gcc 8; gcc 9 and later use the builtin.

Nothing changes for other compilers, measured rather than assumed: the `-O2` object files are byte-identical before and after, the same accept/reject assertions hold against both versions of the header on gcc 16, gcc and clang accept both, and compile time is indistinguishable (240.7 ms against 240.5 ms median over nine alternating runs). The assertions are now in `test/test_unit_movable_function.cxx` as `static_assert`s, because the defect is a compile error rather than a wrong answer.

## 5. The development package ships 2.8 GB of debug info on Fedora

`libcouchbase_cxx_client_static.a` carries every vendored dependency, so its debug info dwarfs everything else in the development package. Whether that reaches users depends on the distribution: EL strips static archives in `brp-strip-static-archive` and Debian in `dh_strip`, but Fedora no longer runs either.

Measured on packages built from this branch, same tarball throughout:

| root | archive in the package | `-devel` / `-dev` package |
| --- | --- | --- |
| rocky+epel-9 | 126 MB | 13.3 MB |
| trixie | 117 MB | 12.2 MB |
| fedora-44, before | **2861 MB** | **332.1 MB** |
| fedora-44, after | 126.7 MB | 14.3 MB |

The archive survives intact — 2140 members, still readable by `ar`. Confined to a package build, since a local install is where someone stepping into the vendored code wants those symbols.

It also made the root markedly quicker. `find-debuginfo` had been processing that debug info too: the fedora-44 build went from 6436 seconds to 1336.

## Verification

Built from this branch on real package builders — RPM through `mock`, DEB through `dpkg-buildpackage` in a per-distribution container — and the notices #1068 added were checked in the built packages rather than in an install tree.

| RPM root | result | notices |
|---|---|---|
| rocky+epel-9 | 9 packages | 22/22 |
| rocky+epel-10 | 9 packages | 22/22 |
| amazonlinux-2023 | 9 packages | 20/22 — correct: the spec builds it without OpenTelemetry, so `curl` and `opentelemetry-cpp` are genuinely absent |
| fedora-44 | 9 packages | 22/22 |
| fedora-43 | 9 packages | 22/22 |
| rocky+epel-8 | 7 packages | 12/12 applicable |

| DEB distro | result | notices |
|---|---|---|
| bookworm, trixie | 6 packages | 22/22 |
| jammy, noble, resolute | 6 packages | 22/22 |

All six distributions build. Kali needed a mirror other than its default, which returned 503; that is an infrastructure detail of the run, not a property of the packaging.
| kali-rolling | 6 packages | 22/22 |

rocky+epel-8 ships seven packages and twelve components rather than nine and twenty-two, which is correct rather than a shortfall: EL8 is outside the `grpc_supported` gate and opts out of OpenTelemetry, so gRPC, abseil, protobuf, re2, c-ares, zlib, utf8_range, api-common-protos, curl and opentelemetry-cpp are not compiled into it and owe no notice. The notices track the options a root is built with.

"22/22" is every third-party component whose code is compiled in, present in the library, tools and fit-performer packages, and absent from `-dev`/`-devel`/`-dbg`/`debuginfo`, which is correct. The Debian packages were also co-installed to confirm the per-package doc directories resolve the dpkg co-ownership restriction: all three install together, each owning its own 46 third-party paths, and removing one leaves the others intact.

## Not addressed here

One correction, and one pre-existing problem now fixed:

Two earlier revisions of this description were wrong about Fedora, and both are corrected in the table above rather than quietly dropped. The first claimed neither Fedora root could compile the vendored abseil; that came from a probe compiling `absl/container/internal/container_memory.h` as the only include in a translation unit, where nothing has yet supplied `<cstdint>`, and every real abseil source includes a sibling header first. The second claimed fedora-44 does not finish packaging; it does, and with the archive stripped it is no longer even slow.
- **rocky+epel-8** failed on gcc 8 in this project's own `movable_function` code, unrelated to packaging and to anything vendored, and neither caused by #1068 (which changed no C++, and no language standard or flags) nor by this change. It is fixed above, and a full `rocky+epel-8` package build now produces seven packages where it previously produced none, with no occurrence of that error in the build log.
