### PR TITLE
CXXCBC-945: tell Copilot that a deleted path is usually a rename

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -348,6 +348,14 @@ flag it when the answer is "nothing":
   not 100), because the file was never compiled, or because the claimed mechanism
   did not occur when run. A finding that names a rule should name where the rule is
   configured.
+- **A path that appears only as a deletion is usually a rename.** This repository
+  moves test files in bulk, so a diff frequently shows the old location removed
+  while the addition sits in a hunk the review did not read. Before reporting that
+  a build file names a source that does not exist, check the path against the
+  branch rather than against the diff. Eight findings in one series of pull
+  requests claimed a CMake target referenced missing framework sources; the files
+  were present, the old directory was gone, and every commit configured, built and
+  ran its tests.
 - **State a concrete failure**: the input or configuration, and what goes wrong.
   "This could be a problem" cannot be actioned or refuted. A finding that predicts
   a specific behaviour is valuable even when it turns out to be wrong, because it


### PR DESCRIPTION
Test files move in bulk in this repository, and a rename shows the old location as a deletion while the addition lands in a hunk the review may not read.

Across the six pull requests of CXXCBC-945 stage 1, **the same finding was reported eight times**: that `cmake/TestFramework.cmake` names sources under `test/framework/` while the diff only shows `test/cng/framework/`, and therefore the build must break. It was wrong every time. The sources were present under the new path, `test/cng/framework/` returned 404 on the branch, and every commit configured, built and ran its self-tests in isolation — which a CMake target naming absent sources could not do.

Each of those reviews carried a note that its full agentic suite could not run, which is the most likely reason it saw one half of the rename.

Stage 2 of the epic migrates roughly a hundred test files. Without this, the finding recurs on essentially every pull request, and the cost is not just the reply — repeated false findings train reviewers to skim the tool, which is how a real finding gets missed. Copilot's *suppressed* comments have caught genuine defects in this epic, including a corrupted test input, so making its output easy to read matters.

The existing guidance already asks for the premise to be verified before reporting; this names the case that produced it and says to check a path against the branch rather than the diff.

One file, one bullet. Kept out of the stage-1 stack because `.github/` is outside the paths that epic's commits are confined to.