### PR TITLE
CXXCBC-990: give the valgrind integration leg headroom

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -153,15 +153,22 @@ jobs:
         tls:
           - plain
           - tls
-        # valgrind runs under memcheck and is far slower than the other
-        # sanitizers (~110-130 min for the full suite), leaving no headroom
-        # under the 120 min step budget. Shard it across two jobs (~1h each)
-        # via ctest -I stride; the other sanitizers are fast and run unsharded.
+        # valgrind runs the suite under memcheck, which costs about 213 minutes
+        # per TLS mode across 241 tests -- far more than the compile-time
+        # sanitizers, and long-tailed enough that one case alone takes ten
+        # minutes. Shard it three ways via ctest -I stride: striding does not
+        # balance that tail, so the shards run 52 to 80 minutes rather than an
+        # even third each, and it is the slowest that has to stay well inside
+        # the 120 min step budget set below. The union of the shards is the
+        # whole suite with no overlap. The other sanitizers are fast and run
+        # unsharded.
         include:
-          - { sanitizer: valgrind, server: 8.0.0, tls: plain, shard_index: 1, shard_total: 2 }
-          - { sanitizer: valgrind, server: 8.0.0, tls: plain, shard_index: 2, shard_total: 2 }
-          - { sanitizer: valgrind, server: 8.0.0, tls: tls, shard_index: 1, shard_total: 2 }
-          - { sanitizer: valgrind, server: 8.0.0, tls: tls, shard_index: 2, shard_total: 2 }
+          - { sanitizer: valgrind, server: 8.0.0, tls: plain, shard_index: 1, shard_total: 3 }
+          - { sanitizer: valgrind, server: 8.0.0, tls: plain, shard_index: 2, shard_total: 3 }
+          - { sanitizer: valgrind, server: 8.0.0, tls: plain, shard_index: 3, shard_total: 3 }
+          - { sanitizer: valgrind, server: 8.0.0, tls: tls, shard_index: 1, shard_total: 3 }
+          - { sanitizer: valgrind, server: 8.0.0, tls: tls, shard_index: 2, shard_total: 3 }
+          - { sanitizer: valgrind, server: 8.0.0, tls: tls, shard_index: 3, shard_total: 3 }
     runs-on: ubuntu-24.04
     steps:
       - name: Install dependencies


### PR DESCRIPTION
Motivation
----------

The valgrind integration leg runs the suite under memcheck, and at two
shards per TLS mode the slowest job spends 113 minutes of its 120-minute
step budget inside ctest. The plain mode is about 213 minutes of
memcheck across 241 tests, and the distribution is long-tailed: one case
takes 595 seconds and six more exceed 180. A single added case, or
ordinary runner variance, is then enough to turn a passing job into a
timeout, and a timeout says nothing about which test was running when
the clock ran out.

Modifications
-------------

Raise the shard count from two to three per TLS mode. The
-I index,,stride mechanism bin/run-integration-tests already implements
is unchanged and only the matrix grows, so the union of the shards is
still the whole suite with no overlap.

Results
-------

Striding does not balance the tail, so the shards run 52 to 80 minutes
rather than an even third each. The slowest uses two thirds of the
budget, so the suite can grow by half again before it is back where it
was. The three shards of each mode together start 241 tests with no
index appearing twice. Two more jobs run, each with its own
cbdinocluster deployment, so total machine time rises by the per-job
setup while the leg's wall-clock time drops by a third.

The leg stays red. Its failures on main are assertions in
timing-sensitive cases -- a scan future completing mid-bootstrap, bucket
wait_until_ready, and cluster use in a forked child -- and re-sharding
does not address them.