### PR TITLE
CXXCBC-947: register one ctest entry per case, and scale budgets for slow runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           sudo apt-get update -y
           # libgrpc++-dev/libprotobuf-dev pull in the gRPC runtime needed to *run* the gRPC-linked
-          # binaries in the prebuilt artifact -- currently cng_codegen_smoke_test. (A later commit
+          # binaries in the prebuilt artifact -- currently cng_protostellar_codegen_smoke. (A later commit
           # links the transport into the client library itself, which extends this to every binary.)
           sudo apt-get install -y libssl-dev cmake gcc g++ curl gdb libprotobuf-dev libgrpc-dev libgrpc++-dev
       - uses: actions/checkout@v4
@@ -143,7 +143,7 @@ jobs:
         run: |
           sudo apt-get update -y
           # libgrpc++-dev/libprotobuf-dev pull in the gRPC runtime needed to *run* the gRPC-linked
-          # binaries in the prebuilt artifact -- currently cng_codegen_smoke_test. (A later commit
+          # binaries in the prebuilt artifact -- currently cng_protostellar_codegen_smoke. (A later commit
           # links the transport into the client library itself, which extends this to every binary.)
           sudo apt-get install -y libssl-dev cmake gcc g++ curl gdb libprotobuf-dev libgrpc-dev libgrpc++-dev
       - uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -701,9 +701,6 @@ if(COUCHBASE_CXX_CLIENT_BUILD_STATIC)
 endif()
 
 option(COUCHBASE_CXX_CLIENT_BUILD_TESTS "Build test programs" ${COUCHBASE_CXX_CLIENT_MASTER_PROJECT})
-if(COUCHBASE_CXX_CLIENT_BUILD_TESTS)
-  include(cmake/Testing.cmake)
-endif()
 
 # CNG (Protostellar) tests use a hand-rolled framework (NOT Catch2), so they can be built
 # independently of the main (Catch2) test suite. The framework itself links no client code; each
@@ -711,12 +708,17 @@ endif()
 option(COUCHBASE_CXX_CLIENT_BUILD_CNG_TESTS "Build CNG (Protostellar) tests"
        ${COUCHBASE_CXX_CLIENT_BUILD_TESTS})
 
-# The hand-rolled framework both test trees build on, and its self-test. Testing is enabled at the
-# top level here so `ctest` from the build root discovers these even when the main (Catch2) suite
-# is disabled and cmake/Testing.cmake was not included.
+# The hand-rolled framework both test trees build on, and its self-test. It precedes
+# cmake/Testing.cmake so couchbase_add_test() is defined before test/CMakeLists.txt is read.
+# Testing is enabled at the top level here so `ctest` from the build root discovers these even when
+# the main (Catch2) suite is disabled and cmake/Testing.cmake was not included.
 if(COUCHBASE_CXX_CLIENT_BUILD_TESTS OR COUCHBASE_CXX_CLIENT_BUILD_CNG_TESTS)
   enable_testing()
   include(cmake/TestFramework.cmake)
+endif()
+
+if(COUCHBASE_CXX_CLIENT_BUILD_TESTS)
+  include(cmake/Testing.cmake)
 endif()
 
 if(COUCHBASE_CXX_CLIENT_BUILD_CNG_TESTS)

--- a/bin/run-integration-tests
+++ b/bin/run-integration-tests
@@ -43,6 +43,18 @@ if [ "x${CB_SANITIZER}" = "xlsan" ]; then
     export LSAN_OPTIONS="suppressions=${PROJECT_ROOT}/.lsan_suppressions"
 fi
 
+# The hand-rolled framework stops waiting on a case that exceeds an absolute millisecond budget and
+# reports it failed. It cannot kill the case: the worker is left detached and still running, which is
+# why main() leaves via _Exit rather than running static destructors underneath it. Valgrind runs
+# 20-50x slower than an uninstrumented build and the sanitizers a few times slower, so without a
+# multiplier those legs report timeouts instead of behaviour. Catch2 has no per-case budget and
+# ignores this.
+if [ "x${CB_SANITIZER}" = "xvalgrind" ]; then
+    export CB_TEST_TIMEOUT_MULTIPLIER="${CB_TEST_TIMEOUT_MULTIPLIER:-50}"
+elif [ "x${CB_SANITIZER}" != "x" ]; then
+    export CB_TEST_TIMEOUT_MULTIPLIER="${CB_TEST_TIMEOUT_MULTIPLIER:-5}"
+fi
+
 cd "${BUILD_DIR}"
 
 CB_USE_GOCAVES=${CB_USE_GOCAVES:-""}

--- a/cmake/TestFramework.cmake
+++ b/cmake/TestFramework.cmake
@@ -1,4 +1,5 @@
-# The shared test framework: the runner, the common main(), and the framework's own self-test.
+# The shared test framework: the runner, the common main(), the registration helpers, and the
+# framework's own self-test.
 #
 # Hand-rolled (CXXCBC-885), deliberately NOT Catch2. It lives outside either test subdirectory
 # because both test trees link it. See test/cng/README.md to build and run the CNG tests.
@@ -6,8 +7,8 @@
 find_package(Threads REQUIRED)
 
 # Each test executable links this and provides its own tests(). fmt comes from spdlog's bundled
-# copy (header include dirs only). ${PROJECT_SOURCE_DIR}/test is PUBLIC so a test includes the
-# framework as "framework/test_runner.hxx" wherever in the test tree it sits.
+# copy (header include dirs only). ${PROJECT_SOURCE_DIR}/test is PUBLIC so every test spells its
+# includes from one root: "framework/test_runner.hxx", "cng/fixtures/live_fixture.hxx".
 add_library(
   test_framework_main STATIC
   ${PROJECT_SOURCE_DIR}/test/framework/test_runner.cxx
@@ -26,30 +27,157 @@ target_link_libraries(test_framework_main PUBLIC Threads::Threads spdlog::spdlog
 set_project_options(test_framework_main)
 set_project_warnings(test_framework_main)
 
-# The framework's own self-test: it drives run() with in-memory suites and asserts on the returned
-# run_result, so it links the framework and nothing else.
-add_executable(test_framework_selftest
-               ${PROJECT_SOURCE_DIR}/test/framework/framework_selftest.cxx)
-target_include_directories(
-  test_framework_selftest SYSTEM BEFORE
-  PRIVATE $<BUILD_INTERFACE:$<TARGET_PROPERTY:spdlog::spdlog,INTERFACE_INCLUDE_DIRECTORIES>>)
-target_link_libraries(test_framework_selftest PRIVATE test_framework_main Threads::Threads)
-set_project_options(test_framework_selftest)
-set_project_warnings(test_framework_selftest)
-add_test(NAME test_framework_selftest COMMAND $<TARGET_FILE:test_framework_selftest>)
-# The harness returns 77 when every case was skipped; map that to ctest's "Skipped".
+# couchbase_discover_tests(<target> PROPERTIES <prop> <value>...)
 #
-# The label must be one a CI leg actually selects, or these cases are compiled, linked and never
-# run. Only unit, integration, transaction, benchmark and cng are selected anywhere in bin/ or
-# .github/workflows/. cng is the one that fits: its steps deliberately do not apply --test-action
-# memcheck, and the inner suites here assert on absolute millisecond budgets that valgrind would
-# blow with no multiplier able to reach them.
-set_tests_properties(test_framework_selftest PROPERTIES SKIP_RETURN_CODE 77 LABELS "cng")
-if(DEFINED COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS AND EXISTS "${COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS}")
-  set_tests_properties(
-    test_framework_selftest
-    PROPERTIES
+# Registers one ctest entry per case, named <target>.<case>, the way catch_discover_tests does for
+# the Catch2 suites. Per-executable registration would be coarser than what the suite already
+# depends on: bin/run-integration-tests shards the valgrind leg with `ctest -I i,,n`, whose stride
+# runs over ctest entries, and --output-junit builds the CI report from one row per entry.
+#
+# The list is produced at post-build by running the executable with --list-tests, which reports
+# every case regardless of what the environment satisfies -- so the registered set does not depend
+# on the machine that built it.
+#
+# NAMING RULE, which the whole scheme relies on: a case name is the name of the function that
+# implements it, so it is a C++ identifier in lower_snake_case -- [A-Za-z_][A-Za-z0-9_]* and nothing
+# else. No spaces, no punctuation, no colons. A Catch2 case is converted to one ONCE, when it is
+# migrated: the category prefix is dropped because the target's ctest label already carries it, and
+# the remaining words are joined with underscores. So
+# "integration: cluster remains usable in a forked child" is migrated as the function
+# cluster_remains_usable_in_a_forked_child.
+#
+# Keep that rule and nothing here needs quoting or escaping: the name is safe as a CMake list
+# element, as a ctest -R pattern, and as an argv entry in bash, zsh, cmd and PowerShell alike. Break
+# it and the fix is the name, never an escaping scheme in this file.
+function(couchbase_discover_tests target)
+  cmake_parse_arguments(ARG "" "" "PROPERTIES" ${ARGN})
+
+  get_property(is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+  if(is_multi_config)
+    set(ctest_file "${CMAKE_CURRENT_BINARY_DIR}/${target}_tests_$<CONFIG>.cmake")
+    set(ctest_file_at_test_time "${CMAKE_CURRENT_BINARY_DIR}/${target}_tests_\${CTEST_CONFIGURATION_TYPE}.cmake")
+    # No BYPRODUCTS here. It accepts a generator expression only from CMake 3.20, and this project
+    # declares 3.19, so a multi-config generate would break on the minimum version this repository
+    # claims to support. The declaration only tells the build graph that the command writes this
+    # file -- it is a `clean` and dependency-tracking hint, not a correctness requirement, and the
+    # per-config file name is worth more than the hint. catch_discover_tests() avoids the question
+    # by keying its file on an argument hash rather than the configuration, which is why one file
+    # there serves every config.
+    set(byproducts "")
+  else()
+    set(ctest_file "${CMAKE_CURRENT_BINARY_DIR}/${target}_tests.cmake")
+    set(ctest_file_at_test_time "${ctest_file}")
+    set(byproducts BYPRODUCTS "${ctest_file}")
+  endif()
+
+  add_custom_command(
+    TARGET ${target}
+    POST_BUILD
+    ${byproducts}
+    COMMAND
+      "${CMAKE_COMMAND}" -D "TEST_TARGET=${target}" -D "TEST_EXECUTABLE=$<TARGET_FILE:${target}>" -D
+      "TEST_PROPERTIES=${ARG_PROPERTIES}" -D "CTEST_FILE=${ctest_file}" -P
+      "${PROJECT_SOURCE_DIR}/cmake/TestFrameworkAddTests.cmake"
+    COMMENT "Enumerating test cases in ${target}"
+    VERBATIM)
+
+  # ctest reads TEST_INCLUDE_FILES at the start of a run, when the generated file may not exist --
+  # a fresh configure, or a build that never got as far as linking this target. Registering a test
+  # that cannot pass is the point: an unbuilt binary must not read as a binary with no failures.
+  #
+  # The placeholder runs cmake -E false rather than a command named after the target: a missing
+  # command fails with a different message on every platform ("command not found", "file not
+  # found", a Windows error box), and one of them has to be recognisable as the intended failure.
+  set(include_file "${CMAKE_CURRENT_BINARY_DIR}/${target}_include.cmake")
+  file(
+    WRITE "${include_file}"
+    "if(EXISTS \"${ctest_file_at_test_time}\")\n"
+    "  include(\"${ctest_file_at_test_time}\")\n"
+    "else()\n"
+    # Positional, not add_test(NAME ... COMMAND ...): the keyword signature is a CMakeLists
+    # feature. Meeting one in an include file, ctest takes the first argument as the test name and
+    # the rest as the command, so it registers an entry literally called "NAME" that reports Not
+    # Run. The positional form is what makes the entry carry the target's name and fail for the
+    # reason it was registered.
+    "  add_test([==[${target}_NOT_BUILT]==] [==[${CMAKE_COMMAND}]==] -E false)\n"
+    # The placeholder carries the same labels as the real cases would. Without them a labelled run
+    # -- which is how CI runs everything -- would filter the placeholder out, and an unbuilt binary
+    # would once again read as a binary with no failures.
+    "  set(properties [==[${ARG_PROPERTIES}]==])\n"
+    "  set_tests_properties(${target}_NOT_BUILT PROPERTIES \${properties})\n"
+    "endif()\n")
+  set_property(DIRECTORY APPEND PROPERTY TEST_INCLUDE_FILES "${include_file}")
+endfunction()
+
+# Which client library a LINK_CLIENT test links. test/cng/CMakeLists.txt narrows this for the
+# couchbase2 tests, which also link the generated protobuf stubs directly.
+set(couchbase_cxx_client_test_library ${couchbase_cxx_client_DEFAULT_LIBRARY})
+
+# couchbase_add_test(<relpath> LABEL <label> [LINK_CLIENT] [LIBS <lib>...])
+#
+# relpath is under test/ without the extension (e.g. cng/protostellar/dispatcher). The target name
+# is that path with the separators flattened, which makes it unique by construction: keying on the
+# file stem instead would collide the moment two subsystems each have a parser.cxx. LINK_CLIENT
+# links the client library and its core header include set, for tests that exercise core code.
+function(couchbase_add_test relpath)
+  cmake_parse_arguments(ARG "LINK_CLIENT" "LABEL" "LIBS" ${ARGN})
+
+  # Every entry is a label some leg in bin/ or .github/workflows/ selects with --label-regex. A
+  # label no runner selects is worse than a typo: it configures, builds and links, and the cases
+  # are then never executed by anything. Do not add one here without the leg that runs it.
+  set(known_labels unit integration transaction benchmark cng)
+  if(NOT ARG_LABEL IN_LIST known_labels)
+    # A typo here is invisible at build time and then quietly drops the binary out of the CI leg
+    # that was supposed to run it.
+    message(FATAL_ERROR "couchbase_add_test(${relpath}): LABEL must be one of ${known_labels}, "
+                        "got \"${ARG_LABEL}\"")
+  endif()
+
+  string(REPLACE "/" "_" target "${relpath}")
+  add_executable(${target} ${PROJECT_SOURCE_DIR}/test/${relpath}.cxx)
+  target_include_directories(${target} PRIVATE ${PROJECT_SOURCE_DIR})
+  target_include_directories(
+    ${target} SYSTEM BEFORE
+    PRIVATE $<BUILD_INTERFACE:$<TARGET_PROPERTY:spdlog::spdlog,INTERFACE_INCLUDE_DIRECTORIES>>)
+  target_link_libraries(${target} PRIVATE test_framework_main Threads::Threads)
+  if(ARG_LINK_CLIENT)
+    target_include_directories(${target} PRIVATE ${PROJECT_BINARY_DIR}/generated
+                                                 ${PROJECT_BINARY_DIR}/generated_$<CONFIG>)
+    target_include_directories(
+      ${target} SYSTEM BEFORE
+      PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third_party/expected/include>
+              $<BUILD_INTERFACE:$<TARGET_PROPERTY:asio,INTERFACE_INCLUDE_DIRECTORIES>>)
+    propagate_public_compile_definitions(${target} spdlog::spdlog asio)
+    target_link_libraries(
+      ${target} PRIVATE ${couchbase_cxx_client_test_library} $<BUILD_INTERFACE:Microsoft.GSL::GSL>
+                        $<BUILD_INTERFACE:taocpp::json>)
+  endif()
+  if(ARG_LIBS)
+    target_link_libraries(${target} PRIVATE ${ARG_LIBS})
+  endif()
+  set_project_options(${target})
+  set_project_warnings(${target})
+
+  # The harness returns 77 when every case was skipped; map that to ctest's "Skipped".
+  set(properties SKIP_RETURN_CODE 77 LABELS "${ARG_LABEL}")
+  # Sanitizers are applied per target (cmake/Sanitizers.cmake), so dependencies fetched and built
+  # as ordinary packages -- gRPC and abseil among them -- carry no instrumentation, and TSan cannot
+  # see the happens-before edges inside their event-engine and futex code. Without
+  # ignore_noninstrumented_modules it reports those as races: the dispatcher tests drive real gRPC
+  # threads and produced 54 such reports. Set on the test rather than in CI so a local `ctest` under
+  # TSan behaves the same way.
+  if(DEFINED COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS AND EXISTS "${COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS}")
+    list(
+      APPEND
+      properties
       ENVIRONMENT
       "TSAN_OPTIONS=halt_on_error=0,second_deadlock_stack=1,ignore_noninstrumented_modules=1,suppressions=${COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS}"
-  )
-endif()
+    )
+  endif()
+  couchbase_discover_tests(${target} PROPERTIES ${properties})
+endfunction()
+
+# cng, because that is the leg whose steps deliberately do not apply --test-action memcheck: the
+# inner suites here assert on absolute millisecond budgets, which valgrind would blow with no
+# multiplier able to reach them.
+couchbase_add_test(framework/selftest LABEL cng)

--- a/cmake/TestFrameworkAddTests.cmake
+++ b/cmake/TestFrameworkAddTests.cmake
@@ -1,0 +1,48 @@
+# Post-build enumerator for couchbase_discover_tests(). Runs the freshly linked test executable
+# with --list-tests and writes one add_test() per case, so ctest sees the same granularity
+# catch_discover_tests gives the Catch2 suites: `ctest -I i,,n` can shard a binary, `-R` can select
+# a single case, and --output-junit carries one row per case.
+#
+# Driven by cmake -P with TEST_TARGET, TEST_EXECUTABLE, TEST_PROPERTIES and CTEST_FILE defined.
+
+execute_process(
+  COMMAND "${TEST_EXECUTABLE}" --list-tests
+  OUTPUT_VARIABLE listing
+  ERROR_VARIABLE listing_error
+  RESULT_VARIABLE listing_result)
+
+if(NOT listing_result EQUAL 0)
+  message(FATAL_ERROR "${TEST_EXECUTABLE} --list-tests failed (${listing_result}):\n${listing_error}")
+endif()
+
+# Splitting on newlines below makes ";" the list separator, so any semicolon already in the text
+# has to be escaped first or one line becomes two entries. Case names cannot contain one -- they are
+# C++ identifiers, see the naming rule in couchbase_discover_tests() -- so this guards whatever else
+# the listing carries beside the name.
+string(REPLACE ";" "\\;" listing "${listing}")
+string(REPLACE "\n" ";" listing "${listing}")
+
+# Bracket-quoted once, then expanded unquoted at ctest time: interpolating the list straight into
+# the file splits it on any space inside a value -- a TSan suppressions path containing one would
+# have silently truncated the ENVIRONMENT property rather than failing.
+set(script "set(properties [==[${TEST_PROPERTIES}]==])\n")
+set(case_count 0)
+foreach(case_name IN LISTS listing)
+  string(STRIP "${case_name}" case_name)
+  if(case_name STREQUAL "")
+    continue()
+  endif()
+  math(EXPR case_count "${case_count} + 1")
+  set(test_name "${TEST_TARGET}.${case_name}")
+  string(APPEND script "add_test([==[${test_name}]==] [==[${TEST_EXECUTABLE}]==] [==[${case_name}]==])\n")
+  string(APPEND script "set_tests_properties([==[${test_name}]==] PROPERTIES \${properties})\n")
+endforeach()
+
+# A binary that reports no cases has to break the build. Writing an empty file instead would leave
+# ctest green with nothing registered, which is the failure this whole scheme exists to make
+# impossible.
+if(case_count EQUAL 0)
+  message(FATAL_ERROR "${TEST_EXECUTABLE} --list-tests reported no test cases")
+endif()
+
+file(WRITE "${CTEST_FILE}" "${script}")

--- a/test/cng/CMakeLists.txt
+++ b/test/cng/CMakeLists.txt
@@ -3,9 +3,7 @@
 # Uses the hand-rolled framework in test/framework/ (CXXCBC-885), deliberately NOT Catch2.
 # See test/cng/README.md to build and run these tests. Enabled via COUCHBASE_CXX_CLIENT_BUILD_CNG_TESTS.
 
-find_package(Threads REQUIRED)
-
-# Which client library the LINK_CLIENT tests link.
+# Which client library the LINK_CLIENT tests link, narrowing couchbase_add_test's default.
 #
 # The couchbase2 tests also link couchbase_cxx_protostellar directly, to construct the generated
 # protobuf messages the converters take. Under COUCHBASE_CXX_CLIENT_PACKAGE_BUILD
@@ -28,11 +26,11 @@ find_package(Threads REQUIRED)
 #
 # Where it is unavailable, fall back to the default and skip the couchbase2 tests below rather than
 # build a target that would fail this way.
-set(cng_test_client_library ${couchbase_cxx_client_DEFAULT_LIBRARY})
 set(cng_test_couchbase2_supported TRUE)
 if(COUCHBASE_CXX_CLIENT_PACKAGE_BUILD)
   if(TARGET couchbase_cxx_client::couchbase_cxx_client_static_intermediate)
-    set(cng_test_client_library couchbase_cxx_client::couchbase_cxx_client_static_intermediate)
+    set(couchbase_cxx_client_test_library
+        couchbase_cxx_client::couchbase_cxx_client_static_intermediate)
   else()
     set(cng_test_couchbase2_supported FALSE)
     if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2)
@@ -46,64 +44,11 @@ if(COUCHBASE_CXX_CLIENT_PACKAGE_BUILD)
   endif()
 endif()
 
-# add_cng_test(<relpath> [LINK_CLIENT] [LIBS <lib>...]) — relpath is under test/cng/ without
-# extension (e.g. protostellar/dispatcher). The executable/ctest name is the file stem prefixed
-# with cng_. LINK_CLIENT links the client library and its core header include set, for tests that
-# exercise core code (e.g. the connection-string parser).
-#
-# The runner and the shared main() come from test_framework_main (cmake/TestFramework.cmake),
-# which also puts ${PROJECT_SOURCE_DIR}/test on the include path.
+# add_cng_test(<relpath> [LINK_CLIENT] [LIBS <lib>...]) — relpath is under test/cng/ without the
+# extension (e.g. protostellar/dispatcher), which couchbase_add_test (cmake/TestFramework.cmake)
+# takes relative to test/ and turns into the target name cng_protostellar_dispatcher.
 function(add_cng_test relpath)
-  cmake_parse_arguments(ARG "LINK_CLIENT" "" "LIBS" ${ARGN})
-  get_filename_component(stem ${relpath} NAME_WE)
-  set(target cng_${stem}_test)
-  # The name comes from the file stem, not the full relpath, so kv/options.cxx and
-  # query/options.cxx would both want cng_options_test. Fail loudly at configure time instead of
-  # letting the second add_executable() error out cryptically (or worse, silently win).
-  if(TARGET ${target})
-    message(FATAL_ERROR "add_cng_test(${relpath}): target ${target} already exists. Two test files "
-                        "share a stem -- rename one of them.")
-  endif()
-  add_executable(${target} ${PROJECT_SOURCE_DIR}/test/cng/${relpath}.cxx)
-  target_include_directories(${target} PRIVATE ${PROJECT_SOURCE_DIR}/test/cng ${PROJECT_SOURCE_DIR})
-  target_include_directories(
-    ${target} SYSTEM BEFORE
-    PRIVATE $<BUILD_INTERFACE:$<TARGET_PROPERTY:spdlog::spdlog,INTERFACE_INCLUDE_DIRECTORIES>>)
-  target_link_libraries(${target} PRIVATE test_framework_main Threads::Threads)
-  if(ARG_LINK_CLIENT)
-    target_include_directories(${target} PRIVATE ${PROJECT_BINARY_DIR}/generated
-                                                 ${PROJECT_BINARY_DIR}/generated_$<CONFIG>)
-    target_include_directories(
-      ${target} SYSTEM BEFORE
-      PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third_party/expected/include>
-              $<BUILD_INTERFACE:$<TARGET_PROPERTY:asio,INTERFACE_INCLUDE_DIRECTORIES>>)
-    propagate_public_compile_definitions(${target} spdlog::spdlog asio)
-    target_link_libraries(
-      ${target} PRIVATE ${cng_test_client_library}
-                        $<BUILD_INTERFACE:Microsoft.GSL::GSL> $<BUILD_INTERFACE:taocpp::json>)
-  endif()
-  if(ARG_LIBS)
-    target_link_libraries(${target} PRIVATE ${ARG_LIBS})
-  endif()
-  set_project_options(${target})
-  set_project_warnings(${target})
-  add_test(NAME ${target} COMMAND $<TARGET_FILE:${target}>)
-  # The harness returns 77 when every case was skipped; map that to ctest's "Skipped".
-  set_tests_properties(${target} PROPERTIES SKIP_RETURN_CODE 77 LABELS "cng")
-  # Same TSan configuration cmake/Testing.cmake attaches to the Catch2 suites. Sanitizers are applied
-  # per target (cmake/Sanitizers.cmake), so gRPC and abseil -- fetched and built as ordinary
-  # dependencies -- carry no instrumentation, and TSan cannot see the happens-before edges inside
-  # their event-engine and futex code. Without ignore_noninstrumented_modules it reports those as
-  # races: dispatcher tests drive real gRPC threads and produced 54 such reports. Set on the test
-  # rather than in CI so a local `ctest` under TSan behaves the same way.
-  if(DEFINED COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS AND EXISTS "${COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS}")
-    set_tests_properties(
-      ${target}
-      PROPERTIES
-        ENVIRONMENT
-        "TSAN_OPTIONS=halt_on_error=0,second_deadlock_stack=1,ignore_noninstrumented_modules=1,suppressions=${COUCHBASE_CXX_CLIENT_TSAN_SUPPRESSIONS}"
-    )
-  endif()
+  couchbase_add_test(cng/${relpath} LABEL cng ${ARGN})
 endfunction()
 
 # couchbase2:// connection-string scheme (CXXCBC-887). Exercises the core parser, so it
@@ -123,7 +68,7 @@ if(COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2
    AND TARGET couchbase_cxx_protostellar
    AND cng_test_couchbase2_supported)
   add_cng_test(protostellar/codegen_smoke)
-  target_link_libraries(cng_codegen_smoke_test PRIVATE couchbase_cxx_protostellar)
+  target_link_libraries(cng_protostellar_codegen_smoke PRIVATE couchbase_cxx_protostellar)
 
   # gRPC<->asio bridge (CXXCBC-889). The transport now lives in the client library, so link
   # that (LINK_CLIENT) plus the stubs library for the generated KvService the in-process test

--- a/test/cng/README.md
+++ b/test/cng/README.md
@@ -230,7 +230,7 @@ A single test binary can also be run directly, which is handy while iterating:
 
 ```console
 $ TEST_CONNECTION_STRING="couchbase2://<host>:<port>?tls_verify=none" \
-    ./build/test/cng/cng_live_kv_test
+    ./build/test/cng/cng_protostellar_live_kv
 ```
 
 ### Overriding the defaults

--- a/test/cng/fixtures/live_fixture.hxx
+++ b/test/cng/fixtures/live_fixture.hxx
@@ -47,7 +47,7 @@
 
 // Inside the guarded region, not above it: this header reaches core/protostellar/dispatcher.hxx,
 // and a core header parsed before the #define above is what the comment there describes.
-#include "protostellar/callback_queue_keepalive.hxx"
+#include "cng/protostellar/callback_queue_keepalive.hxx"
 
 #include <couchbase/error_codes.hxx>
 

--- a/test/cng/protostellar/live_analytics.cxx
+++ b/test/cng/protostellar/live_analytics.cxx
@@ -30,7 +30,7 @@
 
 #define COUCHBASE_CXX_CLIENT_IGNORE_CORE_DEPRECATIONS
 
-#include "fixtures/live_fixture.hxx"
+#include "cng/fixtures/live_fixture.hxx"
 #include "framework/test_runner.hxx"
 
 #include <couchbase/error_codes.hxx>

--- a/test/cng/protostellar/live_bucket_admin.cxx
+++ b/test/cng/protostellar/live_bucket_admin.cxx
@@ -19,7 +19,7 @@
 // admin.bucket.v1: that the bucket list arrives, and that settings written by create() are the
 // settings read back by get().
 
-#include "fixtures/live_fixture.hxx"
+#include "cng/fixtures/live_fixture.hxx"
 #include "framework/test_runner.hxx"
 
 #include "core/management/bucket_settings.hxx"

--- a/test/cng/protostellar/live_collection_admin.cxx
+++ b/test/cng/protostellar/live_collection_admin.cxx
@@ -36,7 +36,7 @@
 // cluster map couchbase2 does not have -- so the request has to be sent and the server's answer
 // taken, and only a live case shows what that answer is.
 
-#include "fixtures/live_fixture.hxx"
+#include "cng/fixtures/live_fixture.hxx"
 #include "framework/test_runner.hxx"
 
 #include "core/management/bucket_settings.hxx"

--- a/test/cng/protostellar/live_connect.cxx
+++ b/test/cng/protostellar/live_connect.cxx
@@ -23,7 +23,7 @@
 
 #define COUCHBASE_CXX_CLIENT_IGNORE_CORE_DEPRECATIONS
 
-#include "fixtures/live_fixture.hxx"
+#include "cng/fixtures/live_fixture.hxx"
 #include "framework/test_runner.hxx"
 
 // core/operations.hxx (complete operation types) must precede core/cluster.hxx, whose execute()

--- a/test/cng/protostellar/live_kv_operations.cxx
+++ b/test/cng/protostellar/live_kv_operations.cxx
@@ -30,7 +30,7 @@
 // which of the KV surface they implement, and a skip says "not covered here" where a failure would
 // wrongly say "the client is broken".
 
-#include "fixtures/live_fixture.hxx"
+#include "cng/fixtures/live_fixture.hxx"
 #include "framework/test_runner.hxx"
 
 #include "core/error_context/key_value.hxx"

--- a/test/cng/protostellar/live_query.cxx
+++ b/test/cng/protostellar/live_query.cxx
@@ -29,7 +29,7 @@
 
 #define COUCHBASE_CXX_CLIENT_IGNORE_CORE_DEPRECATIONS
 
-#include "fixtures/live_fixture.hxx"
+#include "cng/fixtures/live_fixture.hxx"
 #include "framework/test_runner.hxx"
 
 #include "core/json_string.hxx"

--- a/test/cng/protostellar/live_query_index_admin.cxx
+++ b/test/cng/protostellar/live_query_index_admin.cxx
@@ -31,7 +31,7 @@
 // The case below drives the public manager rather than the core request, because the routing hole
 // it covers was invisible from the core request that was already wired.
 
-#include "fixtures/live_fixture.hxx"
+#include "cng/fixtures/live_fixture.hxx"
 #include "framework/test_runner.hxx"
 
 #include "core/operations/management/query_index_create.hxx"

--- a/test/cng/protostellar/live_search.cxx
+++ b/test/cng/protostellar/live_search.cxx
@@ -22,7 +22,7 @@
 // the round trip is pinned by the error the gateway returns for an index that does not exist:
 // that answer can only come from a gateway that ran the query.
 
-#include "fixtures/live_fixture.hxx"
+#include "cng/fixtures/live_fixture.hxx"
 #include "framework/test_runner.hxx"
 
 #include "core/operations.hxx"

--- a/test/cng/protostellar/live_search_index_admin.cxx
+++ b/test/cng/protostellar/live_search_index_admin.cxx
@@ -29,7 +29,7 @@
 // never byte-identical to what was sent. Whether the three parameter blobs stay separate can only
 // be checked against a real definition, by looking for each blob's own member in its own blob.
 
-#include "fixtures/live_fixture.hxx"
+#include "cng/fixtures/live_fixture.hxx"
 #include "framework/test_runner.hxx"
 
 #include "core/operations/management/search_index_analyze_document.hxx"

--- a/test/cng/protostellar/live_view.cxx
+++ b/test/cng/protostellar/live_view.cxx
@@ -25,7 +25,7 @@
 
 #define COUCHBASE_CXX_CLIENT_IGNORE_CORE_DEPRECATIONS
 
-#include "fixtures/live_fixture.hxx"
+#include "cng/fixtures/live_fixture.hxx"
 #include "framework/test_runner.hxx"
 
 #include "core/operations.hxx"

--- a/test/framework/selftest.cxx
+++ b/test/framework/selftest.cxx
@@ -25,8 +25,11 @@
 #include <chrono>
 #include <cstddef>
 #include <ios>
+#include <optional>
 #include <set>
 #include <sstream>
+#include <stdexcept>
+#include <string>
 #include <thread>
 
 namespace couchbase::test
@@ -105,6 +108,9 @@ runner_reports_a_skipped_case()
   const auto r = run_quiet(s, {}, false);
   assert_eq(r.skipped, std::size_t{ 1 }, "one skip counted");
   assert_eq(r.failed, std::size_t{ 0 }, "skip is not a failure");
+  // The other half of the contract couchbase_add_test() wires up as SKIP_RETURN_CODE: a binary that
+  // ran nothing but skips must report ctest Skipped, not success.
+  assert_eq(exit_code(r), 77, "an all-skipped binary reports 77");
 }
 
 void
@@ -202,6 +208,94 @@ a_timeout_is_reported_as_such()
   assert_eq(r.failed, std::size_t{ 1 }, "and still counted as a failure");
 }
 
+void
+case_names_covers_slow_cases_and_ignores_the_environment()
+{
+  const test_suite suite{
+    "listing",
+    { { "regular", body_pass, timeout::instant, test_env::cluster_only } },
+    { { "deliberately_slow", body_pass, timeout::slow } },
+  };
+
+  const auto names = case_names(suite);
+  assert_eq(names.size(), std::size_t{ 2 }, "both lists are enumerated");
+  assert_eq(names[0], std::string{ "regular" }, "in registration order");
+  assert_eq(names[1], std::string{ "deliberately_slow" }, "slow cases come last");
+}
+
+void
+timeout_multiplier_defaults_to_one_and_rejects_anything_but_a_number()
+{
+  assert_eq(timeout_multiplier(std::nullopt), 1.0, "unset means unscaled");
+  assert_eq(timeout_multiplier(std::optional<std::string>{ "10" }), 10.0, "an integer is read");
+  assert_eq(timeout_multiplier(std::optional<std::string>{ "2.5" }), 2.5, "so is a fraction");
+
+  // A trailing suffix must not be read as a bare number: silently running with a budget nobody
+  // asked for is how a leg goes green on timing rather than on behaviour.
+  assert_throws<std::invalid_argument>(
+    []() {
+      (void)timeout_multiplier(std::optional<std::string>{ "10x" });
+    },
+    "a trailing suffix is rejected");
+  assert_throws<std::invalid_argument>(
+    []() {
+      (void)timeout_multiplier(std::optional<std::string>{ "0" });
+    },
+    "zero would kill every case immediately");
+  assert_throws<std::invalid_argument>(
+    []() {
+      (void)timeout_multiplier(std::optional<std::string>{ "-1" });
+    },
+    "a negative factor is rejected");
+  // "inf" parses, and satisfies a bare positivity test. Accepting it makes every scaled budget
+  // undefined at the narrowing cast in scale_timeouts.
+  assert_throws<std::invalid_argument>(
+    []() {
+      (void)timeout_multiplier(std::optional<std::string>{ "inf" });
+    },
+    "a non-finite factor is rejected");
+}
+
+void
+scale_timeouts_multiplies_every_budget()
+{
+  test_suite suite{
+    "budgets",
+    { { "fast", body_pass, std::chrono::milliseconds{ 100 } } },
+    { { "slow", body_pass, std::chrono::milliseconds{ 1'000 } } },
+  };
+
+  scale_timeouts(suite, 10.0);
+  assert_eq(suite.test_cases[0].timeout.count(), 1'000, "the regular list is scaled");
+  assert_eq(suite.slow_test_cases[0].timeout.count(), 10'000, "and so is the slow list");
+
+  // Ceiling, not nearest and not truncation. Only a product whose fraction falls below .5 tells
+  // the three apart: 100 x 1.004 is 101 under ceil and 100 under both floor and llround.
+  test_suite fractional{ "fractional",
+                         { { "case", body_pass, std::chrono::milliseconds{ 100 } } } };
+  scale_timeouts(fractional, 1.004);
+  assert_eq(fractional.test_cases[0].timeout.count(), 101, "a fraction below .5 still rounds up");
+
+  // Rounding must not produce a zero budget, which would fail every case before it started.
+  scale_timeouts(suite, 0.0001);
+  assert_true(suite.test_cases[0].timeout.count() >= 1, "a budget never rounds down to nothing");
+}
+
+void
+a_scaled_budget_lets_a_case_outlive_its_original_one()
+{
+  // body_sleep runs for 200ms; 50ms is not enough and 50ms x 10 is.
+  test_suite suite{ "scaled", { { "sleeper", body_sleep, std::chrono::milliseconds{ 50 } } } };
+
+  const auto unscaled = run_quiet(suite, {}, false);
+  assert_eq(unscaled.timed_out, std::size_t{ 1 }, "the original budget kills the case");
+
+  scale_timeouts(suite, 10.0);
+  const auto scaled = run_quiet(suite, {}, false);
+  assert_eq(scaled.timed_out, std::size_t{ 0 }, "the scaled budget does not");
+  assert_eq(scaled.passed, std::size_t{ 1 }, "and the case reports its own outcome");
+}
+
 } // namespace
 
 auto
@@ -225,6 +319,14 @@ tests() -> test_suite
       { "a_filter_name_matching_nothing_fails", a_filter_name_matching_nothing_fails },
       { "a_suite_that_runs_nothing_does_not_pass", a_suite_that_runs_nothing_does_not_pass },
       { "a_timeout_is_reported_as_such", a_timeout_is_reported_as_such, timeout::fast },
+      { "case_names_covers_slow_cases_and_ignores_the_environment",
+        case_names_covers_slow_cases_and_ignores_the_environment },
+      { "timeout_multiplier_defaults_to_one_and_rejects_anything_but_a_number",
+        timeout_multiplier_defaults_to_one_and_rejects_anything_but_a_number },
+      { "scale_timeouts_multiplies_every_budget", scale_timeouts_multiplies_every_budget },
+      { "a_scaled_budget_lets_a_case_outlive_its_original_one",
+        a_scaled_budget_lets_a_case_outlive_its_original_one,
+        timeout::fast },
     },
   };
 }

--- a/test/framework/test_main.cxx
+++ b/test/framework/test_main.cxx
@@ -19,13 +19,18 @@
 // tests(); this main gathers a name filter from argv, decides mock-vs-real mode from
 // TEST_CONNECTION_STRING, runs the suite, and maps the outcome to a process exit code
 // (0 pass / 1 fail / 77 all-skipped).
+//
+// `--list-tests` prints the case names one per line and exits. cmake/TestFramework.cmake runs it
+// after linking to register one ctest entry per case.
 
 #include "test_runner.hxx"
 
 #include <cstdlib> // std::_Exit
+#include <exception>
 #include <iostream>
 #include <set>
 #include <string>
+#include <string_view>
 
 #include <spdlog/fmt/fmt.h>
 
@@ -34,16 +39,36 @@ main(int argc, char* argv[]) -> int
 {
   using namespace couchbase::test;
 
+  bool list_only{ false };
   std::set<std::string> filter;
   for (int i = 1; i < argc; ++i) {
-    filter.insert(std::string{ argv[i] });
+    if (const std::string_view arg{ argv[i] }; arg == "--list-tests") {
+      list_only = true;
+    } else {
+      filter.emplace(arg);
+    }
+  }
+
+  auto suite = tests();
+
+  if (list_only) {
+    for (const auto& name : case_names(suite)) {
+      std::cout << name << '\n';
+    }
+    return 0;
+  }
+
+  try {
+    scale_timeouts(suite, timeout_multiplier(safe_getenv(timeout_multiplier_variable)));
+  } catch (const std::exception& e) {
+    std::cerr << e.what() << '\n';
+    return 1;
   }
 
   // Real-cluster mode iff TEST_CONNECTION_STRING is set and non-empty (the couchbase-cxx-client
   // integration convention).
   const bool real_cluster = safe_getenv("TEST_CONNECTION_STRING").has_value();
 
-  const auto suite = tests();
   const auto result = run(suite, filter, real_cluster, std::cout);
 
   if (result.failed > 0) {

--- a/test/framework/test_runner.cxx
+++ b/test/framework/test_runner.cxx
@@ -17,12 +17,17 @@
 
 #include "test_runner.hxx"
 
+#include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <cstdint>
 #include <cstdlib>
 #include <exception>
 #include <future>
+#include <limits>
+#include <memory>
 #include <ostream>
+#include <stdexcept>
 #include <thread>
 
 #include <spdlog/fmt/fmt.h>
@@ -170,6 +175,70 @@ exit_code(const run_result& result) -> int
     return 1;
   }
   return 0;
+}
+
+auto
+case_names(const test_suite& suite) -> std::vector<std::string>
+{
+  std::vector<std::string> names;
+  names.reserve(suite.test_cases.size() + suite.slow_test_cases.size());
+  for (const auto& tc : suite.test_cases) {
+    names.push_back(tc.name);
+  }
+  for (const auto& tc : suite.slow_test_cases) {
+    names.push_back(tc.name);
+  }
+  return names;
+}
+
+auto
+timeout_multiplier(const std::optional<std::string>& raw) -> double
+{
+  if (!raw.has_value()) {
+    return 1.0;
+  }
+  std::size_t consumed{ 0 };
+  double factor{ 0.0 };
+  try {
+    factor = std::stod(*raw, &consumed);
+  } catch (const std::exception&) {
+    consumed = 0;
+  }
+  // The whole value has to be a number: "10x" must not be read as 10, because the run would then
+  // silently use a budget nobody asked for.
+  //
+  // isfinite rejects "inf", which passes a bare `> 0.0` test and then makes every scaled budget
+  // undefined at the cast in scale_timeouts. NaN is already rejected: any comparison against it is
+  // false.
+  if (consumed != raw->size() || !std::isfinite(factor) || !(factor > 0.0)) {
+    throw std::invalid_argument(
+      fmt::format("{} must be a positive number, got \"{}\"", timeout_multiplier_variable, *raw));
+  }
+  return factor;
+}
+
+void
+scale_timeouts(test_suite& suite, double factor)
+{
+  const auto scale = [factor](test_case& tc) {
+    // Ceiling, not nearest: this exists to give a case more room on a slower runner, and rounding
+    // a budget down -- which std::llround does for any product with a fraction below .5 -- would
+    // quietly do the opposite of what the caller asked for.
+    const auto product = std::ceil(static_cast<double>(tc.timeout.count()) * factor);
+    // Saturate before narrowing. A product past the integer range is undefined at the cast, and on
+    // a signed overflow the budget would come back negative and clamp to 1ms -- a multiplier asking
+    // for more room would give every case the least possible.
+    constexpr auto ceiling = static_cast<double>(std::numeric_limits<long long>::max());
+    const auto scaled =
+      product >= ceiling ? std::numeric_limits<long long>::max() : static_cast<long long>(product);
+    tc.timeout = std::chrono::milliseconds{ std::max<long long>(scaled, 1) };
+  };
+  for (auto& tc : suite.test_cases) {
+    scale(tc);
+  }
+  for (auto& tc : suite.slow_test_cases) {
+    scale(tc);
+  }
 }
 
 auto

--- a/test/framework/test_runner.hxx
+++ b/test/framework/test_runner.hxx
@@ -24,6 +24,7 @@
 #include <ostream>
 #include <set>
 #include <string>
+#include <vector>
 
 namespace couchbase::test
 {
@@ -53,6 +54,28 @@ run(const test_suite& suite,
 // (the GNU/ctest "skipped" convention); otherwise 0.
 [[nodiscard]] auto
 exit_code(const run_result& result) -> int;
+
+// Every case name in `suite`, in registration order, including cases this environment would not
+// run. CMake enumerates the ctest entries from this list at build time, so a name must be present
+// whether or not a cluster is configured -- otherwise the set of registered tests would depend on
+// the machine that configured the build.
+[[nodiscard]] auto
+case_names(const test_suite& suite) -> std::vector<std::string>;
+
+// Environment variable holding a factor applied to every case's timeout budget.
+inline constexpr auto timeout_multiplier_variable = "CB_TEST_TIMEOUT_MULTIPLIER";
+
+// Interpret the value of timeout_multiplier_variable; std::nullopt yields 1.0. Budgets are
+// absolute milliseconds and a run under valgrind or a sanitizer is an order of magnitude slower,
+// so without a multiplier such a leg reports timeouts rather than behaviour. A value that is not
+// wholly a positive number throws std::invalid_argument: it is a broken invocation, not a request
+// for the default.
+[[nodiscard]] auto
+timeout_multiplier(const std::optional<std::string>& raw) -> double;
+
+// Multiply every budget in `suite` by `factor`, rounding up, to at least one millisecond.
+void
+scale_timeouts(test_suite& suite, double factor);
 
 // Portable std::getenv wrapper returning std::nullopt for unset *or* empty values, matching the
 // wrappers in tools/utils.cxx and examples/external_circuit_breaker. Needed because MSVC treats


### PR DESCRIPTION
Second ticket of [CXXCBC-945](https://issues.couchbase.com/browse/CXXCBC-945). **Stacked on #1070**, whose commit is included below it — GitHub cannot take a base branch that lives in a fork, so this targets `main` and carries both. Review #1070 first; once it merges this reduces to its own commit.

## Why

`catch_discover_tests` gives the Catch2 suites one ctest entry per case. The framework gave one per executable, and two things depend on the finer granularity:

- `bin/run-integration-tests` shards the valgrind leg with `ctest -I ${CB_TEST_SHARD_INDEX},,${CB_TEST_SHARD_TOTAL}`. The stride runs over ctest entries, so a migrated 5,000-line binary would become one indivisible unit no shard could split.
- `--output-junit results.xml` is what the CI report is built from, one row per entry.

Separately, the framework kills a case that exceeds an absolute millisecond budget. Valgrind is 20–50× slower than the build those budgets were tuned against, so that leg would report timeouts rather than behaviour. No framework test runs under valgrind today, which is why it has never surfaced.

## What changed

**`--list-tests`** in the shared `main()` prints every case name, one per line, *including* cases this environment would skip — so the registered set does not depend on the machine that configured the build.

**`couchbase_discover_tests()`** runs it at post-build and writes one `add_test()` per case, named `<target>.<case>`. Two deliberate hard failures:

- a binary that reports **no** cases fails the build rather than writing an empty list;
- a binary that was never linked registers `<target>_NOT_BUILT`, which cannot pass. An unbuilt test must not read as a test with no failures.

**`couchbase_add_test(<relpath> LABEL <label> [LINK_CLIENT] [LIBS ...])`** takes a path under `test/` and derives the target name by flattening it, so `unit/mcbp/parser.cxx` and `unit/json/parser.cxx` can coexist — today that combination is a configure-time fatal error. `add_cng_test()` is now a one-line call into it. An unknown `LABEL` is fatal, because a typo'd label silently drops a binary out of the CI leg meant to run it.

It is included **before** `cmake/Testing.cmake` so the function is defined by the time `test/CMakeLists.txt` is read, which is what the per-file migration tickets need.

**`CB_TEST_TIMEOUT_MULTIPLIER`** scales every budget; `bin/run-integration-tests` sets 50 for valgrind and 5 for the other sanitizers. A value that is not wholly a positive number aborts the run — `10x` must not be read as `10`, because a budget nobody asked for is how a leg goes green on timing rather than behaviour.

### Target names change

Flattening the path renames the CNG targets: `cng_dispatcher_test` → `cng_protostellar_dispatcher`. The only references outside CMake were two comments in `.github/workflows/tests.yml`, updated here.

## Verification

Debug + Ninja, `-DCOUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2=ON -DCOUCHBASE_CXX_CLIENT_BUILD_CNG_TESTS=ON`, no cluster configured.

| Check | Result |
|---|---|
| entries registered | every case in the 40 executables gets its own ctest entry, `cng` and `framework` alike |
| `ctest -I 1,,2` / `-I 2,,2` | the two halves partition the suite: empty intersection, union the whole |
| junit rows | one `<testcase ` per registered entry, none missing and none doubled |
| single case | `-R 'cng_protostellar_kv_converter\.expiry_encodes_every_branch_explicitly'` runs 1 |
| `--list-tests` stability | identical with and without `TEST_CONNECTION_STRING` |
| same stem, different dirs | two throwaway `parser.cxx` files configured, built and registered as `cng_tmpa_parser.it_parses` / `cng_tmpb_parser.it_parses` (removed again) |
| `_NOT_BUILT` | removing a generated list file registers `cng_protostellar_retry_NOT_BUILT`, which fails `(Not Run)` |
| bad multiplier | `CB_TEST_TIMEOUT_MULTIPLIER=10x` → `must be a positive number, got "10x"`, exit 1 |
| multiplier applied | `=10` turns a 5,000 ms budget into 50,000 ms in the runner's own output |
| no transport dependency | `-DCOUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2=OFF` builds the framework and its self-test passes |

Self-test cases were added for the new code: `case_names` covering the slow list, the multiplier parse (including the `10x`, `0` and `-1` rejections), `scale_timeouts` never rounding a budget down to zero, and a case that times out on its original budget and passes on the scaled one.

Not verified here: any TSan, Windows or multi-config (MSVC) leg. The multi-config path in `couchbase_discover_tests` is written but has only been exercised single-config.


[CXXCBC-945]: https://couchbasecloud.atlassian.net/browse/CXXCBC-945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
