### PR TITLE
CXXCBC-977: build the Windows test suite in Release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,8 +66,16 @@ jobs:
         timeout-minutes: 120
         env:
           CB_CACHE_OPTION: sccache
-          # CB_CMAKE_BUILD_TYPE: Release
-          CB_CMAKE_BUILD_TYPE: RelWithDebInfo
+          # Release rather than RelWithDebInfo: these legs link out of disk.
+          # RelWithDebInfo compiles /Zi and links /debug, giving every test
+          # binary a compiler PDB, a linker PDB and an .ilk beside it. The
+          # x86-64 runners absorb that on their D: work volume; windows-11-arm
+          # has only C:, where it takes the volume to 0 MB free and the link
+          # fails with LNK1318. Release emits none of the three. NDEBUG is set
+          # under both, so only the optimisation level changes; what is given
+          # up is symbols in the cdb backtrace bin/build-tests.rb prints when
+          # cbc crashes.
+          CB_CMAKE_BUILD_TYPE: Release
           # No BoringSSL assembly exists for the Windows ARM64 target, so build
           # the crypto sources in portable C-only mode on that leg.
           CB_OPENSSL_NO_ASM: ${{ matrix.os == 'windows-11-arm' && '1' || '' }}

--- a/cmake/Protostellar.cmake
+++ b/cmake/Protostellar.cmake
@@ -207,7 +207,7 @@ enable_sanitizers(couchbase_cxx_protostellar)
 if(MSVC)
   # /bigobj: the generated translation units are large -- search.pb.cc is 18k lines and yields a
   # 7.4 MB object -- and protobuf-generated code this size can exceed the COFF section limit
-  # (fatal error C1128). CI builds RelWithDebInfo, but a Debug MSVC build (the default for
+  # (fatal error C1128). CI builds Release, but a Debug MSVC build (the default for
   # bin/build-tests) produces markedly larger objects. tools/fit_performer gets this flag from
   # set_project_options() for the same class of file; this target does not call that function.
   #


### PR DESCRIPTION
Motivation
----------

The Windows legs run the volume they build on out of space while
linking, and the failure is a resource limit rather than a code defect:
the runner reports "There is not enough space on the disk" and the
linker fails with LNK1318, an unexpected PDB error with FILE_SYSTEM as
the reason. There are no compile errors.

RelWithDebInfo compiles with /Zi and links with /debug, so every test
binary carries a compiler PDB, a linker PDB and an .ilk beside it. The
x86-64 runners have a D: work volume large enough to absorb that;
windows-11-arm builds on C: and does not, which is why that leg has
failed every run on main while windows-2025 has been mostly green.
Something has to give before CXXCBC-945 stage 2, which moves roughly a
hundred more test files onto this leg.

Modifications
-------------

Build the Windows test suite in Release. Neither /Zi nor /debug is set
in that configuration, so none of the three artefact kinds is produced.
Nothing in the tree overrides the configuration's flags for the Visual
Studio generator: cmake/Cache.cmake substitutes /Z7 only for Ninja, and
returns early with a warning on Visual Studio, so the compiler cache is
inactive on these legs either way.

cmake/Protostellar.cmake names the configuration CI builds when
explaining why the generated translation units need /bigobj. That name
follows.

Results
-------

NDEBUG is set under both configurations, so assertions were already
compiled out here and the only change to the code generated is the
inlining level, /Ob1 to /Ob2. What is given up is symbols in the cdb
backtrace bin/build-tests.rb prints when cbc crashes on Windows; these
legs build and smoke-test cbc and run no test suite, so nothing else
consumed them.