### PR TITLE
CXXCBC-946: promote the test framework out of the CNG tree

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -53,8 +53,9 @@ core/crud_component.cxx         New KV operations (get, upsert, replace, …).
 core/collections_component.cxx  CID resolution and dispatch.
 core/response_handler.hxx       Interface for handling MCBP responses.
 test/                           Integration + unit tests (Catch2).
-test/cng/                       couchbase2:// tests — hand-rolled harness in
-                                test/cng/framework/, NOT Catch2. See test/cng/README.md.
+test/framework/                 Hand-rolled test harness, NOT Catch2.
+test/cng/                       couchbase2:// tests — built on test/framework/.
+                                See test/cng/README.md.
 tools/                          cbc CLI, fit_performer, system_metrics.
 cmake/                          Build and packaging: dependency resolution, the RPM spec,
                                 debian/ and APKBUILD templates, tarball_glob.txt. CI runs
@@ -147,7 +148,7 @@ in `test/test_integration_crud_component.cxx`. Tests must not rely on fixed
 ### couchbase2:// (CNG) tests
 
 `test/cng/` is a second suite with its own conventions, and the commands above do
-not apply to it. It uses the hand-rolled harness in `test/cng/framework/` rather
+not apply to it. It uses the hand-rolled harness in `test/framework/` rather
 than Catch2, is gated by `COUCHBASE_CXX_CLIENT_BUILD_CNG_TESTS`, and runs under
 ctest with the `cng` label. Each case declares whether it needs a cluster;
 cluster-only cases skip (exit 77) when `TEST_CONNECTION_STRING` is unset.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -710,10 +710,16 @@ endif()
 # test links only what it exercises (see test/cng/CMakeLists.txt).
 option(COUCHBASE_CXX_CLIENT_BUILD_CNG_TESTS "Build CNG (Protostellar) tests"
        ${COUCHBASE_CXX_CLIENT_BUILD_TESTS})
-if(COUCHBASE_CXX_CLIENT_BUILD_CNG_TESTS)
-  # Enable testing at the top level so `ctest` from the build root discovers the CNG tests even
-  # when the main (Catch2) suite is disabled and cmake/Testing.cmake was not included.
+
+# The hand-rolled framework both test trees build on, and its self-test. Testing is enabled at the
+# top level here so `ctest` from the build root discovers these even when the main (Catch2) suite
+# is disabled and cmake/Testing.cmake was not included.
+if(COUCHBASE_CXX_CLIENT_BUILD_TESTS OR COUCHBASE_CXX_CLIENT_BUILD_CNG_TESTS)
   enable_testing()
+  include(cmake/TestFramework.cmake)
+endif()
+
+if(COUCHBASE_CXX_CLIENT_BUILD_CNG_TESTS)
   add_subdirectory(test/cng)
 endif()
 

--- a/cmake/TestFramework.cmake
+++ b/cmake/TestFramework.cmake
@@ -1,0 +1,55 @@
+# The shared test framework: the runner, the common main(), and the framework's own self-test.
+#
+# Hand-rolled (CXXCBC-885), deliberately NOT Catch2. It lives outside either test subdirectory
+# because both test trees link it. See test/cng/README.md to build and run the CNG tests.
+
+find_package(Threads REQUIRED)
+
+# Each test executable links this and provides its own tests(). fmt comes from spdlog's bundled
+# copy (header include dirs only). ${PROJECT_SOURCE_DIR}/test is PUBLIC so a test includes the
+# framework as "framework/test_runner.hxx" wherever in the test tree it sits.
+add_library(
+  test_framework_main STATIC
+  ${PROJECT_SOURCE_DIR}/test/framework/test_runner.cxx
+  ${PROJECT_SOURCE_DIR}/test/framework/test_main.cxx)
+target_include_directories(test_framework_main PUBLIC ${PROJECT_SOURCE_DIR}/test
+                                                      ${PROJECT_SOURCE_DIR})
+# spdlog is linked, not merely included, so the framework compiles bundled fmt in the same mode as
+# the client library. Borrowing only spdlog's include directories left SPDLOG_COMPILED_LIB undefined
+# here, and spdlog/fmt/fmt.h responds by defining FMT_HEADER_ONLY, which emits definitions of
+# fmt::v11::vformat, report_error, is_printable, write_loc and friends into test_runner.obj and
+# test_main.obj. A test that also links the client then puts those next to the compiled spdlog's
+# copies of the same symbols. ld folds that silently; link.exe does not, and fails with LNK2005.
+# declare_system_library() already marks spdlog's includes SYSTEM, so linking it keeps its headers
+# out of /W4 /WX without the manual BEFORE override.
+target_link_libraries(test_framework_main PUBLIC Threads::Threads spdlog::spdlog)
+set_project_options(test_framework_main)
+set_project_warnings(test_framework_main)
+
+# The framework's own self-test: it drives run() with in-memory suites and asserts on the returned
+# run_result, so it links the framework and nothing else.
+add_executable(test_framework_selftest
+               ${PROJECT_SOURCE_DIR}/test/framework/framework_selftest.cxx)
+target_include_directories(
+  test_framework_selftest SYSTEM BEFORE
+  PRIVATE $<BUILD_INTERFACE:$<TARGET_PROPERTY:spdlog::spdlog,INTERFACE_INCLUDE_DIRECTORIES>>)
+target_link_libraries(test_framework_selftest PRIVATE test_framework_main Threads::Threads)
+set_project_options(test_framework_selftest)
+set_project_warnings(test_framework_selftest)
+add_test(NAME test_framework_selftest COMMAND $<TARGET_FILE:test_framework_selftest>)
+# The harness returns 77 when every case was skipped; map that to ctest's "Skipped".
+#
+# The label must be one a CI leg actually selects, or these cases are compiled, linked and never
+# run. Only unit, integration, transaction, benchmark and cng are selected anywhere in bin/ or
+# .github/workflows/. cng is the one that fits: its steps deliberately do not apply --test-action
+# memcheck, and the inner suites here assert on absolute millisecond budgets that valgrind would
+# blow with no multiplier able to reach them.
+set_tests_properties(test_framework_selftest PROPERTIES SKIP_RETURN_CODE 77 LABELS "cng")
+if(DEFINED COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS AND EXISTS "${COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS}")
+  set_tests_properties(
+    test_framework_selftest
+    PROPERTIES
+      ENVIRONMENT
+      "TSAN_OPTIONS=halt_on_error=0,second_deadlock_stack=1,ignore_noninstrumented_modules=1,suppressions=${COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS}"
+  )
+endif()

--- a/test/cng/CMakeLists.txt
+++ b/test/cng/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CNG (Protostellar) test tree.
 #
-# Uses a small hand-rolled framework (see framework/, CXXCBC-885), deliberately NOT Catch2.
+# Uses the hand-rolled framework in test/framework/ (CXXCBC-885), deliberately NOT Catch2.
 # See test/cng/README.md to build and run these tests. Enabled via COUCHBASE_CXX_CLIENT_BUILD_CNG_TESTS.
 
 find_package(Threads REQUIRED)
@@ -46,30 +46,13 @@ if(COUCHBASE_CXX_CLIENT_PACKAGE_BUILD)
   endif()
 endif()
 
-# Shared harness: the runner + the shared main(). Each test executable links this and provides
-# its own tests(). fmt comes from spdlog's bundled copy (header include dirs only).
-add_library(
-  cng_test_main STATIC
-  ${PROJECT_SOURCE_DIR}/test/cng/framework/test_runner.cxx
-  ${PROJECT_SOURCE_DIR}/test/cng/framework/test_main.cxx)
-target_include_directories(cng_test_main PUBLIC ${PROJECT_SOURCE_DIR}/test/cng
-                                                ${PROJECT_SOURCE_DIR})
-# spdlog is linked, not merely included, so the framework compiles bundled fmt in the same mode as
-# the client library. Borrowing only spdlog's include directories left SPDLOG_COMPILED_LIB undefined
-# here, and spdlog/fmt/fmt.h responds by defining FMT_HEADER_ONLY, which emits definitions of
-# fmt::v11::vformat, report_error, is_printable, write_loc and friends into test_runner.obj and
-# test_main.obj. A test that also links the client -- any add_cng_test(... LINK_CLIENT) -- then puts
-# those next to the compiled spdlog's copies of the same symbols. ld folds that silently; link.exe
-# does not, and fails with LNK2005. declare_system_library() already marks spdlog's includes SYSTEM,
-# so linking it keeps its headers out of /W4 /WX without the manual BEFORE override.
-target_link_libraries(cng_test_main PUBLIC Threads::Threads spdlog::spdlog)
-set_project_options(cng_test_main)
-set_project_warnings(cng_test_main)
-
 # add_cng_test(<relpath> [LINK_CLIENT] [LIBS <lib>...]) — relpath is under test/cng/ without
-# extension (e.g. framework/framework_selftest). The executable/ctest name is the file stem
-# prefixed with cng_. LINK_CLIENT links the client library and its core header include set, for
-# tests that exercise core code (e.g. the connection-string parser).
+# extension (e.g. protostellar/dispatcher). The executable/ctest name is the file stem prefixed
+# with cng_. LINK_CLIENT links the client library and its core header include set, for tests that
+# exercise core code (e.g. the connection-string parser).
+#
+# The runner and the shared main() come from test_framework_main (cmake/TestFramework.cmake),
+# which also puts ${PROJECT_SOURCE_DIR}/test on the include path.
 function(add_cng_test relpath)
   cmake_parse_arguments(ARG "LINK_CLIENT" "" "LIBS" ${ARGN})
   get_filename_component(stem ${relpath} NAME_WE)
@@ -86,7 +69,7 @@ function(add_cng_test relpath)
   target_include_directories(
     ${target} SYSTEM BEFORE
     PRIVATE $<BUILD_INTERFACE:$<TARGET_PROPERTY:spdlog::spdlog,INTERFACE_INCLUDE_DIRECTORIES>>)
-  target_link_libraries(${target} PRIVATE cng_test_main Threads::Threads)
+  target_link_libraries(${target} PRIVATE test_framework_main Threads::Threads)
   if(ARG_LINK_CLIENT)
     target_include_directories(${target} PRIVATE ${PROJECT_BINARY_DIR}/generated
                                                  ${PROJECT_BINARY_DIR}/generated_$<CONFIG>)
@@ -122,8 +105,6 @@ function(add_cng_test relpath)
     )
   endif()
 endfunction()
-
-add_cng_test(framework/framework_selftest)
 
 # couchbase2:// connection-string scheme (CXXCBC-887). Exercises the core parser, so it
 # links the client library.

--- a/test/cng/README.md
+++ b/test/cng/README.md
@@ -1,7 +1,7 @@
 # CNG (`couchbase2://`) tests
 
 These tests exercise the Protostellar / Cloud Native Gateway (CNG) transport. They are built
-with the hand-rolled harness under `framework/` (not Catch2) and are enabled by the
+with the hand-rolled harness under `test/framework/` (not Catch2) and are enabled by the
 `COUCHBASE_CXX_CLIENT_BUILD_CNG_TESTS` CMake option.
 
 Each test declares an environment gate:

--- a/test/cng/cluster/couchbase2_build_support.cxx
+++ b/test/cng/cluster/couchbase2_build_support.cxx
@@ -49,7 +49,7 @@
 #include <string>
 #include <thread>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -133,4 +133,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/connection_string/couchbase2_scheme.cxx
+++ b/test/cng/connection_string/couchbase2_scheme.cxx
@@ -26,7 +26,7 @@
 #include <cstdint>
 #include <string>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -149,4 +149,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/fixtures/live_fixture.hxx
+++ b/test/cng/fixtures/live_fixture.hxx
@@ -63,7 +63,7 @@
 #include <thread>
 #include <utility>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 
 // safe_getenv, not std::getenv: MSVC deprecates getenv (C4996) and these builds are -Werror.
@@ -348,6 +348,6 @@ private:
   bool opened_{ false };
 };
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test
 
 #pragma pop_macro("COUCHBASE_CXX_CLIENT_IGNORE_CORE_DEPRECATIONS")

--- a/test/cng/origin/protocol.cxx
+++ b/test/cng/origin/protocol.cxx
@@ -28,7 +28,7 @@
 #include <string>
 #include <utility>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -154,4 +154,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/analytics_converter.cxx
+++ b/test/cng/protostellar/analytics_converter.cxx
@@ -29,7 +29,7 @@
 #include <utility>
 #include <vector>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -249,4 +249,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/bucket_admin_converter.cxx
+++ b/test/cng/protostellar/bucket_admin_converter.cxx
@@ -25,7 +25,7 @@
 #include <cstdint>
 #include <string>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -191,4 +191,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/callback_queue_churn.cxx
+++ b/test/cng/protostellar/callback_queue_churn.cxx
@@ -58,7 +58,7 @@
 #include <string>
 #include <utility>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -164,4 +164,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/callback_queue_keepalive.hxx
+++ b/test/cng/protostellar/callback_queue_keepalive.hxx
@@ -60,7 +60,7 @@
 #include <memory>
 #include <utility>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 
 // Minimal service so the keepalive channel has something to call. The reference on the callback
@@ -136,4 +136,4 @@ pin_callback_queue()
   static const callback_queue_keepalive keepalive{};
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/codegen_smoke.cxx
+++ b/test/cng/protostellar/codegen_smoke.cxx
@@ -27,7 +27,7 @@
 #include <couchbase/kv/v1/kv.pb.h>
 #include <google/rpc/status.pb.h>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -93,4 +93,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/collection_admin_converter.cxx
+++ b/test/cng/protostellar/collection_admin_converter.cxx
@@ -25,7 +25,7 @@
 #include <cstdint>
 #include <string>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -142,4 +142,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/component.cxx
+++ b/test/cng/protostellar/component.cxx
@@ -50,7 +50,7 @@
 #include <string>
 #include <thread>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -868,4 +868,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/component_kv_operations.cxx
+++ b/test/cng/protostellar/component_kv_operations.cxx
@@ -70,7 +70,7 @@
 #include <system_error>
 #include <utility>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -1541,4 +1541,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/component_timeouts.cxx
+++ b/test/cng/protostellar/component_timeouts.cxx
@@ -59,7 +59,7 @@
 #include <string>
 #include <thread>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -323,4 +323,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/credentials.cxx
+++ b/test/cng/protostellar/credentials.cxx
@@ -33,7 +33,7 @@
 #include <random>
 #include <string>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -252,4 +252,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/dispatcher.cxx
+++ b/test/cng/protostellar/dispatcher.cxx
@@ -40,7 +40,7 @@
 #include <string>
 #include <thread>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -287,4 +287,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/error_utils.cxx
+++ b/test/cng/protostellar/error_utils.cxx
@@ -32,7 +32,7 @@
 #include <string>
 #include <system_error>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -320,4 +320,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/kv_converter.cxx
+++ b/test/cng/protostellar/kv_converter.cxx
@@ -33,7 +33,7 @@
 #include <optional>
 #include <string>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -749,4 +749,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/kv_retry.cxx
+++ b/test/cng/protostellar/kv_retry.cxx
@@ -53,7 +53,7 @@
 #include <string>
 #include <thread>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -569,4 +569,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/live_analytics.cxx
+++ b/test/cng/protostellar/live_analytics.cxx
@@ -30,7 +30,7 @@
 
 #define COUCHBASE_CXX_CLIENT_IGNORE_CORE_DEPRECATIONS
 
-#include "framework/live_fixture.hxx"
+#include "fixtures/live_fixture.hxx"
 #include "framework/test_runner.hxx"
 
 #include <couchbase/error_codes.hxx>
@@ -40,7 +40,7 @@
 #include <thread>
 #include <utility>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -170,4 +170,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/live_bucket_admin.cxx
+++ b/test/cng/protostellar/live_bucket_admin.cxx
@@ -19,7 +19,7 @@
 // admin.bucket.v1: that the bucket list arrives, and that settings written by create() are the
 // settings read back by get().
 
-#include "framework/live_fixture.hxx"
+#include "fixtures/live_fixture.hxx"
 #include "framework/test_runner.hxx"
 
 #include "core/management/bucket_settings.hxx"
@@ -41,7 +41,7 @@
 #include <system_error>
 #include <thread>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -441,4 +441,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/live_collection_admin.cxx
+++ b/test/cng/protostellar/live_collection_admin.cxx
@@ -36,7 +36,7 @@
 // cluster map couchbase2 does not have -- so the request has to be sent and the server's answer
 // taken, and only a live case shows what that answer is.
 
-#include "framework/live_fixture.hxx"
+#include "fixtures/live_fixture.hxx"
 #include "framework/test_runner.hxx"
 
 #include "core/management/bucket_settings.hxx"
@@ -58,7 +58,7 @@
 #include <thread>
 #include <utility>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -638,4 +638,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/live_connect.cxx
+++ b/test/cng/protostellar/live_connect.cxx
@@ -23,7 +23,7 @@
 
 #define COUCHBASE_CXX_CLIENT_IGNORE_CORE_DEPRECATIONS
 
-#include "framework/live_fixture.hxx"
+#include "fixtures/live_fixture.hxx"
 #include "framework/test_runner.hxx"
 
 // core/operations.hxx (complete operation types) must precede core/cluster.hxx, whose execute()
@@ -47,7 +47,7 @@
 #include <future>
 #include <string>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -163,4 +163,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/live_kv.cxx
+++ b/test/cng/protostellar/live_kv.cxx
@@ -47,7 +47,7 @@
 #include <string>
 #include <utility>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -546,4 +546,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/live_kv_operations.cxx
+++ b/test/cng/protostellar/live_kv_operations.cxx
@@ -30,7 +30,7 @@
 // which of the KV surface they implement, and a skip says "not covered here" where a failure would
 // wrongly say "the client is broken".
 
-#include "framework/live_fixture.hxx"
+#include "fixtures/live_fixture.hxx"
 #include "framework/test_runner.hxx"
 
 #include "core/error_context/key_value.hxx"
@@ -42,7 +42,7 @@
 #include <string>
 #include <thread>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -154,7 +154,7 @@ struct expiry_control {
 
   void discard() const
   {
-    ::couchbase::cng::test::discard(fixture_, key_);
+    ::couchbase::test::discard(fixture_, key_);
   }
 
 private:
@@ -483,4 +483,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/live_observability.cxx
+++ b/test/cng/protostellar/live_observability.cxx
@@ -43,7 +43,7 @@
 #include <string>
 #include <vector>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -336,4 +336,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/live_query.cxx
+++ b/test/cng/protostellar/live_query.cxx
@@ -29,7 +29,7 @@
 
 #define COUCHBASE_CXX_CLIENT_IGNORE_CORE_DEPRECATIONS
 
-#include "framework/live_fixture.hxx"
+#include "fixtures/live_fixture.hxx"
 #include "framework/test_runner.hxx"
 
 #include "core/json_string.hxx"
@@ -42,7 +42,7 @@
 #include <thread>
 #include <vector>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -451,4 +451,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/live_query_index_admin.cxx
+++ b/test/cng/protostellar/live_query_index_admin.cxx
@@ -31,7 +31,7 @@
 // The case below drives the public manager rather than the core request, because the routing hole
 // it covers was invisible from the core request that was already wired.
 
-#include "framework/live_fixture.hxx"
+#include "fixtures/live_fixture.hxx"
 #include "framework/test_runner.hxx"
 
 #include "core/operations/management/query_index_create.hxx"
@@ -49,7 +49,7 @@
 #include <utility>
 #include <vector>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -505,4 +505,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/live_search.cxx
+++ b/test/cng/protostellar/live_search.cxx
@@ -22,7 +22,7 @@
 // the round trip is pinned by the error the gateway returns for an index that does not exist:
 // that answer can only come from a gateway that ran the query.
 
-#include "framework/live_fixture.hxx"
+#include "fixtures/live_fixture.hxx"
 #include "framework/test_runner.hxx"
 
 #include "core/operations.hxx"
@@ -35,7 +35,7 @@
 #include <string>
 #include <thread>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -161,4 +161,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/live_search_index_admin.cxx
+++ b/test/cng/protostellar/live_search_index_admin.cxx
@@ -29,7 +29,7 @@
 // never byte-identical to what was sent. Whether the three parameter blobs stay separate can only
 // be checked against a real definition, by looking for each blob's own member in its own blob.
 
-#include "framework/live_fixture.hxx"
+#include "fixtures/live_fixture.hxx"
 #include "framework/test_runner.hxx"
 
 #include "core/operations/management/search_index_analyze_document.hxx"
@@ -54,7 +54,7 @@
 #include <utility>
 #include <vector>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -597,4 +597,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/live_view.cxx
+++ b/test/cng/protostellar/live_view.cxx
@@ -25,7 +25,7 @@
 
 #define COUCHBASE_CXX_CLIENT_IGNORE_CORE_DEPRECATIONS
 
-#include "framework/live_fixture.hxx"
+#include "fixtures/live_fixture.hxx"
 #include "framework/test_runner.hxx"
 
 #include "core/operations.hxx"
@@ -37,7 +37,7 @@
 #include <string>
 #include <thread>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -147,4 +147,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/ping_diagnostics.cxx
+++ b/test/cng/protostellar/ping_diagnostics.cxx
@@ -28,7 +28,7 @@
 #include <string>
 #include <utility>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -79,4 +79,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/query_converter.cxx
+++ b/test/cng/protostellar/query_converter.cxx
@@ -35,7 +35,7 @@
 #include <utility>
 #include <vector>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -488,4 +488,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/query_index_admin_component.cxx
+++ b/test/cng/protostellar/query_index_admin_component.cxx
@@ -45,7 +45,7 @@
 #include <string>
 #include <utility>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -117,4 +117,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/query_index_admin_converter.cxx
+++ b/test/cng/protostellar/query_index_admin_converter.cxx
@@ -32,7 +32,7 @@
 #include <string>
 #include <vector>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -442,4 +442,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/query_streaming.cxx
+++ b/test/cng/protostellar/query_streaming.cxx
@@ -45,7 +45,7 @@
 #include <thread>
 #include <vector>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -542,4 +542,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/retry.cxx
+++ b/test/cng/protostellar/retry.cxx
@@ -52,7 +52,7 @@
 #include <string>
 #include <thread>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -455,4 +455,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/search_converter.cxx
+++ b/test/cng/protostellar/search_converter.cxx
@@ -27,7 +27,7 @@
 #include <cstdint>
 #include <string>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -311,4 +311,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/search_index_admin_component.cxx
+++ b/test/cng/protostellar/search_index_admin_component.cxx
@@ -51,7 +51,7 @@
 #include <utility>
 #include <vector>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -517,4 +517,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/search_index_admin_converter.cxx
+++ b/test/cng/protostellar/search_index_admin_converter.cxx
@@ -26,7 +26,7 @@
 
 #include <string>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -290,4 +290,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/streaming.cxx
+++ b/test/cng/protostellar/streaming.cxx
@@ -49,7 +49,7 @@
 #include <utility>
 #include <vector>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -867,4 +867,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/cng/protostellar/view_converter.cxx
+++ b/test/cng/protostellar/view_converter.cxx
@@ -23,7 +23,7 @@
 
 #include <string>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -135,4 +135,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/framework/framework_selftest.cxx
+++ b/test/framework/framework_selftest.cxx
@@ -15,7 +15,7 @@
  *   limitations under the License.
  */
 
-// Self-test for the CNG test framework. It exercises the runner's pass / fail / skip / timeout /
+// Self-test for the test framework. It exercises the runner's pass / fail / skip / timeout /
 // env-gating / filter behaviour by driving run() with in-memory sub-suites and asserting on the
 // returned run_result. Because it asserts on the runner's *return value* (rather than letting an
 // inner failure propagate), every case here passes and this binary exits 0.
@@ -28,7 +28,7 @@
 #include <sstream>
 #include <thread>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -213,4 +213,4 @@ tests() -> test_suite
   };
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/framework/test_framework.hxx
+++ b/test/framework/test_framework.hxx
@@ -17,7 +17,7 @@
 
 #pragma once
 
-// A small hand-rolled test framework for the CNG (Protostellar) test tree.
+// A small hand-rolled test framework for this repository's test suites.
 //
 // This deliberately does NOT use Catch2 (the couchbase-cxx-client default). Its design is
 // ported from the author's stand-alone harness, adapted from C++23 to the C++17 that this
@@ -36,12 +36,12 @@
 #include <vector>
 
 // The wrapper (not <spdlog/fmt/bundled/format.h>) is required: it selects bundled fmt and derives
-// the header-only-vs-compiled mode from SPDLOG_COMPILED_LIB, which cng_test_main picks up by
+// the header-only-vs-compiled mode from SPDLOG_COMPILED_LIB, which test_framework_main picks up by
 // linking spdlog::spdlog. Including the bundled header directly would bypass that and reintroduce
-// the duplicate fmt definitions that MSVC rejects -- see the note in test/cng/CMakeLists.txt.
+// the duplicate fmt definitions that MSVC rejects -- see the note in cmake/TestFramework.cmake.
 #include <spdlog/fmt/fmt.h>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 
 // C++17 stand-in for std::source_location (C++20). Where __builtin_FILE/LINE/FUNCTION exist they
@@ -54,19 +54,19 @@ namespace couchbase::cng::test
 // 16.6-17.0 takes the "unknown" branch: correct, just less informative. Not special-cased because
 // no CI leg builds those versions, and an untested #if is worse than a documented limitation.
 #if defined(__has_builtin)
-#define COUCHBASE_CNG_HAS_LOCATION_BUILTINS                                                        \
+#define COUCHBASE_TEST_HAS_LOCATION_BUILTINS                                                       \
   (__has_builtin(__builtin_FILE) && __has_builtin(__builtin_LINE) &&                               \
    __has_builtin(__builtin_FUNCTION))
 #elif defined(__clang__)
-#define COUCHBASE_CNG_HAS_LOCATION_BUILTINS 1
+#define COUCHBASE_TEST_HAS_LOCATION_BUILTINS 1
 #else
-#define COUCHBASE_CNG_HAS_LOCATION_BUILTINS 0
+#define COUCHBASE_TEST_HAS_LOCATION_BUILTINS 0
 #endif
 
 class source_location
 {
 public:
-#if COUCHBASE_CNG_HAS_LOCATION_BUILTINS
+#if COUCHBASE_TEST_HAS_LOCATION_BUILTINS
   static constexpr auto current(const char* file = __builtin_FILE(),
                                 int line = __builtin_LINE(),
                                 const char* function = __builtin_FUNCTION()) noexcept
@@ -103,7 +103,7 @@ private:
   const char* function_{ "" };
 };
 
-#undef COUCHBASE_CNG_HAS_LOCATION_BUILTINS
+#undef COUCHBASE_TEST_HAS_LOCATION_BUILTINS
 
 // Timeout presets — use these instead of raw millisecond values so timing expectations are
 // explicit. Mirrors the presets in the source harness.
@@ -290,4 +290,4 @@ assert_throws(Fn&& fn,
   }
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/framework/test_main.cxx
+++ b/test/framework/test_main.cxx
@@ -15,9 +15,10 @@
  *   limitations under the License.
  */
 
-// Shared entry point for every CNG test executable. A test file provides tests(); this main
-// gathers a name filter from argv, decides mock-vs-real mode from TEST_CONNECTION_STRING, runs
-// the suite, and maps the outcome to a process exit code (0 pass / 1 fail / 77 all-skipped).
+// Shared entry point for every test executable built on the framework. A test file provides
+// tests(); this main gathers a name filter from argv, decides mock-vs-real mode from
+// TEST_CONNECTION_STRING, runs the suite, and maps the outcome to a process exit code
+// (0 pass / 1 fail / 77 all-skipped).
 
 #include "test_runner.hxx"
 
@@ -31,7 +32,7 @@
 auto
 main(int argc, char* argv[]) -> int
 {
-  using namespace couchbase::cng::test;
+  using namespace couchbase::test;
 
   std::set<std::string> filter;
   for (int i = 1; i < argc; ++i) {

--- a/test/framework/test_runner.cxx
+++ b/test/framework/test_runner.cxx
@@ -26,7 +26,7 @@
 
 #include <spdlog/fmt/fmt.h>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 namespace
 {
@@ -192,4 +192,4 @@ safe_getenv(const std::string& name) noexcept -> std::optional<std::string>
 #endif
 }
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test

--- a/test/framework/test_runner.hxx
+++ b/test/framework/test_runner.hxx
@@ -25,7 +25,7 @@
 #include <set>
 #include <string>
 
-namespace couchbase::cng::test
+namespace couchbase::test
 {
 
 struct run_result {
@@ -56,9 +56,9 @@ exit_code(const run_result& result) -> int;
 
 // Portable std::getenv wrapper returning std::nullopt for unset *or* empty values, matching the
 // wrappers in tools/utils.cxx and examples/external_circuit_breaker. Needed because MSVC treats
-// plain getenv() as deprecated, and the CNG tree builds with /W4 /WX. Lives here so every CNG
-// test executable shares one implementation.
+// plain getenv() as deprecated, and the test tree builds with /W4 /WX. Lives here so every test
+// executable shares one implementation.
 [[nodiscard]] auto
 safe_getenv(const std::string& name) noexcept -> std::optional<std::string>;
 
-} // namespace couchbase::cng::test
+} // namespace couchbase::test


### PR DESCRIPTION
First ticket of [CXXCBC-945](https://issues.couchbase.com/browse/CXXCBC-945), which migrates the Catch2 suites onto the hand-rolled framework and drops Catch2 as a dependency. Outside `test/` this touches `cmake/TestFramework.cmake`, the two READMEs, `.github/copilot-instructions.md`, and root `CMakeLists.txt` — the last of which is the one change with reach beyond the test tree: the gate widens from `if(COUCHBASE_CXX_CLIENT_BUILD_CNG_TESTS)` to `if(COUCHBASE_CXX_CLIENT_BUILD_TESTS OR COUCHBASE_CXX_CLIENT_BUILD_CNG_TESTS)`, so `test_framework_main` and the self-test are built in a Catch2-only configuration too.

## What moves

| From | To |
|---|---|
| `test/cng/framework/test_framework.hxx` | `test/framework/test_framework.hxx` |
| `test/cng/framework/test_runner.{hxx,cxx}` | `test/framework/` |
| `test/cng/framework/test_main.cxx` | `test/framework/test_main.cxx` |
| `test/cng/framework/framework_selftest.cxx` | `test/framework/framework_selftest.cxx` |
| `test/cng/framework/live_fixture.hxx` | `test/cng/fixtures/live_fixture.hxx` |

`live_fixture.hxx` stays in the CNG tree because it constructs a protostellar component; the rest of the directory is transport-agnostic.

The CMake target `cng_test_main` becomes `test_framework_main`, defined in `cmake/TestFramework.cmake`. Its public include path is `${PROJECT_SOURCE_DIR}/test` rather than `${PROJECT_SOURCE_DIR}/test/cng`, so the 40 files that say `#include "framework/test_runner.hxx"` are unchanged — only the 10 that reach for the fixture had to be edited.

The namespace loses its `cng` segment: `couchbase::cng::test` → `couchbase::test`, which is where `test/test_helper.hxx` already puts the Catch2 matchers.

## Verification

Debug + Ninja, `-DCOUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2=ON -DCOUCHBASE_CXX_CLIENT_BUILD_CNG_TESTS=ON`, no cluster configured.

The `ctest -N` list before and after differs by exactly one line, which is the intended change:

```
-cng_framework_selftest_test     (label: cng)
+test_framework_selftest         (label: cng)
```

Only the entry's name changes. The label stays `cng`, because that is the leg which runs it: every `ctest` invocation in `bin/` and `.github/workflows/` is label-filtered, and the only labels selected anywhere are `unit`, `integration`, `transaction`, `benchmark` and `cng`. A label no runner selects would leave the self-test compiled, linked and executed by nothing. Everything else under `-L cng` is identical: the same cases run, pass, and skip for want of `TEST_CONNECTION_STRING`, before and after.

Configuring with `-DCOUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2=OFF` builds `test_framework_main` and `test_framework_selftest` in 13 steps — spdlog and nothing else — and the self-test passes, which is what "the framework carries no transport dependency" means concretely.

Not verified here: any TSan or Windows leg. The self-test keeps the same `TSAN_OPTIONS` property `add_cng_test` attached to it.


[CXXCBC-945]: https://couchbasecloud.atlassian.net/browse/CXXCBC-945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

