### PR TITLE
CXXCBC-989: assert the manifest a collection test actually observed

### DIFF
--- a/test/test_integration_management.cxx
+++ b/test/test_integration_management.cxx
@@ -1289,7 +1289,7 @@ TEST_CASE("integration: collection management", "[integration]")
         REQUIRE(test::utils::wait_until([&]() {
           collection = get_collection(
             integration.cluster, integration.ctx.bucket, scope_name, collection_name);
-          return collection.has_value();
+          return collection.has_value() && collection->max_expiry == max_expiry;
         }));
 
         REQUIRE(collection->max_expiry == max_expiry);
@@ -1383,37 +1383,31 @@ TEST_CASE("integration: collection management", "[integration]")
       }
       auto error = manager.create_collection(scope_name, collection_name, settings).get();
       REQUIRE_SUCCESS(error.ec());
-      auto created = test::utils::wait_until([&scope_name, &collection_name, &manager]() {
-        auto [get_ctx, result] = manager.get_all_scopes().get();
-        if (!get_ctx.ec()) {
-          for (auto& scope : result) {
-            if (scope.name == scope_name) {
-              for (auto& collection : scope.collections) {
-                if (collection.name == collection_name) {
-                  return true;
+      // Assert on the manifest this wait observed rather than on a second get_all_scopes(): the
+      // two calls need not reach the same node, and a node whose manifest has not caught up lists
+      // the collection with a maxTTL of 0. Waiting for the value here and reading it again there
+      // would leave that window open.
+      const auto expect_max_expiry = integration.cluster_version().is_enterprise();
+      couchbase::management::bucket::collection_spec spec;
+      auto created = test::utils::wait_until(
+        [&scope_name, &collection_name, &manager, &spec, max_expiry, expect_max_expiry]() {
+          auto [get_ctx, result] = manager.get_all_scopes().get();
+          if (!get_ctx.ec()) {
+            for (auto& scope : result) {
+              if (scope.name == scope_name) {
+                for (auto& collection : scope.collections) {
+                  if (collection.name == collection_name) {
+                    spec = collection;
+                    return !expect_max_expiry || spec.max_expiry == max_expiry;
+                  }
                 }
               }
             }
           }
-        }
-        return false;
-      });
+          return false;
+        });
       REQUIRE(created);
-    }
-    {
-      auto [error, scopes] = manager.get_all_scopes().get();
-      REQUIRE_SUCCESS(error.ec());
-      couchbase::management::bucket::collection_spec spec;
-      for (auto& scope : scopes) {
-        if (scope.name == scope_name) {
-          for (auto& collection : scope.collections) {
-            if (collection.name == collection_name) {
-              spec = collection;
-            }
-          }
-        }
-      }
-      if (integration.cluster_version().is_enterprise()) {
+      if (expect_max_expiry) {
         REQUIRE(spec.max_expiry == max_expiry);
       }
     }
@@ -1515,7 +1509,7 @@ TEST_CASE("integration: collection management create collection with max expiry"
     REQUIRE(test::utils::wait_until([&]() {
       collection =
         get_collection(integration.cluster, integration.ctx.bucket, scope_name, collection_name);
-      return collection.has_value();
+      return collection.has_value() && collection->max_expiry == 3600;
     }));
     REQUIRE(collection->max_expiry == 3600);
   }
@@ -1546,7 +1540,7 @@ TEST_CASE("integration: collection management create collection with max expiry"
       REQUIRE(test::utils::wait_until([&]() {
         collection =
           get_collection(integration.cluster, integration.ctx.bucket, scope_name, collection_name);
-        return collection.has_value();
+        return collection.has_value() && collection->max_expiry == -1;
       }));
       REQUIRE(collection->max_expiry == -1);
     } else {


### PR DESCRIPTION
[CXXCBC-989](https://couchbasecloud.atlassian.net/browse/CXXCBC-989)

`integration: collection management` fails intermittently on

```
REQUIRE( spec.max_expiry == max_expiry )
with expansion:  0 == 5
```

The wait before it polls `get_all_scopes()` until the collection's **name** appears. A separate block then calls `get_all_scopes()` **again** and asserts `maxTTL` on that second answer. Nothing ties the two answers together: they need not reach the same node, and a node whose manifest has not caught up lists the collection with a `maxTTL` of 0 — so the assertion can read a manifest that neither the wait nor the create ever saw.

Four more places in the file wait on `collection.has_value()` and then assert `max_expiry` (the `5`, `3600` and `-1` cases), each reading a property its wait never covered. The update-max-expiry test lower in the same file already does it correctly: `return collection.has_value() && collection->max_expiry == 3600;`.

### Fix

Assert on the manifest the wait observed — dropping the second read — and fold the asserted value into every one of these predicates, so a wait that succeeds means the answer in hand carries the value. The public-API create keeps its enterprise gate, since community editions never set `maxTTL` and waiting for it there would never finish.

### Evidence, and what is not established

The same assertion failed on **unrelated branches and unrelated server versions in one CI wave** — #1080 on 8.0.0 and #1083 on 7.2.9 — with identical output. Neither change can affect `maxTTL` propagation, which is what identifies this as the test rather than the code under review.

The mechanism is inferred from that and from the shape of the code, and is **not reproduced**. A probe that logged `max_expiry` at the moment the name first became visible found the value already present on all 8 runs against a local six-node 8.0.1 cluster, so the window is not observable there. What the change does guarantee regardless is that the assertion and the wait read the same answer, which the previous shape did not.

The three affected cases pass 4 of 4 runs after the change (91 assertions), and 6 of 6 with an earlier, weaker version of it.


[CXXCBC-989]: https://couchbasecloud.atlassian.net/browse/CXXCBC-989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ