### PR TITLE
CXXCBC-985: complete a request the bucket parked in a retry backoff

### DIFF
--- a/core/bucket.cxx
+++ b/core/bucket.cxx
@@ -364,19 +364,37 @@ public:
     -> bool
   {
     auto action = retry_orchestrator::should_retry(request, reason);
-    auto retried = action.need_to_retry();
-    if (retried) {
-      auto timer = std::make_shared<asio::steady_timer>(ctx_);
-      timer->expires_after(action.duration());
-      timer->async_wait([self = shared_from_this(), request](auto error) {
-        if (error == asio::error::operation_aborted) {
-          return;
-        }
-        self->direct_re_queue(request, true);
-      });
-      request->set_retry_backoff(timer);
+    if (!action.need_to_retry()) {
+      return false;
     }
-    return retried;
+
+    // Park the request where close() can reach it. The timer below is the only
+    // thing that would re-dispatch it, and asio abandons a pending wait when the
+    // io_context goes away rather than completing it, so a request reachable only
+    // from that handler is neither completed nor released. A queue also lets
+    // cancel() take it back out, since a request de-queues from whichever queue
+    // holds it.
+    if (auto ec = retry_backoff_queue_.push(request, 0); ec) {
+      // Nothing will retry it: the bucket has closed, or it is already cancelled.
+      request->try_callback({}, errc::common::request_canceled);
+      return true;
+    }
+
+    auto timer = std::make_shared<asio::steady_timer>(ctx_);
+    timer->expires_after(action.duration());
+    timer->async_wait([self = shared_from_this(), request](auto error) {
+      if (!self->retry_backoff_queue_.remove(request)) {
+        // close() completed it, or it was cancelled: either way it is done.
+        return;
+      }
+      if (error == asio::error::operation_aborted) {
+        request->try_callback({}, errc::common::request_canceled);
+        return;
+      }
+      self->direct_re_queue(request, true);
+    });
+    request->set_retry_backoff(timer);
+    return true;
   }
 
   auto route_request(const std::shared_ptr<mcbp::queue_request>& req)
@@ -835,6 +853,14 @@ public:
 
     drain_deferred_queue(errc::common::request_canceled);
 
+    // A request waiting for a retry backoff is only ever re-dispatched by its
+    // timer, which a closed bucket never fires. Complete them here, for the same
+    // reason the deferred queue is drained above.
+    retry_backoff_queue_.close();
+    retry_backoff_queue_.drain([](const auto& request) {
+      request->try_callback({}, errc::common::request_canceled);
+    });
+
     if (state_listener_ != nullptr) {
       state_listener_->unregister_config_listener(shared_from_this());
     }
@@ -1261,6 +1287,9 @@ private:
 
   std::queue<utils::movable_function<void(std::error_code)>> deferred_commands_{};
   std::mutex deferred_commands_mutex_{};
+
+  // Requests waiting for a retry backoff, so that close() can complete them.
+  mcbp::operation_queue retry_backoff_queue_{};
 
   std::map<size_t, io::mcbp_session> sessions_{};
   // The very first session is only moved into sessions_ once it finishes bootstrapping; until then

--- a/test/test_unit_mcbp_operation_queue.cxx
+++ b/test/test_unit_mcbp_operation_queue.cxx
@@ -23,6 +23,7 @@
 #include <couchbase/error_codes.hxx>
 
 #include <memory>
+#include <vector>
 
 namespace
 {
@@ -74,6 +75,37 @@ TEST_CASE("unit: a removed request is released by the queue", "[unit]")
     REQUIRE(queue->remove(request));
   }
   REQUIRE(observer.expired());
+}
+
+TEST_CASE("unit: a closed queue refuses a push", "[unit]")
+{
+  // This is what keeps a request from being parked in a queue that has already
+  // been drained: the caller sees the error and completes the request itself.
+  auto queue = std::make_shared<operation_queue>();
+  queue->close();
+
+  auto request = make_request();
+  REQUIRE(queue->push(request, 0) == couchbase::errc::network::operation_queue_closed);
+}
+
+TEST_CASE("unit: draining a closed queue hands over its requests and releases them", "[unit]")
+{
+  auto queue = std::make_shared<operation_queue>();
+  auto request = make_request();
+  REQUIRE_SUCCESS(queue->push(request, 0));
+
+  queue->close();
+  std::vector<std::shared_ptr<queue_request>> drained;
+  queue->drain([&drained](auto r) {
+    drained.emplace_back(std::move(r));
+  });
+  REQUIRE(drained.size() == 1);
+  REQUIRE(drained.front() == request);
+
+  // Ownership is handed over, not shared: a drained request can be pushed into
+  // another queue, and the queue it came from no longer holds it.
+  auto other = std::make_shared<operation_queue>();
+  REQUIRE_SUCCESS(other->push(request, 0));
 }
 
 TEST_CASE("unit: cancelling a queued request takes it out of the queue", "[unit]")


### PR DESCRIPTION
[CXXCBC-985](https://couchbasecloud.atlassian.net/browse/CXXCBC-985)

> **Stacked on #1080.** The first commit here is #1080's; this fix depends on it, because `retry_backoff_queue_.remove()` cannot work without the `operation_queue::remove()` fix. Merge #1080 first, then rebase this.

`bucket_impl::backoff_and_retry()` arms a timer whose handler holds the only reference to the request and is the only thing that would ever re-dispatch it. Nothing else knows the request exists: `close()` drains `deferred_commands_` but has no equivalent for these, and asio **abandons** a pending wait when the `io_context` is destroyed rather than completing it with `operation_aborted`, so the handler is destroyed without running and the request is neither completed nor released.

Note the outcome the usual `if (ec == operation_aborted) return;` idiom does not cover: not "fired", not "cancelled", but "never called at all".

### How it surfaced

An ASan build of `test_integration_range_scan` leaked at exit in the 128-stream sampling case, in about a quarter of runs, with every assertion passing and every record an *indirect* leak — a pure `shared_ptr` cycle with no root to point at.

A live-instance probe over `queue_request` and `collection_id_cache_entry_impl`, dumped after the Catch2 session and before LeakSanitizer, showed the same thing in every leaking run and nothing in every clean one:

- one surviving `collection_id_cache_entry_impl`, `id_ = 0xfffffffe` (`pending_collection_id`);
- its queue holding every surviving request (9–79 across runs; the ASan record count stays at 112 because identical stacks are grouped);
- every survivor a `range_scan_create`, `completed=false`, `strong=1`, `queued_with_` pointing at that queue.

So the entry was waiting on a collection-id resolution that never completed. A stack trace from `~queue_request()` for an uncompleted `get_collection_id` named the drop site exactly:

```
queue_request::~queue_request()
  bucket_impl::backoff_and_retry(...)::lambda::~lambda      core/bucket.cxx:356
  asio::detail::wait_handler::do_complete → scheduler_operation::destroy()
  asio::detail::scheduler::abandon_operations()
  asio::detail::epoll_reactor::shutdown()
  asio::io_context::~io_context()
  test::utils::integration_test_guard::~integration_test_guard()
```

The stranded requests' callbacks reach the cache entry back through the range-scan stream, its agent and the collections component, which is what closes the cycle and drags the cluster, its sessions and its TLS context in with it.

### Fix

Park the request in an operation queue owned by the bucket and complete what is left in it from `close()`, for the same reason the deferred queue is drained there. A push the queue refuses (bucket closed, or request already cancelled) completes the request instead of parking it, so a request racing `close()` is never stranded.

Beyond the leak this fixes a user-visible hang: a request waiting for a retry backoff when the cluster closes previously got no callback at all, and its own deadline could not save it once the io_context was gone.

### Verification

ASan build, 6-node 8.0.1 cluster. Every run asserted its own executed-case count.

| | leaking runs |
|---|---|
| `*128 concurrent streams and batch item limit 0` before | 4/14, 5/20, 5/16, 4/14 |
| same case after | 0/20, and 0/10 again on the final build |

Full suites after the fix, all with zero leak records: `range_scan` 3/3 runs (6675 assertions), `crud` 3/3 (499), `collections` 3/3, `durability` 3/3, and the whole unit suite.

`test_unit_mcbp_operation_queue` gains two cases for the queue semantics this fix relies on: a closed queue refuses a push, and draining a closed queue hands its requests over and clears their ownership. The bucket wiring itself is covered by the integration measurement above rather than a unit test — `backoff_and_retry()` is only reachable with a session that has a config and is then stopped, which the offline bucket fixture cannot build.

### Not fixed here

Two siblings found while reading this path, filed separately: [CXXCBC-986](https://couchbasecloud.atlassian.net/browse/CXXCBC-986) (a collection-id refresh that cannot be dispatched strands the request) and [CXXCBC-987](https://couchbasecloud.atlassian.net/browse/CXXCBC-987) (`resolve_response()`'s `request_canceled` branch ignores the result of `backoff_and_retry()`, so a refused retry leaves the operation with no callback).


[CXXCBC-985]: https://couchbasecloud.atlassian.net/browse/CXXCBC-985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CXXCBC-986]: https://couchbasecloud.atlassian.net/browse/CXXCBC-986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

### Rebased onto main (2026-08-19)

Rebased past CXXCBC-984 ([#1080](https://github.com/couchbase/couchbase-cxx-client/pull/1080)) and CXXCBC-987 ([#1084](https://github.com/couchbase/couchbase-cxx-client/pull/1084)); no conflict, but #1084 added a caller that depends on this change's return contract:

```c++
      if (!backoff_and_retry(req, ...)) {
        // The retry was refused, so nothing else will carry this request
        req->try_callback(resp, ec);
      }
```

That contract still holds. `false` means nothing has taken the request, so the caller must complete it. `true` means it is either already completed — the push failed because the bucket is closed or the request is cancelled, and `backoff_and_retry()` completes it with `request_canceled` before returning — or it is owned by `retry_backoff_queue_` and will be finished by the timer, by `cancel()`, or by `close()`'s drain. No path returns `true` leaving the request without an owner, which is exactly what #1084's caller assumes.

`core/bucket.cxx` compiles clean under the project's warning set.
