### PR TITLE
CXXCBC-988: tear the test guard down when its constructor fails

### DIFF
--- a/test/test_integration_connect.cxx
+++ b/test/test_integration_connect.cxx
@@ -59,6 +59,22 @@ TEST_CASE("integration: connecting with empty bootstrap nodes list", "[integrati
   io_thread.join();
 }
 
+TEST_CASE("integration: a guard whose cluster cannot open reports it instead of aborting",
+          "[integration]")
+{
+  auto ctx = test::utils::test_context::load_from_environment();
+  // No bootstrap nodes, so open() reports invalid_argument without touching the network.
+  ctx.connection_string = "couchbase://";
+
+  REQUIRE_THROWS_AS(test::utils::integration_test_guard{ ctx }, std::system_error);
+
+  // Reaching this line is the assertion. The guard starts its io threads before opening the
+  // cluster, and a constructor that throws leaves the destructor unrun: unless the constructor
+  // joins them itself, the threads are still joinable when the members are destroyed and
+  // ~thread() takes the whole binary down with std::terminate.
+  SUCCEED();
+}
+
 TEST_CASE("integration: connecting with unresponsive first node in bootstrap nodes list",
           "[integration]")
 {

--- a/test/utils/integration_test_guard.cxx
+++ b/test/utils/integration_test_guard.cxx
@@ -45,16 +45,38 @@ set_thread_name(const char* name)
 #endif
 }
 
+// Stop the io threads and join them. A constructor that throws leaves the destructor unrun, and
+// destroying a joinable std::thread calls std::terminate: the process aborts instead of failing the
+// test case, taking every remaining case in the binary with it.
+static void
+stop_io_threads(asio::io_context& io, std::vector<std::thread>& threads)
+{
+  io.stop();
+  for (auto& thread : threads) {
+    if (thread.joinable()) {
+      thread.join();
+    }
+  }
+  threads.clear();
+}
+
 static auto
 spawn_io_threads(asio::io_context& io, std::size_t number_of_threads) -> std::vector<std::thread>
 {
   std::vector<std::thread> threads;
   threads.reserve(number_of_threads);
-  for (std::size_t i = 0; i < number_of_threads; i++) {
-    threads.emplace_back([&io, i]() mutable {
-      set_thread_name(fmt::format("cxx_io_{}", i).c_str());
-      io.run();
-    });
+  try {
+    for (std::size_t i = 0; i < number_of_threads; i++) {
+      threads.emplace_back([&io, i]() mutable {
+        set_thread_name(fmt::format("cxx_io_{}", i).c_str());
+        io.run();
+      });
+    }
+  } catch (...) {
+    // std::thread's constructor throws when the process cannot take another thread. Unwinding this
+    // vector would then destroy the threads already running, which aborts for the same reason.
+    stop_io_threads(io, threads);
+    throw;
   }
   return threads;
 }
@@ -102,7 +124,12 @@ build_origin(const test_context& ctx,
 }
 
 integration_test_guard::integration_test_guard()
-  : ctx(test_context::load_from_environment())
+  : integration_test_guard(test_context::load_from_environment())
+{
+}
+
+integration_test_guard::integration_test_guard(test_context context)
+  : ctx(std::move(context))
   , io(static_cast<int>(ctx.number_of_io_threads))
   , cluster(couchbase::core::cluster(io))
 {
@@ -117,9 +144,14 @@ integration_test_guard::integration_test_guard()
     auth.password = ctx.password;
   }
   io_threads = spawn_io_threads(io, ctx.number_of_io_threads);
-  origin = build_origin(ctx, auth, connstr);
-  open_cluster(cluster, origin);
-  gate_on_readiness(cluster, ctx.bucket);
+  try {
+    origin = build_origin(ctx, auth, connstr);
+    open_cluster(cluster, origin);
+    gate_on_readiness(cluster, ctx.bucket);
+  } catch (...) {
+    tear_down();
+    throw;
+  }
 }
 
 integration_test_guard::integration_test_guard(const couchbase::core::cluster_options& opts)
@@ -136,17 +168,32 @@ integration_test_guard::integration_test_guard(const couchbase::core::cluster_op
   connstr.options.enable_mutation_tokens = opts.enable_mutation_tokens;
   origin = build_origin(ctx, auth, connstr);
   io_threads = spawn_io_threads(io, ctx.number_of_io_threads);
-  open_cluster(cluster, origin);
-  gate_on_readiness(cluster, ctx.bucket);
+  try {
+    open_cluster(cluster, origin);
+    gate_on_readiness(cluster, ctx.bucket);
+  } catch (...) {
+    tear_down();
+    throw;
+  }
 }
 
 integration_test_guard::~integration_test_guard()
 {
-  close_cluster(cluster);
-  io.stop();
-  for (auto& thread : io_threads) {
-    thread.join();
+  tear_down();
+}
+
+void
+integration_test_guard::tear_down()
+{
+  // Closing first leaves nothing for the sanitizers to report: the cluster graph is only released
+  // once close() has run, and it needs the io threads to still be running to do that.
+  try {
+    close_cluster(cluster);
+  } catch (...) {
+    // A cluster that never opened has nothing to close, and on the constructor's error path the
+    // exception being carried out is the one worth reporting.
   }
+  stop_io_threads(io, io_threads);
 }
 
 auto

--- a/test/utils/integration_test_guard.hxx
+++ b/test/utils/integration_test_guard.hxx
@@ -42,8 +42,15 @@ class integration_test_guard
 {
 public:
   integration_test_guard();
+  // Builds the guard against a context the caller supplies rather than the environment, so a test
+  // can point it at a cluster that will not open.
+  explicit integration_test_guard(test_context context);
   integration_test_guard(const couchbase::core::cluster_options& opts);
   ~integration_test_guard();
+
+  // Closes the cluster and joins the io threads. Also called when a constructor fails, so that a
+  // partially built guard leaves no joinable thread behind.
+  void tear_down();
 
   inline auto load_bucket_info(bool refresh = false)
     -> const couchbase::core::operations::management::bucket_describe_response::bucket_info&


### PR DESCRIPTION
[CXXCBC-988](https://couchbasecloud.atlassian.net/browse/CXXCBC-988)

`integration_test_guard`'s constructors start the io threads and then do work that can throw:

```c++
io_threads = spawn_io_threads(io, ctx.number_of_io_threads);
origin = build_origin(ctx, auth, connstr);
open_cluster(cluster, origin);        // throws std::system_error if the cluster is unreachable
gate_on_readiness(cluster, ctx.bucket);
```

A constructor that throws leaves the destructor unrun, so `io.stop()` and the joins never happen. The members are destroyed instead, and `~vector<std::thread>` destroys threads that are still joinable, which calls `std::terminate`:

```
terminate called without an active exception

#8  std::thread::~thread () at .../bits/std_thread.h:184
#12 std::vector<std::thread, std::allocator<std::thread> >::~vector ()
#13 test::utils::integration_test_guard::integration_test_guard () at test/utils/integration_test_guard.cxx:123
#14 CATCH2_INTERNAL_TEST_2 () at test/test_integration_read_replica.cxx:98
```

So an unreachable or unhealthy cluster does not fail a test case — it aborts the process, and every remaining case in that binary never runs.

Two costs, both paid twice while debugging something else today. A run that reports one failure has silently skipped everything after it, so the suite quietly loses coverage. And `SIGABRT` out of a sanitizer build reads as memory corruption in the SDK, so time goes into looking there before anyone notices the process died in the harness.

### Fix

The constructors tear down what they built before letting the exception out, through the same `tear_down()` the destructor uses: close the cluster, stop the io context, join every thread still joinable. Closing before joining is what keeps the sanitizers quiet — the cluster graph is only released once `close()` has run, and that needs the io threads alive. A cluster that never opened has nothing to close, so a failure there is swallowed deliberately: on the constructor's error path the exception already being carried out is the one worth reporting.

`spawn_io_threads()` has the same hazard one level down, and gets the same treatment. `std::thread`'s constructor throws when the process cannot take another thread, and unwinding a vector that already holds running threads aborts for exactly the reason above — so the threads started so far are stopped before the failure propagates:

```c++
  try {
    for (std::size_t i = 0; i < number_of_threads; i++) {
      threads.emplace_back(...);
    }
  } catch (...) {
    stop_io_threads(io, threads);
    throw;
  }
```

### Regression test

The path is now pinned rather than only manually checked. A further constructor takes the `test_context` instead of reading the environment — the default constructor delegates to it — so a case can aim the guard at a cluster that will not open, with no global state and no `setenv` shim:

```c++
  auto ctx = test::utils::test_context::load_from_environment();
  // No bootstrap nodes, so open() reports invalid_argument without touching the network.
  ctx.connection_string = "couchbase://";

  REQUIRE_THROWS_AS(test::utils::integration_test_guard{ ctx }, std::system_error);
```

It lives in the existing `test_integration_connect` binary, so no new test target is added, and it needs no cluster.

Reverting only the constructor's `catch` and rebuilding:

| `test_integration_connect`, the new case alone | without the fix | with the fix |
|---|---|---|
| result | `SIGABRT - Abort (abnormal termination) signal` | `All tests passed (2 assertions in 1 test case)` |
| exit code | 134, core dumped | 0 |

### Verification

Reproduced deterministically by pointing `TEST_CONNECTION_STRING` at an address with no server on it.

| `test_integration_read_replica` | before | after |
|---|---|---|
| cases run | 1 of 11 | **11 of 11** |
| reported reason | `SIGABRT` | `unexpected exception with message: unambiguous_timeout (14)` |
| exit code | 134 | 10 |

Against a live six-node 8.0.1 cluster the suite is unchanged — 11 cases, 7 passed, 4 skipped, 20 assertions — with no leak records under AddressSanitizer.


[CXXCBC-988]: https://couchbasecloud.atlassian.net/browse/CXXCBC-988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
