### PR TITLE
CXXCBC-948: let a case declare what it needs, and let the runner decide

### DIFF
--- a/cmake/TestFramework.cmake
+++ b/cmake/TestFramework.cmake
@@ -11,6 +11,8 @@ find_package(Threads REQUIRED)
 # includes from one root: "framework/test_runner.hxx", "cng/fixtures/live_fixture.hxx".
 add_library(
   test_framework_main STATIC
+  ${PROJECT_SOURCE_DIR}/test/framework/context.cxx
+  ${PROJECT_SOURCE_DIR}/test/framework/requirement.cxx
   ${PROJECT_SOURCE_DIR}/test/framework/test_runner.cxx
   ${PROJECT_SOURCE_DIR}/test/framework/test_main.cxx)
 target_include_directories(test_framework_main PUBLIC ${PROJECT_SOURCE_DIR}/test
@@ -26,6 +28,51 @@ target_include_directories(test_framework_main PUBLIC ${PROJECT_SOURCE_DIR}/test
 target_link_libraries(test_framework_main PUBLIC Threads::Threads spdlog::spdlog)
 set_project_options(test_framework_main)
 set_project_warnings(test_framework_main)
+
+# The shared cluster helpers. Promoted out of test/CMakeLists.txt because the framework's cluster
+# probes are built on them, so they have to exist whenever either suite is built rather than only
+# when the Catch2 suite is.
+if(NOT TARGET test_utils)
+  add_subdirectory(test/utils)
+endif()
+
+# Exactly one of these provides make_probe_backend(), and couchbase_add_test() picks which by
+# whether the test links the client library. OBJECT rather than STATIC so the definition is always
+# contributed: an archive is only searched when something already references what it holds, and the
+# reference here comes from the framework's own main().
+#
+# The null one answers every probe with "I cannot ask", which the runner reports as undetermined and
+# therefore as a failure. A test that asks about the server from a binary with no way to reach one
+# is a registration mistake, and skipping it would hide the mistake for as long as it existed.
+add_library(test_framework_null_probes OBJECT ${PROJECT_SOURCE_DIR}/test/framework/null_probes.cxx)
+target_include_directories(test_framework_null_probes PRIVATE ${PROJECT_SOURCE_DIR}/test)
+target_include_directories(
+  test_framework_null_probes SYSTEM BEFORE
+  PRIVATE $<BUILD_INTERFACE:$<TARGET_PROPERTY:spdlog::spdlog,INTERFACE_INCLUDE_DIRECTORIES>>)
+set_target_properties(test_framework_null_probes PROPERTIES POSITION_INDEPENDENT_CODE ON)
+set_project_options(test_framework_null_probes)
+set_project_warnings(test_framework_null_probes)
+
+# The real one drives a connection through test::utils::integration_test_guard, so it is the only
+# part of the framework that includes core headers -- and it is a .cxx, which is what keeps
+# context.hxx lean.
+add_library(test_framework_cluster_probes OBJECT
+            ${PROJECT_SOURCE_DIR}/test/framework/cluster_probes.cxx)
+target_include_directories(
+  test_framework_cluster_probes PRIVATE ${PROJECT_SOURCE_DIR}/test ${PROJECT_SOURCE_DIR}
+                                       ${PROJECT_BINARY_DIR}/generated
+                                       ${PROJECT_BINARY_DIR}/generated_$<CONFIG>)
+target_include_directories(
+  test_framework_cluster_probes SYSTEM BEFORE
+  PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third_party/expected/include>
+          $<BUILD_INTERFACE:$<TARGET_PROPERTY:spdlog::spdlog,INTERFACE_INCLUDE_DIRECTORIES>>
+          $<BUILD_INTERFACE:$<TARGET_PROPERTY:asio,INTERFACE_INCLUDE_DIRECTORIES>>)
+propagate_public_compile_definitions(test_framework_cluster_probes spdlog::spdlog asio)
+target_link_libraries(test_framework_cluster_probes PRIVATE $<BUILD_INTERFACE:Microsoft.GSL::GSL>
+                                                            $<BUILD_INTERFACE:taocpp::json>)
+set_target_properties(test_framework_cluster_probes PROPERTIES POSITION_INDEPENDENT_CODE ON)
+set_project_options(test_framework_cluster_probes)
+set_project_warnings(test_framework_cluster_probes)
 
 # couchbase_discover_tests(<target> PROPERTIES <prop> <value>...)
 #
@@ -149,14 +196,35 @@ function(couchbase_add_test relpath)
               $<BUILD_INTERFACE:$<TARGET_PROPERTY:asio,INTERFACE_INCLUDE_DIRECTORIES>>)
     propagate_public_compile_definitions(${target} spdlog::spdlog asio)
     target_link_libraries(
-      ${target} PRIVATE ${couchbase_cxx_client_test_library} $<BUILD_INTERFACE:Microsoft.GSL::GSL>
-                        $<BUILD_INTERFACE:taocpp::json>)
+      ${target}
+      PRIVATE ${couchbase_cxx_client_test_library} test_framework_cluster_probes test_utils
+              $<BUILD_INTERFACE:Microsoft.GSL::GSL> $<BUILD_INTERFACE:taocpp::json>)
+  else()
+    target_link_libraries(${target} PRIVATE test_framework_null_probes)
   endif()
   if(ARG_LIBS)
     target_link_libraries(${target} PRIVATE ${ARG_LIBS})
   endif()
   set_project_options(${target})
   set_project_warnings(${target})
+
+  # Join the aggregate that build_<suite>_tests depends on. bin/build-tests builds that aggregate
+  # rather than `all` whenever CB_TEST_SUITE is set, and a target missing from it is not built --
+  # which leaves the discovery file absent and the case registered as the _NOT_BUILT placeholder.
+  #
+  # cmake/Testing.cmake blanks these properties, and it is included after this file, so an append
+  # made while this file is being read is discarded. Only calls from test/CMakeLists.txt, which
+  # Testing.cmake reads later, survive -- which is why a framework test that needs to be in an
+  # aggregate is registered there and not here. cng has no aggregate; it is built only by `all`.
+  if(ARG_LABEL STREQUAL "unit")
+    set_property(GLOBAL APPEND PROPERTY COUCHBASE_UNIT_TESTS ${target})
+  elseif(ARG_LABEL STREQUAL "integration")
+    set_property(GLOBAL APPEND PROPERTY COUCHBASE_INTEGRATION_TESTS ${target})
+  elseif(ARG_LABEL STREQUAL "transaction")
+    set_property(GLOBAL APPEND PROPERTY COUCHBASE_TRANSACTION_TESTS ${target})
+  elseif(ARG_LABEL STREQUAL "benchmark")
+    set_property(GLOBAL APPEND PROPERTY COUCHBASE_BENCHMARKS ${target})
+  endif()
 
   # The harness returns 77 when every case was skipped; map that to ctest's "Skipped".
   set(properties SKIP_RETURN_CODE 77 LABELS "${ARG_LABEL}")

--- a/cmake/TestFrameworkAddTests.cmake
+++ b/cmake/TestFrameworkAddTests.cmake
@@ -27,7 +27,10 @@ string(REPLACE "\n" ";" listing "${listing}")
 # have silently truncated the ENVIRONMENT property rather than failing.
 set(script "set(properties [==[${TEST_PROPERTIES}]==])\n")
 set(case_count 0)
-foreach(case_name IN LISTS listing)
+foreach(line IN LISTS listing)
+  # Each line is "<case name>\t<what it requires>". Only the name is registered; the requirements
+  # are there for whoever runs --list-tests by hand.
+  string(REGEX REPLACE "\t.*$" "" case_name "${line}")
   string(STRIP "${case_name}" case_name)
   if(case_name STREQUAL "")
     continue()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-add_subdirectory(utils)
-
 integration_test(connect)
 integration_test(crud)
 integration_test(query)
@@ -114,3 +112,10 @@ if(COUCHBASE_CXX_CLIENT_COLUMNAR)
   integration_test(columnar_management)
   unit_test(columnar_retry)
 endif()
+
+# The framework's cluster-probe selftest. Registered here rather than in cmake/TestFramework.cmake
+# because couchbase_add_test() appends the target to COUCHBASE_INTEGRATION_TESTS, and
+# cmake/Testing.cmake blanks that property after TestFramework.cmake has been read -- an append made
+# from there would be discarded, and build_integration_tests would omit the target. It links the
+# client, so it has no place in the CNG-only configuration that reads TestFramework.cmake alone.
+couchbase_add_test(framework/cluster_probes_selftest LABEL integration LINK_CLIENT)

--- a/test/cng/README.md
+++ b/test/cng/README.md
@@ -4,11 +4,19 @@ These tests exercise the Protostellar / Cloud Native Gateway (CNG) transport. Th
 with the hand-rolled harness under `test/framework/` (not Catch2) and are enabled by the
 `COUCHBASE_CXX_CLIENT_BUILD_CNG_TESTS` CMake option.
 
-Each test declares an environment gate:
+Each case declares what it requires of the environment, beside its registration rather than inside
+its body — `{ needs::real_cluster() }`, `{ needs::service("n1ql") }`, and so on. The runner checks
+those before the case and decides:
 
-- **env-agnostic** — runs anywhere; uses in-process or loopback gRPC servers. No cluster needed.
-- **cluster-only** — needs a reachable `couchbase2://` gateway; skipped when
-  `TEST_CONNECTION_STRING` is unset (the harness exits `77`, which ctest reports as *Skipped*).
+- **satisfied** — the case runs.
+- **not satisfied** — the case is skipped, and the run ends with a list of what was missing and how
+  many cases each gap turned away. A case with no requirements needs no server: it is pure, or it
+  stands up an in-process gRPC server of its own.
+- **undetermined** — the case **fails**. A configured gateway that cannot be reached is not the same
+  as no gateway configured, and only the second is a reason to skip.
+
+`ctest` reports a binary whose every case was skipped as *Skipped* (the harness exits `77`).
+`<binary> --list-tests` prints each case with what it requires.
 
 Getting the cluster-only tests to run means standing up a Couchbase cluster whose Cloud Native
 Gateway is deployed, and pointing the tests at its `couchbase2://` endpoint. The rest of this

--- a/test/cng/cluster/couchbase2_build_support.cxx
+++ b/test/cng/cluster/couchbase2_build_support.cxx
@@ -60,7 +60,7 @@ using ::couchbase::core::utils::parse_connection_string;
 // Parsing is deliberately identical in both builds: it is the library's public behaviour and must
 // not depend on how the library was compiled. Only the open outcome differs.
 void
-couchbase2_parses_identically_regardless_of_build_support()
+couchbase2_parses_identically_regardless_of_build_support([[maybe_unused]] context& ctx)
 {
   const auto parsed = parse_connection_string("couchbase2://gateway.example.com");
   assert_true(parsed.error == std::nullopt, "couchbase2:// parses without error in any build");
@@ -70,7 +70,8 @@ couchbase2_parses_identically_regardless_of_build_support()
 }
 
 void
-opening_couchbase2_without_build_support_reports_feature_not_available()
+opening_couchbase2_without_build_support_reports_feature_not_available(
+  [[maybe_unused]] context& ctx)
 {
 #ifdef COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2
   skip("this build has couchbase2 support, so the unsupported-build branch is not compiled");

--- a/test/cng/connection_string/couchbase2_scheme.cxx
+++ b/test/cng/connection_string/couchbase2_scheme.cxx
@@ -34,7 +34,7 @@ using ::couchbase::core::utils::connection_string;
 using ::couchbase::core::utils::parse_connection_string;
 
 void
-couchbase2_defaults()
+couchbase2_defaults([[maybe_unused]] context& ctx)
 {
   const auto cs = parse_connection_string("couchbase2://localhost");
   assert_false(cs.error.has_value(), "parses without error");
@@ -51,7 +51,7 @@ couchbase2_defaults()
 }
 
 void
-couchbase2_explicit_port_wins()
+couchbase2_explicit_port_wins([[maybe_unused]] context& ctx)
 {
   const auto cs = parse_connection_string("couchbase2://example.com:12345");
   assert_false(cs.error.has_value(), "parses without error");
@@ -64,7 +64,7 @@ couchbase2_explicit_port_wins()
 // through: exactly one host is meaningful. Silently using the first and dropping the rest would
 // hide a misconfiguration, so the parser rejects it. couchbase-jvm-clients rejects the same shape.
 void
-couchbase2_rejects_multiple_hosts()
+couchbase2_rejects_multiple_hosts([[maybe_unused]] context& ctx)
 {
   const auto cs = parse_connection_string("couchbase2://a.example.com,b.example.com,c.example.com");
   assert_true(cs.error.has_value(), "multiple hosts are rejected");
@@ -79,7 +79,7 @@ couchbase2_rejects_multiple_hosts()
 // The gateway uses neither MCBP nor HTTP config bootstrap, so a per-node mode suffix cannot be
 // honoured. Rejected for the same reason as extra hosts.
 void
-couchbase2_rejects_mode_suffix()
+couchbase2_rejects_mode_suffix([[maybe_unused]] context& ctx)
 {
   for (const auto* input : { "couchbase2://host=mcd", "couchbase2://host=http" }) {
     const auto cs = parse_connection_string(input);
@@ -93,7 +93,7 @@ couchbase2_rejects_mode_suffix()
 // off regardless of the string looking SRV-eligible (single DNS host, no port), which is exactly
 // the shape that enables it for couchbase://.
 void
-couchbase2_disables_dns_srv()
+couchbase2_disables_dns_srv([[maybe_unused]] context& ctx)
 {
   const auto cs = parse_connection_string("couchbase2://localhost");
   assert_false(cs.error.has_value(), "parses without error");
@@ -104,7 +104,7 @@ couchbase2_disables_dns_srv()
 }
 
 void
-couchbase2_params_pass_through()
+couchbase2_params_pass_through([[maybe_unused]] context& ctx)
 {
   const auto cs = parse_connection_string("couchbase2://host?kv_timeout=5000");
   assert_false(cs.error.has_value(), "parses with options without error");
@@ -113,7 +113,7 @@ couchbase2_params_pass_through()
 }
 
 void
-classic_schemes_remain_mcbp()
+classic_schemes_remain_mcbp([[maybe_unused]] context& ctx)
 {
   const auto plain = parse_connection_string("couchbase://host");
   assert_false(plain.uses_protostellar(), "couchbase is MCBP");

--- a/test/cng/origin/protocol.cxx
+++ b/test/cng/origin/protocol.cxx
@@ -37,7 +37,7 @@ using ::couchbase::core::origin;
 using ::couchbase::core::utils::parse_connection_string;
 
 void
-couchbase2_origin_is_protostellar()
+couchbase2_origin_is_protostellar([[maybe_unused]] context& ctx)
 {
   const auto cs = parse_connection_string("couchbase2://localhost");
   assert_false(cs.error.has_value(), "connection string parses");
@@ -46,7 +46,7 @@ couchbase2_origin_is_protostellar()
 }
 
 void
-classic_origin_is_not_protostellar()
+classic_origin_is_not_protostellar([[maybe_unused]] context& ctx)
 {
   const auto cs = parse_connection_string("couchbase://localhost");
   assert_false(cs.error.has_value(), "connection string parses");
@@ -55,7 +55,7 @@ classic_origin_is_not_protostellar()
 }
 
 void
-protocol_survives_copy_and_move()
+protocol_survives_copy_and_move([[maybe_unused]] context& ctx)
 {
   const auto cs = parse_connection_string("couchbase2://localhost");
   assert_false(cs.error.has_value(), "connection string parses");
@@ -94,7 +94,7 @@ protocol_survives_copy_and_move()
 // the flag therefore costs an unconditional 500 ms backoff per session. Pinned here so the
 // semantics cannot regress silently.
 void
-rotation_state_resets_on_copy_and_travels_on_move()
+rotation_state_resets_on_copy_and_travels_on_move([[maybe_unused]] context& ctx)
 {
   auto cs = parse_connection_string("couchbase://a.example.com,b.example.com");
   assert_false(cs.error.has_value(), "connection string parses");

--- a/test/cng/protostellar/analytics_converter.cxx
+++ b/test/cng/protostellar/analytics_converter.cxx
@@ -52,7 +52,7 @@ binary_json(const std::string& json) -> couchbase::core::json_string
 }
 
 void
-encode_maps_core_fields()
+encode_maps_core_fields([[maybe_unused]] context& ctx)
 {
   ops::analytics_request request;
   request.statement = "SELECT 1";
@@ -81,7 +81,7 @@ encode_maps_core_fields()
 // sends
 // "". Asserting the length as well as the value keeps an empty-vs-empty comparison from passing.
 void
-parameters_from_the_binary_arm_carry_their_payload()
+parameters_from_the_binary_arm_carry_their_payload([[maybe_unused]] context& ctx)
 {
   const std::string payload{ R"({"a":1})" };
 
@@ -101,7 +101,7 @@ parameters_from_the_binary_arm_carry_their_payload()
 // A default-constructed json_string holds neither arm; it must encode as empty rather than trip
 // over the variant.
 void
-an_empty_parameter_encodes_as_empty()
+an_empty_parameter_encodes_as_empty([[maybe_unused]] context& ctx)
 {
   ops::analytics_request request;
   request.statement = "SELECT $1";
@@ -113,7 +113,7 @@ an_empty_parameter_encodes_as_empty()
 }
 
 void
-can_encode_rejects_unsupported_features()
+can_encode_rejects_unsupported_features([[maybe_unused]] context& ctx)
 {
   ops::analytics_request base;
   base.statement = "SELECT 1";
@@ -135,7 +135,7 @@ can_encode_rejects_unsupported_features()
 // analytics_scope_name, so there is nowhere to put a bucket/scope pair; encoding any of these would
 // drop the qualification and run the statement against the wrong scope.
 void
-can_encode_rejects_every_scope_qualification()
+can_encode_rejects_every_scope_qualification([[maybe_unused]] context& ctx)
 {
   ops::analytics_request base;
   base.statement = "SELECT 1";
@@ -154,7 +154,7 @@ can_encode_rejects_every_scope_qualification()
 }
 
 void
-decode_meta_data_maps_status_metrics_warnings()
+decode_meta_data_maps_status_metrics_warnings([[maybe_unused]] context& ctx)
 {
   v1::AnalyticsQueryResponse_MetaData proto;
   proto.set_request_id("req-9");
@@ -184,7 +184,7 @@ decode_meta_data_maps_status_metrics_warnings()
 // converter. Appending would duplicate warnings on this path only, and would grow without bound if
 // a gateway ever sent more than one MetaData message on a stream.
 void
-warnings_are_replaced_when_metadata_is_decoded_again()
+warnings_are_replaced_when_metadata_is_decoded_again([[maybe_unused]] context& ctx)
 {
   v1::AnalyticsQueryResponse_MetaData proto;
   proto.set_status("success");
@@ -205,7 +205,7 @@ warnings_are_replaced_when_metadata_is_decoded_again()
 // to reach the same enumerator, and anything unrecognised must land on `unknown` rather than on the
 // zero-valued `running`, which would read as a query still in flight.
 void
-status_strings_map_to_the_core_enum()
+status_strings_map_to_the_core_enum([[maybe_unused]] context& ctx)
 {
   const auto decode = [](const char* status) {
     v1::AnalyticsQueryResponse_MetaData proto;

--- a/test/cng/protostellar/bucket_admin_converter.cxx
+++ b/test/cng/protostellar/bucket_admin_converter.cxx
@@ -34,7 +34,7 @@ namespace mgmt = ::couchbase::core::management::cluster;
 namespace v1 = ::couchbase::admin::bucket::v1;
 
 void
-apply_settings_maps_fields()
+apply_settings_maps_fields([[maybe_unused]] context& ctx)
 {
   mgmt::bucket_settings settings;
   settings.name = "b";
@@ -60,7 +60,7 @@ apply_settings_maps_fields()
 }
 
 void
-apply_settings_omits_unset_ram_quota()
+apply_settings_omits_unset_ram_quota([[maybe_unused]] context& ctx)
 {
   mgmt::bucket_settings settings;
   settings.name = "b";
@@ -77,7 +77,7 @@ apply_settings_omits_unset_ram_quota()
 }
 
 void
-apply_settings_rejects_memcached()
+apply_settings_rejects_memcached([[maybe_unused]] context& ctx)
 {
   mgmt::bucket_settings settings;
   settings.name = "legacy";
@@ -89,7 +89,7 @@ apply_settings_rejects_memcached()
 }
 
 void
-decode_bucket_maps_fields()
+decode_bucket_maps_fields([[maybe_unused]] context& ctx)
 {
   v1::ListBucketsResponse_Bucket proto;
   proto.set_bucket_name("travel");
@@ -114,7 +114,7 @@ decode_bucket_maps_fields()
 // Each of these settings is one the encode side writes, so a decode that skips it makes
 // get_bucket -> modify -> update_bucket send a default back and reset the bucket.
 void
-decode_bucket_reads_the_settings_update_would_resend()
+decode_bucket_reads_the_settings_update_would_resend([[maybe_unused]] context& ctx)
 {
   v1::ListBucketsResponse_Bucket proto;
   proto.set_bucket_name("magma");
@@ -139,7 +139,7 @@ decode_bucket_reads_the_settings_update_would_resend()
 }
 
 void
-decode_bucket_leaves_absent_optional_settings_unset()
+decode_bucket_leaves_absent_optional_settings_unset([[maybe_unused]] context& ctx)
 {
   v1::ListBucketsResponse_Bucket proto;
   proto.set_bucket_name("b");
@@ -156,7 +156,7 @@ decode_bucket_leaves_absent_optional_settings_unset()
 }
 
 void
-decode_bucket_drops_a_history_retention_the_core_field_cannot_hold()
+decode_bucket_drops_a_history_retention_the_core_field_cannot_hold([[maybe_unused]] context& ctx)
 {
   v1::ListBucketsResponse_Bucket proto;
   proto.set_bucket_name("b");

--- a/test/cng/protostellar/callback_queue_churn.cxx
+++ b/test/cng/protostellar/callback_queue_churn.cxx
@@ -131,7 +131,7 @@ cycles_from_environment() -> int
 }
 
 void
-cycling_servers_does_not_abort_the_process()
+cycling_servers_does_not_abort_the_process([[maybe_unused]] context& ctx)
 {
   if (!safe_getenv("CNG_CALLBACK_QUEUE_NO_KEEPALIVE").has_value()) {
     pin_callback_queue();
@@ -159,6 +159,7 @@ tests() -> test_suite
     {
       { "cycling_servers_does_not_abort_the_process",
         cycling_servers_does_not_abort_the_process,
+        {},
         timeout::network },
     },
   };

--- a/test/cng/protostellar/codegen_smoke.cxx
+++ b/test/cng/protostellar/codegen_smoke.cxx
@@ -32,7 +32,7 @@ namespace couchbase::test
 namespace
 {
 void
-kv_message_roundtrips()
+kv_message_roundtrips([[maybe_unused]] context& ctx)
 {
   ::couchbase::kv::v1::GetRequest req;
   req.set_bucket_name("travel-sample");
@@ -52,7 +52,7 @@ kv_message_roundtrips()
 }
 
 void
-googleapis_status_message_is_available()
+googleapis_status_message_is_available([[maybe_unused]] context& ctx)
 {
   // Proves google/rpc/status.proto (the sole googleapis import) was fetched and compiled.
   ::google::rpc::Status status;
@@ -62,7 +62,7 @@ googleapis_status_message_is_available()
 }
 
 void
-grpc_service_stub_is_generated()
+grpc_service_stub_is_generated([[maybe_unused]] context& ctx)
 {
   // Proves the gRPC plugin ran and its output linked: the generated service exposes its full
   // name, and the Stub type is a complete type.
@@ -84,11 +84,12 @@ tests() -> test_suite
     {
       // All three are in-memory message/stub checks with no I/O, so they get the tightest preset
       // rather than the 5 s network default.
-      { "kv_message_roundtrips", kv_message_roundtrips, timeout::instant },
+      { "kv_message_roundtrips", kv_message_roundtrips, {}, timeout::instant },
       { "googleapis_status_message_is_available",
         googleapis_status_message_is_available,
+        {},
         timeout::instant },
-      { "grpc_service_stub_is_generated", grpc_service_stub_is_generated, timeout::instant },
+      { "grpc_service_stub_is_generated", grpc_service_stub_is_generated, {}, timeout::instant },
     },
   };
 }

--- a/test/cng/protostellar/collection_admin_converter.cxx
+++ b/test/cng/protostellar/collection_admin_converter.cxx
@@ -33,7 +33,7 @@ namespace ca = ::couchbase::core::protostellar::collection_admin;
 namespace v1 = ::couchbase::admin::collection::v1;
 
 void
-decode_manifest_maps_scopes_and_collections()
+decode_manifest_maps_scopes_and_collections([[maybe_unused]] context& ctx)
 {
   v1::ListCollectionsResponse proto;
   proto.set_manifest_uid(42);
@@ -67,7 +67,7 @@ decode_manifest_maps_scopes_and_collections()
 // max_expiry is the one collection field whose meaning is carried by a sign the wire cannot hold,
 // so the two halves of the mapping are pinned separately and then against each other.
 void
-encode_max_expiry_moves_the_sentinel_into_field_presence()
+encode_max_expiry_moves_the_sentinel_into_field_presence([[maybe_unused]] context& ctx)
 {
   const auto no_expiry = ca::encode_max_expiry(-1);
   assert_true(no_expiry.has_value(), "no-expiry is written to the wire");
@@ -81,7 +81,7 @@ encode_max_expiry_moves_the_sentinel_into_field_presence()
 }
 
 void
-decode_max_expiry_reads_field_presence_back_as_the_sentinel()
+decode_max_expiry_reads_field_presence_back_as_the_sentinel([[maybe_unused]] context& ctx)
 {
   v1::ListCollectionsResponse proto;
   auto* scope = proto.add_scopes();
@@ -106,7 +106,7 @@ decode_max_expiry_reads_field_presence_back_as_the_sentinel()
 // The encode and decode above are only correct together: reading a collection back has to return
 // the max_expiry it was created with, which is what a caller comparing the two ever sees.
 void
-max_expiry_round_trips_through_the_wire_form()
+max_expiry_round_trips_through_the_wire_form([[maybe_unused]] context& ctx)
 {
   for (const auto expected : { std::int32_t{ -1 }, std::int32_t{ 0 }, std::int32_t{ 900 } }) {
     v1::ListCollectionsResponse proto;

--- a/test/cng/protostellar/component.cxx
+++ b/test/cng/protostellar/component.cxx
@@ -242,7 +242,7 @@ make_id(std::string key) -> document_id
 }
 
 void
-get_round_trips_on_the_io_thread()
+get_round_trips_on_the_io_thread([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   asio::io_context io;
@@ -268,7 +268,7 @@ get_round_trips_on_the_io_thread()
 }
 
 void
-get_maps_not_found_into_the_error_context()
+get_maps_not_found_into_the_error_context([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   asio::io_context io;
@@ -290,7 +290,7 @@ get_maps_not_found_into_the_error_context()
 }
 
 void
-upsert_returns_cas_and_mutation_token()
+upsert_returns_cas_and_mutation_token([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   asio::io_context io;
@@ -315,7 +315,7 @@ upsert_returns_cas_and_mutation_token()
 }
 
 void
-get_decompresses_compressed_content()
+get_decompresses_compressed_content([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   asio::io_context io;
@@ -339,7 +339,7 @@ get_decompresses_compressed_content()
 }
 
 void
-upsert_compresses_large_payload_when_enabled()
+upsert_compresses_large_payload_when_enabled([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   asio::io_context io;
@@ -373,7 +373,7 @@ upsert_compresses_large_payload_when_enabled()
 }
 
 void
-insert_returns_cas_and_mutation_token()
+insert_returns_cas_and_mutation_token([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   asio::io_context io;
@@ -398,7 +398,7 @@ insert_returns_cas_and_mutation_token()
 }
 
 void
-insert_maps_already_exists_into_error_context()
+insert_maps_already_exists_into_error_context([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   asio::io_context io;
@@ -421,7 +421,7 @@ insert_maps_already_exists_into_error_context()
 }
 
 void
-replace_returns_cas_and_mutation_token()
+replace_returns_cas_and_mutation_token([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   asio::io_context io;
@@ -446,7 +446,7 @@ replace_returns_cas_and_mutation_token()
 }
 
 void
-replace_maps_not_found_into_error_context()
+replace_maps_not_found_into_error_context([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   asio::io_context io;
@@ -469,7 +469,7 @@ replace_maps_not_found_into_error_context()
 }
 
 void
-remove_returns_cas_and_mutation_token()
+remove_returns_cas_and_mutation_token([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   asio::io_context io;
@@ -493,7 +493,7 @@ remove_returns_cas_and_mutation_token()
 }
 
 void
-remove_maps_not_found_into_error_context()
+remove_maps_not_found_into_error_context([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   asio::io_context io;
@@ -515,7 +515,7 @@ remove_maps_not_found_into_error_context()
 }
 
 void
-authorization_header_passed_to_grpc_context()
+authorization_header_passed_to_grpc_context([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   asio::io_context io;
@@ -552,7 +552,7 @@ authorization_header_passed_to_grpc_context()
 // takes 400ms -- if the default were used the call would succeed instead), and that a timed-out
 // read reports unambiguous_timeout, since a get cannot have changed the document.
 void
-get_honours_the_request_timeout()
+get_honours_the_request_timeout([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   server.service().reply_delay.store(400ms);
@@ -582,7 +582,7 @@ get_honours_the_request_timeout()
 // The mutating arm of the same mapping. Kept as a separate case because a single shared
 // classification would satisfy the read-only assertion above by accident.
 void
-mutation_timeout_is_reported_as_ambiguous()
+mutation_timeout_is_reported_as_ambiguous([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   server.service().reply_delay.store(400ms);
@@ -614,7 +614,7 @@ mutation_timeout_is_reported_as_ambiguous()
 // calls_received is what makes this a real assertion rather than a restatement of the error code:
 // it proves the request was rejected before reaching the wire, not dispatched and then failed.
 void
-an_exhausted_budget_is_rejected_before_dispatch()
+an_exhausted_budget_is_rejected_before_dispatch([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   asio::io_context io;
@@ -649,7 +649,7 @@ an_exhausted_budget_is_rejected_before_dispatch()
 // the caller: request.timeout is unset here, so the component's own default is what resolves to
 // zero.
 void
-an_exhausted_default_timeout_is_also_rejected()
+an_exhausted_default_timeout_is_also_rejected([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   asio::io_context io;
@@ -680,7 +680,7 @@ an_exhausted_default_timeout_is_also_rejected()
 // and then rejected by the gateway" would both surface as invalid_argument, and only the counter
 // separates them.
 void
-a_counter_seed_above_int64_max_is_rejected_before_dispatch()
+a_counter_seed_above_int64_max_is_rejected_before_dispatch([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   asio::io_context io;
@@ -712,7 +712,7 @@ a_counter_seed_above_int64_max_is_rejected_before_dispatch()
 // Cancelling an in-flight call still completes the handler, exactly once. A cancellation that
 // dropped the completion would hang whatever is waiting on it, which is worse than the error.
 void
-cancellation_completes_the_handler_once()
+cancellation_completes_the_handler_once([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   server.service().reply_delay.store(400ms);
@@ -740,7 +740,7 @@ cancellation_completes_the_handler_once()
 }
 
 void
-get_projected_encodes_projections_and_decodes_response()
+get_projected_encodes_projections_and_decodes_response([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   asio::io_context io;
@@ -770,7 +770,7 @@ get_projected_encodes_projections_and_decodes_response()
 // the request's own field. Both halves are asserted on one call: what left the client, and what it
 // made of the compressed answer that opting in invites.
 void
-get_projected_negotiates_and_decodes_compression()
+get_projected_negotiates_and_decodes_compression([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   asio::io_context io;
@@ -808,61 +808,82 @@ tests() -> test_suite
   return {
     "protostellar_component",
     {
-      { "get_round_trips_on_the_io_thread", get_round_trips_on_the_io_thread, timeout::network },
+      { "get_round_trips_on_the_io_thread",
+        get_round_trips_on_the_io_thread,
+        {},
+        timeout::network },
       { "get_projected_negotiates_and_decodes_compression",
         get_projected_negotiates_and_decodes_compression,
+        {},
         timeout::network },
       { "get_projected_encodes_projections_and_decodes_response",
         get_projected_encodes_projections_and_decodes_response,
+        {},
         timeout::network },
       { "get_maps_not_found_into_the_error_context",
         get_maps_not_found_into_the_error_context,
+        {},
         timeout::network },
       { "get_decompresses_compressed_content",
         get_decompresses_compressed_content,
+        {},
         timeout::network },
       { "upsert_compresses_large_payload_when_enabled",
         upsert_compresses_large_payload_when_enabled,
+        {},
         timeout::network },
       { "upsert_returns_cas_and_mutation_token",
         upsert_returns_cas_and_mutation_token,
+        {},
         timeout::network },
       { "insert_returns_cas_and_mutation_token",
         insert_returns_cas_and_mutation_token,
+        {},
         timeout::network },
       { "insert_maps_already_exists_into_error_context",
         insert_maps_already_exists_into_error_context,
+        {},
         timeout::network },
       { "replace_returns_cas_and_mutation_token",
         replace_returns_cas_and_mutation_token,
+        {},
         timeout::network },
       { "replace_maps_not_found_into_error_context",
         replace_maps_not_found_into_error_context,
+        {},
         timeout::network },
       { "remove_returns_cas_and_mutation_token",
         remove_returns_cas_and_mutation_token,
+        {},
         timeout::network },
       { "remove_maps_not_found_into_error_context",
         remove_maps_not_found_into_error_context,
+        {},
         timeout::network },
-      { "get_honours_the_request_timeout", get_honours_the_request_timeout, timeout::network },
+      { "get_honours_the_request_timeout", get_honours_the_request_timeout, {}, timeout::network },
       { "mutation_timeout_is_reported_as_ambiguous",
         mutation_timeout_is_reported_as_ambiguous,
+        {},
         timeout::network },
       { "a_counter_seed_above_int64_max_is_rejected_before_dispatch",
         a_counter_seed_above_int64_max_is_rejected_before_dispatch,
+        {},
         timeout::network },
       { "an_exhausted_budget_is_rejected_before_dispatch",
         an_exhausted_budget_is_rejected_before_dispatch,
+        {},
         timeout::network },
       { "an_exhausted_default_timeout_is_also_rejected",
         an_exhausted_default_timeout_is_also_rejected,
+        {},
         timeout::network },
       { "cancellation_completes_the_handler_once",
         cancellation_completes_the_handler_once,
+        {},
         timeout::network },
       { "authorization_header_passed_to_grpc_context",
         authorization_header_passed_to_grpc_context,
+        {},
         timeout::network },
     },
   };

--- a/test/cng/protostellar/component_kv_operations.cxx
+++ b/test/cng/protostellar/component_kv_operations.cxx
@@ -509,7 +509,7 @@ run(in_process_server& server, Request request)
 // --- touch --------------------------------------------------------------------------------------
 
 void
-touch_encodes_a_relative_expiry_and_returns_the_cas()
+touch_encodes_a_relative_expiry_and_returns_the_cas([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   ops::touch_request request;
@@ -527,7 +527,7 @@ touch_encodes_a_relative_expiry_and_returns_the_cas()
 }
 
 void
-touch_encodes_an_expiry_beyond_thirty_days_as_an_absolute_time()
+touch_encodes_an_expiry_beyond_thirty_days_as_an_absolute_time([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   ops::touch_request request;
@@ -546,7 +546,7 @@ touch_encodes_an_expiry_beyond_thirty_days_as_an_absolute_time()
 }
 
 void
-touch_maps_a_missing_document_into_the_error_context()
+touch_maps_a_missing_document_into_the_error_context([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   ops::touch_request request;
@@ -562,7 +562,7 @@ touch_maps_a_missing_document_into_the_error_context()
 // --- exists -------------------------------------------------------------------------------------
 
 void
-exists_reports_a_present_document()
+exists_reports_a_present_document([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   ops::exists_request request;
@@ -576,7 +576,7 @@ exists_reports_a_present_document()
 }
 
 void
-exists_reports_a_missing_document_as_a_success()
+exists_reports_a_missing_document_as_a_success([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   ops::exists_request request;
@@ -594,7 +594,7 @@ exists_reports_a_missing_document_as_a_success()
 // --- get_and_lock -------------------------------------------------------------------------------
 
 void
-get_and_lock_encodes_the_lock_time_and_returns_the_value()
+get_and_lock_encodes_the_lock_time_and_returns_the_value([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   ops::get_and_lock_request request;
@@ -610,7 +610,7 @@ get_and_lock_encodes_the_lock_time_and_returns_the_value()
 }
 
 void
-get_and_lock_maps_a_locked_document_into_document_locked()
+get_and_lock_maps_a_locked_document_into_document_locked([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   ops::get_and_lock_request request;
@@ -624,7 +624,7 @@ get_and_lock_maps_a_locked_document_into_document_locked()
 }
 
 void
-get_and_lock_decompresses_compressed_content()
+get_and_lock_decompresses_compressed_content([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   ops::get_and_lock_request request;
@@ -643,7 +643,7 @@ get_and_lock_decompresses_compressed_content()
 // --- unlock -------------------------------------------------------------------------------------
 
 void
-unlock_sends_the_cas_and_completes()
+unlock_sends_the_cas_and_completes([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   ops::unlock_request request;
@@ -657,7 +657,7 @@ unlock_sends_the_cas_and_completes()
 }
 
 void
-unlock_maps_a_cas_mismatch()
+unlock_maps_a_cas_mismatch([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   ops::unlock_request request;
@@ -671,7 +671,7 @@ unlock_maps_a_cas_mismatch()
 }
 
 void
-unlock_maps_a_document_that_is_not_locked()
+unlock_maps_a_document_that_is_not_locked([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   ops::unlock_request request;
@@ -687,7 +687,7 @@ unlock_maps_a_document_that_is_not_locked()
 // --- get_and_touch ------------------------------------------------------------------------------
 
 void
-get_and_touch_encodes_the_expiry_and_returns_the_value()
+get_and_touch_encodes_the_expiry_and_returns_the_value([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   ops::get_and_touch_request request;
@@ -704,7 +704,7 @@ get_and_touch_encodes_the_expiry_and_returns_the_value()
 }
 
 void
-get_and_touch_decompresses_compressed_content()
+get_and_touch_decompresses_compressed_content([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   ops::get_and_touch_request request;
@@ -721,7 +721,7 @@ get_and_touch_decompresses_compressed_content()
 // --- increment / decrement ----------------------------------------------------------------------
 
 void
-increment_encodes_the_delta_and_initial_and_returns_the_counter()
+increment_encodes_the_delta_and_initial_and_returns_the_counter([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   ops::increment_request request;
@@ -743,7 +743,7 @@ increment_encodes_the_delta_and_initial_and_returns_the_counter()
 }
 
 void
-increment_omits_the_initial_value_when_it_is_unset()
+increment_omits_the_initial_value_when_it_is_unset([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   ops::increment_request request;
@@ -760,7 +760,7 @@ increment_omits_the_initial_value_when_it_is_unset()
 }
 
 void
-decrement_encodes_the_delta_and_initial_and_returns_the_counter()
+decrement_encodes_the_delta_and_initial_and_returns_the_counter([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   ops::decrement_request request;
@@ -782,7 +782,7 @@ decrement_encodes_the_delta_and_initial_and_returns_the_counter()
 }
 
 void
-decrement_reaches_the_decrement_stub_and_not_increment()
+decrement_reaches_the_decrement_stub_and_not_increment([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   ops::decrement_request request;
@@ -801,7 +801,7 @@ decrement_reaches_the_decrement_stub_and_not_increment()
 // --- append / prepend ---------------------------------------------------------------------------
 
 void
-append_sends_the_content_and_returns_the_cas_and_token()
+append_sends_the_content_and_returns_the_cas_and_token([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   ops::append_request request;
@@ -818,7 +818,7 @@ append_sends_the_content_and_returns_the_cas_and_token()
 }
 
 void
-append_omits_the_cas_when_the_caller_did_not_set_one()
+append_omits_the_cas_when_the_caller_did_not_set_one([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   ops::append_request request;
@@ -834,7 +834,7 @@ append_omits_the_cas_when_the_caller_did_not_set_one()
 }
 
 void
-append_sends_the_cas_when_the_caller_set_one()
+append_sends_the_cas_when_the_caller_set_one([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   ops::append_request request;
@@ -850,7 +850,7 @@ append_sends_the_cas_when_the_caller_set_one()
 }
 
 void
-append_maps_a_cas_mismatch()
+append_maps_a_cas_mismatch([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   ops::append_request request;
@@ -865,7 +865,7 @@ append_maps_a_cas_mismatch()
 }
 
 void
-append_maps_a_missing_document()
+append_maps_a_missing_document([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   ops::append_request request;
@@ -881,7 +881,7 @@ append_maps_a_missing_document()
 }
 
 void
-prepend_sends_the_content_and_reaches_the_prepend_stub()
+prepend_sends_the_content_and_reaches_the_prepend_stub([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   ops::prepend_request request;
@@ -1090,7 +1090,7 @@ check_gateway_errors(std::initializer_list<gateway_error> applicable,
 }
 
 void
-touch_maps_every_status_the_gateway_can_return()
+touch_maps_every_status_the_gateway_can_return([[maybe_unused]] context& ctx)
 {
   // kvserver.go Touch: CollectionMissing, CollectionNoWriteAccess, DocLocked, DocMissing, Generic,
   // ScopeMissing. Touch takes the *write* access path even though it changes only the expiry.
@@ -1110,7 +1110,7 @@ touch_maps_every_status_the_gateway_can_return()
 }
 
 void
-exists_maps_every_status_the_gateway_can_return()
+exists_maps_every_status_the_gateway_can_return([[maybe_unused]] context& ctx)
 {
   // kvserver.go Exists: CollectionMissing, CollectionNoReadAccess, Generic, ScopeMissing -- and
   // notably NOT DocMissing. The server cannot report a missing document as an error here, which is
@@ -1128,7 +1128,7 @@ exists_maps_every_status_the_gateway_can_return()
 }
 
 void
-get_and_lock_maps_every_status_the_gateway_can_return()
+get_and_lock_maps_every_status_the_gateway_can_return([[maybe_unused]] context& ctx)
 {
   // kvserver.go GetAndLock: CollectionMissing, CollectionNoReadAccess, DocLocked, DocMissing,
   // Generic, ScopeMissing. DocLocked here is the double-lock case -- locking an already-locked
@@ -1149,7 +1149,7 @@ get_and_lock_maps_every_status_the_gateway_can_return()
 }
 
 void
-unlock_maps_every_status_the_gateway_can_return()
+unlock_maps_every_status_the_gateway_can_return([[maybe_unused]] context& ctx)
 {
   // kvserver.go Unlock: CollectionMissing, CollectionNoWriteAccess, DocCasMismatch, DocMissing,
   // DocNotLocked, Generic, ScopeMissing. There is deliberately no DocLocked in that set -- see
@@ -1171,7 +1171,7 @@ unlock_maps_every_status_the_gateway_can_return()
 }
 
 void
-get_and_touch_maps_every_status_the_gateway_can_return()
+get_and_touch_maps_every_status_the_gateway_can_return([[maybe_unused]] context& ctx)
 {
   check_gateway_errors({ gateway_error::collection_missing,
                          gateway_error::collection_no_read_access,
@@ -1189,7 +1189,7 @@ get_and_touch_maps_every_status_the_gateway_can_return()
 }
 
 void
-increment_maps_every_status_the_gateway_can_return()
+increment_maps_every_status_the_gateway_can_return([[maybe_unused]] context& ctx)
 {
   // kvserver.go Increment adds DocNotNumeric, DurabilityImpossible and SyncWriteAmbiguous, and has
   // no CasMismatch -- IncrementRequest carries no cas field to mismatch against.
@@ -1212,7 +1212,7 @@ increment_maps_every_status_the_gateway_can_return()
 }
 
 void
-decrement_maps_every_status_the_gateway_can_return()
+decrement_maps_every_status_the_gateway_can_return([[maybe_unused]] context& ctx)
 {
   check_gateway_errors({ gateway_error::collection_missing,
                          gateway_error::collection_no_write_access,
@@ -1233,7 +1233,7 @@ decrement_maps_every_status_the_gateway_can_return()
 }
 
 void
-append_maps_every_status_the_gateway_can_return()
+append_maps_every_status_the_gateway_can_return([[maybe_unused]] context& ctx)
 {
   // kvserver.go Append/Prepend are the only two of these nine that can return both CasMismatch and
   // ValueTooLarge, and neither can return DocNotNumeric.
@@ -1257,7 +1257,7 @@ append_maps_every_status_the_gateway_can_return()
 }
 
 void
-prepend_maps_every_status_the_gateway_can_return()
+prepend_maps_every_status_the_gateway_can_return([[maybe_unused]] context& ctx)
 {
   check_gateway_errors({ gateway_error::collection_missing,
                          gateway_error::collection_no_write_access,
@@ -1281,7 +1281,7 @@ prepend_maps_every_status_the_gateway_can_return()
 // --- the contested corners, each pinned with its source ---------------------------------------
 
 void
-unlock_reports_a_bad_cas_as_cas_mismatch_not_locked()
+unlock_reports_a_bad_cas_as_cas_mismatch_not_locked([[maybe_unused]] context& ctx)
 {
   // The classic protocol makes this opcode-dependent: core/protocol/status.cxx maps status
   // `locked` to cas_mismatch when the opcode is `unlock`, and to document_locked otherwise. The
@@ -1303,7 +1303,7 @@ unlock_reports_a_bad_cas_as_cas_mismatch_not_locked()
 }
 
 void
-a_cas_mismatch_arrives_as_error_info_not_precondition_failure()
+a_cas_mismatch_arrives_as_error_info_not_precondition_failure([[maybe_unused]] context& ctx)
 {
   // NewDocCasMismatchStatus packs ErrorInfo{Reason: "CAS_MISMATCH"}; every other contested KV
   // error packs PreconditionFailure. A mapping that only ever looked at PreconditionFailure would
@@ -1322,7 +1322,7 @@ a_cas_mismatch_arrives_as_error_info_not_precondition_failure()
 }
 
 void
-a_locked_document_is_reported_so_the_retry_layer_can_see_it()
+a_locked_document_is_reported_so_the_retry_layer_can_see_it([[maybe_unused]] context& ctx)
 {
   // The contested one. The classic transport does not surface a locked document to the caller at
   // all: core/bucket.cxx and core/io/mcbp_command.hxx raise retry_reason::key_value_locked, which
@@ -1348,7 +1348,7 @@ a_locked_document_is_reported_so_the_retry_layer_can_see_it()
 }
 
 void
-a_detail_free_deadline_is_ambiguous_for_a_mutation_and_not_for_a_read()
+a_detail_free_deadline_is_ambiguous_for_a_mutation_and_not_for_a_read([[maybe_unused]] context& ctx)
 {
   // NewSyncWriteAmbiguousStatus attaches no details at all, so the code is the only signal. A
   // mutation that timed out may already have been applied; a read cannot have changed anything, so
@@ -1372,7 +1372,7 @@ a_detail_free_deadline_is_ambiguous_for_a_mutation_and_not_for_a_read()
 }
 
 void
-an_unrecognised_server_error_is_reported_as_cancelled()
+an_unrecognised_server_error_is_reported_as_cancelled([[maybe_unused]] context& ctx)
 {
   // Surprising, and worth pinning precisely because it is surprising. NewGenericStatus is the
   // gateway's fallback for anything it cannot classify, and its context.Canceled arm returns
@@ -1393,7 +1393,7 @@ an_unrecognised_server_error_is_reported_as_cancelled()
 // --- resource-type routing ------------------------------------------------------------------
 
 void
-a_not_found_resource_type_selects_the_specific_error()
+a_not_found_resource_type_selects_the_specific_error([[maybe_unused]] context& ctx)
 {
   // NOT_FOUND alone cannot say what was missing. RFC 77 puts that in the ResourceInfo detail, and
   // collapsing all four onto document_not_found would tell an operator with a typo in a bucket name
@@ -1433,109 +1433,146 @@ tests() -> test_suite
     {
       { "touch_encodes_a_relative_expiry_and_returns_the_cas",
         touch_encodes_a_relative_expiry_and_returns_the_cas,
+        {},
         timeout::network },
       { "touch_encodes_an_expiry_beyond_thirty_days_as_an_absolute_time",
         touch_encodes_an_expiry_beyond_thirty_days_as_an_absolute_time,
+        {},
         timeout::network },
       { "touch_maps_a_missing_document_into_the_error_context",
         touch_maps_a_missing_document_into_the_error_context,
+        {},
         timeout::network },
-      { "exists_reports_a_present_document", exists_reports_a_present_document, timeout::network },
+      { "exists_reports_a_present_document",
+        exists_reports_a_present_document,
+        {},
+        timeout::network },
       { "exists_reports_a_missing_document_as_a_success",
         exists_reports_a_missing_document_as_a_success,
+        {},
         timeout::network },
       { "get_and_lock_encodes_the_lock_time_and_returns_the_value",
         get_and_lock_encodes_the_lock_time_and_returns_the_value,
+        {},
         timeout::network },
       { "get_and_lock_maps_a_locked_document_into_document_locked",
         get_and_lock_maps_a_locked_document_into_document_locked,
+        {},
         timeout::network },
       { "get_and_lock_decompresses_compressed_content",
         get_and_lock_decompresses_compressed_content,
+        {},
         timeout::network },
       { "unlock_sends_the_cas_and_completes",
         unlock_sends_the_cas_and_completes,
+        {},
         timeout::network },
-      { "unlock_maps_a_cas_mismatch", unlock_maps_a_cas_mismatch, timeout::network },
+      { "unlock_maps_a_cas_mismatch", unlock_maps_a_cas_mismatch, {}, timeout::network },
       { "unlock_maps_a_document_that_is_not_locked",
         unlock_maps_a_document_that_is_not_locked,
+        {},
         timeout::network },
       { "get_and_touch_encodes_the_expiry_and_returns_the_value",
         get_and_touch_encodes_the_expiry_and_returns_the_value,
+        {},
         timeout::network },
       { "get_and_touch_decompresses_compressed_content",
         get_and_touch_decompresses_compressed_content,
+        {},
         timeout::network },
       { "increment_encodes_the_delta_and_initial_and_returns_the_counter",
         increment_encodes_the_delta_and_initial_and_returns_the_counter,
+        {},
         timeout::network },
       { "increment_omits_the_initial_value_when_it_is_unset",
         increment_omits_the_initial_value_when_it_is_unset,
+        {},
         timeout::network },
       { "decrement_encodes_the_delta_and_initial_and_returns_the_counter",
         decrement_encodes_the_delta_and_initial_and_returns_the_counter,
+        {},
         timeout::network },
       { "decrement_reaches_the_decrement_stub_and_not_increment",
         decrement_reaches_the_decrement_stub_and_not_increment,
+        {},
         timeout::network },
       { "append_sends_the_content_and_returns_the_cas_and_token",
         append_sends_the_content_and_returns_the_cas_and_token,
+        {},
         timeout::network },
       { "append_omits_the_cas_when_the_caller_did_not_set_one",
         append_omits_the_cas_when_the_caller_did_not_set_one,
+        {},
         timeout::network },
       { "append_sends_the_cas_when_the_caller_set_one",
         append_sends_the_cas_when_the_caller_set_one,
+        {},
         timeout::network },
-      { "append_maps_a_cas_mismatch", append_maps_a_cas_mismatch, timeout::network },
-      { "append_maps_a_missing_document", append_maps_a_missing_document, timeout::network },
+      { "append_maps_a_cas_mismatch", append_maps_a_cas_mismatch, {}, timeout::network },
+      { "append_maps_a_missing_document", append_maps_a_missing_document, {}, timeout::network },
       { "prepend_sends_the_content_and_reaches_the_prepend_stub",
         prepend_sends_the_content_and_reaches_the_prepend_stub,
+        {},
         timeout::network },
       { "a_not_found_resource_type_selects_the_specific_error",
         a_not_found_resource_type_selects_the_specific_error,
+        {},
         timeout::network },
       { "touch_maps_every_status_the_gateway_can_return",
         touch_maps_every_status_the_gateway_can_return,
+        {},
         timeout::network },
       { "exists_maps_every_status_the_gateway_can_return",
         exists_maps_every_status_the_gateway_can_return,
+        {},
         timeout::network },
       { "get_and_lock_maps_every_status_the_gateway_can_return",
         get_and_lock_maps_every_status_the_gateway_can_return,
+        {},
         timeout::network },
       { "unlock_maps_every_status_the_gateway_can_return",
         unlock_maps_every_status_the_gateway_can_return,
+        {},
         timeout::network },
       { "get_and_touch_maps_every_status_the_gateway_can_return",
         get_and_touch_maps_every_status_the_gateway_can_return,
+        {},
         timeout::network },
       { "increment_maps_every_status_the_gateway_can_return",
         increment_maps_every_status_the_gateway_can_return,
+        {},
         timeout::network },
       { "decrement_maps_every_status_the_gateway_can_return",
         decrement_maps_every_status_the_gateway_can_return,
+        {},
         timeout::network },
       { "append_maps_every_status_the_gateway_can_return",
         append_maps_every_status_the_gateway_can_return,
+        {},
         timeout::network },
       { "prepend_maps_every_status_the_gateway_can_return",
         prepend_maps_every_status_the_gateway_can_return,
+        {},
         timeout::network },
       { "unlock_reports_a_bad_cas_as_cas_mismatch_not_locked",
         unlock_reports_a_bad_cas_as_cas_mismatch_not_locked,
+        {},
         timeout::network },
       { "a_cas_mismatch_arrives_as_error_info_not_precondition_failure",
         a_cas_mismatch_arrives_as_error_info_not_precondition_failure,
+        {},
         timeout::network },
       { "a_locked_document_is_reported_so_the_retry_layer_can_see_it",
         a_locked_document_is_reported_so_the_retry_layer_can_see_it,
+        {},
         timeout::network },
       { "a_detail_free_deadline_is_ambiguous_for_a_mutation_and_not_for_a_read",
         a_detail_free_deadline_is_ambiguous_for_a_mutation_and_not_for_a_read,
+        {},
         timeout::network },
       { "an_unrecognised_server_error_is_reported_as_cancelled",
         an_unrecognised_server_error_is_reported_as_cancelled,
+        {},
         timeout::network },
     },
   };

--- a/test/cng/protostellar/component_timeouts.cxx
+++ b/test/cng/protostellar/component_timeouts.cxx
@@ -83,7 +83,7 @@ sample_timeouts() -> ps::component_timeouts
 }
 
 void
-non_durable_uses_the_standard_kv_timeout()
+non_durable_uses_the_standard_kv_timeout([[maybe_unused]] context& ctx)
 {
   const auto t = sample_timeouts();
   assert_true(ps::resolve_kv_timeout(std::nullopt, couchbase::durability_level::none, t) == 2'500ms,
@@ -91,7 +91,7 @@ non_durable_uses_the_standard_kv_timeout()
 }
 
 void
-durable_uses_the_durable_timeout()
+durable_uses_the_durable_timeout([[maybe_unused]] context& ctx)
 {
   const auto t = sample_timeouts();
   assert_true(ps::resolve_kv_timeout(std::nullopt, couchbase::durability_level::majority, t) ==
@@ -107,7 +107,7 @@ durable_uses_the_durable_timeout()
 }
 
 void
-explicit_request_timeout_always_wins()
+explicit_request_timeout_always_wins([[maybe_unused]] context& ctx)
 {
   const auto t = sample_timeouts();
   assert_true(ps::resolve_kv_timeout(1'234ms, couchbase::durability_level::none, t) == 1'234ms,
@@ -126,7 +126,7 @@ explicit_request_timeout_always_wins()
 // a guard applied to only the persistence levels -- which is the shape of the disagreement between
 // SDKs here -- would slip past a majority-only case.
 void
-an_explicit_timeout_is_never_raised_to_a_floor()
+an_explicit_timeout_is_never_raised_to_a_floor([[maybe_unused]] context& ctx)
 {
   const auto t = sample_timeouts();
   const std::array<couchbase::durability_level, 3> durable_levels{
@@ -146,7 +146,7 @@ an_explicit_timeout_is_never_raised_to_a_floor()
 // for none. That is what keeps a read out of the durable budget: get_request has no
 // durability_level member at all, so there is no value it could supply that selects it.
 void
-a_request_that_cannot_be_durable_asks_for_no_durability()
+a_request_that_cannot_be_durable_asks_for_no_durability([[maybe_unused]] context& ctx)
 {
   const ops::get_request read;
   assert_true(ps::requested_durability(read) == couchbase::durability_level::none,
@@ -268,7 +268,8 @@ observed_budget_for(Request request) -> std::int64_t
 // upper one the durable budget came from the built-in default rather than the configured value,
 // which is what happens when key_value_durable is never populated from the cluster options.
 void
-a_durable_mutation_without_a_timeout_gets_the_configured_durable_budget()
+a_durable_mutation_without_a_timeout_gets_the_configured_durable_budget(
+  [[maybe_unused]] context& ctx)
 {
   ops::upsert_request mutation;
   mutation.id = document_id{ "b", "s", "c", "k" };
@@ -288,7 +289,7 @@ a_durable_mutation_without_a_timeout_gets_the_configured_durable_budget()
 // The negative half: resolving a durable default must not widen an operation that did not ask for
 // durability. A read cannot carry a level at all, so it keeps the standard budget.
 void
-a_read_is_never_given_the_durable_budget()
+a_read_is_never_given_the_durable_budget([[maybe_unused]] context& ctx)
 {
   ops::get_request read;
   read.id = document_id{ "b", "s", "c", "k" };
@@ -315,9 +316,11 @@ tests() -> test_suite
         a_request_that_cannot_be_durable_asks_for_no_durability },
       { "a_durable_mutation_without_a_timeout_gets_the_configured_durable_budget",
         a_durable_mutation_without_a_timeout_gets_the_configured_durable_budget,
+        {},
         timeout::slow },
       { "a_read_is_never_given_the_durable_budget",
         a_read_is_never_given_the_durable_budget,
+        {},
         timeout::slow },
     },
   };

--- a/test/cng/protostellar/credentials.cxx
+++ b/test/cng/protostellar/credentials.cxx
@@ -43,7 +43,7 @@ using ::couchbase::core::cluster_options;
 using ::couchbase::core::tls_verify_mode;
 
 void
-basic_and_bearer_header_values()
+basic_and_bearer_header_values([[maybe_unused]] context& ctx)
 {
   const auto expected_basic = "Basic " + ::couchbase::core::base64::encode("Administrator:secret");
   assert_eq(ps::basic_auth_value("Administrator", "secret"), expected_basic, "basic header value");
@@ -51,7 +51,7 @@ basic_and_bearer_header_values()
 }
 
 void
-authorization_header_selects_scheme()
+authorization_header_selects_scheme([[maybe_unused]] context& ctx)
 {
   cluster_credentials password;
   password.username = "Administrator";
@@ -79,7 +79,7 @@ authorization_header_selects_scheme()
 // itself rather than a copied fingerprint, so rotating that constant cannot leave this passing
 // vacuously.
 void
-ssl_root_certs_prefer_explicit_then_capella_and_mozilla()
+ssl_root_certs_prefer_explicit_then_capella_and_mozilla([[maybe_unused]] context& ctx)
 {
   const cluster_credentials no_creds;
   const std::string capella{ ::couchbase::core::default_ca::capellaCaCert };
@@ -117,7 +117,7 @@ ssl_root_certs_prefer_explicit_then_capella_and_mozilla()
 }
 
 void
-ssl_client_certificate_is_read_from_files()
+ssl_client_certificate_is_read_from_files([[maybe_unused]] context& ctx)
 {
   // Own a private directory rather than writing fixed names into the shared temp directory: under a
   // parallel ctest two runs would otherwise race on the same paths, and a leftover file from a
@@ -148,7 +148,7 @@ ssl_client_certificate_is_read_from_files()
 }
 
 void
-channel_credentials_switch_on_tls()
+channel_credentials_switch_on_tls([[maybe_unused]] context& ctx)
 {
   const cluster_credentials creds;
 
@@ -170,7 +170,7 @@ channel_credentials_switch_on_tls()
 // grpc::ChannelCredentials is opaque, so the branch is not recoverable from it afterwards. The
 // function therefore branches on tls_peer_verification_disabled(), and this pins that predicate.
 void
-peer_verification_is_disabled_only_by_tls_verify_none()
+peer_verification_is_disabled_only_by_tls_verify_none([[maybe_unused]] context& ctx)
 {
   cluster_options defaults;
   assert_false(ps::tls_peer_verification_disabled(defaults),
@@ -202,7 +202,7 @@ peer_verification_is_disabled_only_by_tls_verify_none()
 // configured client identity or a JWT quietly relaxed verification. Sweep every credential shape
 // against both verify modes and assert the answer tracks tls_verify alone.
 void
-peer_verification_does_not_depend_on_the_credential_shape()
+peer_verification_does_not_depend_on_the_credential_shape([[maybe_unused]] context& ctx)
 {
   cluster_credentials password;
   password.username = "Administrator";

--- a/test/cng/protostellar/dispatcher.cxx
+++ b/test/cng/protostellar/dispatcher.cxx
@@ -165,7 +165,7 @@ run_get(std::chrono::milliseconds timeout, in_process_server& server, bool cance
 }
 
 void
-delivers_response_on_io_thread()
+delivers_response_on_io_thread([[maybe_unused]] context& ctx)
 {
   in_process_server server{ 0ms };
   const auto run_thread = std::this_thread::get_id();
@@ -180,7 +180,7 @@ delivers_response_on_io_thread()
 }
 
 void
-deadline_surfaces_as_deadline_exceeded()
+deadline_surfaces_as_deadline_exceeded([[maybe_unused]] context& ctx)
 {
   in_process_server server{ 2000ms }; // server delays well beyond the client deadline
   const auto outcome = run_get(100ms, server, /*cancel_immediately=*/false);
@@ -197,7 +197,8 @@ deadline_surfaces_as_deadline_exceeded()
 // Every caller in component.cxx already rejects a non-positive timeout before dispatch, so this
 // covers the primitive's own guarantee rather than a reachable production path.
 void
-a_non_positive_timeout_expires_the_call_rather_than_removing_the_deadline()
+a_non_positive_timeout_expires_the_call_rather_than_removing_the_deadline(
+  [[maybe_unused]] context& ctx)
 {
   in_process_server server{ 2000ms };
   for (const auto timeout : { 0ms, -1ms, -30'000ms }) {
@@ -211,7 +212,7 @@ a_non_positive_timeout_expires_the_call_rather_than_removing_the_deadline()
 }
 
 void
-cancellation_surfaces_as_cancelled()
+cancellation_surfaces_as_cancelled([[maybe_unused]] context& ctx)
 {
   in_process_server server{ 2000ms };
   const auto outcome = run_get(timeout::network, server, /*cancel_immediately=*/true);
@@ -228,7 +229,7 @@ cancellation_surfaces_as_cancelled()
 // still in flight when the block ends, so they have to outlive the dispatcher whose destructor
 // drains it.
 void
-destructor_cancels_and_drains_an_in_flight_call()
+destructor_cancels_and_drains_an_in_flight_call([[maybe_unused]] context& ctx)
 {
   in_process_server server{ 2000ms }; // the server outlasts the drain unless the call is cancelled
   const auto channel = server.channel();
@@ -270,18 +271,22 @@ tests() -> test_suite
   return {
     "protostellar_dispatcher",
     {
-      { "delivers_response_on_io_thread", delivers_response_on_io_thread, timeout::network },
+      { "delivers_response_on_io_thread", delivers_response_on_io_thread, {}, timeout::network },
       { "deadline_surfaces_as_deadline_exceeded",
         deadline_surfaces_as_deadline_exceeded,
+        {},
         timeout::network },
       { "a_non_positive_timeout_expires_the_call_rather_than_removing_the_deadline",
         a_non_positive_timeout_expires_the_call_rather_than_removing_the_deadline,
+        {},
         timeout::network },
       { "cancellation_surfaces_as_cancelled",
         cancellation_surfaces_as_cancelled,
+        {},
         timeout::network },
       { "destructor_cancels_and_drains_an_in_flight_call",
         destructor_cancels_and_drains_an_in_flight_call,
+        {},
         timeout::network },
     },
   };

--- a/test/cng/protostellar/error_utils.cxx
+++ b/test/cng/protostellar/error_utils.cxx
@@ -68,7 +68,7 @@ resource(const std::string& resource_type) -> google::rpc::ResourceInfo
 }
 
 void
-ok_maps_to_success()
+ok_maps_to_success([[maybe_unused]] context& ctx)
 {
   assert_false(
     static_cast<bool>(ps::map_status_code(grpc::StatusCode::OK, ps::operation_kind::mutating)),
@@ -76,7 +76,7 @@ ok_maps_to_success()
 }
 
 void
-status_codes_map_to_expected_errc()
+status_codes_map_to_expected_errc([[maybe_unused]] context& ctx)
 {
   assert_true(ps::map_status_code(grpc::StatusCode::NOT_FOUND, ps::operation_kind::mutating) ==
                 couchbase::errc::key_value::document_not_found,
@@ -118,7 +118,7 @@ status_codes_map_to_expected_errc()
 // since an upsert is idempotent and still mutates. Asserted through every layer that carries the
 // bit, so none of them can quietly drop it.
 void
-deadline_exceeded_depends_on_the_operation_kind()
+deadline_exceeded_depends_on_the_operation_kind([[maybe_unused]] context& ctx)
 {
   assert_true(
     ps::map_status_code(grpc::StatusCode::DEADLINE_EXCEEDED, ps::operation_kind::read_only) ==
@@ -147,7 +147,7 @@ deadline_exceeded_depends_on_the_operation_kind()
 }
 
 void
-map_status_uses_the_status_code()
+map_status_uses_the_status_code([[maybe_unused]] context& ctx)
 {
   const grpc::Status status{ grpc::StatusCode::NOT_FOUND, "missing" };
   assert_true(ps::map_status(status, ps::operation_kind::mutating) ==
@@ -156,7 +156,7 @@ map_status_uses_the_status_code()
 }
 
 void
-precondition_details_map_to_specific_kv_errors()
+precondition_details_map_to_specific_kv_errors([[maybe_unused]] context& ctx)
 {
   assert_true(ps::map_status(
                 status_with_detail(grpc::StatusCode::FAILED_PRECONDITION, precondition("LOCKED")),
@@ -199,7 +199,7 @@ precondition_details_map_to_specific_kv_errors()
 }
 
 void
-resource_info_selects_typed_not_found_and_exists()
+resource_info_selects_typed_not_found_and_exists([[maybe_unused]] context& ctx)
 {
   assert_true(ps::map_status(status_with_detail(grpc::StatusCode::NOT_FOUND, resource("bucket")),
                              ps::operation_kind::mutating) ==
@@ -230,7 +230,7 @@ resource_info_selects_typed_not_found_and_exists()
 }
 
 void
-error_message_prefers_rich_details()
+error_message_prefers_rich_details([[maybe_unused]] context& ctx)
 {
   google::rpc::Status rich;
   rich.set_code(static_cast<std::int32_t>(grpc::StatusCode::NOT_FOUND));
@@ -249,18 +249,18 @@ error_message_prefers_rich_details()
 }
 
 void
-make_error_context_maps_code_and_attaches_message()
+make_error_context_maps_code_and_attaches_message([[maybe_unused]] context& ctx)
 {
   const couchbase::core::document_id id{ "bucket", "scope", "collection", "key" };
 
   const grpc::Status failure{ grpc::StatusCode::NOT_FOUND, "document 'key' not found" };
-  const auto ctx = ps::make_error_context(failure, id, ps::operation_kind::mutating);
-  assert_true(ctx.ec() == couchbase::errc::key_value::document_not_found,
+  const auto error_ctx = ps::make_error_context(failure, id, ps::operation_kind::mutating);
+  assert_true(error_ctx.ec() == couchbase::errc::key_value::document_not_found,
               "make_error_context maps the status code");
-  assert_eq(ctx.id(), std::string{ "key" }, "carries the document key");
-  assert_eq(ctx.bucket(), std::string{ "bucket" }, "carries the bucket");
-  assert_true(ctx.extended_error_info().has_value(), "failure attaches extended error info");
-  assert_eq(ctx.extended_error_info()->context(),
+  assert_eq(error_ctx.id(), std::string{ "key" }, "carries the document key");
+  assert_eq(error_ctx.bucket(), std::string{ "bucket" }, "carries the bucket");
+  assert_true(error_ctx.extended_error_info().has_value(), "failure attaches extended error info");
+  assert_eq(error_ctx.extended_error_info()->context(),
             std::string{ "document 'key' not found" },
             "server message lands in the error context");
 
@@ -271,7 +271,7 @@ make_error_context_maps_code_and_attaches_message()
 }
 
 void
-retry_reason_for_classifies_retryable_errors()
+retry_reason_for_classifies_retryable_errors([[maybe_unused]] context& ctx)
 {
   // UNAVAILABLE -> temporary_failure is the one transport-level retryable condition.
   const auto retryable = ps::retry_reason_for(couchbase::errc::common::temporary_failure);

--- a/test/cng/protostellar/kv_converter.cxx
+++ b/test/cng/protostellar/kv_converter.cxx
@@ -51,7 +51,7 @@ test_id() -> document_id
 }
 
 void
-get_request_encodes_location()
+get_request_encodes_location([[maybe_unused]] context& ctx)
 {
   ops::get_request request;
   request.id = document_id{ "travel-sample", "inventory", "airline", "airline_10" };
@@ -63,7 +63,7 @@ get_request_encodes_location()
 }
 
 void
-get_response_decodes_value_cas_flags()
+get_response_decodes_value_cas_flags([[maybe_unused]] context& ctx)
 {
   v1::GetResponse proto;
   proto.set_content_uncompressed("{\"type\":\"airline\"}");
@@ -120,7 +120,7 @@ assert_expiry(const Proto& proto, const expiry_case& expected, const std::string
 
 // upsert, insert and replace all share set_expiry, so every branch is pinned on each of them.
 void
-expiry_encodes_every_branch_explicitly()
+expiry_encodes_every_branch_explicitly([[maybe_unused]] context& ctx)
 {
   for (const auto& expected : expiry_cases) {
     const auto label = "expiry=" + std::to_string(expected.expiry);
@@ -152,7 +152,7 @@ expiry_encodes_every_branch_explicitly()
 // (see a_counter_seed_above_int64_max_is_rejected_before_dispatch), because this converter returns
 // the request message by value and has no error channel of its own.
 void
-counter_initial_value_is_optional_and_encodes_its_upper_bound()
+counter_initial_value_is_optional_and_encodes_its_upper_bound([[maybe_unused]] context& ctx)
 {
   ops::increment_request without_seed;
   without_seed.id = test_id();
@@ -190,7 +190,7 @@ counter_initial_value_is_optional_and_encodes_its_upper_bound()
 // channel for the expiry and it must always be set. An omitted oneof would leave the gateway
 // nothing to act on, so get_and_touch(id, 0) would report success and leave the old TTL in place.
 void
-expiry_encodes_every_branch_for_get_and_touch_and_the_counters()
+expiry_encodes_every_branch_for_get_and_touch_and_the_counters([[maybe_unused]] context& ctx)
 {
   for (const auto& expected : expiry_cases) {
     const auto label = "expiry=" + std::to_string(expected.expiry);
@@ -216,7 +216,7 @@ expiry_encodes_every_branch_for_get_and_touch_and_the_counters()
 // preserve_expiry wins over expiry, which is what upsert_options and replace_options document, and
 // the gateway's encoding for it is an omitted oneof (kvserver.go:484 for upsert, :581 for replace).
 void
-preserve_expiry_omits_the_expiry_oneof()
+preserve_expiry_omits_the_expiry_oneof([[maybe_unused]] context& ctx)
 {
   ops::upsert_request upsert;
   upsert.id = test_id();
@@ -259,7 +259,7 @@ preserve_expiry_omits_the_expiry_oneof()
 // flag is only legal alongside a non-zero expiry, where it would mean the same thing, so it carries
 // no information this encoder needs.
 void
-upsert_never_emits_a_gateway_rejected_expiry_shape()
+upsert_never_emits_a_gateway_rejected_expiry_shape([[maybe_unused]] context& ctx)
 {
   for (const bool preserve : { false, true }) {
     for (const auto& expected : expiry_cases) {
@@ -290,7 +290,7 @@ upsert_never_emits_a_gateway_rejected_expiry_shape()
 // :131-137 for GetAndTouch). A zero expiry therefore has to be sent, not omitted; the gateway maps
 // it to never-expires (helpers.go:49-51), which is what touch(0) means on the classic path too.
 void
-touch_always_sends_an_expiry_arm()
+touch_always_sends_an_expiry_arm([[maybe_unused]] context& ctx)
 {
   for (const auto& expected : expiry_cases) {
     ops::touch_request touch;
@@ -301,7 +301,7 @@ touch_always_sends_an_expiry_arm()
 }
 
 void
-upsert_request_encodes_all_fields()
+upsert_request_encodes_all_fields([[maybe_unused]] context& ctx)
 {
   ops::upsert_request request;
   request.id = test_id();
@@ -321,7 +321,7 @@ upsert_request_encodes_all_fields()
 }
 
 void
-mutation_response_decodes_cas_and_token()
+mutation_response_decodes_cas_and_token([[maybe_unused]] context& ctx)
 {
   v1::UpsertResponse proto;
   proto.set_cas(0xaa55ULL);
@@ -340,7 +340,7 @@ mutation_response_decodes_cas_and_token()
 }
 
 void
-replace_and_remove_encode_cas()
+replace_and_remove_encode_cas([[maybe_unused]] context& ctx)
 {
   ops::replace_request replace;
   replace.id = test_id();
@@ -369,7 +369,7 @@ replace_and_remove_encode_cas()
 // order; a level shifted by one is still a value the gateway accepts, so the write succeeds and the
 // caller silently gets weaker or stronger guarantees than were asked for.
 void
-durability_levels_map_to_their_own_proto_levels()
+durability_levels_map_to_their_own_proto_levels([[maybe_unused]] context& ctx)
 {
   assert_true(pk::to_proto_durability(couchbase::durability_level::majority) ==
                 v1::DURABILITY_LEVEL_MAJORITY,
@@ -384,7 +384,7 @@ durability_levels_map_to_their_own_proto_levels()
 }
 
 void
-durability_none_is_left_unset()
+durability_none_is_left_unset([[maybe_unused]] context& ctx)
 {
   assert_false(pk::to_proto_durability(couchbase::durability_level::none).has_value(),
                "none -> unset");
@@ -398,7 +398,7 @@ durability_none_is_left_unset()
 }
 
 void
-lifecycle_ops_encode_expected_fields()
+lifecycle_ops_encode_expected_fields([[maybe_unused]] context& ctx)
 {
   ops::touch_request touch;
   touch.id = document_id{ "b", "s", "c", "k" };
@@ -422,7 +422,7 @@ lifecycle_ops_encode_expected_fields()
 }
 
 void
-exists_and_lock_responses_decode()
+exists_and_lock_responses_decode([[maybe_unused]] context& ctx)
 {
   v1::ExistsResponse exists_proto;
   exists_proto.set_result(true);
@@ -441,7 +441,7 @@ exists_and_lock_responses_decode()
 }
 
 void
-counter_encodes_and_decodes()
+counter_encodes_and_decodes([[maybe_unused]] context& ctx)
 {
   ops::increment_request inc;
   inc.id = document_id{ "b", "s", "c", "counter" };
@@ -465,7 +465,7 @@ counter_encodes_and_decodes()
 }
 
 void
-append_encodes_content_and_cas()
+append_encodes_content_and_cas([[maybe_unused]] context& ctx)
 {
   ops::append_request append;
   append.id = document_id{ "b", "s", "c", "k" };
@@ -482,7 +482,7 @@ append_encodes_content_and_cas()
 // would be the one path unable to accept a compressed body. gocb, the Java SDK and the .NET SDK all
 // put the projection paths and the compression mode on the same request.
 void
-read_compression_opt_in_follows_settings()
+read_compression_opt_in_follows_settings([[maybe_unused]] context& ctx)
 {
   ops::get_request get;
   get.id = test_id();
@@ -519,7 +519,7 @@ read_compression_opt_in_follows_settings()
 // inflate it. A path that read content_uncompressed directly would hand back the empty-string
 // singleton with a success status.
 void
-every_read_path_decodes_compressed_content()
+every_read_path_decodes_compressed_content([[maybe_unused]] context& ctx)
 {
   const std::string plain(256, 'x');
   const auto frame = pk::maybe_compress(cu::to_binary(plain), pk::compression_settings{});
@@ -548,7 +548,7 @@ every_read_path_decodes_compressed_content()
 }
 
 void
-compression_round_trips_large_values()
+compression_round_trips_large_values([[maybe_unused]] context& ctx)
 {
   const std::string big(1024, 'a'); // well over min_size and highly compressible
   ops::upsert_request request;
@@ -575,7 +575,7 @@ compression_round_trips_large_values()
 // data-loss trap the unguarded content oneof had before compression landed. decode_content returns
 // nullopt and the decoder reports the server-side fault instead of inventing a value.
 void
-malformed_compressed_content_fails_closed()
+malformed_compressed_content_fails_closed([[maybe_unused]] context& ctx)
 {
   v1::GetResponse proto;
   proto.set_content_compressed(std::string(64, '\xff')); // not a snappy frame
@@ -600,7 +600,7 @@ malformed_compressed_content_fails_closed()
 // maximum message size can have been carried here, and a std::bad_alloc raised inside a gRPC
 // completion would take the process down rather than fail the operation.
 void
-an_oversized_declared_length_is_refused()
+an_oversized_declared_length_is_refused([[maybe_unused]] context& ctx)
 {
   std::optional<std::string> frame;
   {
@@ -619,7 +619,7 @@ an_oversized_declared_length_is_refused()
 }
 
 void
-the_min_size_threshold_admits_a_value_of_exactly_min_size()
+the_min_size_threshold_admits_a_value_of_exactly_min_size([[maybe_unused]] context& ctx)
 {
   const pk::compression_settings settings{};
   const auto compresses = [&settings](std::size_t size) {
@@ -637,7 +637,7 @@ the_min_size_threshold_admits_a_value_of_exactly_min_size()
 // a power-of-two original, which makes both the division and the comparison exact in binary
 // floating point -- an approximate ratio would not tell the inclusive bound from the exclusive one.
 void
-the_min_ratio_threshold_is_inclusive()
+the_min_ratio_threshold_is_inclusive([[maybe_unused]] context& ctx)
 {
   const std::string original(1024, 'a');
   const auto value = cu::to_binary(original);
@@ -656,7 +656,7 @@ the_min_ratio_threshold_is_inclusive()
 // A value can clear min_size and still be worth sending raw. Without the ratio check every
 // incompressible payload would go out larger than it arrived.
 void
-an_incompressible_value_is_sent_uncompressed()
+an_incompressible_value_is_sent_uncompressed([[maybe_unused]] context& ctx)
 {
   // A fixed linear congruential sequence rather than <random>: the bytes have to be the same on
   // every platform for the ratio the assertion depends on to be the same.
@@ -677,7 +677,7 @@ an_incompressible_value_is_sent_uncompressed()
 }
 
 void
-cluster_options_maps_compression_settings()
+cluster_options_maps_compression_settings([[maybe_unused]] context& ctx)
 {
   couchbase::core::cluster_options options;
   options.enable_compression = false;
@@ -691,7 +691,7 @@ cluster_options_maps_compression_settings()
 }
 
 void
-custom_compression_thresholds_are_honoured()
+custom_compression_thresholds_are_honoured([[maybe_unused]] context& ctx)
 {
   const std::string text(256, 'a');
   ops::upsert_request request;

--- a/test/cng/protostellar/kv_retry.cxx
+++ b/test/cng/protostellar/kv_retry.cxx
@@ -157,7 +157,7 @@ private:
 // The assertion is placed between those two outcomes, so it fails if an attempt is ever handed more
 // time than the operation has left.
 void
-a_retried_kv_operation_stays_within_its_budget()
+a_retried_kv_operation_stays_within_its_budget([[maybe_unused]] context& ctx)
 {
   int port = 0;
   stalling_kv_service service;
@@ -251,7 +251,7 @@ a_retried_kv_operation_stays_within_its_budget()
 // where the bound comes from: a bound sourced from anywhere else would not honour it. The wait is
 // bounded so that "never completes" fails the case rather than hanging the suite.
 void
-an_operation_without_a_timeout_is_bounded_by_the_cluster_default()
+an_operation_without_a_timeout_is_bounded_by_the_cluster_default([[maybe_unused]] context& ctx)
 {
   int port = 0;
   unavailable_kv_service service;
@@ -328,7 +328,7 @@ an_operation_without_a_timeout_is_bounded_by_the_cluster_default()
 // The service decides the number of retries rather than the clock, which is what makes the exact
 // count assertable.
 void
-a_retried_operation_reports_its_attempts_and_reasons()
+a_retried_operation_reports_its_attempts_and_reasons([[maybe_unused]] context& ctx)
 {
   int port = 0;
   flaky_kv_service service{ 2 };
@@ -395,7 +395,7 @@ a_retried_operation_reports_its_attempts_and_reasons()
 //
 // The read in the sibling cases covers the other arm: idempotent, so unambiguous either way.
 void
-a_retried_mutation_that_runs_out_of_budget_is_ambiguous()
+a_retried_mutation_that_runs_out_of_budget_is_ambiguous([[maybe_unused]] context& ctx)
 {
   int port = 0;
   unavailable_kv_service service;
@@ -468,7 +468,7 @@ a_retried_mutation_that_runs_out_of_budget_is_ambiguous()
 //
 // The bounded wait is what keeps a dropped completion a failing assertion rather than a hung suite.
 void
-closing_the_cluster_during_a_backoff_still_answers()
+closing_the_cluster_during_a_backoff_still_answers([[maybe_unused]] context& ctx)
 {
   int port = 0;
   unavailable_kv_service service;
@@ -558,18 +558,23 @@ tests() -> test_suite
     {
       { "a_retried_kv_operation_stays_within_its_budget",
         a_retried_kv_operation_stays_within_its_budget,
+        {},
         timeout::slow },
       { "an_operation_without_a_timeout_is_bounded_by_the_cluster_default",
         an_operation_without_a_timeout_is_bounded_by_the_cluster_default,
+        {},
         timeout::slow },
       { "a_retried_operation_reports_its_attempts_and_reasons",
         a_retried_operation_reports_its_attempts_and_reasons,
+        {},
         timeout::slow },
       { "a_retried_mutation_that_runs_out_of_budget_is_ambiguous",
         a_retried_mutation_that_runs_out_of_budget_is_ambiguous,
+        {},
         timeout::slow },
       { "closing_the_cluster_during_a_backoff_still_answers",
         closing_the_cluster_during_a_backoff_still_answers,
+        {},
         timeout::slow },
     },
   };

--- a/test/cng/protostellar/live_analytics.cxx
+++ b/test/cng/protostellar/live_analytics.cxx
@@ -55,7 +55,7 @@ analytics(const std::string& statement) -> ops::analytics_request
 }
 
 void
-analytics_round_trip_against_live_gateway()
+analytics_round_trip_against_live_gateway([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -79,7 +79,7 @@ analytics_round_trip_against_live_gateway()
 // from a gateway UNIMPLEMENTED, which carries a gRPC message -- and it is the same signal
 // skip_unless_service_implemented() relies on, so this case is what keeps that helper honest.
 void
-scope_qualified_analytics_is_refused_by_the_client()
+scope_qualified_analytics_is_refused_by_the_client([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -102,7 +102,7 @@ scope_qualified_analytics_is_refused_by_the_client()
 }
 
 void
-an_unsupported_option_is_refused_without_a_round_trip()
+an_unsupported_option_is_refused_without_a_round_trip([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -123,7 +123,7 @@ an_unsupported_option_is_refused_without_a_round_trip()
 // deadline at all. Nothing is sent, which is why the timeout is unambiguous even though analytics
 // statements can mutate.
 void
-an_expired_budget_is_refused_on_the_io_context()
+an_expired_budget_is_refused_on_the_io_context([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -152,20 +152,20 @@ tests() -> test_suite
     {
       { "analytics_round_trip_against_live_gateway",
         analytics_round_trip_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "scope_qualified_analytics_is_refused_by_the_client",
         scope_qualified_analytics_is_refused_by_the_client,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "an_unsupported_option_is_refused_without_a_round_trip",
         an_unsupported_option_is_refused_without_a_round_trip,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "an_expired_budget_is_refused_on_the_io_context",
         an_expired_budget_is_refused_on_the_io_context,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
     },
   };
 }

--- a/test/cng/protostellar/live_bucket_admin.cxx
+++ b/test/cng/protostellar/live_bucket_admin.cxx
@@ -49,7 +49,7 @@ namespace ops = ::couchbase::core::operations;
 namespace mgmt = ::couchbase::core::management::cluster;
 
 void
-list_buckets_against_live_gateway()
+list_buckets_against_live_gateway([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -156,7 +156,7 @@ wait_for_bucket(live_cluster_fixture& fixture,
 }
 
 void
-bucket_settings_round_trip_against_live_gateway()
+bucket_settings_round_trip_against_live_gateway([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -201,7 +201,7 @@ bucket_settings_round_trip_against_live_gateway()
 // durability the cluster has too few data servers for, and a single-node cluster has too few for
 // any of them. Folding it in would make the whole round trip skip there instead of just this.
 void
-minimum_durability_round_trips_against_live_gateway()
+minimum_durability_round_trips_against_live_gateway([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -230,7 +230,7 @@ minimum_durability_round_trips_against_live_gateway()
 // update -> flush -> drop over one bucket, which is the shape gocbcoreps' bucket admin tests use.
 // Each step is checked through a subsequent read rather than on its own status alone.
 void
-bucket_lifecycle_against_live_gateway()
+bucket_lifecycle_against_live_gateway([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -313,7 +313,7 @@ bucket_lifecycle_against_live_gateway()
 // what turns a bare NOT_FOUND into bucket_not_found rather than document_not_found. None of them
 // needs spare quota: each is refused before anything is allocated.
 void
-bucket_errors_carry_the_bucket_specific_code()
+bucket_errors_carry_the_bucket_specific_code([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -383,7 +383,7 @@ bucket_errors_carry_the_bucket_specific_code()
 // memcached buckets have no couchbase2 representation, so the request is refused by the client
 // before anything is sent, on the io context like every other completion.
 void
-a_memcached_bucket_is_refused_by_the_client()
+a_memcached_bucket_is_refused_by_the_client([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -415,28 +415,28 @@ tests() -> test_suite
     {
       { "list_buckets_against_live_gateway",
         list_buckets_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "bucket_settings_round_trip_against_live_gateway",
         bucket_settings_round_trip_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "minimum_durability_round_trips_against_live_gateway",
         minimum_durability_round_trips_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "bucket_lifecycle_against_live_gateway",
         bucket_lifecycle_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "bucket_errors_carry_the_bucket_specific_code",
         bucket_errors_carry_the_bucket_specific_code,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "a_memcached_bucket_is_refused_by_the_client",
         a_memcached_bucket_is_refused_by_the_client,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
     },
   };
 }

--- a/test/cng/protostellar/live_collection_admin.cxx
+++ b/test/cng/protostellar/live_collection_admin.cxx
@@ -291,7 +291,7 @@ create_scope(live_cluster_fixture& fixture, const std::string& scope_name)
 }
 
 void
-list_collections_against_live_gateway()
+list_collections_against_live_gateway([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -310,7 +310,7 @@ list_collections_against_live_gateway()
 // for the second stores the first. Either way the collection has an expiry policy its creator did
 // not ask for, and nothing fails.
 void
-collection_max_expiry_round_trips_against_live_gateway()
+collection_max_expiry_round_trips_against_live_gateway([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -347,7 +347,7 @@ collection_max_expiry_round_trips_against_live_gateway()
 // this collection back on the bucket default", and on UpdateCollection an unset field means "leave
 // it alone" instead. The component refuses it, and the collection has to be left as it was.
 void
-collection_update_max_expiry_against_live_gateway()
+collection_update_max_expiry_against_live_gateway([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -390,7 +390,8 @@ collection_update_max_expiry_against_live_gateway()
 // without the refusal -2 would create a never-expiring collection and report success. Both RPCs
 // carry the field, so both are checked.
 void
-collection_max_expiry_below_the_sentinel_is_refused_against_live_gateway()
+collection_max_expiry_below_the_sentinel_is_refused_against_live_gateway(
+  [[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -431,7 +432,7 @@ collection_max_expiry_below_the_sentinel_is_refused_against_live_gateway()
 // wire, so a collection read back carrying the bucket's TTL would mean the layers had been
 // flattened somewhere between the server and the core struct.
 void
-collection_max_expiry_is_layered_over_the_bucket_default()
+collection_max_expiry_is_layered_over_the_bucket_default([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -478,7 +479,7 @@ collection_max_expiry_is_layered_over_the_bucket_default()
 // did not say" arrive identically, and the manifest cannot report a collection as history-off. The
 // classic path reads ns_server's own `"history": false` and does report it.
 void
-collection_history_retention_round_trips_against_live_gateway()
+collection_history_retention_round_trips_against_live_gateway([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -554,7 +555,8 @@ collection_history_retention_round_trips_against_live_gateway()
 // These assertions record what the codes are, not what they should be. They fail if the gateway
 // starts mapping them alike, which is the point: the difference is worth noticing.
 void
-collection_history_retention_on_a_couchstore_bucket_against_live_gateway()
+collection_history_retention_on_a_couchstore_bucket_against_live_gateway(
+  [[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -608,32 +610,32 @@ tests() -> test_suite
     {
       { "list_collections_against_live_gateway",
         list_collections_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "collection_max_expiry_round_trips_against_live_gateway",
         collection_max_expiry_round_trips_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "collection_update_max_expiry_against_live_gateway",
         collection_update_max_expiry_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "collection_max_expiry_below_the_sentinel_is_refused_against_live_gateway",
         collection_max_expiry_below_the_sentinel_is_refused_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "collection_max_expiry_is_layered_over_the_bucket_default",
         collection_max_expiry_is_layered_over_the_bucket_default,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "collection_history_retention_round_trips_against_live_gateway",
         collection_history_retention_round_trips_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "collection_history_retention_on_a_couchstore_bucket_against_live_gateway",
         collection_history_retention_on_a_couchstore_bucket_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
     },
   };
 }

--- a/test/cng/protostellar/live_connect.cxx
+++ b/test/cng/protostellar/live_connect.cxx
@@ -67,7 +67,7 @@ env_or(const char* name, const char* fallback) -> std::string
 }
 
 void
-connect_and_round_trip_kv()
+connect_and_round_trip_kv([[maybe_unused]] context& ctx)
 {
   const auto connstr = safe_getenv("TEST_CONNECTION_STRING"); // NOLINT(concurrency-mt-unsafe)
   if (!connstr) {
@@ -157,8 +157,8 @@ tests() -> test_suite
     {
       { "connect_and_round_trip_kv",
         connect_and_round_trip_kv,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
     },
   };
 }

--- a/test/cng/protostellar/live_kv.cxx
+++ b/test/cng/protostellar/live_kv.cxx
@@ -71,7 +71,7 @@ env_or(const char* name, const char* fallback) -> std::string
 }
 
 void
-kv_crud_round_trip_against_live_gateway()
+kv_crud_round_trip_against_live_gateway([[maybe_unused]] context& ctx)
 {
   const auto connstr_opt = safe_getenv("TEST_CONNECTION_STRING");
   if (!connstr_opt.has_value()) {
@@ -171,7 +171,7 @@ kv_crud_round_trip_against_live_gateway()
 }
 
 void
-insert_and_replace_round_trip_against_live_gateway()
+insert_and_replace_round_trip_against_live_gateway([[maybe_unused]] context& ctx)
 {
   const auto connstr_opt = safe_getenv("TEST_CONNECTION_STRING");
   if (!connstr_opt.has_value()) {
@@ -322,7 +322,7 @@ insert_and_replace_round_trip_against_live_gateway()
 // Each level gets its own io_context and component so that a level which hangs or fails is
 // attributed to itself rather than to whichever one happens to run first.
 void
-durable_mutations_against_live_gateway()
+durable_mutations_against_live_gateway([[maybe_unused]] context& ctx)
 {
   const auto connstr_opt = safe_getenv("TEST_CONNECTION_STRING");
   if (!connstr_opt.has_value()) {
@@ -420,7 +420,7 @@ durable_mutations_against_live_gateway()
 // The projected read is the second half: it reaches the gateway's ordinary Get handler, so it
 // negotiates compression like any other read and has to complete rather than be refused.
 void
-compressed_values_round_trip_against_live_gateway()
+compressed_values_round_trip_against_live_gateway([[maybe_unused]] context& ctx)
 {
   const auto connstr_opt = safe_getenv("TEST_CONNECTION_STRING");
   if (!connstr_opt.has_value()) {
@@ -528,20 +528,20 @@ tests() -> test_suite
     {
       { "kv_crud_round_trip_against_live_gateway",
         kv_crud_round_trip_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "insert_and_replace_round_trip_against_live_gateway",
         insert_and_replace_round_trip_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "durable_mutations_against_live_gateway",
         durable_mutations_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "compressed_values_round_trip_against_live_gateway",
         compressed_values_round_trip_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
     },
   };
 }

--- a/test/cng/protostellar/live_kv_operations.cxx
+++ b/test/cng/protostellar/live_kv_operations.cxx
@@ -163,7 +163,7 @@ private:
 };
 
 void
-exists_distinguishes_a_present_document_from_a_missing_one()
+exists_distinguishes_a_present_document_from_a_missing_one([[maybe_unused]] context& ctx)
 {
   live_kv_fixture fixture;
   const std::string key{ "cng-live-exists" };
@@ -192,7 +192,7 @@ exists_distinguishes_a_present_document_from_a_missing_one()
 }
 
 void
-touch_expires_a_document()
+touch_expires_a_document([[maybe_unused]] context& ctx)
 {
   live_kv_fixture fixture;
   const std::string key{ "cng-live-touch" };
@@ -221,7 +221,7 @@ touch_expires_a_document()
 }
 
 void
-get_and_lock_blocks_a_write_and_unlock_releases_it()
+get_and_lock_blocks_a_write_and_unlock_releases_it([[maybe_unused]] context& ctx)
 {
   live_kv_fixture fixture;
   const std::string key{ "cng-live-lock" };
@@ -263,7 +263,7 @@ get_and_lock_blocks_a_write_and_unlock_releases_it()
 }
 
 void
-unlock_with_the_wrong_cas_is_refused()
+unlock_with_the_wrong_cas_is_refused([[maybe_unused]] context& ctx)
 {
   live_kv_fixture fixture;
   const std::string key{ "cng-live-unlock-cas" };
@@ -295,7 +295,7 @@ unlock_with_the_wrong_cas_is_refused()
 }
 
 void
-get_and_touch_returns_the_value_and_applies_the_expiry()
+get_and_touch_returns_the_value_and_applies_the_expiry([[maybe_unused]] context& ctx)
 {
   live_kv_fixture fixture;
   const std::string key{ "cng-live-gat" };
@@ -319,7 +319,7 @@ get_and_touch_returns_the_value_and_applies_the_expiry()
 }
 
 void
-counters_increment_and_decrement_a_live_value()
+counters_increment_and_decrement_a_live_value([[maybe_unused]] context& ctx)
 {
   live_kv_fixture fixture;
   const std::string key{ "cng-live-counter" };
@@ -361,7 +361,7 @@ counters_increment_and_decrement_a_live_value()
 }
 
 void
-append_and_prepend_extend_a_live_value()
+append_and_prepend_extend_a_live_value([[maybe_unused]] context& ctx)
 {
   live_kv_fixture fixture;
   const std::string key{ "cng-live-append" };
@@ -393,7 +393,7 @@ append_and_prepend_extend_a_live_value()
 }
 
 void
-incrementing_a_non_numeric_document_is_reported_as_delta_invalid()
+incrementing_a_non_numeric_document_is_reported_as_delta_invalid([[maybe_unused]] context& ctx)
 {
   live_kv_fixture fixture;
   const std::string key{ "cng-live-not-numeric" };
@@ -417,7 +417,7 @@ incrementing_a_non_numeric_document_is_reported_as_delta_invalid()
 }
 
 void
-append_to_a_missing_document_is_reported_as_not_found()
+append_to_a_missing_document_is_reported_as_not_found([[maybe_unused]] context& ctx)
 {
   live_kv_fixture fixture;
   const std::string key{ "cng-live-append-missing" };
@@ -445,40 +445,40 @@ tests() -> test_suite
     {
       { "exists_distinguishes_a_present_document_from_a_missing_one",
         exists_distinguishes_a_present_document_from_a_missing_one,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "touch_expires_a_document",
         touch_expires_a_document,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "get_and_lock_blocks_a_write_and_unlock_releases_it",
         get_and_lock_blocks_a_write_and_unlock_releases_it,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "unlock_with_the_wrong_cas_is_refused",
         unlock_with_the_wrong_cas_is_refused,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "get_and_touch_returns_the_value_and_applies_the_expiry",
         get_and_touch_returns_the_value_and_applies_the_expiry,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "counters_increment_and_decrement_a_live_value",
         counters_increment_and_decrement_a_live_value,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "append_and_prepend_extend_a_live_value",
         append_and_prepend_extend_a_live_value,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "incrementing_a_non_numeric_document_is_reported_as_delta_invalid",
         incrementing_a_non_numeric_document_is_reported_as_delta_invalid,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "append_to_a_missing_document_is_reported_as_not_found",
         append_to_a_missing_document_is_reported_as_not_found,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
     },
   };
 }

--- a/test/cng/protostellar/live_observability.cxx
+++ b/test/cng/protostellar/live_observability.cxx
@@ -227,7 +227,7 @@ env_or(const char* name, const char* fallback) -> std::string
 }
 
 void
-kv_op_emits_span_and_metric_over_couchbase2()
+kv_op_emits_span_and_metric_over_couchbase2([[maybe_unused]] context& ctx)
 {
   const auto connstr = safe_getenv("TEST_CONNECTION_STRING");
   if (!connstr.has_value()) {
@@ -330,8 +330,8 @@ tests() -> test_suite
     {
       { "kv_op_emits_span_and_metric_over_couchbase2",
         kv_op_emits_span_and_metric_over_couchbase2,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
     },
   };
 }

--- a/test/cng/protostellar/live_query.cxx
+++ b/test/cng/protostellar/live_query.cxx
@@ -72,7 +72,7 @@ select(const std::string& statement) -> ops::query_request
 }
 
 void
-a_constant_projection_round_trips()
+a_constant_projection_round_trips([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -92,7 +92,7 @@ a_constant_projection_round_trips()
 // returns a static empty string for the binary arm, so before the fix the gateway received
 // `positional_parameters: [""]` and echoed an empty value here -- a wrong answer, not an error.
 void
-a_positional_parameter_reaches_the_query_engine()
+a_positional_parameter_reaches_the_query_engine([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -111,7 +111,7 @@ a_positional_parameter_reaches_the_query_engine()
 }
 
 void
-a_named_parameter_reaches_the_query_engine()
+a_named_parameter_reaches_the_query_engine([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -131,7 +131,7 @@ a_named_parameter_reaches_the_query_engine()
 // reader that stops at the first message with metadata, or that treats one message as one row,
 // loses part of the result.
 void
-a_result_larger_than_one_batch_arrives_complete_and_in_order()
+a_result_larger_than_one_batch_arrives_complete_and_in_order([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -151,7 +151,7 @@ a_result_larger_than_one_batch_arrives_complete_and_in_order()
 }
 
 void
-an_empty_result_still_carries_metadata()
+an_empty_result_still_carries_metadata([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -170,7 +170,7 @@ an_empty_result_still_carries_metadata()
 // to send disable_metrics for the default to hold. Without that line the SDK would return metrics
 // nobody asked for.
 void
-metrics_are_absent_unless_requested()
+metrics_are_absent_unless_requested([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -181,7 +181,7 @@ metrics_are_absent_unless_requested()
 }
 
 void
-metrics_are_returned_when_requested()
+metrics_are_returned_when_requested([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -198,7 +198,7 @@ metrics_are_returned_when_requested()
 }
 
 void
-a_profile_is_returned_when_requested()
+a_profile_is_returned_when_requested([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -215,7 +215,7 @@ a_profile_is_returned_when_requested()
 // NewInvalidQueryStatus), so this is `invalid_argument` over couchbase2 where the classic path
 // reports `parsing_failure`. couchbase-jvm-clients asserts the same divergence.
 void
-a_syntax_error_is_reported_as_invalid_argument()
+a_syntax_error_is_reported_as_invalid_argument([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -231,7 +231,7 @@ a_syntax_error_is_reported_as_invalid_argument()
 }
 
 void
-a_write_in_a_read_only_query_is_rejected()
+a_write_in_a_read_only_query_is_rejected([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -247,7 +247,7 @@ a_write_in_a_read_only_query_is_rejected()
 // NOT_FOUND carries a ResourceInfo whose type is "queryindex", which is what separates this from
 // the KV-flavoured document_not_found the bare code would map to.
 void
-dropping_a_missing_index_reports_index_not_found()
+dropping_a_missing_index_reports_index_not_found([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -262,7 +262,7 @@ dropping_a_missing_index_reports_index_not_found()
 // queryserver.go:144 refuses a request that carries both, and the converter sends both whenever
 // the caller sets both -- so this pins what the caller sees rather than leaving it to chance.
 void
-conflicting_consistency_is_rejected()
+conflicting_consistency_is_rejected([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -278,7 +278,7 @@ conflicting_consistency_is_rejected()
 
 // queryserver.go:178. Same shape as above: the converter forwards both, the gateway decides.
 void
-named_and_positional_parameters_together_are_rejected()
+named_and_positional_parameters_together_are_rejected([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -299,7 +299,7 @@ named_and_positional_parameters_together_are_rejected()
 // after execute() has returned. Checking the thread is what separates "rejected" from "rejected by
 // calling back inline", which no assertion on the response can see.
 void
-an_unsupported_option_is_refused_without_a_round_trip()
+an_unsupported_option_is_refused_without_a_round_trip([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -320,7 +320,7 @@ an_unsupported_option_is_refused_without_a_round_trip()
 
 // The same contract on the other path that answers without sending anything.
 void
-an_expired_budget_is_refused_on_the_io_context()
+an_expired_budget_is_refused_on_the_io_context([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -342,7 +342,7 @@ an_expired_budget_is_refused_on_the_io_context()
 // of time provably changed nothing, so reporting it as ambiguous would tell a caller that declines
 // to retry ambiguous operations to give up on one that is safe to repeat.
 void
-an_expired_deadline_is_unambiguous_for_a_read_only_query()
+an_expired_deadline_is_unambiguous_for_a_read_only_query([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -357,7 +357,7 @@ an_expired_deadline_is_unambiguous_for_a_read_only_query()
 }
 
 void
-an_expired_deadline_is_ambiguous_for_a_mutating_query()
+an_expired_deadline_is_ambiguous_for_a_mutating_query([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -381,72 +381,72 @@ tests() -> test_suite
     {
       { "a_constant_projection_round_trips",
         a_constant_projection_round_trips,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "a_positional_parameter_reaches_the_query_engine",
         a_positional_parameter_reaches_the_query_engine,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "a_named_parameter_reaches_the_query_engine",
         a_named_parameter_reaches_the_query_engine,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "a_result_larger_than_one_batch_arrives_complete_and_in_order",
         a_result_larger_than_one_batch_arrives_complete_and_in_order,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "an_empty_result_still_carries_metadata",
         an_empty_result_still_carries_metadata,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "metrics_are_absent_unless_requested",
         metrics_are_absent_unless_requested,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "metrics_are_returned_when_requested",
         metrics_are_returned_when_requested,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "a_profile_is_returned_when_requested",
         a_profile_is_returned_when_requested,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "a_syntax_error_is_reported_as_invalid_argument",
         a_syntax_error_is_reported_as_invalid_argument,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "a_write_in_a_read_only_query_is_rejected",
         a_write_in_a_read_only_query_is_rejected,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "dropping_a_missing_index_reports_index_not_found",
         dropping_a_missing_index_reports_index_not_found,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "conflicting_consistency_is_rejected",
         conflicting_consistency_is_rejected,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "named_and_positional_parameters_together_are_rejected",
         named_and_positional_parameters_together_are_rejected,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "an_unsupported_option_is_refused_without_a_round_trip",
         an_unsupported_option_is_refused_without_a_round_trip,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "an_expired_budget_is_refused_on_the_io_context",
         an_expired_budget_is_refused_on_the_io_context,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "an_expired_deadline_is_unambiguous_for_a_read_only_query",
         an_expired_deadline_is_unambiguous_for_a_read_only_query,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "an_expired_deadline_is_ambiguous_for_a_mutating_query",
         an_expired_deadline_is_ambiguous_for_a_mutating_query,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
     },
   };
 }

--- a/test/cng/protostellar/live_query_index_admin.cxx
+++ b/test/cng/protostellar/live_query_index_admin.cxx
@@ -159,7 +159,7 @@ drop_index(live_cluster_fixture& fixture,
 }
 
 void
-list_query_indexes_against_live_gateway()
+list_query_indexes_against_live_gateway([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -170,7 +170,7 @@ list_query_indexes_against_live_gateway()
 // them into the statement as they arrive. "two words" is the case the classic path's own
 // integration test pins, and it is a syntax error without the quoting.
 void
-an_index_key_that_needs_escaping_round_trips_against_live_gateway()
+an_index_key_that_needs_escaping_round_trips_against_live_gateway([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -201,7 +201,7 @@ an_index_key_that_needs_escaping_round_trips_against_live_gateway()
 // outcome here is a refusal rather than a one-key index. Both are asserted, because which one a
 // server gives is the server's business and neither is what broken escaping produces.
 void
-a_hostile_index_key_cannot_add_terms_against_live_gateway()
+a_hostile_index_key_cannot_add_terms_against_live_gateway([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -242,7 +242,7 @@ a_hostile_index_key_cannot_add_terms_against_live_gateway()
 // to be served by the time this runs, so feature_not_available here is the client declining to
 // send a request it cannot express -- which is the behaviour under test.
 void
-a_conditional_secondary_index_is_refused_over_couchbase2()
+a_conditional_secondary_index_is_refused_over_couchbase2([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -269,7 +269,7 @@ a_conditional_secondary_index_is_refused_over_couchbase2()
 // arrive is only visible against a server -- and the metadata below is the decode read back from a
 // real GetAllIndexes rather than a hand-built message.
 void
-the_secondary_index_lifecycle_round_trips_against_live_gateway()
+the_secondary_index_lifecycle_round_trips_against_live_gateway([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -311,7 +311,7 @@ the_secondary_index_lifecycle_round_trips_against_live_gateway()
 // succeeds against a server that has both -- it just manages a different index. Named rather than
 // unnamed so the case does not touch a #primary another test may be relying on.
 void
-the_primary_index_lifecycle_round_trips_against_live_gateway()
+the_primary_index_lifecycle_round_trips_against_live_gateway([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -371,7 +371,7 @@ the_primary_index_lifecycle_round_trips_against_live_gateway()
 // operation failed at its first step over couchbase2 while the RPC it needed sat unused. This
 // drives the public manager, which is the only place that hole was visible.
 void
-build_deferred_indexes_through_the_public_api_against_live_gateway()
+build_deferred_indexes_through_the_public_api_against_live_gateway([[maybe_unused]] context& ctx)
 {
   const auto connection_string = safe_getenv("TEST_CONNECTION_STRING");
   if (!connection_string.has_value()) {
@@ -427,7 +427,8 @@ build_deferred_indexes_through_the_public_api_against_live_gateway()
 // The assertion is therefore that the handler arrives at all. The bounded wait is what keeps a
 // dropped completion a failure instead of a hung suite.
 void
-build_deferred_indexes_on_a_closed_cluster_answers_on_the_calling_thread()
+build_deferred_indexes_on_a_closed_cluster_answers_on_the_calling_thread(
+  [[maybe_unused]] context& ctx)
 {
   const auto connection_string = safe_getenv("TEST_CONNECTION_STRING");
   if (!connection_string.has_value()) {
@@ -471,36 +472,36 @@ tests() -> test_suite
     {
       { "list_query_indexes_against_live_gateway",
         list_query_indexes_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "the_secondary_index_lifecycle_round_trips_against_live_gateway",
         the_secondary_index_lifecycle_round_trips_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "the_primary_index_lifecycle_round_trips_against_live_gateway",
         the_primary_index_lifecycle_round_trips_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "an_index_key_that_needs_escaping_round_trips_against_live_gateway",
         an_index_key_that_needs_escaping_round_trips_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "a_hostile_index_key_cannot_add_terms_against_live_gateway",
         a_hostile_index_key_cannot_add_terms_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "a_conditional_secondary_index_is_refused_over_couchbase2",
         a_conditional_secondary_index_is_refused_over_couchbase2,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "build_deferred_indexes_through_the_public_api_against_live_gateway",
         build_deferred_indexes_through_the_public_api_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "build_deferred_indexes_on_a_closed_cluster_answers_on_the_calling_thread",
         build_deferred_indexes_on_a_closed_cluster_answers_on_the_calling_thread,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
     },
   };
 }

--- a/test/cng/protostellar/live_search.cxx
+++ b/test/cng/protostellar/live_search.cxx
@@ -51,7 +51,7 @@ search(std::string query) -> ops::search_request
 }
 
 void
-search_round_trip_against_live_gateway()
+search_round_trip_against_live_gateway([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -76,7 +76,7 @@ search_round_trip_against_live_gateway()
 // the same signal skip_unless_service_implemented() relies on, so this case keeps that helper
 // honest for the search suite.
 void
-an_untranslated_query_shape_is_refused_by_the_client()
+an_untranslated_query_shape_is_refused_by_the_client([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -95,7 +95,7 @@ an_untranslated_query_shape_is_refused_by_the_client()
 // A query that is not JSON is the caller's own error. Reporting it as feature_not_available would
 // tell them their cluster cannot do search, which is both wrong and unactionable.
 void
-a_malformed_query_is_reported_as_invalid_argument()
+a_malformed_query_is_reported_as_invalid_argument([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -111,7 +111,7 @@ a_malformed_query_is_reported_as_invalid_argument()
 // search it was: a caller correlating by index or client_context_id has no other handle on a
 // request that never reached the wire.
 void
-an_expired_budget_is_refused_on_the_io_context()
+an_expired_budget_is_refused_on_the_io_context([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -143,20 +143,20 @@ tests() -> test_suite
     {
       { "an_expired_budget_is_refused_on_the_io_context",
         an_expired_budget_is_refused_on_the_io_context,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "search_round_trip_against_live_gateway",
         search_round_trip_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "an_untranslated_query_shape_is_refused_by_the_client",
         an_untranslated_query_shape_is_refused_by_the_client,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "a_malformed_query_is_reported_as_invalid_argument",
         a_malformed_query_is_reported_as_invalid_argument,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
     },
   };
 }

--- a/test/cng/protostellar/live_search_index_admin.cxx
+++ b/test/cng/protostellar/live_search_index_admin.cxx
@@ -180,7 +180,7 @@ get_index(live_cluster_fixture& fixture, const std::string& name)
 }
 
 void
-list_search_indexes_against_live_gateway()
+list_search_indexes_against_live_gateway([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -188,7 +188,7 @@ list_search_indexes_against_live_gateway()
 }
 
 void
-the_search_index_lifecycle_round_trips_against_live_gateway()
+the_search_index_lifecycle_round_trips_against_live_gateway([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -232,7 +232,7 @@ the_search_index_lifecycle_round_trips_against_live_gateway()
 }
 
 void
-an_existing_index_is_updated_through_upsert_against_live_gateway()
+an_existing_index_is_updated_through_upsert_against_live_gateway([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -273,7 +273,8 @@ an_existing_index_is_updated_through_upsert_against_live_gateway()
 }
 
 void
-an_upsert_without_a_uuid_for_an_existing_name_is_refused_against_live_gateway()
+an_upsert_without_a_uuid_for_an_existing_name_is_refused_against_live_gateway(
+  [[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -297,7 +298,7 @@ an_upsert_without_a_uuid_for_an_existing_name_is_refused_against_live_gateway()
 }
 
 void
-the_three_parameter_blobs_stay_separate_against_live_gateway()
+the_three_parameter_blobs_stay_separate_against_live_gateway([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -342,7 +343,7 @@ the_three_parameter_blobs_stay_separate_against_live_gateway()
 }
 
 void
-a_definition_that_cannot_be_represented_is_refused_before_it_is_sent()
+a_definition_that_cannot_be_represented_is_refused_before_it_is_sent([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -366,7 +367,8 @@ a_definition_that_cannot_be_represented_is_refused_before_it_is_sent()
 }
 
 void
-an_empty_index_name_is_reported_as_invalid_argument_against_live_gateway()
+an_empty_index_name_is_reported_as_invalid_argument_against_live_gateway(
+  [[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -423,7 +425,7 @@ an_empty_index_name_is_reported_as_invalid_argument_against_live_gateway()
 }
 
 void
-getting_a_missing_index_reports_index_not_found_against_live_gateway()
+getting_a_missing_index_reports_index_not_found_against_live_gateway([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -437,7 +439,7 @@ getting_a_missing_index_reports_index_not_found_against_live_gateway()
 }
 
 void
-the_control_operations_round_trip_against_live_gateway()
+the_control_operations_round_trip_against_live_gateway([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -484,7 +486,7 @@ the_control_operations_round_trip_against_live_gateway()
 }
 
 void
-get_stats_is_refused_over_couchbase2_against_live_gateway()
+get_stats_is_refused_over_couchbase2_against_live_gateway([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -503,7 +505,7 @@ get_stats_is_refused_over_couchbase2_against_live_gateway()
 }
 
 void
-analyze_document_against_live_gateway()
+analyze_document_against_live_gateway([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -551,48 +553,48 @@ tests() -> test_suite
     {
       { "list_search_indexes_against_live_gateway",
         list_search_indexes_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "the_search_index_lifecycle_round_trips_against_live_gateway",
         the_search_index_lifecycle_round_trips_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "an_existing_index_is_updated_through_upsert_against_live_gateway",
         an_existing_index_is_updated_through_upsert_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "an_upsert_without_a_uuid_for_an_existing_name_is_refused_against_live_gateway",
         an_upsert_without_a_uuid_for_an_existing_name_is_refused_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "the_three_parameter_blobs_stay_separate_against_live_gateway",
         the_three_parameter_blobs_stay_separate_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "a_definition_that_cannot_be_represented_is_refused_before_it_is_sent",
         a_definition_that_cannot_be_represented_is_refused_before_it_is_sent,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "an_empty_index_name_is_reported_as_invalid_argument_against_live_gateway",
         an_empty_index_name_is_reported_as_invalid_argument_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "getting_a_missing_index_reports_index_not_found_against_live_gateway",
         getting_a_missing_index_reports_index_not_found_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "the_control_operations_round_trip_against_live_gateway",
         the_control_operations_round_trip_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "get_stats_is_refused_over_couchbase2_against_live_gateway",
         get_stats_is_refused_over_couchbase2_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "analyze_document_against_live_gateway",
         analyze_document_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
     },
   };
 }

--- a/test/cng/protostellar/live_view.cxx
+++ b/test/cng/protostellar/live_view.cxx
@@ -54,7 +54,7 @@ view(const std::string& bucket) -> ops::document_view_request
 }
 
 void
-view_round_trip_against_live_gateway()
+view_round_trip_against_live_gateway([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -78,7 +78,7 @@ view_round_trip_against_live_gateway()
 // signal skip_unless_service_implemented() relies on, so this case keeps that helper honest for the
 // view suite. Without it the suite would consist of one case that always skips.
 void
-an_unsupported_option_is_refused_by_the_client()
+an_unsupported_option_is_refused_by_the_client([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -99,7 +99,7 @@ an_unsupported_option_is_refused_by_the_client()
 // A spent budget is refused before anything is dispatched, and the response still names the view:
 // the failure has to be attributable to a request that never reached the wire.
 void
-an_expired_budget_is_refused_on_the_io_context()
+an_expired_budget_is_refused_on_the_io_context([[maybe_unused]] context& ctx)
 {
   live_cluster_fixture fixture;
   fixture.require_open();
@@ -133,16 +133,16 @@ tests() -> test_suite
     {
       { "an_expired_budget_is_refused_on_the_io_context",
         an_expired_budget_is_refused_on_the_io_context,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "view_round_trip_against_live_gateway",
         view_round_trip_against_live_gateway,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
       { "an_unsupported_option_is_refused_by_the_client",
         an_unsupported_option_is_refused_by_the_client,
-        timeout::integration,
-        test_env::cluster_only },
+        { needs::real_cluster() },
+        timeout::integration },
     },
   };
 }

--- a/test/cng/protostellar/ping_diagnostics.cxx
+++ b/test/cng/protostellar/ping_diagnostics.cxx
@@ -33,7 +33,7 @@ namespace couchbase::test
 namespace
 {
 void
-ping_and_diagnostics_are_feature_not_available_over_couchbase2()
+ping_and_diagnostics_are_feature_not_available_over_couchbase2([[maybe_unused]] context& ctx)
 {
   couchbase::cluster_options options{ "Administrator", "password" };
   // couchbase2:// is TLS; skip verification so the lazy connect does not depend on a real cert.
@@ -73,8 +73,8 @@ tests() -> test_suite
     {
       { "ping_and_diagnostics_are_feature_not_available_over_couchbase2",
         ping_and_diagnostics_are_feature_not_available_over_couchbase2,
-        timeout::integration,
-        test_env::agnostic },
+        {},
+        timeout::integration },
     },
   };
 }

--- a/test/cng/protostellar/query_converter.cxx
+++ b/test/cng/protostellar/query_converter.cxx
@@ -59,7 +59,7 @@ binary_json(const std::string& json) -> couchbase::core::json_string
 }
 
 void
-encode_maps_core_fields()
+encode_maps_core_fields([[maybe_unused]] context& ctx)
 {
   ops::query_request request;
   request.statement = "SELECT 1";
@@ -96,7 +96,7 @@ encode_maps_core_fields()
 // and the binary arm is the only arm the public API produces. Asserting on the payload rather
 // than on "a parameter is present" is what separates the two.
 void
-positional_parameters_carry_their_json_payload()
+positional_parameters_carry_their_json_payload([[maybe_unused]] context& ctx)
 {
   ops::query_request request;
   request.statement = "SELECT * FROM b WHERE id = $1 AND n = $2";
@@ -110,7 +110,7 @@ positional_parameters_carry_their_json_payload()
 }
 
 void
-named_parameters_carry_their_json_payload()
+named_parameters_carry_their_json_payload([[maybe_unused]] context& ctx)
 {
   ops::query_request request;
   request.statement = "SELECT * FROM b WHERE id = $id";
@@ -129,7 +129,7 @@ named_parameters_carry_their_json_payload()
 // A parameter whose JSON contains a NUL or a non-ASCII byte must survive intact and keep its
 // length -- treating the payload as a C string would truncate at the NUL.
 void
-a_parameter_payload_is_copied_byte_for_byte()
+a_parameter_payload_is_copied_byte_for_byte([[maybe_unused]] context& ctx)
 {
   // "a<NUL>b<U+00E9>" as JSON: an embedded NUL and a multi-byte UTF-8 sequence. Built with an
   // explicit length because a NUL would otherwise end the literal.
@@ -146,7 +146,7 @@ a_parameter_payload_is_copied_byte_for_byte()
 // The string arm is unreachable from the public API but is what a direct core caller would build,
 // and json_payload() has to handle both.
 void
-a_string_arm_parameter_is_encoded_too()
+a_string_arm_parameter_is_encoded_too([[maybe_unused]] context& ctx)
 {
   ops::query_request request;
   request.statement = "SELECT $1";
@@ -159,7 +159,7 @@ a_string_arm_parameter_is_encoded_too()
 // A default-constructed json_string holds neither arm. It must encode as empty rather than trip
 // over the variant.
 void
-an_empty_parameter_encodes_as_empty()
+an_empty_parameter_encodes_as_empty([[maybe_unused]] context& ctx)
 {
   ops::query_request request;
   request.statement = "SELECT $1";
@@ -175,7 +175,7 @@ an_empty_parameter_encodes_as_empty()
 // backtick-delimited identifiers therefore has to leave both fields unset rather than send half
 // of one.
 void
-query_context_sets_both_fields_or_neither()
+query_context_sets_both_fields_or_neither([[maybe_unused]] context& ctx)
 {
   ops::query_request base;
   base.statement = "SELECT 1";
@@ -203,7 +203,7 @@ query_context_sets_both_fields_or_neither()
 }
 
 void
-encode_maps_mutation_state_to_consistent_with()
+encode_maps_mutation_state_to_consistent_with([[maybe_unused]] context& ctx)
 {
   ops::query_request request;
   request.statement = "SELECT 1";
@@ -222,7 +222,7 @@ encode_maps_mutation_state_to_consistent_with()
 // otherwise fall through and send the proto default (NOT_BOUNDED / OFF), silently downgrading the
 // caller's consistency or profiling request.
 void
-every_scan_consistency_and_profile_value_maps()
+every_scan_consistency_and_profile_value_maps([[maybe_unused]] context& ctx)
 {
   ops::query_request request;
   request.statement = "SELECT 1";
@@ -253,7 +253,7 @@ every_scan_consistency_and_profile_value_maps()
 // scan_wait is a google.protobuf.Duration, whose seconds and nanos are separate fields. A value
 // with a sub-second remainder is where a lossy cast shows up.
 void
-scan_wait_splits_into_seconds_and_nanos()
+scan_wait_splits_into_seconds_and_nanos([[maybe_unused]] context& ctx)
 {
   ops::query_request request;
   request.statement = "SELECT 1";
@@ -268,7 +268,7 @@ scan_wait_splits_into_seconds_and_nanos()
 }
 
 void
-tuning_fields_map_to_their_proto_counterparts()
+tuning_fields_map_to_their_proto_counterparts([[maybe_unused]] context& ctx)
 {
   ops::query_request request;
   request.statement = "SELECT 1";
@@ -291,7 +291,7 @@ tuning_fields_map_to_their_proto_counterparts()
 // for, so can_encode rejects it -- the same convention the converter uses for every other
 // "cannot express this" case.
 void
-can_encode_rejects_tuning_values_that_do_not_fit_uint32()
+can_encode_rejects_tuning_values_that_do_not_fit_uint32([[maybe_unused]] context& ctx)
 {
   constexpr auto max32 = std::uint64_t{ std::numeric_limits<std::uint32_t>::max() };
 
@@ -321,7 +321,7 @@ can_encode_rejects_tuning_values_that_do_not_fit_uint32()
 }
 
 void
-can_encode_rejects_unsupported_features()
+can_encode_rejects_unsupported_features([[maybe_unused]] context& ctx)
 {
   ops::query_request base;
   base.statement = "SELECT 1";
@@ -356,7 +356,7 @@ can_encode_rejects_unsupported_features()
 }
 
 void
-decode_meta_data_maps_status_metrics_warnings()
+decode_meta_data_maps_status_metrics_warnings([[maybe_unused]] context& ctx)
 {
   v1::QueryResponse_MetaData proto;
   proto.set_request_id("req-7");
@@ -405,7 +405,7 @@ decode_meta_data_maps_status_metrics_warnings()
 // them must leave the corresponding optionals unset rather than fabricate empty values, because
 // the SDK surface distinguishes "not requested" from "requested and empty".
 void
-decode_meta_data_leaves_absent_optionals_unset()
+decode_meta_data_leaves_absent_optionals_unset([[maybe_unused]] context& ctx)
 {
   v1::QueryResponse_MetaData proto;
   proto.set_request_id("req-8");
@@ -423,7 +423,7 @@ decode_meta_data_leaves_absent_optionals_unset()
 // Every Status the schema defines has a string. A value with no case would decode as "unknown",
 // which the SDK surface cannot distinguish from the schema's own STATUS_UNKNOWN.
 void
-every_metadata_status_decodes_to_its_own_string()
+every_metadata_status_decodes_to_its_own_string([[maybe_unused]] context& ctx)
 {
   const std::vector<std::pair<v1::QueryResponse_MetaData_Status, std::string>> expected{
     { v1::QueryResponse_MetaData_Status_STATUS_RUNNING, "running" },

--- a/test/cng/protostellar/query_index_admin_component.cxx
+++ b/test/cng/protostellar/query_index_admin_component.cxx
@@ -68,7 +68,7 @@ conditional_secondary_index() -> om::query_index_create_request
 }
 
 void
-a_refused_index_completes_on_the_io_context()
+a_refused_index_completes_on_the_io_context([[maybe_unused]] context& ctx)
 {
   asio::io_context io;
   component comp{

--- a/test/cng/protostellar/query_index_admin_converter.cxx
+++ b/test/cng/protostellar/query_index_admin_converter.cxx
@@ -166,7 +166,7 @@ hostile_keys() -> std::vector<std::string>
 }
 
 void
-index_keys_are_escaped_into_one_token_each()
+index_keys_are_escaped_into_one_token_each([[maybe_unused]] context& ctx)
 {
   for (const auto& key : hostile_keys()) {
     const auto encoded = qi::encode_index_key(key);
@@ -183,7 +183,7 @@ index_keys_are_escaped_into_one_token_each()
 }
 
 void
-a_hostile_key_cannot_add_terms_to_the_field_list()
+a_hostile_key_cannot_add_terms_to_the_field_list([[maybe_unused]] context& ctx)
 {
   const auto keys = hostile_keys();
   const auto proto = qi::encode_create(create_request(keys));
@@ -196,7 +196,7 @@ a_hostile_key_cannot_add_terms_to_the_field_list()
 }
 
 void
-an_ordinary_key_is_quoted_and_a_quoted_key_is_left_alone()
+an_ordinary_key_is_quoted_and_a_quoted_key_is_left_alone([[maybe_unused]] context& ctx)
 {
   const auto proto = qi::encode_create(create_request({ "field", "two words", "`already`" }));
   assert_eq(static_cast<std::size_t>(proto.fields_size()), std::size_t{ 3 }, "three keys");
@@ -206,7 +206,7 @@ an_ordinary_key_is_quoted_and_a_quoted_key_is_left_alone()
 }
 
 void
-encode_create_fills_the_secondary_request()
+encode_create_fills_the_secondary_request([[maybe_unused]] context& ctx)
 {
   auto request = create_request({ "country" });
   request.scope_name = "inventory";
@@ -234,7 +234,7 @@ encode_create_fills_the_secondary_request()
 }
 
 void
-an_unset_keyspace_part_is_left_unset()
+an_unset_keyspace_part_is_left_unset([[maybe_unused]] context& ctx)
 {
   // A present-but-empty scope names a scope called "", which the gateway rejects; an absent one
   // means the whole bucket. The core request spells both as an empty string.
@@ -251,7 +251,7 @@ an_unset_keyspace_part_is_left_unset()
 }
 
 void
-create_picks_the_rpc_from_is_primary()
+create_picks_the_rpc_from_is_primary([[maybe_unused]] context& ctx)
 {
   auto request = create_request({});
   request.is_primary = true;
@@ -271,7 +271,7 @@ create_picks_the_rpc_from_is_primary()
 }
 
 void
-drop_picks_the_rpc_from_is_primary()
+drop_picks_the_rpc_from_is_primary([[maybe_unused]] context& ctx)
 {
   om::query_index_drop_request request{};
   request.bucket_name = "travel";
@@ -293,7 +293,7 @@ drop_picks_the_rpc_from_is_primary()
 }
 
 void
-a_conditional_secondary_index_cannot_be_encoded()
+a_conditional_secondary_index_cannot_be_encoded([[maybe_unused]] context& ctx)
 {
   auto request = create_request({ "country" });
   assert_true(qi::can_encode(request), "a plain secondary index is encodable");
@@ -308,7 +308,7 @@ a_conditional_secondary_index_cannot_be_encoded()
 }
 
 void
-decode_index_maps_fields()
+decode_index_maps_fields([[maybe_unused]] context& ctx)
 {
   v1::GetAllIndexesResponse_Index proto;
   proto.set_name("ix1");
@@ -341,7 +341,7 @@ decode_index_maps_fields()
 // schema has no value outside the two below today, so this is about what a schema bump decodes to:
 // naming an unrecognised type "gsi" is a claim about the index rather than an admission.
 void
-an_unrecognised_enum_decodes_as_unknown()
+an_unrecognised_enum_decodes_as_unknown([[maybe_unused]] context& ctx)
 {
   const auto out_of_range = static_cast<v1::IndexType>(9999);
   assert_eq(qi::index_type_to_string(out_of_range), std::string{ "unknown" }, "unknown index type");
@@ -354,7 +354,7 @@ an_unrecognised_enum_decodes_as_unknown()
 }
 
 void
-decode_primary_index_has_no_keys()
+decode_primary_index_has_no_keys([[maybe_unused]] context& ctx)
 {
   v1::GetAllIndexesResponse_Index proto;
   proto.set_name("#primary");
@@ -375,7 +375,7 @@ decode_primary_index_has_no_keys()
 // server reported an empty one" are two answers and only presence separates them. Reading
 // emptiness instead collapses the second onto the first.
 void
-an_explicitly_empty_condition_is_not_an_absent_one()
+an_explicitly_empty_condition_is_not_an_absent_one([[maybe_unused]] context& ctx)
 {
   v1::GetAllIndexesResponse_Index proto;
   proto.set_bucket_name("travel");
@@ -400,7 +400,7 @@ an_explicitly_empty_condition_is_not_an_absent_one()
 // GetAllIndexes reports keys in the quoted form, so a key read from one index and passed to
 // create_index() for another must name the same field.
 void
-a_decoded_key_re_encodes_to_itself()
+a_decoded_key_re_encodes_to_itself([[maybe_unused]] context& ctx)
 {
   v1::GetAllIndexesResponse_Index proto;
   proto.set_bucket_name("travel");

--- a/test/cng/protostellar/query_streaming.cxx
+++ b/test/cng/protostellar/query_streaming.cxx
@@ -151,7 +151,7 @@ make_component(asio::io_context& io, in_process_query_server& server) -> compone
 }
 
 void
-row_callback_delivers_rows_incrementally()
+row_callback_delivers_rows_incrementally([[maybe_unused]] context& ctx)
 {
   in_process_query_server server;
   asio::io_context io;
@@ -182,7 +182,7 @@ row_callback_delivers_rows_incrementally()
 }
 
 void
-row_callback_stop_drains_to_metadata()
+row_callback_stop_drains_to_metadata([[maybe_unused]] context& ctx)
 {
   in_process_query_server server;
   asio::io_context io;
@@ -212,7 +212,7 @@ row_callback_stop_drains_to_metadata()
 }
 
 void
-mid_stream_error_after_delivery_maps_to_request_canceled()
+mid_stream_error_after_delivery_maps_to_request_canceled([[maybe_unused]] context& ctx)
 {
   in_process_query_server server;
   asio::io_context io;
@@ -245,7 +245,7 @@ mid_stream_error_after_delivery_maps_to_request_canceled()
 // applied twice by the retry loop. The rows the case never reads are the point -- they are what
 // proves the statement ran.
 void
-a_buffered_mid_stream_error_maps_to_request_canceled()
+a_buffered_mid_stream_error_maps_to_request_canceled([[maybe_unused]] context& ctx)
 {
   in_process_query_server server;
   asio::io_context io;
@@ -268,7 +268,7 @@ a_buffered_mid_stream_error_maps_to_request_canceled()
 }
 
 void
-a_non_retryable_mid_stream_error_preserves_its_error_code()
+a_non_retryable_mid_stream_error_preserves_its_error_code([[maybe_unused]] context& ctx)
 {
   in_process_query_server server;
   asio::io_context io;
@@ -291,7 +291,7 @@ a_non_retryable_mid_stream_error_preserves_its_error_code()
 }
 
 void
-metadata_only_stream_error_maps_to_request_canceled()
+metadata_only_stream_error_maps_to_request_canceled([[maybe_unused]] context& ctx)
 {
   in_process_query_server server;
   asio::io_context io;
@@ -318,7 +318,7 @@ metadata_only_stream_error_maps_to_request_canceled()
 // stream with no deadline -- one that cluster::close() then waits on. Asserting the server saw
 // nothing is what makes this a real check rather than a restatement of the error code.
 void
-an_exhausted_budget_is_rejected_before_dispatch()
+an_exhausted_budget_is_rejected_before_dispatch([[maybe_unused]] context& ctx)
 {
   in_process_query_server server;
   asio::io_context io;
@@ -413,7 +413,7 @@ private:
 };
 
 void
-analytics_streaming_incremental_delivery_and_stop()
+analytics_streaming_incremental_delivery_and_stop([[maybe_unused]] context& ctx)
 {
   in_process_analytics_server server;
   asio::io_context io;
@@ -448,7 +448,7 @@ analytics_streaming_incremental_delivery_and_stop()
 }
 
 void
-analytics_mid_stream_error_maps_to_request_canceled()
+analytics_mid_stream_error_maps_to_request_canceled([[maybe_unused]] context& ctx)
 {
   in_process_analytics_server server;
   asio::io_context io;
@@ -474,7 +474,7 @@ analytics_mid_stream_error_maps_to_request_canceled()
 }
 
 void
-analytics_non_retryable_mid_stream_error_preserves_its_error_code()
+analytics_non_retryable_mid_stream_error_preserves_its_error_code([[maybe_unused]] context& ctx)
 {
   in_process_analytics_server server;
   asio::io_context io;
@@ -510,33 +510,43 @@ tests() -> test_suite
     {
       { "an_exhausted_budget_is_rejected_before_dispatch",
         an_exhausted_budget_is_rejected_before_dispatch,
+        {},
         timeout::network },
       { "row_callback_delivers_rows_incrementally",
         row_callback_delivers_rows_incrementally,
+        {},
         timeout::network },
       { "row_callback_stop_drains_to_metadata",
         row_callback_stop_drains_to_metadata,
+        {},
         timeout::network },
       { "a_buffered_mid_stream_error_maps_to_request_canceled",
         a_buffered_mid_stream_error_maps_to_request_canceled,
+        {},
         timeout::network },
       { "metadata_only_stream_error_maps_to_request_canceled",
         metadata_only_stream_error_maps_to_request_canceled,
+        {},
         timeout::network },
       { "mid_stream_error_after_delivery_maps_to_request_canceled",
         mid_stream_error_after_delivery_maps_to_request_canceled,
+        {},
         timeout::network },
       { "a_non_retryable_mid_stream_error_preserves_its_error_code",
         a_non_retryable_mid_stream_error_preserves_its_error_code,
+        {},
         timeout::network },
       { "analytics_streaming_incremental_delivery_and_stop",
         analytics_streaming_incremental_delivery_and_stop,
+        {},
         timeout::network },
       { "analytics_mid_stream_error_maps_to_request_canceled",
         analytics_mid_stream_error_maps_to_request_canceled,
+        {},
         timeout::network },
       { "analytics_non_retryable_mid_stream_error_preserves_its_error_code",
         analytics_non_retryable_mid_stream_error_preserves_its_error_code,
+        {},
         timeout::network },
     },
   };

--- a/test/cng/protostellar/retry.cxx
+++ b/test/cng/protostellar/retry.cxx
@@ -111,7 +111,7 @@ public:
 };
 
 void
-non_kv_retry_dispatch_semantics()
+non_kv_retry_dispatch_semantics([[maybe_unused]] context& ctx)
 {
   int port = 0;
   retry_query_service service;
@@ -205,7 +205,7 @@ non_kv_retry_dispatch_semantics()
 }
 
 void
-non_kv_retry_budget_exhaustion()
+non_kv_retry_budget_exhaustion([[maybe_unused]] context& ctx)
 {
   int port = 0;
   retry_query_service service;
@@ -283,7 +283,7 @@ non_kv_retry_budget_exhaustion()
 // The wait for a second attempt is what establishes that a retry was recorded, and the bounded wait
 // for the answer is what keeps a dropped completion a failing assertion rather than a hung suite.
 void
-closing_the_cluster_during_a_non_kv_backoff_still_answers()
+closing_the_cluster_during_a_non_kv_backoff_still_answers([[maybe_unused]] context& ctx)
 {
   int port = 0;
   retry_query_service service;
@@ -384,7 +384,7 @@ public:
 };
 
 void
-custom_retry_strategy_rejects_non_kv()
+custom_retry_strategy_rejects_non_kv([[maybe_unused]] context& ctx)
 {
   int port = 0;
   retry_query_service service;
@@ -449,19 +449,20 @@ tests() -> test_suite
     {
       { "non_kv_retry_dispatch_semantics",
         non_kv_retry_dispatch_semantics,
-        timeout::integration,
-        test_env::agnostic },
+        {},
+        timeout::integration },
       { "closing_the_cluster_during_a_non_kv_backoff_still_answers",
         closing_the_cluster_during_a_non_kv_backoff_still_answers,
+        {},
         timeout::slow },
       { "non_kv_retry_budget_exhaustion",
         non_kv_retry_budget_exhaustion,
-        timeout::integration,
-        test_env::agnostic },
+        {},
+        timeout::integration },
       { "custom_retry_strategy_rejects_non_kv",
         custom_retry_strategy_rejects_non_kv,
-        timeout::integration,
-        test_env::agnostic },
+        {},
+        timeout::integration },
     },
   };
 }

--- a/test/cng/protostellar/search_converter.cxx
+++ b/test/cng/protostellar/search_converter.cxx
@@ -45,7 +45,7 @@ base_request() -> ops::search_request
 }
 
 void
-encode_maps_envelope_and_query_string()
+encode_maps_envelope_and_query_string([[maybe_unused]] context& ctx)
 {
   auto request = base_request();
   request.limit = 10;
@@ -70,7 +70,7 @@ encode_maps_envelope_and_query_string()
 }
 
 void
-encode_maps_match_all_and_match_none()
+encode_maps_match_all_and_match_none([[maybe_unused]] context& ctx)
 {
   auto all = base_request();
   all.query = couchbase::core::json_string{ R"({"match_all":{}})" };
@@ -86,7 +86,7 @@ encode_maps_match_all_and_match_none()
 }
 
 void
-encode_returns_nullopt_for_unmappable_query()
+encode_returns_nullopt_for_unmappable_query([[maybe_unused]] context& ctx)
 {
   auto request = base_request();
   request.query = couchbase::core::json_string{ R"({"term":"x","field":"f"})" };
@@ -107,7 +107,7 @@ encode_returns_nullopt_for_unmappable_query()
 // A boost is serialized beside the query key, so rejecting every two-key object would make
 // query_string("foo").boost(2) -- an ordinary supported query -- unroutable.
 void
-encode_maps_a_boosted_query_string()
+encode_maps_a_boosted_query_string([[maybe_unused]] context& ctx)
 {
   auto request = base_request();
   request.query = couchbase::core::json_string{ R"({"query":"foo","boost":2.5})" };
@@ -123,7 +123,7 @@ encode_maps_a_boosted_query_string()
 // Reported as invalid_argument by the component rather than feature_not_available: a query the
 // caller failed to serialize is their own error, not a gap in couchbase2 support.
 void
-malformed_query_json_is_distinguished_from_an_unmappable_shape()
+malformed_query_json_is_distinguished_from_an_unmappable_shape([[maybe_unused]] context& ctx)
 {
   auto malformed = base_request();
   malformed.query = couchbase::core::json_string{ R"({"match_all":)" };
@@ -137,7 +137,7 @@ malformed_query_json_is_distinguished_from_an_unmappable_shape()
 }
 
 void
-can_encode_rejects_gated_features()
+can_encode_rejects_gated_features([[maybe_unused]] context& ctx)
 {
   assert_true(ps::can_encode(base_request()), "plain search passes the coarse gate");
 
@@ -159,7 +159,7 @@ can_encode_rejects_gated_features()
 }
 
 void
-decode_maps_hits_and_metrics()
+decode_maps_hits_and_metrics([[maybe_unused]] context& ctx)
 {
   v1::SearchQueryResponse message;
   auto* hit = message.add_hits();
@@ -199,7 +199,7 @@ decode_maps_hits_and_metrics()
 // and leaves ctx.ec unset, so mapping them to an error code here would make couchbase2 fail a query
 // that couchbase:// answers. Carrying them is what lets a caller notice the results are partial.
 void
-decode_carries_partial_partition_failures()
+decode_carries_partial_partition_failures([[maybe_unused]] context& ctx)
 {
   v1::SearchQueryResponse message;
   auto* metrics = message.mutable_meta_data()->mutable_metrics();
@@ -227,7 +227,7 @@ decode_carries_partial_partition_failures()
 // whose highlighting is silently empty -- an outcome the caller cannot distinguish from a document
 // that simply had no match in that field.
 void
-decode_maps_fragments_fields_and_array_positions()
+decode_maps_fragments_fields_and_array_positions([[maybe_unused]] context& ctx)
 {
   v1::SearchQueryResponse message;
   auto* hit = message.add_hits();
@@ -268,7 +268,7 @@ decode_maps_fragments_fields_and_array_positions()
 // A hit with no highlighting must leave the row's optional members unset rather than carrying an
 // empty object, so a caller can tell "no fragments were requested" from "the field did not match".
 void
-decode_leaves_absent_fragments_and_positions_unset()
+decode_leaves_absent_fragments_and_positions_unset([[maybe_unused]] context& ctx)
 {
   v1::SearchQueryResponse message;
   auto* hit = message.add_hits();

--- a/test/cng/protostellar/search_index_admin_component.cxx
+++ b/test/cng/protostellar/search_index_admin_component.cxx
@@ -233,7 +233,7 @@ definition(std::string name) -> couchbase::core::management::search::index
 }
 
 void
-an_upsert_without_a_uuid_calls_create_index()
+an_upsert_without_a_uuid_calls_create_index([[maybe_unused]] context& ctx)
 {
   in_process_server server;
 
@@ -250,7 +250,7 @@ an_upsert_without_a_uuid_calls_create_index()
 }
 
 void
-an_upsert_with_a_uuid_calls_update_index()
+an_upsert_with_a_uuid_calls_update_index([[maybe_unused]] context& ctx)
 {
   in_process_server server;
 
@@ -273,7 +273,7 @@ an_upsert_with_a_uuid_calls_update_index()
 }
 
 void
-the_control_operations_select_their_paired_rpc()
+the_control_operations_select_their_paired_rpc([[maybe_unused]] context& ctx)
 {
   {
     in_process_server server;
@@ -338,7 +338,7 @@ the_control_operations_select_their_paired_rpc()
 }
 
 void
-an_empty_index_name_is_refused_without_a_round_trip()
+an_empty_index_name_is_refused_without_a_round_trip([[maybe_unused]] context& ctx)
 {
   // The gateway answers an empty name with InvalidArgument too, so the error code on its own does
   // not distinguish a local refusal from a round trip. The empty call list is what does.
@@ -394,7 +394,7 @@ an_empty_index_name_is_refused_without_a_round_trip()
 }
 
 void
-a_definition_that_cannot_be_represented_is_not_sent()
+a_definition_that_cannot_be_represented_is_not_sent([[maybe_unused]] context& ctx)
 {
   in_process_server server;
 
@@ -412,7 +412,7 @@ a_definition_that_cannot_be_represented_is_not_sent()
 }
 
 void
-a_get_response_without_an_index_reports_index_not_found()
+a_get_response_without_an_index_reports_index_not_found([[maybe_unused]] context& ctx)
 {
   in_process_server server;
 
@@ -427,7 +427,7 @@ a_get_response_without_an_index_reports_index_not_found()
 }
 
 void
-an_index_that_cannot_be_decoded_reports_parsing_failure()
+an_index_that_cannot_be_decoded_reports_parsing_failure([[maybe_unused]] context& ctx)
 {
   in_process_server server;
   (*server.service().get_response.mutable_index()->mutable_params())["mapping"] = "not json";
@@ -444,7 +444,7 @@ an_index_that_cannot_be_decoded_reports_parsing_failure()
 }
 
 void
-a_successful_call_reports_status_ok()
+a_successful_call_reports_status_ok([[maybe_unused]] context& ctx)
 {
   // The field the classic path fills from FTS's {"status":"ok"}; admin.search.v1 answers with
   // empty messages, so a successful RPC is what stands in for it.
@@ -478,7 +478,7 @@ a_successful_call_reports_status_ok()
 }
 
 void
-a_failed_call_reports_no_status()
+a_failed_call_reports_no_status([[maybe_unused]] context& ctx)
 {
   // A status the server never reported would say the operation succeeded; the error code is what
   // describes a failure.

--- a/test/cng/protostellar/search_index_admin_converter.cxx
+++ b/test/cng/protostellar/search_index_admin_converter.cxx
@@ -61,7 +61,7 @@ full_index() -> couchbase::core::management::search::index
 }
 
 void
-apply_index_maps_fields_and_params()
+apply_index_maps_fields_and_params([[maybe_unused]] context& ctx)
 {
   auto index = full_index();
 
@@ -79,7 +79,7 @@ apply_index_maps_fields_and_params()
 }
 
 void
-a_create_carries_no_uuid()
+a_create_carries_no_uuid([[maybe_unused]] context& ctx)
 {
   auto index = full_index();
   index.uuid = "existing-uuid";
@@ -93,7 +93,7 @@ a_create_carries_no_uuid()
 }
 
 void
-an_update_carries_the_uuid()
+an_update_carries_the_uuid([[maybe_unused]] context& ctx)
 {
   auto index = full_index();
   index.uuid = "existing-uuid";
@@ -106,7 +106,7 @@ an_update_carries_the_uuid()
 }
 
 void
-all_three_parameter_blobs_survive_the_round_trip()
+all_three_parameter_blobs_survive_the_round_trip([[maybe_unused]] context& ctx)
 {
   const auto index = full_index();
 
@@ -128,7 +128,7 @@ all_three_parameter_blobs_survive_the_round_trip()
 }
 
 void
-an_unset_parameter_blob_stays_unset()
+an_unset_parameter_blob_stays_unset([[maybe_unused]] context& ctx)
 {
   couchbase::core::management::search::index index;
   index.name = "idx";
@@ -150,7 +150,7 @@ an_unset_parameter_blob_stays_unset()
 }
 
 void
-an_unparseable_parameter_blob_is_refused()
+an_unparseable_parameter_blob_is_refused([[maybe_unused]] context& ctx)
 {
   // Each position separately: a guard on one blob does not cover the other two.
   for (const auto* position : { "params", "plan_params", "source_params" }) {
@@ -173,7 +173,7 @@ an_unparseable_parameter_blob_is_refused()
 }
 
 void
-a_non_object_parameter_blob_is_refused()
+a_non_object_parameter_blob_is_refused([[maybe_unused]] context& ctx)
 {
   // Valid JSON, but the map is keyed by an object's members, so an array or a scalar has nowhere
   // to go. Dropping it is what loses a definition silently.
@@ -187,7 +187,7 @@ a_non_object_parameter_blob_is_refused()
 }
 
 void
-a_map_member_that_is_not_json_is_refused()
+a_map_member_that_is_not_json_is_refused([[maybe_unused]] context& ctx)
 {
   for (const auto* position : { "params", "plan_params", "source_params" }) {
     v1::Index proto;
@@ -205,7 +205,7 @@ a_map_member_that_is_not_json_is_refused()
 }
 
 void
-params_to_json_keeps_the_unset_convention_for_an_empty_map()
+params_to_json_keeps_the_unset_convention_for_an_empty_map([[maybe_unused]] context& ctx)
 {
   ::google::protobuf::Map<std::string, std::string> empty;
   const auto rebuilt = si::params_to_json(empty);
@@ -215,7 +215,7 @@ params_to_json_keeps_the_unset_convention_for_an_empty_map()
 }
 
 void
-decode_index_maps_fields()
+decode_index_maps_fields([[maybe_unused]] context& ctx)
 {
   v1::Index proto;
   proto.set_uuid("u1");
@@ -239,7 +239,7 @@ decode_index_maps_fields()
 }
 
 void
-a_definition_survives_the_full_encode_decode_cycle()
+a_definition_survives_the_full_encode_decode_cycle([[maybe_unused]] context& ctx)
 {
   // get_index -> edit -> upsert is the cycle that loses members when a conversion drops what it
   // cannot represent, so the whole definition is compared, not one blob.

--- a/test/cng/protostellar/streaming.cxx
+++ b/test/cng/protostellar/streaming.cxx
@@ -227,7 +227,7 @@ struct stream_fixture {
 // ── Delivery ──────────────────────────────────────────────────────────────────
 
 void
-server_stream_delivers_all_rows_on_the_io_thread()
+server_stream_delivers_all_rows_on_the_io_thread([[maybe_unused]] context& ctx)
 {
   in_process_query_server server{ metadata_plan() };
   asio::io_context io;
@@ -274,7 +274,7 @@ server_stream_delivers_all_rows_on_the_io_thread()
 // sample size of three. Enough messages here that the reactor has to re-issue StartRead many times,
 // and every row is checked rather than the first and last.
 void
-a_long_stream_preserves_order()
+a_long_stream_preserves_order([[maybe_unused]] context& ctx)
 {
   constexpr auto expected_rows = 500;
   in_process_query_server server{ streams_rows(expected_rows) };
@@ -319,7 +319,7 @@ a_long_stream_preserves_order()
 // row to force a read cycle this is the shortest path through the reactor, so it is the one most
 // likely to be broken by a change to the OnReadDone/OnDone handshake.
 void
-an_empty_stream_completes_without_rows()
+an_empty_stream_completes_without_rows([[maybe_unused]] context& ctx)
 {
   in_process_query_server server{ streams_rows(0) };
   asio::io_context io;
@@ -351,7 +351,7 @@ an_empty_stream_completes_without_rows()
 }
 
 void
-a_server_error_reaches_on_done()
+a_server_error_reaches_on_done([[maybe_unused]] context& ctx)
 {
   in_process_query_server server{ fails_with(
     grpc::Status{ grpc::StatusCode::INVALID_ARGUMENT, "syntax error" }) };
@@ -388,7 +388,7 @@ a_server_error_reaches_on_done()
 // rows already handed over stay handed over, and the failure arrives after them, not instead of
 // them.
 void
-rows_delivered_before_a_mid_stream_error_are_kept()
+rows_delivered_before_a_mid_stream_error_are_kept([[maybe_unused]] context& ctx)
 {
   in_process_query_server server{ fails_with(
     grpc::Status{ grpc::StatusCode::INTERNAL, "gateway gave up" }, 3) };
@@ -426,7 +426,7 @@ rows_delivered_before_a_mid_stream_error_are_kept()
 }
 
 void
-a_deadline_expires_a_parked_stream()
+a_deadline_expires_a_parked_stream([[maybe_unused]] context& ctx)
 {
   in_process_query_server server{ parks() };
   asio::io_context io;
@@ -457,7 +457,8 @@ a_deadline_expires_a_parked_stream()
 // of these park on the server, so if the deadline were absent the case would hang until the
 // runner's own timeout rather than fail cleanly.
 void
-a_non_positive_timeout_expires_the_call_rather_than_removing_the_deadline()
+a_non_positive_timeout_expires_the_call_rather_than_removing_the_deadline(
+  [[maybe_unused]] context& ctx)
 {
   in_process_query_server server{ parks() };
   const auto channel = server.channel();
@@ -487,7 +488,7 @@ a_non_positive_timeout_expires_the_call_rather_than_removing_the_deadline()
 }
 
 void
-cancelling_the_pending_call_ends_the_stream()
+cancelling_the_pending_call_ends_the_stream([[maybe_unused]] context& ctx)
 {
   in_process_query_server server{ parks() };
   asio::io_context io;
@@ -530,7 +531,7 @@ cancelling_the_pending_call_ends_the_stream()
 // is read only after the io_context has been destroyed, because until then the queued completion
 // legitimately owns the reactor -- reading it earlier reports 2 whether or not the reactor leaks.
 void
-tearing_down_with_an_unrun_completion_releases_the_reactor()
+tearing_down_with_an_unrun_completion_releases_the_reactor([[maybe_unused]] context& ctx)
 {
   in_process_query_server server{ parks() };
   const auto channel = server.channel();
@@ -559,7 +560,7 @@ tearing_down_with_an_unrun_completion_releases_the_reactor()
 // dispatcher's destructor would wait for a completion that can never arrive and the case would hang
 // rather than fail -- so reaching the assertion at all is most of what is being checked here.
 void
-an_invoker_that_throws_leaves_nothing_registered()
+an_invoker_that_throws_leaves_nothing_registered([[maybe_unused]] context& ctx)
 {
   in_process_query_server server;
   asio::io_context io;
@@ -601,7 +602,7 @@ an_invoker_that_throws_leaves_nothing_registered()
 // posted its completion and deregistered, so all of them are queued by the time the io_context is
 // allowed to finish.
 void
-concurrent_streams_are_all_drained_by_the_destructor()
+concurrent_streams_are_all_drained_by_the_destructor([[maybe_unused]] context& ctx)
 {
   constexpr auto concurrency = std::size_t{ 16 };
   in_process_query_server server{ parks() };
@@ -645,7 +646,7 @@ concurrent_streams_are_all_drained_by_the_destructor()
 // call_tracker::add() contends with itself as well as with the remove() calls arriving on gRPC's
 // threads -- the interleaving a single-threaded launcher cannot produce.
 void
-streams_launched_from_many_threads_all_complete()
+streams_launched_from_many_threads_all_complete([[maybe_unused]] context& ctx)
 {
   constexpr auto launchers = std::size_t{ 4 };
   constexpr auto per_launcher = std::size_t{ 4 };
@@ -709,7 +710,7 @@ streams_launched_from_many_threads_all_complete()
 // Without a cancel hook that releases that hold, ~dispatcher() waits for an OnDone that cannot
 // fire, so this case fails by timing out rather than by assertion.
 void
-destructor_drains_a_parked_stream()
+destructor_drains_a_parked_stream([[maybe_unused]] context& ctx)
 {
   std::promise<void> first_write_promise;
   auto first_write_future = first_write_promise.get_future();
@@ -761,7 +762,8 @@ destructor_drains_a_parked_stream()
 // must not block the drain, so a guard that held the lock across the consumer callback would hang
 // here rather than fail.
 void
-a_row_in_flight_when_the_drain_releases_the_hold_does_not_resume_the_read()
+a_row_in_flight_when_the_drain_releases_the_hold_does_not_resume_the_read(
+  [[maybe_unused]] context& ctx)
 {
   std::promise<void> row_delivered_promise;
   auto row_delivered = row_delivered_promise.get_future();
@@ -829,39 +831,53 @@ tests() -> test_suite
     {
       { "server_stream_delivers_all_rows_on_the_io_thread",
         server_stream_delivers_all_rows_on_the_io_thread,
+        {},
         timeout::network },
-      { "a_long_stream_preserves_order", a_long_stream_preserves_order, timeout::network },
+      { "a_long_stream_preserves_order", a_long_stream_preserves_order, {}, timeout::network },
       { "an_empty_stream_completes_without_rows",
         an_empty_stream_completes_without_rows,
+        {},
         timeout::network },
-      { "a_server_error_reaches_on_done", a_server_error_reaches_on_done, timeout::network },
+      { "a_server_error_reaches_on_done", a_server_error_reaches_on_done, {}, timeout::network },
       { "rows_delivered_before_a_mid_stream_error_are_kept",
         rows_delivered_before_a_mid_stream_error_are_kept,
+        {},
         timeout::network },
       { "a_deadline_expires_a_parked_stream",
         a_deadline_expires_a_parked_stream,
+        {},
         timeout::network },
       { "a_non_positive_timeout_expires_the_call_rather_than_removing_the_deadline",
         a_non_positive_timeout_expires_the_call_rather_than_removing_the_deadline,
+        {},
         timeout::network },
       { "cancelling_the_pending_call_ends_the_stream",
         cancelling_the_pending_call_ends_the_stream,
+        {},
         timeout::network },
       { "tearing_down_with_an_unrun_completion_releases_the_reactor",
         tearing_down_with_an_unrun_completion_releases_the_reactor,
+        {},
         timeout::network },
       { "an_invoker_that_throws_leaves_nothing_registered",
         an_invoker_that_throws_leaves_nothing_registered,
+        {},
         timeout::network },
-      { "destructor_drains_a_parked_stream", destructor_drains_a_parked_stream, timeout::network },
+      { "destructor_drains_a_parked_stream",
+        destructor_drains_a_parked_stream,
+        {},
+        timeout::network },
       { "a_row_in_flight_when_the_drain_releases_the_hold_does_not_resume_the_read",
         a_row_in_flight_when_the_drain_releases_the_hold_does_not_resume_the_read,
+        {},
         timeout::network },
       { "concurrent_streams_are_all_drained_by_the_destructor",
         concurrent_streams_are_all_drained_by_the_destructor,
+        {},
         timeout::network },
       { "streams_launched_from_many_threads_all_complete",
         streams_launched_from_many_threads_all_complete,
+        {},
         timeout::network },
     },
   };

--- a/test/cng/protostellar/view_converter.cxx
+++ b/test/cng/protostellar/view_converter.cxx
@@ -32,7 +32,7 @@ namespace ops = ::couchbase::core::operations;
 namespace v1 = ::couchbase::view::v1;
 
 void
-encode_maps_core_fields()
+encode_maps_core_fields([[maybe_unused]] context& ctx)
 {
   ops::document_view_request request;
   request.bucket_name = "travel";
@@ -72,7 +72,7 @@ encode_maps_core_fields()
 }
 
 void
-can_encode_rejects_unsupported_features()
+can_encode_rejects_unsupported_features([[maybe_unused]] context& ctx)
 {
   ops::document_view_request base;
   base.bucket_name = "b";
@@ -96,7 +96,7 @@ can_encode_rejects_unsupported_features()
 }
 
 void
-decode_rows_maps_rows_and_meta()
+decode_rows_maps_rows_and_meta([[maybe_unused]] context& ctx)
 {
   v1::ViewQueryResponse message;
   auto* row = message.add_rows();

--- a/test/framework/cluster_probes.cxx
+++ b/test/framework/cluster_probes.cxx
@@ -1,0 +1,181 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// The probe backend for a test executable that links the client library: one connection, opened on
+// the first probe, answering from the cluster map and the management endpoints.
+//
+// This is the only file under test/framework/ that includes core headers, and it is a .cxx --
+// context.hxx stays lean, so declaring a requirement costs a test file nothing in compile time.
+//
+// cmake/TestFramework.cmake links this or null_probes.cxx, never both.
+
+#include "context.hxx"
+
+#include "utils/integration_test_guard.hxx"
+#include "utils/server_version.hxx"
+
+#include <system_error>
+#include <utility>
+
+namespace couchbase::test
+{
+namespace
+{
+// ::test::utils, never test::utils: inside namespace couchbase::test the leading `test` binds to
+// this namespace, and lookup stops there rather than falling through to the global one.
+namespace utils = ::test::utils;
+
+auto
+to_edition(utils::server_edition edition) -> server_edition
+{
+  switch (edition) {
+    case utils::server_edition::enterprise:
+      return server_edition::enterprise;
+    case utils::server_edition::community:
+      return server_edition::community;
+    case utils::server_edition::columnar:
+      return server_edition::columnar;
+    case utils::server_edition::unknown:
+      break;
+  }
+  return server_edition::unknown;
+}
+
+auto
+to_deployment(utils::deployment_type deployment) -> deployment_type
+{
+  switch (deployment) {
+    case utils::deployment_type::capella:
+      return deployment_type::capella;
+    case utils::deployment_type::elixir:
+      return deployment_type::elixir;
+    case utils::deployment_type::on_prem:
+      break;
+  }
+  return deployment_type::on_prem;
+}
+
+auto
+to_storage_backend(couchbase::core::management::cluster::bucket_storage_backend backend)
+  -> std::string
+{
+  switch (backend) {
+    case couchbase::core::management::cluster::bucket_storage_backend::couchstore:
+      return "couchstore";
+    case couchbase::core::management::cluster::bucket_storage_backend::magma:
+      return "magma";
+    case couchbase::core::management::cluster::bucket_storage_backend::unknown:
+      break;
+  }
+  return "unknown";
+}
+
+class cluster_probes : public probe_backend
+{
+public:
+  [[nodiscard]] auto server_version() -> couchbase::test::server_version override
+  {
+    return guarded([](utils::integration_test_guard& guard) {
+      const auto version = guard.cluster_version();
+      return couchbase::test::server_version{
+        static_cast<std::uint32_t>(version.major),
+        static_cast<std::uint32_t>(version.minor),
+        static_cast<std::uint32_t>(version.micro),
+        version.developer_preview,
+        to_edition(version.edition),
+        to_deployment(version.deployment),
+      };
+    });
+  }
+
+  [[nodiscard]] auto has_service(const std::string& name) -> bool override
+  {
+    // By the cluster-map spelling ("n1ql", "cbas", "fts") rather than by service_type, so a
+    // requirement names the service the way the server does and no enum mapping can drift.
+    return guarded([&name](utils::integration_test_guard& guard) {
+      return guard.number_of_nodes_with_service(name) > 0;
+    });
+  }
+
+  [[nodiscard]] auto has_bucket_capability(const std::string& capability) -> bool override
+  {
+    return guarded([&capability](utils::integration_test_guard& guard) {
+      return guard.has_bucket_capability(capability);
+    });
+  }
+
+  [[nodiscard]] auto number_of_replicas() -> std::size_t override
+  {
+    return guarded([](utils::integration_test_guard& guard) {
+      return guard.number_of_replicas();
+    });
+  }
+
+  [[nodiscard]] auto number_of_nodes() -> std::size_t override
+  {
+    return guarded([](utils::integration_test_guard& guard) {
+      return guard.number_of_nodes();
+    });
+  }
+
+  [[nodiscard]] auto server_groups() -> std::vector<std::string> override
+  {
+    return guarded([](utils::integration_test_guard& guard) {
+      return guard.server_groups();
+    });
+  }
+
+  [[nodiscard]] auto storage_backend() -> std::string override
+  {
+    return guarded([](utils::integration_test_guard& guard) {
+      return to_storage_backend(guard.storage_backend());
+    });
+  }
+
+private:
+  // The guard opens the connection in its constructor, so it is built on the first probe and not
+  // before. Anything it throws -- a refused connection, a management endpoint that answered with
+  // an error -- becomes probe_failure, which the runner reports as undetermined and therefore as a
+  // failed case. An unreachable cluster must not read as an inapplicable one.
+  template<typename Fn>
+  auto guarded(Fn&& fn) -> decltype(fn(std::declval<utils::integration_test_guard&>()))
+  {
+    try {
+      if (!guard_) {
+        guard_ = std::make_unique<utils::integration_test_guard>();
+      }
+      return std::forward<Fn>(fn)(*guard_);
+    } catch (const std::system_error& e) {
+      throw probe_failure(fmt::format("the cluster could not answer: {}", e.what()));
+    } catch (const std::exception& e) {
+      throw probe_failure(fmt::format("the cluster could not be reached: {}", e.what()));
+    }
+  }
+
+  std::unique_ptr<utils::integration_test_guard> guard_{};
+};
+} // namespace
+
+auto
+make_probe_backend(const configuration& /* config */) -> std::unique_ptr<probe_backend>
+{
+  // The connection details come from test::utils::test_context, which reads the same environment
+  // variables the configuration did. One reader will remain once the Catch2 suites are gone.
+  return std::make_unique<cluster_probes>();
+}
+
+} // namespace couchbase::test

--- a/test/framework/cluster_probes_selftest.cxx
+++ b/test/framework/cluster_probes_selftest.cxx
@@ -1,0 +1,113 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// The cluster-backed probes, against a real cluster.
+//
+// framework/selftest.cxx drives the runner with stand-in backends, which pins the semantics but
+// says nothing about whether cluster_probes.cxx can actually answer. These cases are the other
+// half: they require a cluster, so they skip where there is none and exercise the real connection
+// where there is one. They are also what makes the three outcomes visible from the outside --
+// unset connection string skips them, an unreachable one fails them.
+
+#include "framework/test_runner.hxx"
+
+#include <cstddef>
+#include <string>
+
+namespace couchbase::test
+{
+namespace
+{
+void
+the_version_probe_reports_a_plausible_release(context& ctx)
+{
+  const auto version = ctx.server_version();
+  // 4.x predates every supported release and 99 is not a version anybody ships; between them the
+  // check catches a probe that answered with a default-constructed value.
+  assert_true(version.major >= 4,
+              fmt::format("major version {} is too old to be real", version.major));
+  assert_true(version.major < 99, fmt::format("major version {} is not a release", version.major));
+  assert_true(!version.to_string().empty(), "the version renders");
+}
+
+void
+the_kv_service_is_always_present(context& ctx)
+{
+  // Every Couchbase cluster runs KV. A probe that cannot see it is broken rather than reporting a
+  // cluster without data nodes.
+  assert_true(ctx.has_service("kv"), "the cluster reports a kv node");
+  assert_false(ctx.has_service("no_such_service"), "and does not invent one that does not exist");
+}
+
+void
+the_topology_probes_answer_with_counts(context& ctx)
+{
+  assert_true(ctx.number_of_nodes() >= 1, "the cluster has at least one node");
+  // A default bucket may legitimately have no replicas, so the assertion is on the probe answering
+  // at all rather than on a particular number.
+  const auto replicas = ctx.number_of_replicas();
+  assert_true(replicas <= 3, fmt::format("{} replicas is beyond what a bucket can hold", replicas));
+  // Deliberately not "at least one": server groups are a rack-awareness feature, and a cluster
+  // that was never given one reports none. What is always true is that the probe answers and every
+  // name it returns is a name.
+  for (const auto& group : ctx.server_groups()) {
+    assert_false(group.empty(), "a reported server group has a name");
+  }
+}
+
+void
+the_storage_backend_is_one_the_server_can_name(context& ctx)
+{
+  // Gated on 7.1: before it the server reports no storage backend at all, and the probe correctly
+  // answers "unknown" -- which is not a mapping error to catch, so there is nothing to assert.
+  const auto backend = ctx.storage_backend();
+  assert_true(backend == "couchstore" || backend == "magma",
+              fmt::format("\"{}\" is not a storage backend the server reports", backend));
+}
+
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "framework_cluster_probes",
+    {
+      { "the_version_probe_reports_a_plausible_release",
+        the_version_probe_reports_a_plausible_release,
+        { needs::real_cluster(), needs::service("kv") },
+        timeout::integration },
+      // No needs::service("kv") here, deliberately: the gate would call the same cached probe the
+      // body asserts on, so a probe wrongly answering false would skip this case instead of failing
+      // it -- and the one case whose job is to catch that would be the one that never runs.
+      { "the_kv_service_is_always_present",
+        the_kv_service_is_always_present,
+        { needs::real_cluster() },
+        timeout::integration },
+      { "the_topology_probes_answer_with_counts",
+        the_topology_probes_answer_with_counts,
+        { needs::real_cluster(), needs::service("kv") },
+        timeout::integration },
+      { "the_storage_backend_is_one_the_server_can_name",
+        the_storage_backend_is_one_the_server_can_name,
+        { needs::real_cluster(), needs::service("kv"), needs::cluster_version(v7_1) },
+        timeout::integration },
+    },
+  };
+}
+
+} // namespace couchbase::test

--- a/test/framework/context.cxx
+++ b/test/framework/context.cxx
@@ -1,0 +1,233 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "context.hxx"
+
+#include "test_runner.hxx"
+
+#include <map>
+#include <mutex>
+#include <utility>
+
+namespace couchbase::test
+{
+namespace
+{
+// A probe answered once and remembered, including the failure. Re-running a probe that already
+// failed would turn one unreachable cluster into one round trip per case.
+template<typename T>
+class cached
+{
+public:
+  template<typename Fn>
+  auto get(Fn&& compute) -> T
+  {
+    if (!value_.has_value() && failure_.empty()) {
+      try {
+        value_ = std::forward<Fn>(compute)();
+      } catch (const probe_failure& e) {
+        failure_ = e.what();
+      }
+    }
+    if (!failure_.empty()) {
+      throw probe_failure(failure_);
+    }
+    return *value_;
+  }
+
+private:
+  std::optional<T> value_{};
+  std::string failure_{};
+};
+} // namespace
+
+auto
+configuration::from_environment() -> configuration
+{
+  configuration config;
+
+  if (const auto value = safe_getenv("TEST_CONNECTION_STRING"); value.has_value()) {
+    config.connection_string = *value;
+    config.cluster_configured = true;
+  }
+  if (const auto value = safe_getenv("TEST_USERNAME"); value.has_value()) {
+    config.username = *value;
+  }
+  if (const auto value = safe_getenv("TEST_PASSWORD"); value.has_value()) {
+    config.password = *value;
+  }
+  if (const auto value = safe_getenv("TEST_BUCKET"); value.has_value()) {
+    config.bucket = *value;
+  }
+  // OTHER_TEST_BUCKET is the spelling test/utils/test_context.cxx uses and therefore the one the
+  // suite is driven with; TEST_OTHER_BUCKET is accepted after it so an existing local environment
+  // keeps working.
+  if (const auto value = safe_getenv("OTHER_TEST_BUCKET"); value.has_value()) {
+    config.other_bucket = *value;
+  } else if (const auto legacy = safe_getenv("TEST_OTHER_BUCKET"); legacy.has_value()) {
+    config.other_bucket = *legacy;
+  }
+  // Both spellings: bin/run-integration-tests reads CB_USE_GOCAVES and exports TEST_USE_GOCAVES,
+  // and a developer running a binary by hand sets whichever they remember.
+  //
+  // The value decides, not its presence, and the accepted words match test/utils/test_context.cxx.
+  // Reading presence alone made TEST_USE_GOCAVES=false mean the real cluster to every Catch2 test
+  // and the mock to this framework in the same run -- two readers in one process disagreeing about
+  // which endpoint they are talking to.
+  const auto enabled = [](const std::optional<std::string>& value) {
+    return value.has_value() && (*value == "true" || *value == "yes" || *value == "1");
+  };
+  config.mock = enabled(safe_getenv("TEST_USE_GOCAVES")) || enabled(safe_getenv("CB_USE_GOCAVES"));
+
+  return config;
+}
+
+struct context::impl {
+  // The probes below are reached from more than one thread. run_bounded detaches a worker whose
+  // budget expired -- a requirement phase or a case body alike -- and that worker is normally still
+  // inside a probe, so the next case enters this context before the previous one has left it.
+  //
+  // Every accessor that touches the caches, the backend or the counter takes this lock, and holds
+  // it across the probe itself: that is what keeps the run to one backend rather than one per
+  // racing caller. A probe that hangs therefore blocks the next case until that case's own budget
+  // expires, so a wedged cluster reports every case as undetermined instead of corrupting the
+  // caches.
+  std::mutex mutex;
+
+  configuration config;
+  std::unique_ptr<probe_backend> backend{};
+  std::size_t backends_created{ 0 };
+
+  cached<couchbase::test::server_version> version{};
+  cached<std::size_t> replicas{};
+  cached<std::size_t> nodes{};
+  cached<std::vector<std::string>> groups{};
+  cached<std::string> storage{};
+  std::map<std::string, cached<bool>, std::less<>> services{};
+  std::map<std::string, cached<bool>, std::less<>> capabilities{};
+
+  auto probes() -> probe_backend&
+  {
+    if (backend == nullptr) {
+      // Deliberately not at startup: a case that asks nothing of the server must not open a
+      // connection, and a suite of 300 cases must open at most this one.
+      backend = make_probe_backend(config);
+      ++backends_created;
+    }
+    return *backend;
+  }
+};
+
+context::context(configuration config)
+  : impl_{ std::make_unique<impl>() }
+{
+  impl_->config = std::move(config);
+}
+
+context::context(configuration config, std::unique_ptr<probe_backend> backend)
+  : impl_{ std::make_unique<impl>() }
+{
+  impl_->config = std::move(config);
+  impl_->backend = std::move(backend);
+  impl_->backends_created = 1;
+}
+
+context::~context() = default;
+
+auto
+context::config() const -> const configuration&
+{
+  return impl_->config;
+}
+
+auto
+context::env(const std::string& name) const -> std::optional<std::string>
+{
+  return safe_getenv(name);
+}
+
+auto
+context::server_version() -> couchbase::test::server_version
+{
+  const std::lock_guard<std::mutex> guard{ impl_->mutex };
+  return impl_->version.get([this]() {
+    return impl_->probes().server_version();
+  });
+}
+
+auto
+context::has_service(const std::string& name) -> bool
+{
+  const std::lock_guard<std::mutex> guard{ impl_->mutex };
+  return impl_->services[name].get([this, &name]() {
+    return impl_->probes().has_service(name);
+  });
+}
+
+auto
+context::has_bucket_capability(const std::string& capability) -> bool
+{
+  const std::lock_guard<std::mutex> guard{ impl_->mutex };
+  return impl_->capabilities[capability].get([this, &capability]() {
+    return impl_->probes().has_bucket_capability(capability);
+  });
+}
+
+auto
+context::number_of_replicas() -> std::size_t
+{
+  const std::lock_guard<std::mutex> guard{ impl_->mutex };
+  return impl_->replicas.get([this]() {
+    return impl_->probes().number_of_replicas();
+  });
+}
+
+auto
+context::number_of_nodes() -> std::size_t
+{
+  const std::lock_guard<std::mutex> guard{ impl_->mutex };
+  return impl_->nodes.get([this]() {
+    return impl_->probes().number_of_nodes();
+  });
+}
+
+auto
+context::server_groups() -> std::vector<std::string>
+{
+  const std::lock_guard<std::mutex> guard{ impl_->mutex };
+  return impl_->groups.get([this]() {
+    return impl_->probes().server_groups();
+  });
+}
+
+auto
+context::storage_backend() -> std::string
+{
+  const std::lock_guard<std::mutex> guard{ impl_->mutex };
+  return impl_->storage.get([this]() {
+    return impl_->probes().storage_backend();
+  });
+}
+
+auto
+context::backends_created() const -> std::size_t
+{
+  const std::lock_guard<std::mutex> guard{ impl_->mutex };
+  return impl_->backends_created;
+}
+
+} // namespace couchbase::test

--- a/test/framework/context.hxx
+++ b/test/framework/context.hxx
@@ -1,0 +1,197 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+// What a test case and its requirements are handed: the configuration the run was started with,
+// the process environment, and a small set of cached probes describing the server.
+//
+// This header stays lean on purpose -- <string>, <vector>, <optional>, <memory>, <chrono> and the
+// fmt wrapper. Every probe returns a plain type, so nothing here names a core or public SDK type
+// and a test file that only needs to *describe* its requirements pays no compile cost for the
+// client library. Reaching the cluster itself is cluster_access.hxx, which is not lean.
+
+#include <chrono>
+#include <cstdint>
+#include <exception>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <spdlog/fmt/fmt.h>
+
+namespace couchbase::test
+{
+
+// Thrown by a probe that could not answer. The runner turns one escaping a requirement into
+// `undetermined`, so a requirement never handles errors itself.
+class probe_failure : public std::exception
+{
+public:
+  explicit probe_failure(std::string message)
+    : message_{ std::move(message) }
+  {
+  }
+  [[nodiscard]] auto what() const noexcept -> const char* override
+  {
+    return message_.c_str();
+  }
+
+private:
+  std::string message_;
+};
+
+enum class server_edition : std::uint8_t {
+  unknown,
+  enterprise,
+  community,
+  columnar,
+};
+
+enum class deployment_type : std::uint8_t {
+  on_prem,
+  capella,
+  elixir,
+};
+
+// The lean mirror of test::utils::server_version, carrying what a requirement can ask about and
+// nothing else. Ordered by (major, minor, micro) so a version range is a pair of comparisons.
+struct server_version {
+  std::uint32_t major{ 0 };
+  std::uint32_t minor{ 0 };
+  std::uint32_t micro{ 0 };
+  bool developer_preview{ false };
+  server_edition edition{ server_edition::unknown };
+  deployment_type deployment{ deployment_type::on_prem };
+
+  [[nodiscard]] auto to_string() const -> std::string
+  {
+    return fmt::format("{}.{}.{}", major, minor, micro);
+  }
+
+  [[nodiscard]] friend auto operator<(const server_version& a, const server_version& b) -> bool
+  {
+    if (a.major != b.major) {
+      return a.major < b.major;
+    }
+    if (a.minor != b.minor) {
+      return a.minor < b.minor;
+    }
+    return a.micro < b.micro;
+  }
+  [[nodiscard]] friend auto operator>=(const server_version& a, const server_version& b) -> bool
+  {
+    return !(a < b);
+  }
+};
+
+// Version constants the requirement vocabulary names, so a case says which release introduced the
+// behaviour it pins rather than repeating a number nobody can attribute later.
+inline constexpr server_version v6_5{ 6, 5, 0 };
+inline constexpr server_version v7_0{ 7, 0, 0 };
+inline constexpr server_version v7_1{ 7, 1, 0 };
+inline constexpr server_version v7_2{ 7, 2, 0 };
+inline constexpr server_version v7_6{ 7, 6, 0 };
+inline constexpr server_version v8_0{ 8, 0, 0 };
+
+// Everything the run was started with, resolved once before any case executes. A test body reads
+// these rather than the environment, so what a case depends on is visible here instead of being
+// spread over getenv calls.
+struct configuration {
+  std::string connection_string{};
+  std::string username{ "Administrator" };
+  std::string password{ "password" };
+  std::string bucket{ "default" };
+  std::string other_bucket{ "secBucket" };
+  // Set iff TEST_CONNECTION_STRING is set and non-empty. Distinct from "a cluster answered": an
+  // endpoint that is configured but unreachable is a failure, never a skip.
+  bool cluster_configured{ false };
+  // The gocaves mock, driven by TEST_USE_GOCAVES / CB_USE_GOCAVES the way
+  // bin/run-integration-tests already sets them.
+  bool mock{ false };
+  // Upper bound on a case's whole requirement phase, which runs before every case in the binary.
+  // Distinct from the case's own budget: this one bounds the probing, that one the work, and
+  // CB_TEST_TIMEOUT_MULTIPLIER scales both. A requirement that blocks anyway costs its case this
+  // much and nothing more.
+  std::chrono::milliseconds requirement_budget{ std::chrono::seconds{ 60 } };
+
+  [[nodiscard]] static auto from_environment() -> configuration;
+};
+
+// The probes, behind an interface so the lean framework does not link the client library. Exactly
+// one implementation is linked into a test executable: the null one, whose every probe reports it
+// has no cluster to ask, or the cluster one, which drives a real connection.
+class probe_backend
+{
+public:
+  probe_backend() = default;
+  probe_backend(const probe_backend&) = delete;
+  auto operator=(const probe_backend&) -> probe_backend& = delete;
+  virtual ~probe_backend() = default;
+
+  [[nodiscard]] virtual auto server_version() -> couchbase::test::server_version = 0;
+  [[nodiscard]] virtual auto has_service(const std::string& name) -> bool = 0;
+  [[nodiscard]] virtual auto has_bucket_capability(const std::string& capability) -> bool = 0;
+  [[nodiscard]] virtual auto number_of_replicas() -> std::size_t = 0;
+  [[nodiscard]] virtual auto number_of_nodes() -> std::size_t = 0;
+  [[nodiscard]] virtual auto server_groups() -> std::vector<std::string> = 0;
+  [[nodiscard]] virtual auto storage_backend() -> std::string = 0;
+};
+
+// Defined by whichever backend library the executable links (see cmake/TestFramework.cmake). The
+// context calls it on the first probe, never at startup: a test that asks nothing of the server
+// opens no connection.
+[[nodiscard]] auto
+make_probe_backend(const configuration& config) -> std::unique_ptr<probe_backend>;
+
+class context
+{
+public:
+  explicit context(configuration config);
+  // For the framework's own tests, which drive the probes with a stand-in backend.
+  context(configuration config, std::unique_ptr<probe_backend> backend);
+  context(const context&) = delete;
+  auto operator=(const context&) -> context& = delete;
+  ~context();
+
+  [[nodiscard]] auto config() const -> const configuration&;
+
+  // The process environment, so a case that genuinely needs a variable reads it from here and the
+  // run can report what it consulted.
+  [[nodiscard]] auto env(const std::string& name) const -> std::optional<std::string>;
+
+  // Probes. Each is cached for the lifetime of the process -- a binary with 300 cases must not
+  // open 300 connections -- and each throws probe_failure when it cannot answer.
+  [[nodiscard]] auto server_version() -> couchbase::test::server_version;
+  [[nodiscard]] auto has_service(const std::string& name) -> bool;
+  [[nodiscard]] auto has_bucket_capability(const std::string& capability) -> bool;
+  [[nodiscard]] auto number_of_replicas() -> std::size_t;
+  [[nodiscard]] auto number_of_nodes() -> std::size_t;
+  [[nodiscard]] auto server_groups() -> std::vector<std::string>;
+  [[nodiscard]] auto storage_backend() -> std::string;
+
+  // How many times a backend has been created. The caching above is what keeps a suite from
+  // reconnecting per case, and a number is the only way to hold that claim to account.
+  [[nodiscard]] auto backends_created() const -> std::size_t;
+
+private:
+  struct impl;
+  std::unique_ptr<impl> impl_;
+};
+
+} // namespace couchbase::test

--- a/test/framework/null_probes.cxx
+++ b/test/framework/null_probes.cxx
@@ -1,0 +1,78 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+// The probe backend for a test executable that does not link the client library. Every probe
+// reports that it cannot answer, which the runner turns into `undetermined` and therefore a
+// failure -- a test asking about the server from a binary that cannot reach one is a registration
+// mistake, and silently skipping it would hide the mistake for as long as the test existed.
+//
+// cmake/TestFramework.cmake links this or cluster_probes.cxx, never both.
+
+#include "context.hxx"
+
+namespace couchbase::test
+{
+namespace
+{
+class null_probes : public probe_backend
+{
+public:
+  [[nodiscard]] auto server_version() -> couchbase::test::server_version override
+  {
+    fail();
+  }
+  [[nodiscard]] auto has_service(const std::string& /* name */) -> bool override
+  {
+    fail();
+  }
+  [[nodiscard]] auto has_bucket_capability(const std::string& /* capability */) -> bool override
+  {
+    fail();
+  }
+  [[nodiscard]] auto number_of_replicas() -> std::size_t override
+  {
+    fail();
+  }
+  [[nodiscard]] auto number_of_nodes() -> std::size_t override
+  {
+    fail();
+  }
+  [[nodiscard]] auto server_groups() -> std::vector<std::string> override
+  {
+    fail();
+  }
+  [[nodiscard]] auto storage_backend() -> std::string override
+  {
+    fail();
+  }
+
+private:
+  [[noreturn]] static void fail()
+  {
+    throw probe_failure("this test executable does not link the client library, so it cannot ask "
+                        "the server anything (add LINK_CLIENT to its couchbase_add_test call)");
+  }
+};
+} // namespace
+
+auto
+make_probe_backend(const configuration& /* config */) -> std::unique_ptr<probe_backend>
+{
+  return std::make_unique<null_probes>();
+}
+
+} // namespace couchbase::test

--- a/test/framework/requirement.cxx
+++ b/test/framework/requirement.cxx
@@ -1,0 +1,332 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "requirement.hxx"
+
+// This file formats every requirement description, so it asks for fmt itself rather than
+// relying on a header it includes happening to carry it.
+#include <spdlog/fmt/fmt.h>
+
+#include <functional>
+#include <optional>
+#include <utility>
+
+namespace couchbase::test::needs
+{
+namespace
+{
+// Every built-in requirement is this shape: a sentence, and a predicate over the context that
+// closes over whatever the factory was given. A class per requirement would be the same thing
+// spelled a hundred lines longer; a file-local requirement that wants state of its own still
+// derives from `requirement` directly.
+class simple_requirement : public requirement
+{
+public:
+  simple_requirement(std::string description, std::function<check_result(context&)> check)
+    : description_{ std::move(description) }
+    , check_{ std::move(check) }
+  {
+  }
+
+  [[nodiscard]] auto describe() const -> std::string override
+  {
+    return description_;
+  }
+
+  [[nodiscard]] auto check(context& ctx) const -> check_result override
+  {
+    return check_(ctx);
+  }
+
+private:
+  std::string description_;
+  std::function<check_result(context&)> check_;
+};
+
+auto
+make(std::string description, std::function<check_result(context&)> check) -> requirement_ptr
+{
+  return std::make_shared<const simple_requirement>(std::move(description), std::move(check));
+}
+
+// A cluster has to be configured before any probe is worth attempting. Reported as not_satisfied
+// (a skip) rather than undetermined: nobody asked for a cluster, so nothing is unknown.
+auto
+unconfigured(const context& ctx) -> std::optional<check_result>
+{
+  if (!ctx.config().cluster_configured) {
+    return check_result::missing("no cluster is configured (TEST_CONNECTION_STRING is unset)");
+  }
+  return std::nullopt;
+}
+} // namespace
+
+auto
+real_cluster() -> requirement_ptr
+{
+  return make("a real cluster", [](context& ctx) {
+    if (const auto missing = unconfigured(ctx); missing.has_value()) {
+      return *missing;
+    }
+    if (ctx.config().mock) {
+      return check_result::missing("the mock is in use, not a real cluster");
+    }
+    return check_result::ok();
+  });
+}
+
+auto
+mock() -> requirement_ptr
+{
+  return make("the gocaves mock", [](context& ctx) {
+    // Configured first, as real_cluster() does. Nothing here derives an endpoint from the mock:
+    // the variable selects which server the suite believes it is addressing, not where it is, so a
+    // case gated on the mock has as little to run against as a real one when nothing is set.
+    if (const auto missing = unconfigured(ctx); missing.has_value()) {
+      return *missing;
+    }
+    if (!ctx.config().mock) {
+      // Not "unset": either variable may be set to a value that does not enable it, and the report
+      // has to send the reader to the rule rather than to one spelling of it.
+      return check_result::missing(
+        "the mock is not in use (neither TEST_USE_GOCAVES nor CB_USE_GOCAVES is true, yes or 1)");
+    }
+    return check_result::ok();
+  });
+}
+
+auto
+service(std::string name) -> requirement_ptr
+{
+  // The description is built before the capture moves `name`. As two arguments to the same call
+  // their evaluation order is unspecified, and a compiler that moves first formats an empty name --
+  // which then becomes the key the skip report groups by.
+  auto description = fmt::format("the {} service", name);
+  return make(std::move(description), [name = std::move(name)](context& ctx) {
+    if (const auto missing = unconfigured(ctx); missing.has_value()) {
+      return *missing;
+    }
+    if (!ctx.has_service(name)) {
+      return check_result::missing(fmt::format("the cluster runs no {} node", name));
+    }
+    return check_result::ok();
+  });
+}
+
+auto
+cluster_version(server_version from) -> requirement_ptr
+{
+  return make(fmt::format("a cluster at {} or later", from.to_string()), [from](context& ctx) {
+    if (const auto missing = unconfigured(ctx); missing.has_value()) {
+      return *missing;
+    }
+    if (const auto actual = ctx.server_version(); actual < from) {
+      return check_result::missing(
+        fmt::format("the cluster is {}, below {}", actual.to_string(), from.to_string()));
+    }
+    return check_result::ok();
+  });
+}
+
+auto
+cluster_version(server_version from, server_version until) -> requirement_ptr
+{
+  return make(fmt::format("a cluster in [{}, {})", from.to_string(), until.to_string()),
+              [from, until](context& ctx) {
+                if (const auto missing = unconfigured(ctx); missing.has_value()) {
+                  return *missing;
+                }
+                const auto actual = ctx.server_version();
+                if (actual < from) {
+                  return check_result::missing(fmt::format(
+                    "the cluster is {}, below {}", actual.to_string(), from.to_string()));
+                }
+                if (actual >= until) {
+                  return check_result::missing(fmt::format(
+                    "the cluster is {}, at or above {}", actual.to_string(), until.to_string()));
+                }
+                return check_result::ok();
+              });
+}
+
+auto
+bucket_capability(std::string capability) -> requirement_ptr
+{
+  auto description = fmt::format("the {} bucket capability", capability);
+  return make(std::move(description), [capability = std::move(capability)](context& ctx) {
+    if (const auto missing = unconfigured(ctx); missing.has_value()) {
+      return *missing;
+    }
+    if (!ctx.has_bucket_capability(capability)) {
+      return check_result::missing(fmt::format("the bucket does not report {}", capability));
+    }
+    return check_result::ok();
+  });
+}
+
+namespace
+{
+auto
+deployment_name(deployment_type type) -> std::string
+{
+  switch (type) {
+    case deployment_type::capella:
+      return "Capella";
+    case deployment_type::elixir:
+      return "Elixir";
+    case deployment_type::on_prem:
+      break;
+  }
+  return "on-prem";
+}
+} // namespace
+
+auto
+deployment(deployment_type type) -> requirement_ptr
+{
+  return make(fmt::format("a {} deployment", deployment_name(type)), [type](context& ctx) {
+    if (const auto missing = unconfigured(ctx); missing.has_value()) {
+      return *missing;
+    }
+    if (ctx.server_version().deployment != type) {
+      return check_result::missing(fmt::format("the deployment is not {}", deployment_name(type)));
+    }
+    return check_result::ok();
+  });
+}
+
+auto
+edition(server_edition wanted) -> requirement_ptr
+{
+  // Every enumerator named, and no default. This string is the requirement's description, which is
+  // also the key the skip report groups by, so labelling one edition as another makes the report
+  // give a reason nobody asked for. A ternary silently lumps every future edition in with the last
+  // branch; the switch makes -Wswitch stop the build until the new one is named.
+  std::string name{ "unknown" };
+  switch (wanted) {
+    case server_edition::enterprise:
+      name = "enterprise";
+      break;
+    case server_edition::community:
+      name = "community";
+      break;
+    case server_edition::columnar:
+      name = "columnar";
+      break;
+    case server_edition::unknown:
+      break;
+  }
+  return make(fmt::format("the {} edition", name), [wanted, name](context& ctx) {
+    if (const auto missing = unconfigured(ctx); missing.has_value()) {
+      return *missing;
+    }
+    const auto actual = ctx.server_version().edition;
+    // Not a skip: the case may well be applicable, and reporting it as inapplicable would claim
+    // knowledge the cluster refused to give.
+    if (actual == server_edition::unknown) {
+      return check_result::unknown("the cluster did not report its edition");
+    }
+    if (actual != wanted) {
+      return check_result::missing(fmt::format("the cluster is not {}", name));
+    }
+    return check_result::ok();
+  });
+}
+
+auto
+storage_backend(std::string backend) -> requirement_ptr
+{
+  auto description = fmt::format("a {} bucket", backend);
+  return make(std::move(description), [backend = std::move(backend)](context& ctx) {
+    if (const auto missing = unconfigured(ctx); missing.has_value()) {
+      return *missing;
+    }
+    const auto actual = ctx.storage_backend();
+    // "unknown" is how the SDK spells "the server did not report one" -- a bucket on a release
+    // predating the setting parses that way. Treated as a mismatch it would skip the case and say
+    // "the bucket is unknown, not magma", naming a backend no bucket has and hiding a cluster that
+    // could not answer behind a skip. Not knowing is undetermined, as it is for the edition above.
+    if (actual == "unknown") {
+      return check_result::unknown("the cluster did not report a storage backend");
+    }
+    if (actual != backend) {
+      return check_result::missing(fmt::format("the bucket is {}, not {}", actual, backend));
+    }
+    return check_result::ok();
+  });
+}
+
+auto
+replicas(std::size_t at_least) -> requirement_ptr
+{
+  return make(fmt::format("at least {} replica(s)", at_least), [at_least](context& ctx) {
+    if (const auto missing = unconfigured(ctx); missing.has_value()) {
+      return *missing;
+    }
+    if (const auto actual = ctx.number_of_replicas(); actual < at_least) {
+      return check_result::missing(
+        fmt::format("the bucket has {} replica(s), fewer than {}", actual, at_least));
+    }
+    return check_result::ok();
+  });
+}
+
+auto
+nodes(std::size_t at_least) -> requirement_ptr
+{
+  return make(fmt::format("at least {} node(s)", at_least), [at_least](context& ctx) {
+    if (const auto missing = unconfigured(ctx); missing.has_value()) {
+      return *missing;
+    }
+    if (const auto actual = ctx.number_of_nodes(); actual < at_least) {
+      return check_result::missing(
+        fmt::format("the cluster has {} node(s), fewer than {}", actual, at_least));
+    }
+    return check_result::ok();
+  });
+}
+
+auto
+server_groups(std::size_t at_least) -> requirement_ptr
+{
+  return make(fmt::format("at least {} server group(s)", at_least), [at_least](context& ctx) {
+    if (const auto missing = unconfigured(ctx); missing.has_value()) {
+      return *missing;
+    }
+    if (const auto actual = ctx.server_groups().size(); actual < at_least) {
+      return check_result::missing(
+        fmt::format("the cluster has {} server group(s), fewer than {}", actual, at_least));
+    }
+    return check_result::ok();
+  });
+}
+
+auto
+developer_preview() -> requirement_ptr
+{
+  return make("developer preview enabled", [](context& ctx) {
+    if (const auto missing = unconfigured(ctx); missing.has_value()) {
+      return *missing;
+    }
+    if (!ctx.server_version().developer_preview) {
+      return check_result::missing("the cluster is not in developer preview");
+    }
+    return check_result::ok();
+  });
+}
+
+} // namespace couchbase::test::needs

--- a/test/framework/requirement.hxx
+++ b/test/framework/requirement.hxx
@@ -1,0 +1,134 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026. Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+// What a case needs from the environment it runs in, declared at registration rather than decided
+// inside the case body.
+//
+// A guard at the top of a body answers only for itself: the runner cannot see it, and the reason a
+// case did not run survives only as a line of output. The reporting matters less than the third
+// outcome. A predicate returning bool has to fold "I could not find out" into one of two answers,
+// and in test infrastructure it is always folded into the one that does not fail the build -- so a
+// cluster that cannot be reached skips every case and the leg goes green having verified nothing.
+//
+// check() therefore returns three states. `not_satisfied` skips the case; `undetermined` fails it.
+
+#include "context.hxx"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace couchbase::test
+{
+
+struct check_result {
+  enum class status : std::uint8_t {
+    satisfied,
+    not_satisfied,
+    undetermined,
+  };
+
+  status value{ status::satisfied };
+  std::string detail{};
+
+  [[nodiscard]] static auto ok() -> check_result
+  {
+    return {};
+  }
+  [[nodiscard]] static auto missing(std::string why) -> check_result
+  {
+    return { status::not_satisfied, std::move(why) };
+  }
+  [[nodiscard]] static auto unknown(std::string why) -> check_result
+  {
+    return { status::undetermined, std::move(why) };
+  }
+};
+
+class requirement
+{
+public:
+  requirement() = default;
+  requirement(const requirement&) = delete;
+  auto operator=(const requirement&) -> requirement& = delete;
+  virtual ~requirement() = default;
+
+  // What the case needs, phrased so the skip report reads as a list of gaps in the environment.
+  [[nodiscard]] virtual auto describe() const -> std::string = 0;
+
+  // Whether this environment provides it. A probe_failure thrown here is caught by the runner and
+  // reported as undetermined, so an implementation handles no errors of its own.
+  [[nodiscard]] virtual auto check(context& ctx) const -> check_result = 0;
+};
+
+using requirement_ptr = std::shared_ptr<const requirement>;
+
+// The built-in vocabulary. The names come from the predicates the suite already uses rather than
+// from a taxonomy invented for the framework; a file that needs something else writes its own
+// requirement in the translation unit that needs it.
+namespace needs
+{
+// A configured cluster. Says nothing about whether it answers -- that is what the probing
+// requirements below find out, and their answer to an unreachable endpoint is a failure.
+[[nodiscard]] auto
+real_cluster() -> requirement_ptr;
+
+// The gocaves mock rather than a real server, for behaviour only the mock can produce.
+[[nodiscard]] auto
+mock() -> requirement_ptr;
+
+// A service by its cluster-map name: "kv", "n1ql", "index", "fts", "cbas", "eventing".
+[[nodiscard]] auto
+service(std::string name) -> requirement_ptr;
+
+// A version range, half-open: [from, until). Passing only `from` leaves it unbounded above.
+[[nodiscard]] auto
+cluster_version(server_version from) -> requirement_ptr;
+[[nodiscard]] auto
+cluster_version(server_version from, server_version until) -> requirement_ptr;
+
+// A bucket capability as the cluster map spells it, e.g. "durableWrite", "subdoc.ReplicaRead".
+[[nodiscard]] auto
+bucket_capability(std::string capability) -> requirement_ptr;
+
+[[nodiscard]] auto
+deployment(deployment_type type) -> requirement_ptr;
+
+[[nodiscard]] auto
+edition(server_edition wanted) -> requirement_ptr;
+
+// "couchstore" or "magma".
+[[nodiscard]] auto
+storage_backend(std::string backend) -> requirement_ptr;
+
+[[nodiscard]] auto
+replicas(std::size_t at_least) -> requirement_ptr;
+
+[[nodiscard]] auto
+nodes(std::size_t at_least) -> requirement_ptr;
+
+[[nodiscard]] auto
+server_groups(std::size_t at_least) -> requirement_ptr;
+
+[[nodiscard]] auto
+developer_preview() -> requirement_ptr;
+} // namespace needs
+
+} // namespace couchbase::test

--- a/test/framework/selftest.cxx
+++ b/test/framework/selftest.cxx
@@ -16,15 +16,17 @@
  */
 
 // Self-test for the test framework. It exercises the runner's pass / fail / skip / timeout /
-// env-gating / filter behaviour by driving run() with in-memory sub-suites and asserting on the
+// requirement / filter behaviour by driving run() with in-memory sub-suites and asserting on the
 // returned run_result. Because it asserts on the runner's *return value* (rather than letting an
 // inner failure propagate), every case here passes and this binary exits 0.
 
 #include "test_runner.hxx"
 
+#include <atomic>
 #include <chrono>
 #include <cstddef>
 #include <ios>
+#include <limits>
 #include <optional>
 #include <set>
 #include <sstream>
@@ -37,24 +39,25 @@ namespace couchbase::test
 {
 namespace
 {
-// Case bodies used to build the in-memory sub-suites the runner is tested against.
+// ── stand-ins the runner is driven with ──────────────────────────────────────
+
 void
-body_pass()
+body_pass([[maybe_unused]] context& ctx)
 {
   assert_true(true);
 }
 void
-body_fail()
+body_fail([[maybe_unused]] context& ctx)
 {
   assert_true(false, "intentional failure");
 }
 void
-body_skip()
+body_skip([[maybe_unused]] context& ctx)
 {
   skip("intentional skip");
 }
 void
-body_sleep()
+body_sleep([[maybe_unused]] context& ctx)
 {
   std::this_thread::sleep_for(std::chrono::milliseconds{ 200 });
 }
@@ -63,27 +66,211 @@ body_sleep()
 // run through the runner rather than called directly: what is under test is the outcome the runner
 // reports, and a case body cannot observe its own verdict.
 void
-body_skip_inside_assert_throws()
+body_skip_inside_assert_throws([[maybe_unused]] context& ctx)
 {
   assert_throws<std::exception>([]() {
     skip("intentional skip from inside a callable");
   });
 }
 void
-body_failed_assertion_inside_assert_throws()
+body_failed_assertion_inside_assert_throws([[maybe_unused]] context& ctx)
 {
   assert_throws<std::exception>([]() {
     assert_true(false, "intentional failure from inside a callable");
   });
 }
 
+// A backend that answers from fixed values and counts the calls, so the claim that probes are
+// cached can be checked with a number instead of by reading context.cxx.
+class counting_probes : public probe_backend
+{
+public:
+  std::size_t version_calls{ 0 };
+  std::size_t service_calls{ 0 };
+
+  [[nodiscard]] auto server_version() -> couchbase::test::server_version override
+  {
+    ++version_calls;
+    return { 7, 6, 2, false, server_edition::enterprise, deployment_type::on_prem };
+  }
+  [[nodiscard]] auto has_service(const std::string& name) -> bool override
+  {
+    ++service_calls;
+    return name == "kv";
+  }
+  [[nodiscard]] auto has_bucket_capability(const std::string& capability) -> bool override
+  {
+    return capability == "durableWrite";
+  }
+  [[nodiscard]] auto number_of_replicas() -> std::size_t override
+  {
+    return 1;
+  }
+  [[nodiscard]] auto number_of_nodes() -> std::size_t override
+  {
+    return 3;
+  }
+  [[nodiscard]] auto server_groups() -> std::vector<std::string> override
+  {
+    return { "group_1" };
+  }
+  [[nodiscard]] auto storage_backend() -> std::string override
+  {
+    return "couchstore";
+  }
+};
+
+// counting_probes, but slow enough that a caller which passed the cache check is still inside the
+// probe when the next one arrives. Without that overlap a concurrency test proves nothing: the
+// first caller finishes, and everyone after it reads a warm cache whether the cache is guarded or
+// not.
+class slow_counting_probes : public counting_probes
+{
+public:
+  [[nodiscard]] auto has_service(const std::string& name) -> bool override
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    return counting_probes::has_service(name);
+  }
+};
+
+// Answers every probe, but reports no storage backend -- what a release predating the setting
+// looks like. "unknown" is the SDK's spelling for "the server did not say", not a backend.
+class silent_backend_probes : public counting_probes
+{
+public:
+  [[nodiscard]] auto storage_backend() -> std::string override
+  {
+    return "unknown";
+  }
+};
+
+// A backend that cannot answer, standing in for a configured endpoint that does not respond.
+class unreachable_probes : public probe_backend
+{
+public:
+  std::size_t calls{ 0 };
+
+  [[nodiscard]] auto server_version() -> couchbase::test::server_version override
+  {
+    ++calls;
+    throw probe_failure("connection refused");
+  }
+  [[nodiscard]] auto has_service(const std::string& /* name */) -> bool override
+  {
+    ++calls;
+    throw probe_failure("connection refused");
+  }
+  [[nodiscard]] auto has_bucket_capability(const std::string& /* capability */) -> bool override
+  {
+    throw probe_failure("connection refused");
+  }
+  [[nodiscard]] auto number_of_replicas() -> std::size_t override
+  {
+    throw probe_failure("connection refused");
+  }
+  [[nodiscard]] auto number_of_nodes() -> std::size_t override
+  {
+    throw probe_failure("connection refused");
+  }
+  [[nodiscard]] auto server_groups() -> std::vector<std::string> override
+  {
+    throw probe_failure("connection refused");
+  }
+  [[nodiscard]] auto storage_backend() -> std::string override
+  {
+    throw probe_failure("connection refused");
+  }
+};
+
+// A file-local requirement: what a translation unit writes when it needs something the built-in
+// vocabulary does not cover. Kept here because "a custom requirement is short" is a claim about
+// the interface, and the only honest way to hold it is to write one.
+class needs_even_replicas : public requirement
+{
+public:
+  [[nodiscard]] auto describe() const -> std::string override
+  {
+    return "an even number of replicas";
+  }
+  [[nodiscard]] auto check(context& ctx) const -> check_result override
+  {
+    return ctx.number_of_replicas() % 2 == 0 ? check_result::ok()
+                                             : check_result::missing("the count is odd");
+  }
+};
+
+// A requirement that never answers, and one that answers with an exception of its own.
+class blocking : public requirement
+{
+public:
+  [[nodiscard]] auto describe() const -> std::string override
+  {
+    return "something that never answers";
+  }
+  [[nodiscard]] auto check(context& /* ctx */) const -> check_result override
+  {
+    std::this_thread::sleep_for(std::chrono::seconds{ 30 });
+    return check_result::ok();
+  }
+};
+
+class skipping : public requirement
+{
+public:
+  [[nodiscard]] auto describe() const -> std::string override
+  {
+    return "something that gives up";
+  }
+  [[nodiscard]] auto check(context& /* ctx */) const -> check_result override
+  {
+    skip("the environment cannot provide it");
+    return check_result::ok();
+  }
+};
+
+class throwing : public requirement
+{
+public:
+  [[nodiscard]] auto describe() const -> std::string override
+  {
+    return "something that throws";
+  }
+  [[nodiscard]] auto check(context& /* ctx */) const -> check_result override
+  {
+    throw std::runtime_error("the requirement itself is broken");
+  }
+};
+
+auto
+no_cluster() -> configuration
+{
+  return {}; // cluster_configured defaults to false
+}
+
+auto
+with_cluster() -> configuration
+{
+  configuration config;
+  config.connection_string = "couchbase://localhost";
+  config.cluster_configured = true;
+  return config;
+}
+
 // A sink for the runner's progress output so the self-test stays quiet.
 auto
-run_quiet(const test_suite& suite, const std::set<std::string>& filter, bool real_cluster)
-  -> run_result
+run_quiet(const test_suite& suite, const std::set<std::string>& filter, context& ctx) -> run_result
 {
   std::ostringstream sink;
-  return run(suite, filter, real_cluster, sink);
+  return run(suite, filter, ctx, sink);
+}
+
+// The common case: no cluster, no requirements, nothing to probe.
+auto
+run_bare(const test_suite& suite, const std::set<std::string>& filter = {}) -> run_result
+{
+  context ctx{ no_cluster(), std::make_unique<counting_probes>() };
+  return run_quiet(suite, filter, ctx);
 }
 
 // The message an assertion produced, or empty if it did not fail. assert_throws cannot be used to
@@ -104,42 +291,29 @@ message_of(Fn&& fn) -> std::string
 // ── the self-test cases ──────────────────────────────────────────────────────
 
 void
-should_run_gating_is_correct()
-{
-  assert_true(should_run(test_env::agnostic, false), "agnostic runs in mock mode");
-  assert_true(should_run(test_env::agnostic, true), "agnostic runs in real mode");
-  assert_true(should_run(test_env::any_server, false), "any_server runs in mock mode");
-  assert_true(should_run(test_env::any_server, true), "any_server runs in real mode");
-  assert_true(should_run(test_env::mock_only, false), "mock_only runs in mock mode");
-  assert_false(should_run(test_env::mock_only, true), "mock_only skipped in real mode");
-  assert_false(should_run(test_env::cluster_only, false), "cluster_only skipped in mock mode");
-  assert_true(should_run(test_env::cluster_only, true), "cluster_only runs in real mode");
-}
-
-void
-runner_reports_a_passing_case()
+runner_reports_a_passing_case([[maybe_unused]] context& ctx)
 {
   const test_suite s{ "inner", { { "p", body_pass } } };
-  const auto r = run_quiet(s, {}, false);
+  const auto r = run_bare(s);
   assert_eq(r.passed, std::size_t{ 1 }, "one pass counted");
   assert_eq(r.failed, std::size_t{ 0 }, "no failures");
   assert_eq(exit_code(r), 0, "exit code 0 on success");
 }
 
 void
-runner_detects_a_failing_case()
+runner_detects_a_failing_case([[maybe_unused]] context& ctx)
 {
   const test_suite s{ "inner", { { "f", body_fail } } };
-  const auto r = run_quiet(s, {}, false);
+  const auto r = run_bare(s);
   assert_eq(r.failed, std::size_t{ 1 }, "one failure counted");
   assert_eq(exit_code(r), 1, "exit code 1 on failure");
 }
 
 void
-runner_reports_a_skipped_case()
+runner_reports_a_skipped_case([[maybe_unused]] context& ctx)
 {
   const test_suite s{ "inner", { { "s", body_skip } } };
-  const auto r = run_quiet(s, {}, false);
+  const auto r = run_bare(s);
   assert_eq(r.skipped, std::size_t{ 1 }, "one skip counted");
   assert_eq(r.failed, std::size_t{ 0 }, "skip is not a failure");
   // The other half of the contract couchbase_add_test() wires up as SKIP_RETURN_CODE: a binary that
@@ -148,28 +322,16 @@ runner_reports_a_skipped_case()
 }
 
 void
-runner_detects_a_timeout()
+runner_detects_a_timeout([[maybe_unused]] context& ctx)
 {
   // 200ms body against a 20ms budget must be reported as a failure.
-  const test_suite s{ "inner", { { "t", body_sleep, std::chrono::milliseconds{ 20 } } } };
-  const auto r = run_quiet(s, {}, false);
+  const test_suite s{ "inner", { { "t", body_sleep, {}, std::chrono::milliseconds{ 20 } } } };
+  const auto r = run_bare(s);
   assert_eq(r.failed, std::size_t{ 1 }, "timeout counted as a failure");
 }
 
 void
-env_gating_skips_cluster_only_without_a_cluster()
-{
-  const test_suite s{ "inner", { { "c", body_pass, default_timeout, test_env::cluster_only } } };
-  const auto without = run_quiet(s, {}, /*real_cluster=*/false);
-  assert_eq(without.skipped, std::size_t{ 1 }, "cluster_only skipped without a cluster");
-  assert_eq(without.passed, std::size_t{ 0 }, "cluster_only did not run without a cluster");
-
-  const auto with = run_quiet(s, {}, /*real_cluster=*/true);
-  assert_eq(with.passed, std::size_t{ 1 }, "cluster_only runs with a cluster");
-}
-
-void
-case_output_is_flushed_as_it_is_written()
+case_output_is_flushed_as_it_is_written(context& ctx)
 {
   // ctest gives these binaries a pipe for stdout, where the stream is block-buffered, and a case
   // that aborts the process discards whatever is still buffered -- so the log names neither the
@@ -177,78 +339,329 @@ case_output_is_flushed_as_it_is_written()
   // most needed, so the runner must not leave its stream block-buffered.
   std::ostringstream sink;
   const test_suite s{ "inner", { { "p", body_pass } } };
-  static_cast<void>(run(s, {}, false, sink));
+  static_cast<void>(run(s, {}, ctx, sink));
   assert_true((sink.flags() & std::ios::unitbuf) != 0,
               "the runner flushes its stream after every write");
 }
 
 void
-filter_selects_cases_by_name()
+an_unconfigured_cluster_skips_and_an_unreachable_one_fails([[maybe_unused]] context& ctx)
+{
+  // The distinction the whole three-valued scheme exists for. A boolean predicate has to answer
+  // both of these the same way, and the answer it picks is the one that does not fail the build --
+  // which is how an unreachable endpoint turns a whole leg green.
+  const test_suite s{ "inner", { { "c", body_pass, { needs::service("kv") } } } };
+
+  context unconfigured{ no_cluster(), std::make_unique<unreachable_probes>() };
+  const auto skipped = run_quiet(s, {}, unconfigured);
+  assert_eq(skipped.skipped, std::size_t{ 1 }, "no cluster configured is a skip");
+  assert_eq(skipped.failed, std::size_t{ 0 }, "and not a failure");
+  assert_eq(skipped.skipped_by_requirement.count("the kv service"),
+            std::size_t{ 1 },
+            "the requirement that turned it away is named");
+
+  context unreachable{ with_cluster(), std::make_unique<unreachable_probes>() };
+  const auto failed = run_quiet(s, {}, unreachable);
+  assert_eq(
+    failed.failed, std::size_t{ 1 }, "a configured cluster that cannot answer is a failure");
+  assert_eq(failed.skipped, std::size_t{ 0 }, "and never a skip");
+  assert_eq(failed.passed, std::size_t{ 0 }, "and the body did not run");
+}
+
+void
+a_satisfied_requirement_lets_the_case_run([[maybe_unused]] context& ctx)
+{
+  const test_suite s{
+    "inner",
+    { { "kv", body_pass, { needs::service("kv"), needs::cluster_version(v7_0, v8_0) } },
+      { "n1ql", body_pass, { needs::service("n1ql") } } },
+  };
+  context probed{ with_cluster(), std::make_unique<counting_probes>() };
+  const auto r = run_quiet(s, {}, probed);
+  assert_eq(r.passed, std::size_t{ 1 }, "the case whose requirements hold runs");
+  assert_eq(r.skipped, std::size_t{ 1 }, "the one whose service is absent is skipped");
+  assert_eq(r.failed, std::size_t{ 0 }, "neither is a failure");
+}
+
+void
+a_version_range_is_half_open([[maybe_unused]] context& ctx)
+{
+  // counting_probes reports 7.6.2.
+  const test_suite s{
+    "inner",
+    { { "in_range", body_pass, { needs::cluster_version(v7_6, v8_0) } },
+      { "below", body_pass, { needs::cluster_version(v8_0) } },
+      { "at_upper_bound", body_pass, { needs::cluster_version(v7_0, v7_6) } } },
+  };
+  context probed{ with_cluster(), std::make_unique<counting_probes>() };
+  const auto r = run_quiet(s, {}, probed);
+  assert_eq(r.passed, std::size_t{ 1 }, "only the case whose range contains 7.6.2 runs");
+  assert_eq(
+    r.skipped, std::size_t{ 2 }, "below the floor and at the exclusive ceiling are skipped");
+}
+
+void
+probes_are_cached_across_every_case_in_the_binary([[maybe_unused]] context& ctx)
+{
+  // 20 cases, each asking the same two questions. Reconnecting or re-asking per case is what turns
+  // a suite into a denial-of-service against its own cluster.
+  auto probes = std::make_unique<counting_probes>();
+  auto* counters = probes.get();
+  context probed{ with_cluster(), std::move(probes) };
+
+  std::vector<test_case> cases;
+  cases.reserve(20);
+  for (std::size_t i = 0; i < 20; ++i) {
+    cases.push_back({ fmt::format("case_{}", i),
+                      body_pass,
+                      { needs::service("kv"), needs::cluster_version(v7_0) } });
+  }
+  const test_suite s{ "inner", cases };
+  const auto r = run_quiet(s, {}, probed);
+
+  assert_eq(r.passed, std::size_t{ 20 }, "every case ran");
+  assert_eq(counters->service_calls, std::size_t{ 1 }, "the service was asked about once");
+  assert_eq(counters->version_calls, std::size_t{ 1 }, "and so was the version");
+  assert_eq(probed.backends_created(), std::size_t{ 1 }, "one backend for the whole binary");
+}
+
+void
+one_probe_answers_every_caller_that_arrives_at_once([[maybe_unused]] context& ctx)
+{
+  // run_bounded detaches a worker whose budget expired, and that worker is normally still inside a
+  // probe -- that is why it ran out of budget. The next case then reaches the same context before
+  // the previous one has left it. Unguarded, every arrival passes the empty-cache check, calls the
+  // backend and writes the same std::map entry, which is a data race on the cache rather than a
+  // wrong answer: this asserts the count the guard makes true.
+  auto probes = std::make_unique<slow_counting_probes>();
+  auto* counters = probes.get();
+  context probed{ with_cluster(), std::move(probes) };
+
+  constexpr std::size_t askers = 8;
+  std::atomic<std::size_t> arrived{ 0 };
+  std::vector<std::thread> threads;
+  threads.reserve(askers);
+  for (std::size_t i = 0; i < askers; ++i) {
+    threads.emplace_back([&probed, &arrived]() {
+      ++arrived;
+      while (arrived.load() < askers) {
+        std::this_thread::yield();
+      }
+      (void)probed.has_service("kv");
+    });
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  assert_eq(
+    counters->service_calls, std::size_t{ 1 }, "the backend was asked once, not once per caller");
+}
+
+void
+a_failed_probe_is_not_retried_per_case([[maybe_unused]] context& ctx)
+{
+  // The failure has to be cached too: an unreachable cluster otherwise costs one connection
+  // attempt per case, which is how a broken endpoint turns a fast leg into a timeout.
+  auto probes = std::make_unique<unreachable_probes>();
+  auto* counters = probes.get();
+  context probed{ with_cluster(), std::move(probes) };
+
+  const test_suite s{ "inner",
+                      { { "a", body_pass, { needs::cluster_version(v7_0) } },
+                        { "b", body_pass, { needs::cluster_version(v7_0) } },
+                        { "c", body_pass, { needs::cluster_version(v7_0) } } } };
+  const auto r = run_quiet(s, {}, probed);
+  assert_eq(r.failed, std::size_t{ 3 }, "each case fails on its own account");
+  assert_eq(counters->calls, std::size_t{ 1 }, "but the cluster was asked exactly once");
+}
+
+void
+a_requirement_that_blocks_fails_its_case_rather_than_the_run([[maybe_unused]] context& ctx)
+{
+  // A requirement runs before every case, so one that hangs would stall the leg rather than report
+  // anything. The budget belongs to the framework, not to the requirement, which is why it is on
+  // the configuration and can be shortened here.
+  const test_suite s{ "inner",
+                      { { "blocked", body_pass, { std::make_shared<const blocking>() } } } };
+
+  auto config = no_cluster();
+  config.requirement_budget = std::chrono::milliseconds{ 50 };
+  context bounded{ config, std::make_unique<counting_probes>() };
+
+  const auto r = run_quiet(s, {}, bounded);
+  assert_eq(r.failed, std::size_t{ 1 }, "the case fails");
+  assert_eq(r.passed, std::size_t{ 0 }, "the body never ran");
+  assert_eq(r.skipped, std::size_t{ 0 }, "and it is not reported as inapplicable");
+  assert_eq(r.timed_out,
+            std::size_t{ 1 },
+            "flagged as a timeout, because the abandoned worker dictates how the process exits");
+}
+
+void
+a_requirement_that_throws_fails_its_case([[maybe_unused]] context& ctx)
+{
+  // probe_failure is turned into `undetermined` by design; anything else escaping check() is a bug
+  // in the requirement, and must still land on the case that declared it rather than on the run.
+  const test_suite s{ "inner",
+                      { { "broken", body_pass, { std::make_shared<const throwing>() } } } };
+  const auto r = run_bare(s);
+  assert_eq(r.failed, std::size_t{ 1 }, "a requirement that throws fails its case");
+  assert_eq(r.passed, std::size_t{ 0 }, "and the body did not run");
+  assert_eq(r.skipped, std::size_t{ 0 }, "and it is not reported as inapplicable");
+}
+
+void
+a_requirement_that_skips_does_not_run_its_case([[maybe_unused]] context& ctx)
+{
+  // skip() from inside check() is the fourth thing a requirement can do, alongside the three
+  // check_result statuses. Handling only the statuses left this one falling through to a default
+  // gate that said "run", so the body executed and the case reported passed behind a precondition
+  // that had just declared itself unmet -- a pass with nothing verified, and no output line.
+  const test_suite s{ "inner", { { "gated", body_fail, { std::make_shared<const skipping>() } } } };
+  const auto r = run_bare(s);
+  assert_eq(r.skipped, std::size_t{ 1 }, "a requirement that skips skips its case");
+  assert_eq(r.passed, std::size_t{ 0 }, "the body did not run");
+  // body_fail would have failed had it run, so this pins that the body was never entered rather
+  // than merely that the tally came out even.
+  assert_eq(r.failed, std::size_t{ 0 }, "and it is not a failure");
+}
+
+void
+a_phase_level_verdict_is_not_reported_as_a_requirement_name(context& ctx)
+{
+  // Where the phase itself decides -- a check() that called skip(), or a blown budget -- there is
+  // no requirement to name, and the runner substitutes a sentinel. Interpolated into the ordinary
+  // "needs <what>" line it produced "needs (requirement phase)", which names nothing a reader can
+  // act on. The report has to say what happened instead.
+  std::ostringstream sink;
+  const test_suite s{ "inner", { { "gated", body_fail, { std::make_shared<const skipping>() } } } };
+  const auto r = run(s, {}, ctx, sink);
+  const auto output = sink.str();
+  assert_true(output.find("a requirement check skipped it") != std::string::npos,
+              "the line says the phase skipped the case");
+  assert_true(output.find("needs (requirement phase)") == std::string::npos,
+              "and does not offer the sentinel as something the case needs");
+  // The end-of-run report groups the cases a requirement turned away, so every key in it is
+  // something an environment can be given. The sentinel there prints as "(requirement phase) -- 1
+  // case(s)" under "Skipped for want of:", which reads as a requirement by that name.
+  assert_true(r.skipped_by_requirement.empty(),
+              "the sentinel is not offered as a requirement the environment lacked");
+  assert_eq(r.skipped, std::size_t{ 1 }, "though the case is still counted among the skips");
+}
+
+void
+every_edition_describes_itself_by_name([[maybe_unused]] context& ctx)
+{
+  // The description is the key the skip report groups by, so an edition labelled as another one
+  // makes the run report cases turned away for a requirement nobody declared.
+  assert_eq(needs::edition(server_edition::enterprise)->describe(),
+            std::string{ "the enterprise edition" },
+            "enterprise");
+  assert_eq(needs::edition(server_edition::community)->describe(),
+            std::string{ "the community edition" },
+            "community");
+  assert_eq(needs::edition(server_edition::columnar)->describe(),
+            std::string{ "the columnar edition" },
+            "columnar is not folded in with community");
+}
+
+void
+a_storage_backend_the_cluster_would_not_name_is_undetermined([[maybe_unused]] context& ctx)
+{
+  // Not knowing must fail, not skip. Reported as a mismatch this reads "the bucket is unknown, not
+  // magma" -- a backend no bucket has -- and turns a cluster that could not answer into an
+  // inapplicable case, which is the conflation this framework exists to remove.
+  context probed{ with_cluster(), std::make_unique<silent_backend_probes>() };
+  const test_suite s{ "inner", { { "gated", body_pass, { needs::storage_backend("magma") } } } };
+  const auto r = run_quiet(s, {}, probed);
+  assert_eq(r.failed, std::size_t{ 1 }, "an unreported backend fails its case");
+  assert_eq(r.skipped, std::size_t{ 0 }, "rather than skipping it as inapplicable");
+  assert_eq(r.passed, std::size_t{ 0 }, "and the body did not run");
+}
+
+void
+a_file_local_requirement_needs_no_framework_change([[maybe_unused]] context& ctx)
+{
+  // counting_probes reports one replica, so an even-replica requirement turns the case away.
+  const test_suite s{
+    "inner", { { "even", body_pass, { std::make_shared<const needs_even_replicas>() } } }
+  };
+  context probed{ with_cluster(), std::make_unique<counting_probes>() };
+  const auto r = run_quiet(s, {}, probed);
+  assert_eq(r.skipped, std::size_t{ 1 }, "the custom requirement gates the case");
+  assert_eq(r.skipped_by_requirement.count("an even number of replicas"),
+            std::size_t{ 1 },
+            "and its own description is what the report groups by");
+}
+
+void
+filter_selects_cases_by_name([[maybe_unused]] context& ctx)
 {
   const test_suite s{ "inner", { { "a", body_pass }, { "b", body_pass } } };
-  const auto r = run_quiet(s, { "a" }, false);
+  const auto r = run_bare(s, { "a" });
   assert_eq(r.passed, std::size_t{ 1 }, "only the filtered case runs");
 }
 
 void
-a_failing_case_does_not_suppress_later_cases()
+a_failing_case_does_not_suppress_later_cases([[maybe_unused]] context& ctx)
 {
-  // One ctest test is registered per executable, so abandoning the suite on the first failure
-  // would hide every later regression in the same binary until the first one is fixed.
+  // Abandoning the suite on the first failure would hide every later regression in the same
+  // binary until the first one is fixed.
   const test_suite s{ "inner", { { "f", body_fail }, { "p", body_pass }, { "s", body_skip } } };
-  const auto r = run_quiet(s, {}, false);
+  const auto r = run_bare(s);
   assert_eq(r.failed, std::size_t{ 1 }, "the failure is counted");
   assert_eq(r.passed, std::size_t{ 1 }, "a later case still runs after a failure");
   assert_eq(r.skipped, std::size_t{ 1 }, "a later skip is still reported after a failure");
 }
 
 void
-slow_cases_run_after_a_failure()
+slow_cases_run_after_a_failure([[maybe_unused]] context& ctx)
 {
   test_suite s{ "inner", { { "f", body_fail } } };
   s.slow_test_cases = { { "p", body_pass } };
-  const auto r = run_quiet(s, {}, false);
+  const auto r = run_bare(s);
   assert_eq(r.passed, std::size_t{ 1 }, "slow cases are not abandoned by an earlier failure");
 }
 
 void
-a_filter_name_matching_nothing_fails()
+a_filter_name_matching_nothing_fails([[maybe_unused]] context& ctx)
 {
   const test_suite s{ "inner", { { "a", body_pass } } };
-  const auto r = run_quiet(s, { "typo" }, false);
+  const auto r = run_bare(s, { "typo" });
   assert_eq(r.passed, std::size_t{ 0 }, "nothing ran");
   assert_eq(r.failed, std::size_t{ 1 }, "an unmatched filter name is a failure");
   assert_eq(exit_code(r), 1, "exit code 1, not a silent pass");
 }
 
 void
-a_suite_that_runs_nothing_does_not_pass()
+a_suite_that_runs_nothing_does_not_pass([[maybe_unused]] context& ctx)
 {
   const test_suite empty{ "inner", {} };
-  const auto r = run_quiet(empty, {}, false);
+  const auto r = run_bare(empty);
   assert_eq(r.passed, std::size_t{ 0 }, "nothing ran");
   assert_eq(r.skipped, std::size_t{ 0 }, "nothing skipped");
   assert_eq(exit_code(r), 1, "an empty suite must not report success");
 }
 
 void
-a_timeout_is_reported_as_such()
+a_timeout_is_reported_as_such([[maybe_unused]] context& ctx)
 {
   // main() needs to distinguish a timeout from an ordinary failure: only a timeout leaves a
   // detached worker thread, which dictates how the process exits.
-  const test_suite s{ "inner", { { "t", body_sleep, std::chrono::milliseconds{ 20 } } } };
-  const auto r = run_quiet(s, {}, false);
+  const test_suite s{ "inner", { { "t", body_sleep, {}, std::chrono::milliseconds{ 20 } } } };
+  const auto r = run_bare(s);
   assert_eq(r.timed_out, std::size_t{ 1 }, "the timeout is flagged separately");
   assert_eq(r.failed, std::size_t{ 1 }, "and still counted as a failure");
 }
 
 void
-case_names_covers_slow_cases_and_ignores_the_environment()
+case_names_covers_slow_cases_and_ignores_the_environment([[maybe_unused]] context& ctx)
 {
   const test_suite suite{
     "listing",
-    { { "regular", body_pass, timeout::instant, test_env::cluster_only } },
-    { { "deliberately_slow", body_pass, timeout::slow } },
+    { { "regular", body_pass, { needs::real_cluster() }, timeout::instant } },
+    { { "deliberately_slow", body_pass, {}, timeout::slow } },
   };
 
   const auto names = case_names(suite);
@@ -258,7 +671,26 @@ case_names_covers_slow_cases_and_ignores_the_environment()
 }
 
 void
-timeout_multiplier_defaults_to_one_and_rejects_anything_but_a_number()
+list_output_carries_the_requirements_after_a_tab([[maybe_unused]] context& ctx)
+{
+  // cmake/TestFrameworkAddTests.cmake registers the part before the tab, so the same output has to
+  // serve the build and a person asking why a case never runs.
+  const test_suite suite{
+    "listing",
+    { { "gated", body_pass, { needs::real_cluster(), needs::service("n1ql") } },
+      { "ungated", body_pass } },
+  };
+
+  const auto lines = describe_cases(suite);
+  assert_eq(lines.size(), std::size_t{ 2 }, "one line per case");
+  assert_eq(lines[0],
+            std::string{ "gated\ta real cluster; the n1ql service" },
+            "requirements follow the name, separated by a tab");
+  assert_eq(lines[1], std::string{ "ungated\tno requirements" }, "and a case with none says so");
+}
+
+void
+timeout_multiplier_defaults_to_one_and_rejects_anything_but_a_number([[maybe_unused]] context& ctx)
 {
   assert_eq(timeout_multiplier(std::nullopt), 1.0, "unset means unscaled");
   assert_eq(timeout_multiplier(std::optional<std::string>{ "10" }), 10.0, "an integer is read");
@@ -291,12 +723,12 @@ timeout_multiplier_defaults_to_one_and_rejects_anything_but_a_number()
 }
 
 void
-scale_timeouts_multiplies_every_budget()
+scale_timeouts_multiplies_every_budget([[maybe_unused]] context& ctx)
 {
   test_suite suite{
     "budgets",
-    { { "fast", body_pass, std::chrono::milliseconds{ 100 } } },
-    { { "slow", body_pass, std::chrono::milliseconds{ 1'000 } } },
+    { { "fast", body_pass, {}, std::chrono::milliseconds{ 100 } } },
+    { { "slow", body_pass, {}, std::chrono::milliseconds{ 1'000 } } },
   };
 
   scale_timeouts(suite, 10.0);
@@ -306,34 +738,59 @@ scale_timeouts_multiplies_every_budget()
   // Ceiling, not nearest and not truncation. Only a product whose fraction falls below .5 tells
   // the three apart: 100 x 1.004 is 101 under ceil and 100 under both floor and llround.
   test_suite fractional{ "fractional",
-                         { { "case", body_pass, std::chrono::milliseconds{ 100 } } } };
+                         { { "case", body_pass, {}, std::chrono::milliseconds{ 100 } } } };
   scale_timeouts(fractional, 1.004);
   assert_eq(fractional.test_cases[0].timeout.count(), 101, "a fraction below .5 still rounds up");
 
   // Rounding must not produce a zero budget, which would fail every case before it started.
   scale_timeouts(suite, 0.0001);
   assert_true(suite.test_cases[0].timeout.count() >= 1, "a budget never rounds down to nothing");
+
+  // A product past the representation saturates rather than wrapping. Casting it would be
+  // undefined, and the value it produces in practice is negative, which the floor above then
+  // clamps to 1ms -- so the multiplier asking for the most room would hand out the least. The
+  // bound is the duration's own rep, which is what makes the ceiling the cast is checked against
+  // the same one the cast has to fit.
+  test_suite enormous{ "enormous",
+                       { { "case", body_pass, {}, std::chrono::milliseconds{ 100 } } } };
+  scale_timeouts(enormous, 1e300);
+  assert_eq(enormous.test_cases[0].timeout.count(),
+            std::numeric_limits<std::chrono::milliseconds::rep>::max(),
+            "an unrepresentable budget saturates instead of wrapping negative");
 }
 
 void
-a_scaled_budget_lets_a_case_outlive_its_original_one()
+a_scaled_budget_lets_a_case_outlive_its_original_one([[maybe_unused]] context& ctx)
 {
   // body_sleep runs for 200ms; 50ms is not enough and 50ms x 10 is.
-  test_suite suite{ "scaled", { { "sleeper", body_sleep, std::chrono::milliseconds{ 50 } } } };
+  test_suite suite{ "scaled", { { "sleeper", body_sleep, {}, std::chrono::milliseconds{ 50 } } } };
 
-  const auto unscaled = run_quiet(suite, {}, false);
+  const auto unscaled = run_bare(suite);
   assert_eq(unscaled.timed_out, std::size_t{ 1 }, "the original budget kills the case");
 
   scale_timeouts(suite, 10.0);
-  const auto scaled = run_quiet(suite, {}, false);
+  const auto scaled = run_bare(suite);
   assert_eq(scaled.timed_out, std::size_t{ 0 }, "the scaled budget does not");
   assert_eq(scaled.passed, std::size_t{ 1 }, "and the case reports its own outcome");
+}
+
+void
+the_configuration_reads_the_environment_it_documents(context& ctx)
+{
+  // The context the runner handed this case is the one main() built from the environment, so this
+  // is also the check that a case reaches its own configuration without calling getenv.
+  const auto& config = ctx.config();
+  assert_eq(config.cluster_configured,
+            ctx.env("TEST_CONNECTION_STRING").has_value(),
+            "cluster_configured tracks TEST_CONNECTION_STRING and nothing else");
+  assert_true(!config.bucket.empty(), "a bucket name is always resolved");
+  assert_true(!config.username.empty(), "and so are credentials");
 }
 
 } // namespace
 
 void
-a_skip_inside_assert_throws_skips_its_case()
+a_skip_inside_assert_throws_skips_its_case([[maybe_unused]] context& ctx)
 {
   // std::exception is a base of test_skip_exception, so an expected-exception handler matched ahead
   // of the control-flow ones claims the skip. The body still runs to completion; what is lost is
@@ -345,25 +802,25 @@ a_skip_inside_assert_throws_skips_its_case()
   // because instantiating assert_throws<std::exception> leaves a handler unreachable and
   // -Wexceptions is an error; with those warnings demoted it builds, and the counts below catch it.
   const test_suite s{ "inner", { { "s", body_skip_inside_assert_throws } } };
-  const auto r = run_quiet(s, {}, false);
+  const auto r = run_bare(s);
   assert_eq(r.skipped, std::size_t{ 1 }, "the skip reached the runner");
   assert_eq(r.passed, std::size_t{ 0 }, "and was not counted as the expected exception");
   assert_eq(r.failed, std::size_t{ 0 }, "a skip is not a failure either");
 }
 
 void
-a_failed_assertion_inside_assert_throws_fails_its_case()
+a_failed_assertion_inside_assert_throws_fails_its_case([[maybe_unused]] context& ctx)
 {
   // Same ordering, the other control-flow type. A nested failure carries its own location and
   // message, and being counted as the expected exception discards both.
   const test_suite s{ "inner", { { "s", body_failed_assertion_inside_assert_throws } } };
-  const auto r = run_quiet(s, {}, false);
+  const auto r = run_bare(s);
   assert_eq(r.failed, std::size_t{ 1 }, "the nested failure reached the runner");
   assert_eq(r.passed, std::size_t{ 0 }, "and did not satisfy the expectation");
 }
 
 void
-assert_throws_accepts_a_base_of_the_thrown_type()
+assert_throws_accepts_a_base_of_the_thrown_type([[maybe_unused]] context& ctx)
 {
   // The legitimate use of a base type, which the ordering above must not have cost: asking for
   // std::exception and getting something derived from it is a match.
@@ -376,7 +833,7 @@ assert_throws_accepts_a_base_of_the_thrown_type()
 }
 
 void
-assert_throws_rejects_an_unrelated_type_and_says_so()
+assert_throws_rejects_an_unrelated_type_and_says_so([[maybe_unused]] context& ctx)
 {
   const auto message = message_of([]() {
     assert_throws<std::logic_error>([]() {
@@ -389,7 +846,7 @@ assert_throws_rejects_an_unrelated_type_and_says_so()
 }
 
 void
-assert_throws_rejects_a_callable_that_throws_nothing()
+assert_throws_rejects_a_callable_that_throws_nothing([[maybe_unused]] context& ctx)
 {
   const auto message = message_of([]() {
     assert_throws<std::exception>([]() {
@@ -406,23 +863,45 @@ tests() -> test_suite
   return {
     "framework_selftest",
     {
-      { "should_run_gating_is_correct", should_run_gating_is_correct },
       { "runner_reports_a_passing_case", runner_reports_a_passing_case },
       { "runner_detects_a_failing_case", runner_detects_a_failing_case },
       { "runner_reports_a_skipped_case", runner_reports_a_skipped_case },
-      { "runner_detects_a_timeout", runner_detects_a_timeout, timeout::fast },
-      { "env_gating_skips_cluster_only_without_a_cluster",
-        env_gating_skips_cluster_only_without_a_cluster },
+      { "runner_detects_a_timeout", runner_detects_a_timeout, {}, timeout::fast },
       { "case_output_is_flushed_as_it_is_written", case_output_is_flushed_as_it_is_written },
+      { "an_unconfigured_cluster_skips_and_an_unreachable_one_fails",
+        an_unconfigured_cluster_skips_and_an_unreachable_one_fails },
+      { "a_satisfied_requirement_lets_the_case_run", a_satisfied_requirement_lets_the_case_run },
+      { "a_version_range_is_half_open", a_version_range_is_half_open },
+      { "probes_are_cached_across_every_case_in_the_binary",
+        probes_are_cached_across_every_case_in_the_binary },
+      { "one_probe_answers_every_caller_that_arrives_at_once",
+        one_probe_answers_every_caller_that_arrives_at_once },
+      { "a_failed_probe_is_not_retried_per_case", a_failed_probe_is_not_retried_per_case },
+      { "a_requirement_that_blocks_fails_its_case_rather_than_the_run",
+        a_requirement_that_blocks_fails_its_case_rather_than_the_run,
+        {},
+        timeout::fast },
+      { "a_requirement_that_throws_fails_its_case", a_requirement_that_throws_fails_its_case },
+      { "a_requirement_that_skips_does_not_run_its_case",
+        a_requirement_that_skips_does_not_run_its_case },
+      { "a_phase_level_verdict_is_not_reported_as_a_requirement_name",
+        a_phase_level_verdict_is_not_reported_as_a_requirement_name },
+      { "every_edition_describes_itself_by_name", every_edition_describes_itself_by_name },
+      { "a_storage_backend_the_cluster_would_not_name_is_undetermined",
+        a_storage_backend_the_cluster_would_not_name_is_undetermined },
+      { "a_file_local_requirement_needs_no_framework_change",
+        a_file_local_requirement_needs_no_framework_change },
       { "filter_selects_cases_by_name", filter_selects_cases_by_name },
       { "a_failing_case_does_not_suppress_later_cases",
         a_failing_case_does_not_suppress_later_cases },
       { "slow_cases_run_after_a_failure", slow_cases_run_after_a_failure },
       { "a_filter_name_matching_nothing_fails", a_filter_name_matching_nothing_fails },
       { "a_suite_that_runs_nothing_does_not_pass", a_suite_that_runs_nothing_does_not_pass },
-      { "a_timeout_is_reported_as_such", a_timeout_is_reported_as_such, timeout::fast },
+      { "a_timeout_is_reported_as_such", a_timeout_is_reported_as_such, {}, timeout::fast },
       { "case_names_covers_slow_cases_and_ignores_the_environment",
         case_names_covers_slow_cases_and_ignores_the_environment },
+      { "list_output_carries_the_requirements_after_a_tab",
+        list_output_carries_the_requirements_after_a_tab },
       { "timeout_multiplier_defaults_to_one_and_rejects_anything_but_a_number",
         timeout_multiplier_defaults_to_one_and_rejects_anything_but_a_number },
       { "scale_timeouts_multiplies_every_budget", scale_timeouts_multiplies_every_budget },
@@ -437,7 +916,10 @@ tests() -> test_suite
         assert_throws_rejects_a_callable_that_throws_nothing },
       { "a_scaled_budget_lets_a_case_outlive_its_original_one",
         a_scaled_budget_lets_a_case_outlive_its_original_one,
+        {},
         timeout::fast },
+      { "the_configuration_reads_the_environment_it_documents",
+        the_configuration_reads_the_environment_it_documents },
     },
   };
 }

--- a/test/framework/test_framework.hxx
+++ b/test/framework/test_framework.hxx
@@ -27,6 +27,8 @@
 // A test file provides `tests()` returning a `test_suite`; the runner (see test_runner.hxx)
 // executes each `test_case` on a worker thread with a per-case timeout and reports the outcome.
 
+#include "requirement.hxx"
+
 #include <chrono>
 #include <cstdint>
 #include <exception>
@@ -122,42 +124,9 @@ inline constexpr auto slow = 30'000ms;        // intentional delays
 
 inline constexpr auto default_timeout = timeout::network;
 
-// Which server environment a case needs. `real_cluster` encodes exactly one thing -- whether
-// TEST_CONNECTION_STRING is set -- so its false branch means "no cluster configured", NOT "a mock
-// is running": there is no CNG mock gateway, and none is planned. Tests that need a server of
-// their own stand up an in-process gRPC server and are therefore `agnostic`.
-//
-// So today only `agnostic` and `cluster_only` are used. `any_server` and `mock_only` are carried
-// over from the harness this was ported from and are reserved for a mock that does not exist yet.
-// Note `any_server` would run with nothing to talk to if used now -- give it a third state
-// (no server at all) before adopting it.
-//
-//   * no cluster (unset): agnostic + any_server + mock_only; cluster_only is skipped
-//   * real cluster (set): agnostic + any_server + cluster_only; mock_only is skipped
-enum class test_env : std::uint8_t {
-  agnostic,     // no external server needed (pure unit, or brings its own in-process server)
-  any_server,   // reserved: basic ops against whichever server is active
-  mock_only,    // reserved: needs mock-specific behaviour (fault injection)
-  cluster_only, // needs a real Couchbase cluster / gateway.
-};
-
-[[nodiscard]] constexpr auto
-should_run(test_env env, bool real_cluster) noexcept -> bool
-{
-  switch (env) {
-    case test_env::agnostic:
-    case test_env::any_server:
-      return true;
-    case test_env::mock_only:
-      return !real_cluster;
-    case test_env::cluster_only:
-      return real_cluster;
-  }
-  return true;
-}
-
-// Thrown by skip() to mark a case skipped at runtime — for preconditions the coarse env field
-// cannot express. The runner reports it distinctly from a failure.
+// Thrown by skip() to mark a case skipped at runtime — for the rare precondition no requirement
+// can express. Prefer a requirement: a skip from inside the body is invisible until the case runs,
+// and cannot be reported by --list-tests. The runner reports it distinctly from a failure.
 class test_skip_exception : public std::exception
 {
 public:
@@ -198,9 +167,11 @@ private:
 
 struct test_case {
   std::string name;
-  void (*func)();
+  // An ordinary function, so it can be navigated to and called like one. What it needs from the
+  // environment is declared beside it rather than checked inside it.
+  void (*func)(context&);
+  std::vector<requirement_ptr> requirements{};
   std::chrono::milliseconds timeout{ default_timeout };
-  test_env env{ test_env::agnostic };
 };
 
 struct test_suite {

--- a/test/framework/test_main.cxx
+++ b/test/framework/test_main.cxx
@@ -16,12 +16,15 @@
  */
 
 // Shared entry point for every test executable built on the framework. A test file provides
-// tests(); this main gathers a name filter from argv, decides mock-vs-real mode from
-// TEST_CONNECTION_STRING, runs the suite, and maps the outcome to a process exit code
+// tests(); this main gathers a name filter from argv, resolves the configuration from the
+// environment, runs the suite, and maps the outcome to a process exit code
 // (0 pass / 1 fail / 77 all-skipped).
 //
-// `--list-tests` prints the case names one per line and exits. cmake/TestFramework.cmake runs it
-// after linking to register one ctest entry per case.
+// `--list-tests` prints each case name and what it requires, then exits. cmake/TestFramework.cmake
+// runs it after linking to register one ctest entry per case.
+//
+// Every other argument is a case name to run. An argument that matches no case is a failure, not a
+// request to run nothing.
 
 #include "test_runner.hxx"
 
@@ -42,7 +45,8 @@ main(int argc, char* argv[]) -> int
   bool list_only{ false };
   std::set<std::string> filter;
   for (int i = 1; i < argc; ++i) {
-    if (const std::string_view arg{ argv[i] }; arg == "--list-tests") {
+    const std::string_view arg{ argv[i] };
+    if (arg == "--list-tests") {
       list_only = true;
     } else {
       filter.emplace(arg);
@@ -52,24 +56,38 @@ main(int argc, char* argv[]) -> int
   auto suite = tests();
 
   if (list_only) {
-    for (const auto& name : case_names(suite)) {
-      std::cout << name << '\n';
+    for (const auto& line : describe_cases(suite)) {
+      std::cout << line << '\n';
     }
     return 0;
   }
 
+  auto config = configuration::from_environment();
   try {
-    scale_timeouts(suite, timeout_multiplier(safe_getenv(timeout_multiplier_variable)));
+    const auto factor = timeout_multiplier(safe_getenv(timeout_multiplier_variable));
+    scale_timeouts(suite, factor);
+    // The requirement phase runs under its own budget on the configuration, not on any case, so it
+    // has to be scaled by the same factor or the multiplier misses the phase that opens the
+    // cluster.
+    scale_timeouts(config, factor);
   } catch (const std::exception& e) {
     std::cerr << e.what() << '\n';
     return 1;
   }
 
-  // Real-cluster mode iff TEST_CONNECTION_STRING is set and non-empty (the couchbase-cxx-client
-  // integration convention).
-  const bool real_cluster = safe_getenv("TEST_CONNECTION_STRING").has_value();
+  context ctx{ std::move(config) };
 
-  const auto result = run(suite, filter, real_cluster, std::cout);
+  const auto result = run(suite, filter, ctx, std::cout);
+
+  // Grouped, because the count alone is what lets a predicate that is permanently false in CI go
+  // unnoticed: 37 skipped reads the same whether the environment lacked one thing or everything.
+  if (!result.skipped_by_requirement.empty()) {
+    std::cout << "\nSkipped for want of:\n";
+    for (const auto& [requirement, count] : result.skipped_by_requirement) {
+      std::cout << fmt::format("  {} — {} case(s)\n", requirement, count);
+    }
+    std::cout << '\n';
+  }
 
   if (result.failed > 0) {
     std::cout << fmt::format("Suite \"{}\": {} passed, {} skipped, {} FAILED\n",

--- a/test/framework/test_runner.cxx
+++ b/test/framework/test_runner.cxx
@@ -23,12 +23,14 @@
 #include <cstdint>
 #include <cstdlib>
 #include <exception>
+#include <functional>
 #include <future>
 #include <limits>
 #include <memory>
 #include <ostream>
 #include <stdexcept>
 #include <thread>
+#include <utility>
 
 #include <spdlog/fmt/fmt.h>
 
@@ -56,13 +58,13 @@ human(std::chrono::nanoseconds ns) -> std::string
   return fmt::format("{:.1f}ms", std::chrono::duration<double, std::milli>(ns).count());
 }
 
-// Run one case on a worker thread, enforcing `timeout`. On timeout the worker is detached: the
+// Run `body` on a worker thread, enforcing `timeout`. On timeout the worker is detached: the
 // packaged_task moved into it co-owns the future's shared state, so the detached thread writes
 // only to that heap state (never to this stack frame) and the result is simply never read.
 auto
-run_case(void (*func)(), std::chrono::milliseconds timeout) -> case_result
+run_bounded(std::function<void()> body, std::chrono::milliseconds timeout) -> case_result
 {
-  std::packaged_task<void()> task(func);
+  std::packaged_task<void()> task(std::move(body));
   auto future = task.get_future();
   const auto start = std::chrono::steady_clock::now();
   std::thread worker(std::move(task));
@@ -89,13 +91,95 @@ run_case(void (*func)(), std::chrono::milliseconds timeout) -> case_result
            fmt::format("timed out after {}", human(timeout)),
            /*timed_out=*/true };
 }
+
+// Stands in for a requirement's description when the verdict was reached by the phase itself --
+// a blown budget, or a check() that called skip() -- so no single requirement is responsible. It is
+// not a noun that reads after "needs", which is why the two report lines phrase it separately.
+constexpr auto requirement_phase = "(requirement phase)";
+
+// What the requirement phase concluded about one case.
+struct gate_result {
+  enum class verdict : std::uint8_t {
+    run,
+    skip,
+    fail
+  };
+  verdict outcome{ verdict::run };
+  std::string requirement{}; // which one decided, for the grouped skip report
+  std::string detail{};
+  // A requirement that blew its budget leaves a worker detached, exactly as a case body does, and
+  // the process must leave the same way (see main()).
+  bool timed_out{ false };
+};
+
+// Check every requirement of a case, in declaration order, stopping at the first that does not
+// hold. The whole phase runs on the bounded worker: a requirement that blocks must cost this case
+// its budget, not the run.
+auto
+check_requirements(const test_case& tc, context& ctx) -> gate_result
+{
+  if (tc.requirements.empty()) {
+    return {};
+  }
+
+  // On the heap, and captured by value: run_bounded detaches the worker when the budget is blown,
+  // so a stack local here would be written to by that worker after this function returned. `tc` and
+  // `ctx` are captured by reference because both outlive the run, and `ctx` is safe to reach from a
+  // worker that outlived its budget because it serialises its own probes -- outliving the run is
+  // what makes the reference valid, not what makes the access race-free.
+  auto gate = std::make_shared<gate_result>();
+  const auto bounded = run_bounded(
+    [&tc, &ctx, gate]() {
+      for (const auto& req : tc.requirements) {
+        if (req == nullptr) {
+          *gate = { gate_result::verdict::fail, "(null)", "a null requirement was registered" };
+          return;
+        }
+        check_result checked;
+        try {
+          checked = req->check(ctx);
+        } catch (const probe_failure& e) {
+          // The probe could not answer. Not knowing whether a case applies is not the same as
+          // knowing it does not, and only one of the two may pass silently.
+          checked = check_result::unknown(e.what());
+        }
+        switch (checked.value) {
+          case check_result::status::satisfied:
+            break;
+          case check_result::status::not_satisfied:
+            *gate = { gate_result::verdict::skip, req->describe(), std::move(checked.detail) };
+            return;
+          case check_result::status::undetermined:
+            *gate = { gate_result::verdict::fail, req->describe(), std::move(checked.detail) };
+            return;
+        }
+      }
+    },
+    ctx.config().requirement_budget);
+
+  if (bounded.outcome == case_result::status::failed) {
+    return { gate_result::verdict::fail,
+             requirement_phase,
+             bounded.timed_out ? fmt::format("checking requirements exceeded {}",
+                                             human(ctx.config().requirement_budget))
+                               : bounded.message,
+             bounded.timed_out };
+  }
+  // A requirement whose check() called skip() rather than returning a status. Falling through to
+  // the default-constructed gate would say "run", so the body would execute and report passed
+  // behind a precondition that declared itself unmet. Skip, not fail: skip() is a statement that
+  // the case does not apply, which is what not_satisfied means; undetermined keeps its own fail
+  // path.
+  if (bounded.outcome == case_result::status::skipped) {
+    return { gate_result::verdict::skip, requirement_phase, bounded.message };
+  }
+  return *gate;
+}
 } // namespace
 
 auto
-run(const test_suite& suite,
-    const std::set<std::string>& filter,
-    bool real_cluster,
-    std::ostream& out) -> run_result
+run(const test_suite& suite, const std::set<std::string>& filter, context& ctx, std::ostream& out)
+  -> run_result
 {
   // Flush each line as it is written. ctest runs these binaries with stdout on a pipe, where the
   // stream is block-buffered, and a case that aborts the process discards the whole buffer: the log
@@ -115,13 +199,52 @@ run(const test_suite& suite,
         }
         matched.insert(tc.name);
       }
-      if (!should_run(tc.env, real_cluster)) {
-        out << fmt::format("Skipping \"{}\" (environment not applicable)\n", tc.name);
+
+      const auto gate = check_requirements(tc, ctx);
+      if (gate.outcome == gate_result::verdict::skip) {
+        const auto decided_by_the_phase = gate.requirement == requirement_phase;
+        out << (decided_by_the_phase
+                  ? fmt::format("Skipping \"{}\": a requirement check skipped it ({})\n",
+                                tc.name,
+                                gate.detail)
+                  : fmt::format(
+                      "Skipping \"{}\": needs {} ({})\n", tc.name, gate.requirement, gate.detail));
         ++result.skipped;
+        // Grouped only where a requirement is what turned the case away. The sentinel is not one,
+        // and the report it feeds lists what an environment failed to provide -- a row reading
+        // "(requirement phase)" names something nobody can supply. The line above already says
+        // what happened, and the case is still counted among the skips.
+        if (!decided_by_the_phase) {
+          ++result.skipped_by_requirement[gate.requirement];
+        }
         continue;
       }
+      if (gate.outcome == gate_result::verdict::fail) {
+        out << (gate.requirement == requirement_phase
+                  ? fmt::format("\"{}\" FAILED: its requirements could not be checked: {}\n",
+                                tc.name,
+                                gate.detail)
+                  : fmt::format("\"{}\" FAILED: could not establish whether it needs {}: {}\n",
+                                tc.name,
+                                gate.requirement,
+                                gate.detail));
+        ++result.failed;
+        if (gate.timed_out) {
+          ++result.timed_out;
+        }
+        // The run continues after a timeout rather than ending. The detached worker is still inside
+        // a probe, but the context serialises its own probes, so the next case's phase waits rather
+        // than racing it; and a wedged cluster reporting every remaining case as undetermined is
+        // more use than a run that stops at the first one and says nothing about the rest.
+        continue;
+      }
+
       out << fmt::format("Running \"{}\" (budget: {})...\n", tc.name, human(tc.timeout));
-      const auto r = run_case(tc.func, tc.timeout);
+      const auto r = run_bounded(
+        [&tc, &ctx]() {
+          tc.func(ctx);
+        },
+        tc.timeout);
       switch (r.outcome) {
         case case_result::status::passed:
           out << fmt::format("\"{}\" passed ({})\n", tc.name, human(r.duration));
@@ -192,6 +315,28 @@ case_names(const test_suite& suite) -> std::vector<std::string>
 }
 
 auto
+describe_cases(const test_suite& suite) -> std::vector<std::string>
+{
+  std::vector<std::string> lines;
+  const auto describe = [&lines](const std::vector<test_case>& cases) {
+    for (const auto& tc : cases) {
+      std::string requirements;
+      for (const auto& req : tc.requirements) {
+        if (!requirements.empty()) {
+          requirements += "; ";
+        }
+        requirements += req == nullptr ? "(null)" : req->describe();
+      }
+      lines.push_back(
+        fmt::format("{}\t{}", tc.name, requirements.empty() ? "no requirements" : requirements));
+    }
+  };
+  describe(suite.test_cases);
+  describe(suite.slow_test_cases);
+  return lines;
+}
+
+auto
 timeout_multiplier(const std::optional<std::string>& raw) -> double
 {
   if (!raw.has_value()) {
@@ -217,21 +362,34 @@ timeout_multiplier(const std::optional<std::string>& raw) -> double
   return factor;
 }
 
+namespace
+{
+auto
+scale_budget(std::chrono::milliseconds budget, double factor) -> std::chrono::milliseconds
+{
+  // Ceiling, not nearest: this exists to give a case more room on a slower runner, and rounding
+  // a budget down -- which std::llround does for any product with a fraction below .5 -- would
+  // quietly do the opposite of what the caller asked for.
+  const auto product = std::ceil(static_cast<double>(budget.count()) * factor);
+  // Saturate before narrowing. A product past the integer range is undefined at the cast, and on
+  // a signed overflow the budget would come back negative and clamp to 1ms -- a multiplier asking
+  // for more room would give every case the least possible. The bound has to come from the
+  // duration's own representation rather than long long: the standard fixes only that it is signed
+  // and at least 45 bits, and a ceiling taken from a wider type would admit exactly the cast this
+  // guards against.
+  using rep = std::chrono::milliseconds::rep;
+  constexpr auto ceiling = static_cast<double>(std::numeric_limits<rep>::max());
+  const auto scaled =
+    product >= ceiling ? std::numeric_limits<rep>::max() : static_cast<rep>(product);
+  return std::chrono::milliseconds{ std::max<rep>(scaled, 1) };
+}
+} // namespace
+
 void
 scale_timeouts(test_suite& suite, double factor)
 {
   const auto scale = [factor](test_case& tc) {
-    // Ceiling, not nearest: this exists to give a case more room on a slower runner, and rounding
-    // a budget down -- which std::llround does for any product with a fraction below .5 -- would
-    // quietly do the opposite of what the caller asked for.
-    const auto product = std::ceil(static_cast<double>(tc.timeout.count()) * factor);
-    // Saturate before narrowing. A product past the integer range is undefined at the cast, and on
-    // a signed overflow the budget would come back negative and clamp to 1ms -- a multiplier asking
-    // for more room would give every case the least possible.
-    constexpr auto ceiling = static_cast<double>(std::numeric_limits<long long>::max());
-    const auto scaled =
-      product >= ceiling ? std::numeric_limits<long long>::max() : static_cast<long long>(product);
-    tc.timeout = std::chrono::milliseconds{ std::max<long long>(scaled, 1) };
+    tc.timeout = scale_budget(tc.timeout, factor);
   };
   for (auto& tc : suite.test_cases) {
     scale(tc);
@@ -241,6 +399,15 @@ scale_timeouts(test_suite& suite, double factor)
   }
 }
 
+void
+scale_timeouts(configuration& config, double factor)
+{
+  // The requirement phase is where the cluster is opened, so it is the phase a slow runner is most
+  // likely to blow -- and exceeding it is reported as a failure, not a skip. Leaving it unscaled
+  // made the multiplier that exists for slow legs unable to reach the one budget they need most.
+  config.requirement_budget = scale_budget(config.requirement_budget, factor);
+}
+
 auto
 safe_getenv(const std::string& name) noexcept -> std::optional<std::string>
 {
@@ -248,24 +415,35 @@ safe_getenv(const std::string& name) noexcept -> std::optional<std::string>
     return std::nullopt;
   }
 
+  // noexcept, and it builds a std::string: an allocation failure would otherwise terminate rather
+  // than report. Every caller treats "no value" as "unset", which is the honest answer when the
+  // environment could not be read.
+  try {
 #if defined(_WIN32)
-  char* buf = nullptr;
-  std::size_t len = 0;
-  if (_dupenv_s(&buf, &len, name.c_str()) == 0 && buf != nullptr) {
-    std::string value(buf);
-    free(buf); // NOLINT(cppcoreguidelines-no-malloc) — _dupenv_s allocates with malloc
-    if (!value.empty()) {
-      return value;
+    char* buf = nullptr;
+    std::size_t len = 0;
+    if (_dupenv_s(&buf, &len, name.c_str()) == 0 && buf != nullptr) {
+      // Ownership is taken before the string is built. Building it can throw, and the catch below
+      // would then swallow the exception and lose the buffer with it -- a leak no test would ever
+      // see, because it happens only on the allocation failure the catch exists to absorb.
+      const std::unique_ptr<char, decltype(&std::free)> owned{
+        buf, &std::free // NOLINT(cppcoreguidelines-no-malloc) — _dupenv_s allocates with malloc
+      };
+      if (owned.get()[0] != '\0') {
+        return std::string{ owned.get() };
+      }
     }
-  }
-  return std::nullopt;
+    return std::nullopt;
 #else
-  if (const char* value = std::getenv(name.c_str()); // NOLINT(concurrency-mt-unsafe)
-      value != nullptr && value[0] != '\0') {
-    return std::string{ value };
-  }
-  return std::nullopt;
+    if (const char* value = std::getenv(name.c_str()); // NOLINT(concurrency-mt-unsafe)
+        value != nullptr && value[0] != '\0') {
+      return std::string{ value };
+    }
+    return std::nullopt;
 #endif
+  } catch (...) {
+    return std::nullopt;
+  }
 }
 
 } // namespace couchbase::test

--- a/test/framework/test_runner.hxx
+++ b/test/framework/test_runner.hxx
@@ -20,6 +20,7 @@
 #include "test_framework.hxx"
 
 #include <cstddef>
+#include <map>
 #include <optional>
 #include <ostream>
 #include <set>
@@ -33,6 +34,12 @@ struct run_result {
   std::size_t passed{ 0 };
   std::size_t skipped{ 0 };
   std::size_t failed{ 0 };
+  // Why cases were skipped: requirement description -> how many cases it turned away. Printed at
+  // the end of a run, because "37 skipped" without the reasons is how a permanently-false
+  // predicate stays invisible for a year. Every key is a requirement an environment could be given,
+  // so a skip the requirement phase itself decided -- a check() that called skip() -- appears in
+  // `skipped` alone; it has no requirement to name.
+  std::map<std::string, std::size_t> skipped_by_requirement{};
   // Cases that exceeded their budget. Counted in `failed` too; tracked separately because a
   // timeout leaves a detached worker thread running, which changes how the process must exit
   // (see main()).
@@ -40,15 +47,14 @@ struct run_result {
 };
 
 // Run a suite. `filter` empty => run every case; otherwise only cases whose name is in `filter`;
-// a filter name matching no case is itself a failure. `real_cluster` selects env-gated cases (see
-// should_run). Progress lines go to `out`. Every selected case runs even after one fails, so a
-// single CI round-trip reports every regression in the binary. Exposed (rather than buried in
-// main) so a self-test can drive it with in-memory suites.
+// a filter name matching no case is itself a failure. Each case's requirements are checked
+// against `ctx` first: unsatisfied skips it, undetermined fails it. Progress lines go to `out`.
+// Every selected case runs even after one fails, so a single CI round-trip reports every
+// regression in the binary. Exposed (rather than buried in main) so a self-test can drive it with
+// in-memory suites.
 auto
-run(const test_suite& suite,
-    const std::set<std::string>& filter,
-    bool real_cluster,
-    std::ostream& out) -> run_result;
+run(const test_suite& suite, const std::set<std::string>& filter, context& ctx, std::ostream& out)
+  -> run_result;
 
 // Process exit code for a result: any failure => 1; nothing ran but something skipped => 77
 // (the GNU/ctest "skipped" convention); otherwise 0.
@@ -61,6 +67,12 @@ exit_code(const run_result& result) -> int;
 // the machine that configured the build.
 [[nodiscard]] auto
 case_names(const test_suite& suite) -> std::vector<std::string>;
+
+// What --list-tests prints: the case name, then a tab, then what the case requires. The tab is
+// load-bearing -- cmake/TestFrameworkAddTests.cmake registers the part before it, so the same
+// output serves the build and a person trying to find out why a case never runs.
+[[nodiscard]] auto
+describe_cases(const test_suite& suite) -> std::vector<std::string>;
 
 // Environment variable holding a factor applied to every case's timeout budget.
 inline constexpr auto timeout_multiplier_variable = "CB_TEST_TIMEOUT_MULTIPLIER";
@@ -76,6 +88,11 @@ timeout_multiplier(const std::optional<std::string>& raw) -> double;
 // Multiply every budget in `suite` by `factor`, rounding up, to at least one millisecond.
 void
 scale_timeouts(test_suite& suite, double factor);
+
+// The same, for the budget the requirement phase runs under. Separate because the configuration is
+// resolved after the suite, and both have to be scaled by the same factor.
+void
+scale_timeouts(configuration& config, double factor);
 
 // Portable std::getenv wrapper returning std::nullopt for unset *or* empty values, matching the
 // wrappers in tools/utils.cxx and examples/external_circuit_breaker. Needed because MSVC treats


### PR DESCRIPTION
Third ticket of [CXXCBC-945](https://couchbasecloud.atlassian.net/browse/CXXCBC-945), filed as CXXCBC-948 and sequenced before CXXCBC-949 on purpose: the pilot migration needs this vocabulary to exist.

CXXCBC-946 (#1070) and CXXCBC-947 (#1071) have merged, so this now carries a single commit against `main`. CXXCBC-949, CXXCBC-950 and CXXCBC-975 sit on top of it in #1073, #1074 and #1075, each carrying the commits below it.

## Why

301 places in the suite decide for themselves whether a case should run:

```cpp
if (!integration.cluster_version().supports_query()) {
  SKIP("cluster does not support query");
}
```

Each is free to differ from its neighbours, none is visible to the runner, and the reason a case did not run survives only as a line of output. A predicate that is permanently false in CI produces a case that never executes, reports nothing, and is indistinguishable from one that passes.

The same guards conflate two situations that must not be conflated: *no cluster is configured* and *the configured cluster could not be reached* both end as a skip, so an unreachable endpoint turns an entire integration leg green.

## What changed

A case declares what it needs beside its registration, and the runner checks it before the body:

```cpp
{ "upsert_round_trips", upsert_round_trips, { needs::real_cluster() }, timeout::integration },
{ "query_over_collection", query_over_collection,
  { needs::real_cluster(), needs::service("n1ql"), needs::cluster_version(v7_6) } },
```

`check()` returns **three** states, not a boolean:

| verdict | effect |
|---|---|
| satisfied | the case runs |
| not satisfied | the case is skipped, and the run reports what was missing |
| **undetermined** | the case **fails** |

The third is the whole point. A boolean has to fold "I could not find out" into one of the two answers, and in test infrastructure it is always folded into the one that does not fail the build.

**Vocabulary** (`needs::`), twelve names: `real_cluster`, `mock`, `service`, `cluster_version(from[, until])`, `bucket_capability`, `deployment`, `edition`, `storage_backend`, `replicas`, `nodes`, `server_groups`, `developer_preview`. Names come from the predicates already in the tree rather than a taxonomy invented for the framework. A case needing something outside the list declares it in its own file — `needs_even_replicas` in `selftest.cxx` is a short struct with one `check()`, and required no framework change.

**Context.** Requirements and bodies read the server through a `context` whose probes return plain types and are cached for the life of the process. `context.hxx` includes `<chrono> <cstdint> <exception> <memory> <optional> <string> <vector>` and the fmt wrapper — nothing else — so declaring a requirement costs a test file no compile time. The connection sits behind a `probe_backend`; a test executable links the null one (every probe reports it cannot ask, which fails the case) or the cluster one, chosen by `LINK_CLIENT`.

The context serialises its own probes. `run_bounded` detaches a worker whose budget expired, and that worker is normally still inside a probe — that is why it ran out of budget — so the next case reaches the context before the previous one has left it. Every accessor that touches the caches, the backend or the counter takes one lock, held across the probe, which is what holds a run to one backend rather than one per racing caller. A probe that hangs therefore blocks the next case until that case's own budget expires, and a cluster that stops answering reports every case as undetermined instead of corrupting the caches.

**No-hang, in three layers.** The requirement phase runs on the bounded worker under `configuration::requirement_budget`, which is separate from each case's own budget — this one bounds the probing, that one the work, and `CB_TEST_TIMEOUT_MULTIPLIER` scales both. A `probe_failure` escaping a `check()` becomes undetermined. Probe results *and probe failures* are cached, so an unreachable cluster costs one connect attempt per binary rather than one per case.

`test_env` is gone. Case bodies now take `context&`.

## A defect this found

**Requirement descriptions came out empty.** `make(fmt::format("the {} service", name), [name = std::move(name)]{...})` — two arguments to the same call, unspecified evaluation order, and the compiler moved first. The description became `the  service`, which is also the key the skip report groups by. Caught by the self-test, fixed by building the description before the capture.

## Verification

Debug + Ninja, `-DCOUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2=ON -DCOUCHBASE_CXX_CLIENT_BUILD_CNG_TESTS=ON`.

| Criterion | Evidence |
|---|---|
| unconfigured and unreachable are **not** the same outcome | self-test `an_unconfigured_cluster_skips_and_an_unreachable_one_fails`: no connection string skips and reports the requirement by name; a configured endpoint that cannot answer fails |
| an all-skipped binary reports ctest Skipped | self-test `runner_reports_a_skipped_case` asserts `exit_code(r) == 77`, the value `couchbase_add_test()` wires as `SKIP_RETURN_CODE` |
| at most one connection for probing | self-test `a_failed_probe_is_not_retried_per_case`: the failure is cached, so an unreachable endpoint costs one connect attempt per binary |
| probes cached across cases | self-test: 20 cases × 2 requirements → `service_calls == 1`, `version_calls == 1`, `backends_created() == 1` |
| concurrent probing yields one backend call | self-test `one_probe_answers_every_caller_that_arrives_at_once`: eight threads meet at a barrier against a 50 ms probe, `service_calls == 1`. Removing the lock gives 8 |
| a requirement that blocks fails its case, binary still exits | self-test with `requirement_budget = 50 ms` against a 30 s requirement: the case is recorded failed with `timed_out == 1`, and the runner returns |
| a probe that throws yields undetermined without escaping | self-test `a_requirement_that_throws_fails_its_case` |
| a phase-level verdict is not reported as a requirement name | self-test `a_phase_level_verdict_is_not_reported_as_a_requirement_name`: the line reads `a requirement check skipped it (…)`, never `needs (requirement phase)`, and the sentinel reaches neither the grouped report nor `skipped_by_requirement` |
| `--list-tests` prints requirements | `a_satisfied_requirement_lets_the_case_run\tno requirements` (tab-separated; CMake registers the part before the tab) |
| skips grouped by requirement | `Skipped for want of:` carries only requirement descriptions; a skip the requirement phase itself decided is counted in the totals and grouped under nothing |
| headers stay lean | no `#include` of `core/`, `couchbase/`, asio or taocpp under `test/framework/*.hxx` |
| Catch2 config unaffected | `-DCOUCHBASE_CXX_CLIENT_BUILD_TESTS=ON` configures and builds `test_utils`, `test_unit_utils` and the new probe test |
| a budget past the representation saturates | `scale_timeouts(suite, 1e300)` returns `milliseconds::rep`'s maximum rather than wrapping negative and clamping to 1ms; the ceiling is taken from that `rep`, not from `long long` |
| framework still standalone | `-DCOUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2=OFF` builds the framework and its self-test with no client library linked |

`test/framework/cluster_probes_selftest.cxx` is new and carries the **integration** label: the cluster-backed probes need a cluster, and shipping that backend without a test that exercises it is the thing this epic exists to stop.

## Deliberately not here

**Cluster sharing.** Nothing hands a cluster to a test body yet — the CNG tests build their own fixtures — so there is no sharing policy, no `needs::isolated_cluster`, and no switch to turn sharing off. `cluster_access.hxx` and the policy land with the pilot file that is their first consumer. Building them now would mean shipping infrastructure no test uses.

**The `integration_test_guard` constructor fix.** An unreachable cluster used to terminate the process: the constructor spawned io threads and then threw, so the thread vector was destroyed while joinable. That is fixed on `main` by CXXCBC-988, which is more thorough than the version this branch once carried, so `test/utils/integration_test_guard.cxx` here is byte-identical to `main`.

`test/utils/` moved out from under `COUCHBASE_CXX_CLIENT_BUILD_TESTS` so both suites can use it; it contains no Catch2.


[CXXCBC-945]: https://couchbasecloud.atlassian.net/browse/CXXCBC-945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


