### PR TITLE
CXXCBC-981: bounds-check the replica chain row in server_by_vbucket

### DIFF
--- a/core/range_scan_load_balancer.cxx
+++ b/core/range_scan_load_balancer.cxx
@@ -81,8 +81,15 @@ range_scan_load_balancer::range_scan_load_balancer(
 {
   std::map<std::int16_t, std::queue<std::uint16_t>> node_to_vbucket_map{};
   for (std::size_t vbucket_id = 0; vbucket_id < vbucket_map.size(); vbucket_id++) {
-    auto node_id = vbucket_map[vbucket_id][0];
-    node_to_vbucket_map[node_id].push(gsl::narrow_cast<std::uint16_t>(vbucket_id));
+    const auto& chain = vbucket_map[vbucket_id];
+    if (chain.empty()) {
+      // A row that names no node at all cannot be scanned, and there is no node
+      // to queue it against. range_scan_orchestrator refuses such a map before
+      // it starts any stream, so leaving the vbucket out here cannot silently
+      // shorten a scan.
+      continue;
+    }
+    node_to_vbucket_map[chain[0]].push(gsl::narrow_cast<std::uint16_t>(vbucket_id));
   }
   for (auto [node_id, vbucket_ids] : node_to_vbucket_map) {
     nodes_.emplace(node_id, std::move(vbucket_ids));

--- a/core/range_scan_orchestrator.cxx
+++ b/core/range_scan_orchestrator.cxx
@@ -31,6 +31,7 @@
 
 #include <gsl/util>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <future>
@@ -398,6 +399,16 @@ public:
       return cb(errc::common::invalid_argument, {});
     }
 
+    // A scan needs an active copy for every vbucket, and every row of the map is
+    // indexed below to find one. A row that names no node at all leaves the scan
+    // unable to cover its vbucket, which is reported rather than served as a
+    // silently short result.
+    if (std::any_of(vbucket_map_.begin(), vbucket_map_.end(), [](const auto& chain) {
+          return chain.empty();
+        })) {
+      return cb(errc::network::configuration_not_available, {});
+    }
+
     const get_collection_id_options get_cid_options{ options_.retry_strategy,
                                                      options_.timeout,
                                                      options_.parent_span };
@@ -429,7 +440,8 @@ public:
           };
 
           // Get the active node for the vbucket (values in vbucket map are the active node id
-          // followed by the ids of the replicas)
+          // followed by the ids of the replicas). scan() has already established that every row
+          // names one.
           auto node_id = self->vbucket_map_[vbucket][0];
 
           auto stream = std::make_shared<range_scan_stream>(

--- a/core/topology/configuration.cxx
+++ b/core/topology/configuration.cxx
@@ -302,7 +302,16 @@ configuration::server_by_vbucket(std::uint16_t vbucket, std::size_t index) const
   if (!vbmap.has_value() || vbucket >= vbmap->size()) {
     return {};
   }
-  if (auto server_index = vbmap->at(vbucket)[index]; server_index >= 0) {
+  // A chain row may be shorter than num_replicas + 1: the server publishes the
+  // new replica count as soon as the bucket is reconfigured, while the vbucket
+  // map keeps its old width until the rebalance that places the replicas.
+  // Callers derive the index from num_replicas, so a surplus index must read as
+  // "no server" rather than past the end of the row.
+  const auto& chain = vbmap->at(vbucket);
+  if (index >= chain.size()) {
+    return {};
+  }
+  if (auto server_index = chain[index]; server_index >= 0) {
     return static_cast<std::size_t>(server_index);
   }
   return {};
@@ -312,7 +321,9 @@ auto
 configuration::map_key(const std::string& key, std::size_t index) const
   -> std::pair<std::uint16_t, std::optional<std::size_t>>
 {
-  if (!vbmap.has_value()) {
+  // The number of vbuckets comes from the map itself, so a map without rows
+  // cannot be asked which vbucket a key belongs to.
+  if (!vbmap.has_value() || vbmap->empty()) {
     return { 0, {} };
   }
   const std::uint32_t crc = utils::hash_crc32(key.data(), key.size());
@@ -324,7 +335,9 @@ auto
 configuration::map_key(const std::vector<std::byte>& key, std::size_t index) const
   -> std::pair<std::uint16_t, std::optional<std::size_t>>
 {
-  if (!vbmap.has_value()) {
+  // The number of vbuckets comes from the map itself, so a map without rows
+  // cannot be asked which vbucket a key belongs to.
+  if (!vbmap.has_value() || vbmap->empty()) {
     return { 0, {} };
   }
   const std::uint32_t crc = utils::hash_crc32(key.data(), key.size());

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -85,6 +85,7 @@ unit_test(management_bucket)
 unit_test(management_analytics)
 unit_test(node_id)
 unit_test(wait_until_ready)
+unit_test(topology_configuration)
 target_link_libraries(test_unit_jsonsl PRIVATE jsonsl)
 
 integration_benchmark(get)

--- a/test/test_unit_range_scan.cxx
+++ b/test/test_unit_range_scan.cxx
@@ -104,3 +104,28 @@ TEST_CASE("unit: range scan load balancer", "[unit]")
     REQUIRE_FALSE(balancer.select_vbucket().has_value());
   }
 }
+
+TEST_CASE("unit: range scan load balancer with a vbucket that has no active copy", "[unit]")
+{
+  // A row that names no node at all is left out rather than read past its end,
+  // and no node is invented to hold it. range_scan_orchestrator refuses a map
+  // in this state, so the vbucket cannot go missing from a scan that runs.
+  couchbase::core::range_scan_load_balancer balancer{ {
+    { 0 },
+    {},
+    { 1 },
+  } };
+
+  std::set<std::uint16_t> selection{};
+  for (auto i = 0; i < 2; i++) {
+    auto v = balancer.select_vbucket();
+
+    REQUIRE(v.has_value());
+
+    auto [_, inserted] = selection.insert(v.value());
+    REQUIRE(inserted);
+  }
+
+  REQUIRE(selection == std::set<std::uint16_t>{ 0, 2 });
+  REQUIRE_FALSE(balancer.select_vbucket().has_value());
+}

--- a/test/test_unit_topology_configuration.cxx
+++ b/test/test_unit_topology_configuration.cxx
@@ -1,0 +1,132 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "test_helper.hxx"
+
+#include "core/document_id.hxx"
+#include "core/impl/replica_utils.hxx"
+#include "core/topology/configuration.hxx"
+
+#include <couchbase/read_preference.hxx>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <vector>
+
+namespace
+{
+using couchbase::read_preference;
+using couchbase::core::topology::configuration;
+using vbucket_map = configuration::vbucket_map;
+
+auto
+config_with_vbmap(std::optional<vbucket_map> vbmap,
+                  std::optional<std::uint32_t> num_replicas,
+                  std::size_t number_of_nodes = 0) -> configuration
+{
+  configuration config{};
+  config.vbmap = std::move(vbmap);
+  config.num_replicas = num_replicas;
+  for (std::size_t index = 0; index < number_of_nodes; ++index) {
+    configuration::node node{};
+    node.index = index;
+    config.nodes.emplace_back(node);
+  }
+  return config;
+}
+} // namespace
+
+TEST_CASE("unit: server_by_vbucket bounds", "[unit]")
+{
+  SECTION("absent vbucket map")
+  {
+    REQUIRE_FALSE(config_with_vbmap(std::nullopt, 1).server_by_vbucket(0, 0).has_value());
+  }
+
+  SECTION("vbucket beyond the map")
+  {
+    const auto config = config_with_vbmap(vbucket_map{ { 0, 1 } }, 1);
+    REQUIRE_FALSE(config.server_by_vbucket(1, 0).has_value());
+  }
+
+  SECTION("index equal to the chain length")
+  {
+    const auto config = config_with_vbmap(vbucket_map{ { 0, 1 } }, 1);
+    REQUIRE_FALSE(config.server_by_vbucket(0, 2).has_value());
+  }
+
+  SECTION("index beyond the chain length")
+  {
+    const auto config = config_with_vbmap(vbucket_map{ { 0, 1 } }, 1);
+    REQUIRE_FALSE(config.server_by_vbucket(0, 42).has_value());
+  }
+
+  SECTION("index zero against an empty chain")
+  {
+    const auto config = config_with_vbmap(vbucket_map{ {} }, 0);
+    REQUIRE_FALSE(config.server_by_vbucket(0, 0).has_value());
+  }
+
+  SECTION("unassigned slot (-1) yields no server")
+  {
+    const auto config = config_with_vbmap(vbucket_map{ { 0, -1 } }, 1);
+    REQUIRE_FALSE(config.server_by_vbucket(0, 1).has_value());
+  }
+
+  SECTION("assigned slot yields the node index")
+  {
+    const auto config = config_with_vbmap(vbucket_map{ { 3, 7 } }, 1);
+    REQUIRE(config.server_by_vbucket(0, 0) == 3);
+    REQUIRE(config.server_by_vbucket(0, 1) == 7);
+  }
+}
+
+TEST_CASE("unit: replica reads against a chain shorter than num_replicas", "[unit]")
+{
+  // A configuration may advertise more replicas than its vbucket-map rows
+  // list: the two fields are parsed independently. Callers derive the replica
+  // index from num_replicas, so the surplus indexes must not be read.
+  const auto config =
+    std::make_shared<configuration>(config_with_vbmap(vbucket_map{ { 0, 1 } }, 2, 3));
+  const couchbase::core::document_id id{ "default", "_default", "_default", "foo" };
+
+  const auto nodes = couchbase::core::impl::effective_nodes(
+    id, config, read_preference::no_preference, /* preferred_server_group */ "");
+
+  REQUIRE(nodes.size() == 2);
+  REQUIRE_FALSE(nodes[0].is_replica);
+  REQUIRE(nodes[0].index == 0);
+  REQUIRE(nodes[1].is_replica);
+  REQUIRE(nodes[1].index == 1);
+}
+
+TEST_CASE("unit: map_key against a vbucket map without rows", "[unit]")
+{
+  // The vbucket count comes from the map itself, so a map present but without
+  // rows must not be asked which vbucket a key belongs to.
+  const auto config = config_with_vbmap(vbucket_map{}, 1);
+
+  const auto [vbucket, server] = config.map_key("foo", 0);
+  REQUIRE(vbucket == 0);
+  REQUIRE_FALSE(server.has_value());
+
+  const std::vector<std::byte> binary_key{ std::byte{ 'f' }, std::byte{ 'o' }, std::byte{ 'o' } };
+  const auto [binary_vbucket, binary_server] = config.map_key(binary_key, 0);
+  REQUIRE(binary_vbucket == 0);
+  REQUIRE_FALSE(binary_server.has_value());
+}


### PR DESCRIPTION
https://jira.issues.couchbase.com/browse/CXXCBC-981

`configuration::server_by_vbucket()` bounds-checked the outer vbucket-map vector and then indexed the replica chain row without checking its length. Nothing maintains the invariant that a row holds `num_replicas + 1` entries — `numReplicas` and the row widths are parsed independently in `configuration_json.hxx`, while `effective_nodes()` and `observe_poll` derive the replica index from `num_replicas`.

The fix guards the row in the accessor every caller routes through (`map_key()` both overloads, `effective_nodes()`, `observe_poll`, `bucket::map_id()`). A surplus index returns an empty optional, which is the answer callers already handle for an unassigned (`-1`) slot, so no caller changes and a short row behaves exactly like a `-1`-padded one.

This is not only a crash fix. `_GLIBCXX_ASSERTIONS` is what turned the read into an abort on the build the reproduction ran on; without it the read returns whatever follows the row, and a non-negative `int16_t` below `nodes.size()` there is a plausible node index that routes the request to a node the vbucket does not live on.

## How a short row happens on a live server

A bucket reconfigured to more replicas publishes the new count immediately and keeps the narrower map until the rebalance that places them. Against Couchbase Server 8.0.1, a bucket created with `replicaNumber=0` and then updated to `replicaNumber=2` publishes `numReplicas: 2` with rows of length 1, and stays in that state (a single-node cluster cannot place the replicas):

```
t= 0.04  numReplicas=2  rowlen=[1..1]  SHORT=True
```

Note that "not enough nodes to place replicas" alone does *not* produce this: a bucket created directly with `replicaNumber=2` on one node is published with full-width rows padded with `-1`. The reconfiguration is what leaves the two fields disagreeing.

## Reachability, before the fix

Both live paths abort on the unguarded build against that bucket — no new API involved:

```
get_all_replicas → stl_vector.h:1272: Assertion '__n < this->size()' failed
  #6 configuration::server_by_vbucket (vbucket=47, index=1)  configuration.cxx:310
  #7 configuration::map_key (key="cxxcbc981", index=1)       configuration.cxx:325
  #8 impl::effective_nodes                                    replica_utils.cxx:41
  #9 get_all_replicas_request::execute            document_get_all_replicas.hxx:85

upsert with replicate_to::one → same assertion, via observe_poll
```

The existing replica-read integration cases skip when `number_of_nodes() <= number_of_replicas()`, which is why CI has not caught this.

## The same accessor divided by the map's size

`configuration::map_key()` derives the vbucket as `crc % vbmap->size()` after checking only that the map is present. A map that is present but carries no rows makes that a division by zero — `bucket::map_id()` reaches it for every key-value operation. Both overloads now reject an empty map the way they already reject an absent one, returning vbucket 0 and no server. Caught by ASan (`SUMMARY: AddressSanitizer: FPE configuration.cxx:328`) while adding the row guard's tests.

## The two range-scan sites

`range_scan_orchestrator` and `range_scan_load_balancer` read the active copy as `vbucket_map[vbucket][0]` with only the outer vector checked, bypassing the accessor. They are out of bounds only for a row that names no node at all, which is not the shape the reconfiguration window produces — but a zero-width row cannot be worth guarding in the accessor and not in two direct reads of the same map.

A scan needs an active copy for every vbucket it covers, so this case is refused rather than worked around: `range_scan_orchestrator::scan()` reports `errc::network::configuration_not_available` before it starts a stream, and the load balancer leaves such vbuckets unqueued. Grouping them under node id `-1` — the id the map uses for a copy that is not placed — was the smaller diff, but it invents a node no request can reach and hands the scan vbuckets it can never cover, so a scan would come back silently short. Nothing changes for a row whose active copy is `-1`: that row still names a node id, and it still routes as it does today.

## Verification

Unit: `test/test_unit_topology_configuration.cxx` covers index at the row length, index past it, index 0 against an empty row, an unassigned slot, an assigned slot, `map_key()` against a map without rows, and `effective_nodes()` driven by a short-row configuration. `test/test_unit_range_scan.cxx` covers a load balancer built from a map whose middle row is empty: the two routable vbuckets are selected once each and no third is offered. Every crashing case was watched failing before the fix — the row reads as an `_GLIBCXX_ASSERTIONS` abort, `map_key()` as an ASan-reported `FPE` — and the behaviour-pinning cases passed before it, so the guards cannot be written in a way that changes them. The orchestrator's refusal has no unit case: constructing it needs a KV agent and an `io_context`. The full unit suite (373 tests) passes under an AddressSanitizer build (clang, with `_GLIBCXX_ASSERTIONS` active).

Real cluster: after the fix, replica reads against the short-row bucket return the active copy only, and a `replicate_to::one` write fails with `ambiguous_timeout` — the same outcome a `-1`-padded row already produces. A well-formed bucket whose rows are `-1`-padded produces byte-identical outcomes, confirming the guard adds no new behaviour. On a three-node cluster with a two-replica bucket, `test_integration_read_replica` and `test_integration_durability` pass unchanged.

## Release

This merges once to `main`, and `release-1.4` is branched from that merge, so the fix reaches both 1.4.1 and 1.5.0 without a cherry-pick. It shares no code with the GetReplica feature (CXXCBC-980) that depends on it.

Two consequences of that ordering. Nothing 1.5-only may merge to `main` before the branch point, or it lands in 1.4.1 as well. And the tests live in `test/test_unit_topology_configuration.cxx` rather than in the feature's test file, so the 1.4 branch carries a file named after what it tests.
