### PR TITLE
CXXCBC-975: take the formatting library out of the framework headers

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -178,7 +178,31 @@ assert_eq(opts.key_value_timeout.count(), 20'000, "check key_value_timeout==2000
 
 Include the lightest header that does the job. Six unit files currently include `test_helper_integration.hxx` — dragging in `core/cluster.hxx` and `core/operations.hxx` — without ever constructing a cluster.
 
-`framework/test_registry.hxx` is what a test file needs. `framework/errors.hxx` is separate because it names `couchbase::error`, and a file that does not assert on one should not pay for it.
+`framework/test_registry.hxx` is what a test file needs, and it deliberately reaches nothing heavy: no formatting library, no `core/`, no `couchbase/`. `framework/errors.hxx` is separate because it names `couchbase::error`, and a file that does not assert on one should not pay for it. `framework/test_runner.hxx` is framework internals; a test does not include it.
+
+**Assertion messages are string literals.** Across the whole suite, five call sites out of about 1,370 build a message from values, and the framework is arranged so those five pay for it rather than everybody:
+
+```cpp
+assert_eq(actual, expected, "the value survives the round trip");        // yes: a literal
+assert_eq(actual, expected, fmt::format("round trip of {}", key));       // only if you must
+```
+
+The failure message already prints the operands — that is what `operand_printer` is for — so building one by hand is nearly always redundant. If a file genuinely needs it, that file includes `<spdlog/fmt/fmt.h>` itself.
+
+### Printing a type in a failure message
+
+`assert_eq` and `assert_ne` show both operands for any type with an `operand_printer`. Integers, `bool`, `char`, floating point, the string types and enums are built in; `framework/errors.hxx` adds `std::error_code` and `couchbase::error`. A type with none is not an error — the assertion still fires, it just omits the values. To teach the framework a type, specialise it next to the test that needs it:
+
+```cpp
+template<>
+struct couchbase::test::operand_printer<my_type> {
+  static constexpr bool available = true;
+  [[nodiscard]] static auto to_text(const my_type& value) -> std::string
+  {
+    return value.name();
+  }
+};
+```
 
 ## Comments in tests
 

--- a/test/cng/fixtures/live_fixture.hxx
+++ b/test/cng/fixtures/live_fixture.hxx
@@ -17,7 +17,8 @@
 
 #pragma once
 
-#include "framework/test_runner.hxx"
+#include "framework/context.hxx" // safe_getenv
+#include "framework/test_framework.hxx"
 
 // Views are deprecated in the public API but still part of the core surface these fixtures reach,
 // so the core includes below are parsed with the deprecation suppressed -- the same convention
@@ -133,12 +134,15 @@ skip_unless_service_implemented(const Context& ctx,
   if (ctx.ec != errc::common::feature_not_available) {
     return;
   }
+  // Concatenated rather than formatted: ten CNG test files include this header, and a formatting
+  // library in it would put that cost on all of them for two messages.
   assert_false(ctx.first_error_message.empty(),
-               fmt::format("{} reported feature_not_available with no gateway message, so the "
-                           "request was refused by the client and never reached the gateway",
-                           service),
+               std::string{ service } +
+                 " reported feature_not_available with no gateway message, so the request was "
+                 "refused by the client and never reached the gateway",
                loc);
-  skip(fmt::format("gateway does not implement {} ({})", service, ctx.first_error_message));
+  skip("gateway does not implement " + std::string{ service } + " (" + ctx.first_error_message +
+       ")");
 }
 
 // A component wired to the gateway named by TEST_CONNECTION_STRING, with the io_context already

--- a/test/cng/protostellar/live_query_index_admin.cxx
+++ b/test/cng/protostellar/live_query_index_admin.cxx
@@ -32,7 +32,11 @@
 // it covers was invisible from the core request that was already wired.
 
 #include "cng/fixtures/live_fixture.hxx"
+
+// This file builds a message rather than passing a literal, so it asks for fmt itself;
+// framework/test_framework.hxx deliberately does not.
 #include "framework/test_registry.hxx"
+#include <spdlog/fmt/fmt.h>
 
 #include "core/operations/management/query_index_create.hxx"
 #include "core/operations/management/query_index_drop.hxx"

--- a/test/cng/protostellar/query_index_admin_converter.cxx
+++ b/test/cng/protostellar/query_index_admin_converter.cxx
@@ -26,6 +26,10 @@
 
 #include "framework/test_registry.hxx"
 
+// This file builds a message rather than passing a literal, so it asks for fmt itself;
+// framework/test_framework.hxx deliberately does not.
+#include <spdlog/fmt/fmt.h>
+
 #include "core/protostellar/query_index_admin_converter.hxx"
 
 #include <cstddef>

--- a/test/framework/cluster_probes.cxx
+++ b/test/framework/cluster_probes.cxx
@@ -25,6 +25,8 @@
 
 #include "context.hxx"
 
+#include <spdlog/fmt/fmt.h>
+
 #include "utils/integration_test_guard.hxx"
 #include "utils/server_version.hxx"
 

--- a/test/framework/context.cxx
+++ b/test/framework/context.cxx
@@ -17,9 +17,9 @@
 
 #include "context.hxx"
 
-#include "test_runner.hxx"
-
+#include <cstdlib>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <utility>
 
@@ -228,6 +228,44 @@ context::backends_created() const -> std::size_t
 {
   const std::lock_guard<std::mutex> guard{ impl_->mutex };
   return impl_->backends_created;
+}
+
+auto
+safe_getenv(const std::string& name) noexcept -> std::optional<std::string>
+{
+  if (name.empty()) {
+    return std::nullopt;
+  }
+
+  // noexcept, and it builds a std::string: an allocation failure would otherwise terminate rather
+  // than report. Every caller treats "no value" as "unset", which is the honest answer when the
+  // environment could not be read.
+  try {
+#if defined(_WIN32)
+    char* buf = nullptr;
+    std::size_t len = 0;
+    if (_dupenv_s(&buf, &len, name.c_str()) == 0 && buf != nullptr) {
+      // Ownership is taken before the string is built. Building it can throw, and the catch below
+      // would then swallow the exception and lose the buffer with it -- a leak no test would ever
+      // see, because it happens only on the allocation failure the catch exists to absorb.
+      const std::unique_ptr<char, decltype(&std::free)> owned{
+        buf, &std::free // NOLINT(cppcoreguidelines-no-malloc) — _dupenv_s allocates with malloc
+      };
+      if (owned.get()[0] != '\0') {
+        return std::string{ owned.get() };
+      }
+    }
+    return std::nullopt;
+#else
+    if (const char* value = std::getenv(name.c_str()); // NOLINT(concurrency-mt-unsafe)
+        value != nullptr && value[0] != '\0') {
+      return std::string{ value };
+    }
+    return std::nullopt;
+#endif
+  } catch (...) {
+    return std::nullopt;
+  }
 }
 
 } // namespace couchbase::test

--- a/test/framework/context.hxx
+++ b/test/framework/context.hxx
@@ -20,10 +20,9 @@
 // What a test case and its requirements are handed: the configuration the run was started with,
 // the process environment, and a small set of cached probes describing the server.
 //
-// This header stays lean on purpose -- <string>, <vector>, <optional>, <memory>, <chrono> and the
-// fmt wrapper. Every probe returns a plain type, so nothing here names a core or public SDK type
-// and a test file that only needs to *describe* its requirements pays no compile cost for the
-// client library. Reaching the cluster itself is cluster_access.hxx, which is not lean.
+// This header stays lean on purpose: standard library only, and not a formatting library either.
+// Every probe returns a plain type, so nothing here names a core or public SDK type, and a test
+// file that only needs to *describe* its requirements pays no compile cost for the client library.
 
 #include <chrono>
 #include <cstdint>
@@ -32,8 +31,6 @@
 #include <optional>
 #include <string>
 #include <vector>
-
-#include <spdlog/fmt/fmt.h>
 
 namespace couchbase::test
 {
@@ -81,7 +78,7 @@ struct server_version {
 
   [[nodiscard]] auto to_string() const -> std::string
   {
-    return fmt::format("{}.{}.{}", major, minor, micro);
+    return std::to_string(major) + '.' + std::to_string(minor) + '.' + std::to_string(micro);
   }
 
   [[nodiscard]] friend auto operator<(const server_version& a, const server_version& b) -> bool
@@ -158,6 +155,14 @@ public:
 // opens no connection.
 [[nodiscard]] auto
 make_probe_backend(const configuration& config) -> std::unique_ptr<probe_backend>;
+
+// Portable std::getenv wrapper returning std::nullopt for unset *or* empty values, matching the
+// wrappers in tools/utils.cxx and examples/external_circuit_breaker. Needed because MSVC treats
+// plain getenv() as deprecated, and the test tree builds with /W4 /WX. Lives here so every test
+// executable shares one implementation; context::env() is the same thing reached through a case's
+// own context.
+[[nodiscard]] auto
+safe_getenv(const std::string& name) noexcept -> std::optional<std::string>;
 
 class context
 {

--- a/test/framework/errors.hxx
+++ b/test/framework/errors.hxx
@@ -34,24 +34,6 @@
 #include <string>
 #include <system_error>
 
-// fmt has no formatter for std::error_code unless <fmt/std.h> is included, which nothing here
-// does. Specialised so assert_eq and assert_ne on error codes print operands rather than degrading
-// to the bare message. couchbase::error deliberately gets none: couchbase/fmt/error.hxx already
-// provides one, and a second definition in a translation unit that included both would be an ODR
-// violation.
-template<>
-struct fmt::formatter<std::error_code> : fmt::formatter<std::string> {
-  template<typename FormatContext>
-  auto format(const std::error_code& ec, FormatContext& ctx) const
-  {
-    if (!ec) {
-      return fmt::formatter<std::string>::format("success", ctx);
-    }
-    return fmt::formatter<std::string>::format(
-      fmt::format("{}:{} ({})", ec.category().name(), ec.value(), ec.message()), ctx);
-  }
-};
-
 namespace couchbase::test
 {
 
@@ -61,7 +43,8 @@ describe(const std::error_code& ec) -> std::string
   if (!ec) {
     return "success";
   }
-  return fmt::format("{}:{} ({})", ec.category().name(), ec.value(), ec.message());
+  return std::string{ ec.category().name() } + ':' + std::to_string(ec.value()) + " (" +
+         ec.message() + ")";
 }
 
 [[nodiscard]] inline auto
@@ -80,14 +63,34 @@ describe(const couchbase::error& error) -> std::string
   return result;
 }
 
+// So assert_eq and assert_ne on error values print operands rather than nothing. A class template
+// specialisation is found at the point of instantiation, so it works from a header included after
+// test_framework.hxx -- which a free function overload would not.
+template<>
+struct operand_printer<std::error_code> {
+  static constexpr bool available = true;
+  [[nodiscard]] static auto to_text(const std::error_code& ec) -> std::string
+  {
+    return describe(ec);
+  }
+};
+
+template<>
+struct operand_printer<couchbase::error> {
+  static constexpr bool available = true;
+  [[nodiscard]] static auto to_text(const couchbase::error& error) -> std::string
+  {
+    return describe(error);
+  }
+};
+
 inline void
 assert_success(const std::error_code& ec,
                std::string_view message = "expected success",
                source_location loc = source_location::current())
 {
   if (ec) {
-    throw test_assertion_failure(
-      fmt::format("{}:{}: {} ({})", loc.file_name(), loc.line(), message, describe(ec)));
+    throw test_assertion_failure(detail::at(loc, message) + " (" + describe(ec) + ")");
   }
 }
 
@@ -97,8 +100,7 @@ assert_success(const couchbase::error& error,
                source_location loc = source_location::current())
 {
   if (error.ec()) {
-    throw test_assertion_failure(
-      fmt::format("{}:{}: {} ({})", loc.file_name(), loc.line(), message, describe(error)));
+    throw test_assertion_failure(detail::at(loc, message) + " (" + describe(error) + ")");
   }
 }
 
@@ -111,12 +113,8 @@ assert_error(const std::error_code& ec,
              source_location loc = source_location::current())
 {
   if (ec != expected) {
-    throw test_assertion_failure(fmt::format("{}:{}: {} (actual: {}, expected: {})",
-                                             loc.file_name(),
-                                             loc.line(),
-                                             message,
-                                             describe(ec),
-                                             describe(expected)));
+    throw test_assertion_failure(detail::at(loc, message) + " (actual: " + describe(ec) +
+                                 ", expected: " + describe(expected) + ")");
   }
 }
 
@@ -127,12 +125,8 @@ assert_error(const couchbase::error& error,
              source_location loc = source_location::current())
 {
   if (error.ec() != expected) {
-    throw test_assertion_failure(fmt::format("{}:{}: {} (actual: {}, expected: {})",
-                                             loc.file_name(),
-                                             loc.line(),
-                                             message,
-                                             describe(error),
-                                             describe(expected)));
+    throw test_assertion_failure(detail::at(loc, message) + " (actual: " + describe(error) +
+                                 ", expected: " + describe(expected) + ")");
   }
 }
 

--- a/test/framework/errors_selftest.cxx
+++ b/test/framework/errors_selftest.cxx
@@ -23,6 +23,7 @@
 // is constructed by hand.
 
 #include "framework/errors.hxx"
+
 #include "framework/test_registry.hxx"
 
 #include <couchbase/error_codes.hxx>
@@ -111,10 +112,10 @@ assert_error_distinguishes_one_failure_from_another([[maybe_unused]] context& ct
 }
 
 void
-error_codes_format_as_operands([[maybe_unused]] context& ctx)
+error_codes_render_as_operands([[maybe_unused]] context& ctx)
 {
-  // assert_eq prints operands only where fmt can format them. Without the specialisation in
-  // errors.hxx, a mismatch between two error codes would say "expected equal" and nothing else.
+  // assert_eq prints operands only for types with an operand_printer. Without the specialisations
+  // in errors.hxx, a mismatch between two error codes would say "expected equal" and nothing else.
   const auto message = message_of([]() {
     assert_eq(make_error_code(couchbase::errc::common::unambiguous_timeout),
               make_error_code(couchbase::errc::common::request_canceled));
@@ -122,7 +123,11 @@ error_codes_format_as_operands([[maybe_unused]] context& ctx)
   assert_contains(message, "unambiguous_timeout", "the actual code renders");
   assert_contains(message, "request_canceled", "and so does the expected one");
 
-  assert_eq(fmt::format("{}", std::error_code{}), std::string{ "success" }, "success renders");
+  assert_true(operand_printer<std::error_code>::available, "error codes are printable");
+  assert_true(operand_printer<couchbase::error>::available, "and so are errors");
+  assert_eq(operand_printer<std::error_code>::to_text(std::error_code{}),
+            std::string{ "success" },
+            "a default error code renders as success");
 }
 } // namespace
 
@@ -136,7 +141,7 @@ tests() -> test_suite
       { CASE(a_failed_error_code_names_its_category_value_and_message) },
       { CASE(a_failed_error_names_its_message_and_cause) },
       { CASE(assert_error_distinguishes_one_failure_from_another) },
-      { CASE(error_codes_format_as_operands) },
+      { CASE(error_codes_render_as_operands) },
     },
   };
 }

--- a/test/framework/selftest.cxx
+++ b/test/framework/selftest.cxx
@@ -22,6 +22,13 @@
 
 #include "test_registry.hxx"
 
+// This one drives run() directly, which the registry header deliberately does not expose.
+#include "test_runner.hxx"
+
+// This file builds a message rather than passing a literal, so it asks for fmt itself;
+// framework/test_framework.hxx deliberately does not.
+#include <spdlog/fmt/fmt.h>
+
 #include <atomic>
 #include <chrono>
 #include <cstddef>
@@ -860,6 +867,22 @@ the_added_assertions_report_what_they_saw([[maybe_unused]] context& ctx)
                   }),
                   "both are: 7",
                   "assert_ne prints the value");
+  // assert_ne fails when its operands are equal, so both render the same text for almost any pair
+  // -- and a version that printed the wrong one would look identical. A char and its code compare
+  // equal while rendering differently, which pins which operand is shown. Deliberately not bool
+  // against int: MSVC rejects that mix under /WX with C4805.
+  assert_contains(message_of([]() {
+                    assert_ne('A', 65);
+                  }),
+                  "both are: 'A'",
+                  "assert_ne prints the first operand, not the second");
+  // Distinct-looking operands that compare equal, so rendering the wrong one is visible. Two
+  // identical ints cannot tell the two apart.
+  assert_contains(message_of([]() {
+                    assert_ne(std::string{ "same" }, "same");
+                  }),
+                  R"(both are: "same")",
+                  "assert_ne prints the operand it compared, not a placeholder");
   assert_contains(message_of([]() {
                     assert_contains("abc", "xyz");
                   }),
@@ -894,6 +917,132 @@ the_added_assertions_report_what_they_saw([[maybe_unused]] context& ctx)
                   }),
                   "unreachable branch",
                   "fail() prints its message");
+}
+
+void
+a_failure_names_the_file_and_line_it_came_from([[maybe_unused]] context& ctx)
+{
+  // The prefix every assertion carries. Without it a failing case reports what went wrong but not
+  // where, which is the first thing anybody needs.
+  const auto here = source_location::current();
+  const auto text = detail::at(here, "the message");
+
+  assert_contains(text, "selftest.cxx:", "the file is named");
+  assert_contains(text, ":" + std::to_string(here.line()) + ": ", "and so is the line");
+  assert_starts_with(text, here.file_name(), "the location comes first");
+  assert_true(text.size() > std::string{ here.file_name() }.size() + 1,
+              "and the message follows it");
+  assert_contains(text, "the message", "which is the message that was passed");
+}
+
+void
+operands_render_without_a_formatting_library([[maybe_unused]] context& ctx)
+{
+  // The framework renders operands itself so that no test translation unit has to include a
+  // formatting library to see the values that differed. These are the types that reaches.
+  assert_eq(detail::render(42), std::string{ "42" }, "an integer");
+  assert_eq(detail::render(-7), std::string{ "-7" }, "a negative integer");
+  assert_eq(detail::render(true), std::string{ "true" }, "a bool is a word, not a 1");
+  assert_eq(detail::render(false), std::string{ "false" }, "and so is false");
+  assert_eq(detail::render('x'), std::string{ "'x'" }, "a char is quoted");
+
+  // Escaped, not written through. what() hands back c_str(), so a NUL rendered into the message
+  // would end it at the operand -- the reader gets "(actual: '" and never learns the expectation.
+  assert_eq(detail::render('\0'), std::string{ R"('\0')" }, "a NUL renders as an escape");
+  assert_eq(detail::render('\n'), std::string{ R"('\n')" }, "and so does a newline");
+  assert_eq(
+    detail::render('\x01'), std::string{ R"('\x01')" }, "other control bytes go out as hex");
+
+  // Trailing zeros are trimmed: std::to_string pads to six decimals, and "2.000000 ± 0.125000"
+  // buries the numbers the reader came for.
+  assert_eq(detail::render(1.5), std::string{ "1.5" }, "a fraction keeps its digits");
+  assert_eq(detail::render(2.0), std::string{ "2" }, "a whole double loses its padding");
+  assert_eq(detail::render(0.125), std::string{ "0.125" }, "and a small one keeps all of its");
+
+  // Six fixed decimals took everything below 5e-7 to "0", so a tolerance printed as "+/- 0" and
+  // two different values printed the same with no reason given. Both halves are pinned: the value
+  // survives, and values this far apart do not collide.
+  assert_eq(detail::render(1e-9), std::string{ "1e-09" }, "a small value is not flattened to zero");
+  assert_true(detail::render(1e-7) != detail::render(2e-7),
+              "and two different small values do not render identically");
+
+  // Six significant digits renders both of these "1". The precision widens until the text parses
+  // back to the double it came from, which is what stops values that differ late from printing
+  // alike -- the same failure as the small ones above, one decade further out.
+  assert_true(detail::render(1.0000001) != detail::render(1.0000002),
+              "two doubles differing beyond six digits do not render identically");
+  assert_eq(
+    detail::render(0.1), std::string{ "0.1" }, "and a value that needs no widening is left alone");
+
+  // Quoted, so a difference that is only whitespace is visible.
+  assert_eq(detail::render(std::string{ "got " }), std::string{ "\"got \"" }, "a string is quoted");
+
+  // The same reason the char printer escapes: what() hands back c_str(), so a NUL inside a string
+  // operand ended the message at that operand. Reachable -- the KV cases compare document bodies
+  // as strings, and a body written through the binary transcoder can carry one.
+  assert_eq(detail::render(std::string{ "a\0b", 3 }),
+            std::string{ R"("a\0b")" },
+            "a NUL inside a string is escaped, not written through");
+  assert_eq(detail::render(std::string_view{ "x\ty", 3 }),
+            std::string{ R"("x\ty")" },
+            "and so is a control byte in a view");
+  assert_eq(detail::render(std::string_view{ "v" }), std::string{ "\"v\"" }, "so is a view");
+  assert_eq(detail::render("literal"), std::string{ "\"literal\"" }, "so is a string literal");
+  assert_eq(detail::render(static_cast<const char*>(nullptr)),
+            std::string{ "(null)" },
+            "a null pointer says so rather than crashing");
+
+  enum class colour : std::uint8_t {
+    red = 3
+  };
+  assert_eq(detail::render(colour::red), std::string{ "3" }, "an enum renders its value");
+
+  // 3 fits every integer type, so it pins neither the width nor the signedness of the cast.
+  enum class wide : std::uint64_t {
+    big = 4'294'967'296
+  };
+  // Wider than int, which is what this reaches. The cast is through std::intmax_t, so an unsigned
+  // enumerator above INT64_MAX would render negative -- unreachable here, because no enum in the
+  // tree has one and one would be pathological, so the boundary is named rather than tested.
+  assert_eq(detail::render(wide::big),
+            std::string{ "4294967296" },
+            "an enum wider than int keeps its value");
+
+  enum class depth : std::int8_t {
+    below = -2
+  };
+  assert_eq(
+    detail::render(depth::below), std::string{ "-2" }, "a negative enumerator keeps its sign");
+
+  // decay_t strips volatile and the printers take a const reference, so this combination has to be
+  // handled explicitly or it is a compile error inside the framework header rather than at the
+  // assertion that caused it.
+  const volatile bool flag = true;
+  assert_eq(detail::render(flag), std::string{ "true" }, "a volatile operand still renders");
+}
+
+void
+a_type_with_no_printer_still_fails_its_assertion([[maybe_unused]] context& ctx)
+{
+  // The point of the customisation point being opt-in: a type nobody taught the framework to print
+  // must not stop the assertion from firing, it just loses the operands.
+  struct opaque {
+    auto operator==(const opaque& /* other */) const -> bool
+    {
+      return false;
+    }
+  };
+  assert_false(detail::printable<opaque>, "the type has no printer");
+
+  std::string message;
+  try {
+    assert_eq(opaque{}, opaque{}, "two opaque values");
+  } catch (const test_assertion_failure& e) {
+    message = e.what();
+  }
+  assert_contains(message, "two opaque values", "the assertion still fires and names itself");
+  assert_true(message.find("actual:") == std::string::npos,
+              "and says nothing it cannot say truthfully");
 }
 
 void
@@ -1196,6 +1345,9 @@ tests() -> test_suite
       { CASE(a_skip_inside_assert_throws_with_skips_its_case) },
       { CASE(a_failed_assertion_inside_assert_throws_with_fails_its_case) },
       { CASE(a_scaled_budget_lets_a_case_outlive_its_original_one), {}, timeout::fast },
+      { CASE(a_failure_names_the_file_and_line_it_came_from) },
+      { CASE(operands_render_without_a_formatting_library) },
+      { CASE(a_type_with_no_printer_still_fails_its_assertion) },
       { CASE(the_added_assertions_report_what_they_saw) },
       { CASE(the_configuration_reads_the_environment_it_documents) },
     },

--- a/test/framework/test_framework.hxx
+++ b/test/framework/test_framework.hxx
@@ -31,17 +31,14 @@
 
 #include <chrono>
 #include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 #include <exception>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <utility>
 #include <vector>
-
-// The wrapper (not <spdlog/fmt/bundled/format.h>) is required: it selects bundled fmt and derives
-// the header-only-vs-compiled mode from SPDLOG_COMPILED_LIB, which test_framework_main picks up by
-// linking spdlog::spdlog. Including the bundled header directly would bypass that and reintroduce
-// the duplicate fmt definitions that MSVC rejects -- see the note in cmake/TestFramework.cmake.
-#include <spdlog/fmt/fmt.h>
 
 namespace couchbase::test
 {
@@ -189,6 +186,237 @@ struct test_suite {
 auto
 tests() -> test_suite;
 
+// ── Rendering an operand ──────────────────────────────────────────────────────
+//
+// A failure message wants to show the values that differed, and showing them is the only reason a
+// test framework needs formatting at all. Doing it with a formatting library means every test
+// translation unit pays for that library's headers: <spdlog/fmt/fmt.h> preprocesses to about 63,800
+// lines as this tree compiles it, against 45,900 for catch2/catch_test_macros.hpp -- so roughly the
+// cost of the Catch2 header it replaces, spent to render an int or a string.
+//
+// So the framework renders operands itself, through this customisation point. The printers below
+// need nothing beyond <string> and <type_traits>; the header as a whole still includes what its
+// declarations need. A type with no specialisation is not an error: its assertion still fires, and
+// simply omits the operands rather than dragging in a way to print them.
+//
+// A test that wants richer text in a message is free to build one -- with fmt, or anything else --
+// and pass it; that cost then falls on the file that asked for it.
+namespace detail
+{
+// what() hands back c_str(), so a raw control byte written into a message ends it there: a NUL in
+// an operand leaves the reader with "(actual: \"" and no expectation. Every printer that can carry
+// one routes through here, so the char and string forms cannot drift apart.
+inline void
+escape_into(std::string& text, char value)
+{
+  switch (value) {
+    case '\0':
+      text += "\\0";
+      return;
+    case '\n':
+      text += "\\n";
+      return;
+    case '\r':
+      text += "\\r";
+      return;
+    case '\t':
+      text += "\\t";
+      return;
+    default:
+      break;
+  }
+  const auto byte = static_cast<unsigned char>(value);
+  if (byte < 0x20U || byte == 0x7fU) {
+    constexpr char digits[] = "0123456789abcdef";
+    text += "\\x";
+    text += digits[byte >> 4U];
+    text += digits[byte & 0x0fU];
+    return;
+  }
+  text += value;
+}
+
+[[nodiscard]] inline auto
+quoted(std::string_view value) -> std::string
+{
+  std::string text{ '"' };
+  for (const auto byte : value) {
+    escape_into(text, byte);
+  }
+  text += '"';
+  return text;
+}
+} // namespace detail
+
+template<typename T, typename Enable = void>
+struct operand_printer {
+  static constexpr bool available = false;
+  [[nodiscard]] static auto to_text(const T& /* value */) -> std::string
+  {
+    return {};
+  }
+};
+
+template<typename T>
+struct operand_printer<
+  T,
+  std::enable_if_t<std::is_integral_v<T> && !std::is_same_v<T, bool> && !std::is_same_v<T, char>>> {
+  static constexpr bool available = true;
+  [[nodiscard]] static auto to_text(const T& value) -> std::string
+  {
+    return std::to_string(value);
+  }
+};
+
+template<>
+struct operand_printer<bool> {
+  static constexpr bool available = true;
+  [[nodiscard]] static auto to_text(const bool& value) -> std::string
+  {
+    return value ? "true" : "false";
+  }
+};
+
+template<>
+struct operand_printer<char> {
+  static constexpr bool available = true;
+  [[nodiscard]] static auto to_text(const char& value) -> std::string
+  {
+    std::string text{ '\'' };
+    detail::escape_into(text, value);
+    text += '\'';
+    return text;
+  }
+};
+
+template<typename T>
+struct operand_printer<T, std::enable_if_t<std::is_floating_point_v<T>>> {
+  static constexpr bool available = true;
+  [[nodiscard]] static auto to_text(const T& value) -> std::string
+  {
+    // The shortest form that reads back as the same value. std::to_string pads to six fixed
+    // decimals, so everything below 5e-7 trimmed to "0": a tolerance printed as "+/- 0", and two
+    // different values printed identically with no reason given -- which is the failure the
+    // char-pointer static_assert further down this header exists to prevent. <sstream> would cost
+    // more to include than everything else here put together, so this goes through snprintf and
+    // widens the precision until the text parses back to the value it came from.
+    char buffer[64]{};
+    if constexpr (std::is_same_v<T, long double>) {
+      for (int precision = 6; precision <= 21; ++precision) {
+        static_cast<void>(std::snprintf(buffer, sizeof(buffer), "%.*Lg", precision, value));
+        if (std::strtold(buffer, nullptr) == value) {
+          break;
+        }
+      }
+    } else {
+      const auto widened = static_cast<double>(value);
+      for (int precision = 6; precision <= 17; ++precision) {
+        static_cast<void>(std::snprintf(buffer, sizeof(buffer), "%.*g", precision, widened));
+        if (std::strtod(buffer, nullptr) == widened) {
+          break;
+        }
+      }
+    }
+    return std::string{ buffer };
+  }
+};
+
+// Quoted, so a trailing space or an empty string is visible rather than being read as a typo in the
+// message.
+template<>
+struct operand_printer<std::string> {
+  static constexpr bool available = true;
+  [[nodiscard]] static auto to_text(const std::string& value) -> std::string
+  {
+    return detail::quoted(value);
+  }
+};
+
+template<>
+struct operand_printer<std::string_view> {
+  static constexpr bool available = true;
+  [[nodiscard]] static auto to_text(const std::string_view& value) -> std::string
+  {
+    return detail::quoted(value);
+  }
+};
+
+// A string literal has type const char[N], and std::decay_t applies array-to-pointer decay, so the
+// operand reaches a printer as const char* and this is the specialisation selected. Taken by value,
+// which is what a decayed pointer is.
+template<>
+struct operand_printer<const char*> {
+  static constexpr bool available = true;
+  [[nodiscard]] static auto to_text(const char* value) -> std::string
+  {
+    return value == nullptr ? "(null)" : detail::quoted(value);
+  }
+};
+
+// Written out rather than inheriting from the const overload: clang-format 22 and 24 disagree on
+// how to lay out an empty derived-struct body, and CI runs 22.
+template<>
+struct operand_printer<char*> {
+  static constexpr bool available = true;
+  [[nodiscard]] static auto to_text(const char* value) -> std::string
+  {
+    return operand_printer<const char*>::to_text(value);
+  }
+};
+
+// The underlying value, not a name: the framework cannot know the enumerators, and a number the
+// reader can look up beats no operands at all.
+template<typename T>
+struct operand_printer<T, std::enable_if_t<std::is_enum_v<T>>> {
+  static constexpr bool available = true;
+  [[nodiscard]] static auto to_text(const T& value) -> std::string
+  {
+    return std::to_string(static_cast<std::intmax_t>(value));
+  }
+};
+
+namespace detail
+{
+template<typename T>
+inline constexpr bool printable = operand_printer<std::decay_t<T>>::available;
+
+template<typename T>
+[[nodiscard]] inline auto
+render(const T& value) -> std::string
+{
+  // std::decay_t strips volatile, so printable<volatile bool> is true and this branch is
+  // instantiated -- but a const volatile lvalue cannot bind to the printer's const& parameter, and
+  // the error would land inside this header rather than on the assertion that caused it. Copying
+  // is the only legal way to drop volatile. Gated, because a plain static_cast would break the
+  // string-literal path, where decay_t<const char[N]> is const char*.
+  if constexpr (std::is_volatile_v<T>) {
+    // Scalars only, and the assert says so rather than leaving a page of template errors: dropping
+    // volatile needs a copy, and a class type's copy constructor takes const& and cannot bind a
+    // const volatile lvalue. Reading such an object through a non-volatile reference is not an
+    // option either -- that is undefined for an object that really is volatile.
+    static_assert(std::is_scalar_v<std::decay_t<T>>,
+                  "a volatile operand must be a scalar: dropping volatile requires a copy, and a "
+                  "class type cannot be copied from a const volatile lvalue");
+    return operand_printer<std::decay_t<T>>::to_text(std::decay_t<T>{ value });
+  } else {
+    return operand_printer<std::decay_t<T>>::to_text(value);
+  }
+}
+
+// "file.cxx:12: what the assertion means". Built by concatenation rather than by a format call, so
+// nothing here needs a formatting library.
+[[nodiscard]] inline auto
+at(source_location loc, std::string_view message) -> std::string
+{
+  std::string text{ loc.file_name() };
+  text += ':';
+  text += std::to_string(loc.line());
+  text += ": ";
+  text.append(message.data(), message.size());
+  return text;
+}
+} // namespace detail
+
 // ── Assertions ────────────────────────────────────────────────────────────────
 
 [[noreturn]] inline void
@@ -203,7 +431,7 @@ assert_true(bool value,
             source_location loc = source_location::current())
 {
   if (!value) {
-    throw test_assertion_failure(fmt::format("{}:{}: {}", loc.file_name(), loc.line(), message));
+    throw test_assertion_failure(detail::at(loc, message));
   }
 }
 
@@ -215,10 +443,24 @@ assert_false(bool value,
   assert_true(!value, message, loc);
 }
 
-// Report both operands when they are formattable. Without this the message says only "expected
-// equal", so a failure tells you the values differed but not what they were -- the one place where
-// not using Catch2 (whose expression decomposition prints operands) costs something concrete. The
-// `if constexpr` keeps assert_eq usable with types fmt cannot format.
+// Comparing two char pointers compares addresses, not text: two distinct buffers holding "hello"
+// are unequal, and both operands then render as "hello" -- a failure message showing two identical
+// values and no reason. Only rejected when BOTH sides are char pointers; the mixed form
+// assert_eq(e.what(), std::string{...}) compares by value and is what the suite already writes.
+namespace detail
+{
+template<typename T>
+inline constexpr bool is_char_pointer =
+  std::is_same_v<std::decay_t<T>, char*> || std::is_same_v<std::decay_t<T>, const char*>;
+
+template<typename A, typename B>
+inline constexpr bool both_char_pointers = is_char_pointer<A> && is_char_pointer<B>;
+} // namespace detail
+
+// Report both operands where the types can be rendered. Without this the message says only
+// "expected equal", so a failure tells you the values differed but not what they were -- the one
+// place where not using Catch2 (whose expression decomposition prints operands) costs something
+// concrete.
 template<typename A, typename B>
 inline void
 assert_eq(const A& actual,
@@ -226,17 +468,16 @@ assert_eq(const A& actual,
           std::string_view message = "expected equal",
           source_location loc = source_location::current())
 {
+  static_assert(!detail::both_char_pointers<A, B>,
+                "comparing two char pointers compares addresses, not text: wrap one side in "
+                "std::string_view or std::string");
   if (!(actual == expected)) {
-    if constexpr (fmt::is_formattable<A>::value && fmt::is_formattable<B>::value) {
-      throw test_assertion_failure(fmt::format("{}:{}: {} (actual: {}, expected: {})",
-                                               loc.file_name(),
-                                               loc.line(),
-                                               message,
-                                               actual,
-                                               expected));
-    } else {
-      throw test_assertion_failure(fmt::format("{}:{}: {}", loc.file_name(), loc.line(), message));
+    auto text = detail::at(loc, message);
+    if constexpr (detail::printable<A> && detail::printable<B>) {
+      text +=
+        " (actual: " + detail::render(actual) + ", expected: " + detail::render(expected) + ")";
     }
+    throw test_assertion_failure(std::move(text));
   }
 }
 
@@ -247,13 +488,15 @@ assert_ne(const A& actual,
           std::string_view message = "expected different",
           source_location loc = source_location::current())
 {
+  static_assert(!detail::both_char_pointers<A, B>,
+                "comparing two char pointers compares addresses, not text: wrap one side in "
+                "std::string_view or std::string");
   if (actual == unexpected) {
-    if constexpr (fmt::is_formattable<A>::value) {
-      throw test_assertion_failure(
-        fmt::format("{}:{}: {} (both are: {})", loc.file_name(), loc.line(), message, actual));
-    } else {
-      throw test_assertion_failure(fmt::format("{}:{}: {}", loc.file_name(), loc.line(), message));
+    auto text = detail::at(loc, message);
+    if constexpr (detail::printable<A>) {
+      text += " (both are: " + detail::render(actual) + ")";
     }
+    throw test_assertion_failure(std::move(text));
   }
 }
 
@@ -264,12 +507,8 @@ assert_contains(std::string_view haystack,
                 source_location loc = source_location::current())
 {
   if (haystack.find(needle) == std::string_view::npos) {
-    throw test_assertion_failure(fmt::format(R"({}:{}: {} ("{}" is not in "{}"))",
-                                             loc.file_name(),
-                                             loc.line(),
-                                             message,
-                                             needle,
-                                             haystack));
+    throw test_assertion_failure(detail::at(loc, message) + " (" + detail::quoted(needle) +
+                                 " is not in " + detail::quoted(haystack) + ")");
   }
 }
 
@@ -280,12 +519,8 @@ assert_starts_with(std::string_view value,
                    source_location loc = source_location::current())
 {
   if (value.size() < prefix.size() || value.compare(0, prefix.size(), prefix) != 0) {
-    throw test_assertion_failure(fmt::format(R"({}:{}: {} ("{}" does not start with "{}"))",
-                                             loc.file_name(),
-                                             loc.line(),
-                                             message,
-                                             value,
-                                             prefix));
+    throw test_assertion_failure(detail::at(loc, message) + " (" + detail::quoted(value) +
+                                 " does not start with " + detail::quoted(prefix) + ")");
   }
 }
 
@@ -301,13 +536,9 @@ assert_near(double actual,
 {
   const auto difference = actual > expected ? actual - expected : expected - actual;
   if (!(difference <= tolerance)) {
-    throw test_assertion_failure(fmt::format("{}:{}: {} (actual: {}, expected: {} ± {})",
-                                             loc.file_name(),
-                                             loc.line(),
-                                             message,
-                                             actual,
-                                             expected,
-                                             tolerance));
+    throw test_assertion_failure(detail::at(loc, message) + " (actual: " + detail::render(actual) +
+                                 ", expected: " + detail::render(expected) + " ± " +
+                                 detail::render(tolerance) + ")");
   }
 }
 
@@ -316,7 +547,7 @@ assert_near(double actual,
 [[noreturn]] inline void
 fail(std::string_view message, source_location loc = source_location::current())
 {
-  throw test_assertion_failure(fmt::format("{}:{}: {}", loc.file_name(), loc.line(), message));
+  throw test_assertion_failure(detail::at(loc, message));
 }
 
 // Invoke `fn` and require it not to throw. The exception's own message is reported: a case that
@@ -334,14 +565,10 @@ assert_no_throw(Fn&& fn,
   } catch (const test_assertion_failure&) {
     throw;
   } catch (const std::exception& e) {
-    throw test_assertion_failure(
-      fmt::format("{}:{}: {} ({})", loc.file_name(), loc.line(), message, e.what()));
+    throw test_assertion_failure(detail::at(loc, message) + " (" + e.what() + ")");
   } catch (...) {
-    throw test_assertion_failure(
-      fmt::format("{}:{}: {} (an exception not derived from std::exception)",
-                  loc.file_name(),
-                  loc.line(),
-                  message));
+    throw test_assertion_failure(detail::at(loc, message) +
+                                 " (an exception not derived from std::exception)");
   }
 }
 
@@ -374,12 +601,11 @@ assert_throws(Fn&& fn,
   } catch (const Exc&) {
     threw_expected = true;
   } catch (...) {
-    throw test_assertion_failure(fmt::format(
-      "{}:{}: {} (a different exception type was thrown)", loc.file_name(), loc.line(), message));
+    throw test_assertion_failure(detail::at(loc, message) +
+                                 " (a different exception type was thrown)");
   }
   if (!threw_expected) {
-    throw test_assertion_failure(
-      fmt::format("{}:{}: {} (nothing was thrown)", loc.file_name(), loc.line(), message));
+    throw test_assertion_failure(detail::at(loc, message) + " (nothing was thrown)");
   }
 }
 
@@ -412,18 +638,17 @@ assert_throws_with(std::string_view substring,
     threw_expected = true;
     what = e.what();
   } catch (...) {
-    throw test_assertion_failure(fmt::format(
-      "{}:{}: {} (a different exception type was thrown)", loc.file_name(), loc.line(), message));
+    throw test_assertion_failure(detail::at(loc, message) +
+                                 " (a different exception type was thrown)");
   }
   if (!threw_expected) {
-    throw test_assertion_failure(
-      fmt::format("{}:{}: {} (nothing was thrown)", loc.file_name(), loc.line(), message));
+    throw test_assertion_failure(detail::at(loc, message) + " (nothing was thrown)");
   }
   // Both halves: the substring alone does not tell the reader what the exception actually said, and
   // that is the thing they need in order to decide whether the code or the expectation is wrong.
   if (what.find(substring) == std::string_view::npos) {
-    throw test_assertion_failure(fmt::format(
-      R"({}:{}: {} ("{}" is not in "{}"))", loc.file_name(), loc.line(), message, substring, what));
+    throw test_assertion_failure(detail::at(loc, message) + " (" + detail::quoted(substring) +
+                                 " is not in " + detail::quoted(what) + ")");
   }
 }
 

--- a/test/framework/test_registry.hxx
+++ b/test/framework/test_registry.hxx
@@ -27,7 +27,10 @@
   A test file uses one or the other.
 #endif
 
-#include "test_runner.hxx"
+// test_framework.hxx, not test_runner.hxx: a test file needs the suite, the cases, the requirements
+// and the assertions, and none of the runner's API. Including the runner would put <map>, <set> and
+// <ostream> into every test translation unit for functions only the framework's own main() calls.
+#include "test_framework.hxx"
 
 #include <string>
 

--- a/test/framework/test_runner.cxx
+++ b/test/framework/test_runner.cxx
@@ -408,42 +408,4 @@ scale_timeouts(configuration& config, double factor)
   config.requirement_budget = scale_budget(config.requirement_budget, factor);
 }
 
-auto
-safe_getenv(const std::string& name) noexcept -> std::optional<std::string>
-{
-  if (name.empty()) {
-    return std::nullopt;
-  }
-
-  // noexcept, and it builds a std::string: an allocation failure would otherwise terminate rather
-  // than report. Every caller treats "no value" as "unset", which is the honest answer when the
-  // environment could not be read.
-  try {
-#if defined(_WIN32)
-    char* buf = nullptr;
-    std::size_t len = 0;
-    if (_dupenv_s(&buf, &len, name.c_str()) == 0 && buf != nullptr) {
-      // Ownership is taken before the string is built. Building it can throw, and the catch below
-      // would then swallow the exception and lose the buffer with it -- a leak no test would ever
-      // see, because it happens only on the allocation failure the catch exists to absorb.
-      const std::unique_ptr<char, decltype(&std::free)> owned{
-        buf, &std::free // NOLINT(cppcoreguidelines-no-malloc) — _dupenv_s allocates with malloc
-      };
-      if (owned.get()[0] != '\0') {
-        return std::string{ owned.get() };
-      }
-    }
-    return std::nullopt;
-#else
-    if (const char* value = std::getenv(name.c_str()); // NOLINT(concurrency-mt-unsafe)
-        value != nullptr && value[0] != '\0') {
-      return std::string{ value };
-    }
-    return std::nullopt;
-#endif
-  } catch (...) {
-    return std::nullopt;
-  }
-}
-
 } // namespace couchbase::test

--- a/test/framework/test_runner.hxx
+++ b/test/framework/test_runner.hxx
@@ -94,11 +94,4 @@ scale_timeouts(test_suite& suite, double factor);
 void
 scale_timeouts(configuration& config, double factor);
 
-// Portable std::getenv wrapper returning std::nullopt for unset *or* empty values, matching the
-// wrappers in tools/utils.cxx and examples/external_circuit_breaker. Needed because MSVC treats
-// plain getenv() as deprecated, and the test tree builds with /W4 /WX. Lives here so every test
-// executable shares one implementation.
-[[nodiscard]] auto
-safe_getenv(const std::string& name) noexcept -> std::optional<std::string>;
-
 } // namespace couchbase::test


### PR DESCRIPTION
[CXXCBC-975](https://couchbasecloud.atlassian.net/browse/CXXCBC-975), the follow-up CXXCBC-949 filed against itself. Stage 1 of the epic has merged — CXXCBC-946 (#1070), CXXCBC-947 (#1071), CXXCBC-948 (#1072), CXXCBC-949 (#1073) and CXXCBC-950 (#1074) — so this now carries a single commit against `main`. CXXCBC-1006 sits on top of it in #1100.

## The question, and the answer

#1073 measured the epic's compile-time justification and reported that it did not hold: `framework/test_registry.hxx` cost **0.390 s** against `catch2/catch_test_macros.hpp`'s **0.216 s**. The plan recorded there was to swap `<spdlog/fmt/fmt.h>` for fmt's `base.h`.

The better question was asked in review: *does a test framework need a formatting library in its header at all?*

It does not. Counted across the framework-based tree:

| | |
|---|---|
| assertion call sites | **1,370** |
| …that build the message from values | **5** |
| …that pass a string literal | **1,365** |

`fmt/format.h` was in every translation unit for the benefit of five call sites.

## What replaced it

Operands — the one thing that genuinely needs rendering — go through a customisation point:

```cpp
template<typename T, typename Enable = void>
struct operand_printer {
  static constexpr bool available = false;
  [[nodiscard]] static auto to_text(const T&) -> std::string { return {}; }
};
```

Specialised for integrals, `bool`, `char`, floating point, `std::string`, `std::string_view`, `const char*` and enums; `framework/errors.hxx` adds `std::error_code` and `couchbase::error`. Messages are assembled by concatenation. The operand printers need `<string>`, `<type_traits>`, and `<cstdio>`/`<cstdlib>` for the double form — which renders in the shortest text that parses back to the same value, so a small tolerance does not collapse to `0`. Measured, `framework/test_registry.hxx` preprocesses to 44,778 lines against `catch2/catch_test_macros.hpp`'s 45,823, so the comparison in the table below is unchanged by those two.

`assert_throws_with` is converted here too, though CXXCBC-1005 introduced it: that landed on `main` (#1099) after this commit was written, carrying three `fmt::format` calls into a header this commit exists to take fmt out of. Its substring failure reuses the `detail::quoted` rendering `assert_contains` already uses, so the text it prints is unchanged.

A **class template specialisation** rather than a free-function overload is load-bearing: it is found at the point of instantiation, so `errors.hxx` can extend the set from a header included *after* `test_framework.hxx`. An overload could not — two-phase lookup would never see it, and ADL for `std::error_code` looks in `std`.

A type with no specialisation is not an error. Its assertion still fires; it just omits the operands rather than dragging in a way to print them.

**`test_registry.hxx` also stopped including `test_runner.hxx`.** A test file needs the suite, the cases, the requirements and the assertions — not `run()`, `exit_code()` or `case_names()`. Including the runner was putting `<map>`, `<set>` and `<ostream>` into every test translation unit for functions only the framework's own `main()` calls. `safe_getenv` moved to `context.hxx` with it, being environment access rather than runner API.

## Result

Empty TU, GCC 16, Debug, `CCACHE_DISABLE=1`, best of three, 0.016 s baseline subtracted.

| header | before | after |
|---|---|---|
| **`framework/test_registry.hxx`** — what a test includes | **0.390 s** | **0.243 s** |
| `framework/test_framework.hxx` | 0.343 s | 0.236 s |
| `framework/context.hxx` | 0.323 s | 0.215 s |
| `framework/errors.hxx` — heavy, opt-in | 0.398 s | 0.284 s |
| `catch2/catch_test_macros.hpp` | 0.216 s | 0.228 s (same header; noise between runs) |
| `test_helper.hxx` — what a Catch2 test actually includes | 0.880 s | 0.942 s (same; noise) |

**38% off the header a test includes.** Two honest readings, both of which belong in the record:

- Against `catch2/catch_test_macros.hpp` alone the framework is at **parity**, not ahead. The floor is the eight standard headers the API needs — 0.200 s between them, `<string>` alone being 0.114 s — and nothing gets below that while `test_suite` holds a `std::string` and a `std::vector`.
- Against what a Catch2 test file **actually** includes, `test_helper.hxx`, it is **3.9× cheaper** (3.3× if the migrated file also needs `errors.hxx`). That is the comparison that describes the migration.

## The MSVC hazard did not arise

#1073 deferred this work because swapping to `bundled/base.h` would have bypassed the `SPDLOG_COMPILED_LIB` logic that stops `FMT_HEADER_ONLY` emitting duplicate `fmt::v11::vformat` definitions and failing `link.exe` with LNK2005.

Removing fmt from the headers entirely makes that swap unnecessary. Every remaining fmt user — `requirement.cxx`, `test_runner.cxx`, `test_main.cxx`, `cluster_probes.cxx` and the five test files that build a message — still goes through `<spdlog/fmt/fmt.h>`. `grep -rn 'spdlog/fmt/bundled' test/framework test/cng` is empty. The mode logic is untouched.

## Messages, before and after

Produced by a throwaway binary compiled against this branch and then removed:

```
int:         the answer (actual: 41, expected: 42)
double:      a ratio (actual: 1.5, expected: 2.25)
bool:        a flag (actual: true, expected: false)
string:      a name (actual: "got ", expected: "want")
enum:        an enum (actual: 2, expected: 14)
error_code:  an error code (actual: couchbase.common:2 (request_canceled (2)), expected: success)
unprintable: a type with no printer
ne:          two sevens (both are: 7)
near:        a tolerance (actual: 1, expected: 2 ± 0.125)
contains:    expected to contain ("xyz" is not in "abc")
success:     expected success (couchbase.key_value:101 (document_not_found (101)))
```

Two are *better* than what fmt produced: strings are quoted, so `"got "` shows the trailing space that caused the mismatch, and doubles lose `std::to_string`'s six-decimal padding (`2`, not `2.000000`).

## Verification

| Check | Result |
|---|---|
| no framework header mentions fmt | `grep -rn 'fmt' test/framework/*.hxx` → three comments, no include, no call |
| no direct bundled-fmt include | `grep -rn 'spdlog/fmt/bundled' test/framework test/cng` → empty |
| CNG configuration | **359/359 pass** |
| Catch2 configuration | **50/50 pass** |
| framework standalone (`COUCHBASE2=OFF`) | **28/28 pass** |
| operand rendering | `framework_selftest.operands_render_without_a_formatting_library` — 13 assertions covering every printer, including the trailing-zero trim and the `nullptr` case |
| a type with no printer | `framework_selftest.a_type_with_no_printer_still_fails_its_assertion` — the assertion still fires and says nothing it cannot say truthfully |
| error operands | `framework_errors_selftest.error_codes_render_as_operands` |

Not verified: any TSan, valgrind, Windows or multi-config leg.

`test/README.md` gains the rule (messages are literals; here is how to teach the framework a type) and §11.1 of the design document is rewritten with both readings of the result rather than the one that flatters it.


[CXXCBC-975]: https://couchbasecloud.atlassian.net/browse/CXXCBC-975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ





