### PR TITLE
CXXCBC-992: stop two cases failing on a memcheck-slowed runner

### DIFF
--- a/test/test_integration_fork.cxx
+++ b/test/test_integration_fork.cxx
@@ -267,14 +267,12 @@ TEST_CASE("integration: cluster remains usable in a forked child", "[integration
   // SIGKILL makes sure the wedged child is gone rather than left running for the rest of
   // the suite. EINTR keeps the poll going; anything else is a real waitpid() failure.
   //
-  // The budget only has to be short enough to beat CTest's own timeout, and long enough
-  // never to fire on a child that is merely slow. The first version used four minutes,
-  // reasoning about the wan_development bootstrap timeout, and it fired in CI on a child
-  // that had already succeeded -- the real cost was valgrind's exit-time leak report, not
-  // anything the child was waiting for. That cause is removed above by closing the cluster
-  // before _Exit(); this stays as a backstop against an actual hang, with enough headroom
-  // that a loaded sanitizer box does not trip it.
-  constexpr int child_deadline_minutes{ 6 };
+  // The budget only has to stay under CTest's own per-test timeout -- its 1500 second
+  // default here -- and be long enough never to fire on a child that is merely slow.
+  // Memcheck's exit-time report over the child's still-reachable blocks, described at the
+  // top of this file, is what sets that floor. What this guards is an actual hang, which is
+  // unbounded, so the headroom costs nothing on a child that exits normally.
+  constexpr int child_deadline_minutes{ 15 };
   int status{};
   pid_t reaped{ -1 };
   const auto child_deadline =

--- a/test/test_integration_wait_until_ready.cxx
+++ b/test/test_integration_wait_until_ready.cxx
@@ -41,7 +41,11 @@ TEST_CASE("integration: cluster wait_until_ready", "[integration]")
   {
     couchbase::wait_until_ready_options options{};
     options.service_types({ couchbase::service_type::key_value });
-    auto err = cluster.wait_until_ready(10s, options).get();
+    // Every wait in this file that has to succeed is given 60s, matching the readiness waits
+    // further down. The call returns as soon as the desired state is reached, so the budget is
+    // only a ceiling and costs nothing when the cluster is healthy -- but under memcheck ten
+    // seconds is not a ceiling, it is a deadline the ping cannot meet.
+    auto err = cluster.wait_until_ready(60s, options).get();
     REQUIRE_SUCCESS(err.ec());
   }
 
@@ -50,7 +54,7 @@ TEST_CASE("integration: cluster wait_until_ready", "[integration]")
     couchbase::wait_until_ready_options options{};
     options.desired_state(couchbase::cluster_state::degraded);
     options.service_types({ couchbase::service_type::key_value });
-    auto err = cluster.wait_until_ready(10s, options).get();
+    auto err = cluster.wait_until_ready(60s, options).get();
     REQUIRE_SUCCESS(err.ec());
   }
 
@@ -70,7 +74,7 @@ TEST_CASE("integration: cluster wait_until_ready", "[integration]")
     std::atomic<int> calls{ 0 };
     auto barrier = std::make_shared<std::promise<couchbase::error>>();
     auto future = barrier->get_future();
-    cluster.wait_until_ready(10s, options, [&calls, barrier](auto err) {
+    cluster.wait_until_ready(60s, options, [&calls, barrier](auto err) {
       ++calls;
       barrier->set_value(err);
     });
@@ -104,7 +108,7 @@ TEST_CASE("integration: bucket wait_until_ready", "[integration]")
   {
     couchbase::wait_until_ready_options options{};
     options.service_types({ couchbase::service_type::key_value });
-    auto err = cluster.bucket(integration.ctx.bucket).wait_until_ready(10s, options).get();
+    auto err = cluster.bucket(integration.ctx.bucket).wait_until_ready(60s, options).get();
     REQUIRE_SUCCESS(err.ec());
   }
 
@@ -113,7 +117,7 @@ TEST_CASE("integration: bucket wait_until_ready", "[integration]")
     couchbase::wait_until_ready_options options{};
     options.desired_state(couchbase::cluster_state::degraded);
     options.service_types({ couchbase::service_type::key_value });
-    auto err = cluster.bucket(integration.ctx.bucket).wait_until_ready(10s, options).get();
+    auto err = cluster.bucket(integration.ctx.bucket).wait_until_ready(60s, options).get();
     REQUIRE_SUCCESS(err.ec());
   }
 
@@ -127,7 +131,7 @@ TEST_CASE("integration: bucket wait_until_ready", "[integration]")
     }
     couchbase::wait_until_ready_options options{};
     options.service_types({ couchbase::service_type::query });
-    auto err = cluster.bucket(integration.ctx.bucket).wait_until_ready(10s, options).get();
+    auto err = cluster.bucket(integration.ctx.bucket).wait_until_ready(60s, options).get();
     REQUIRE_SUCCESS(err.ec());
   }
 
@@ -136,7 +140,7 @@ TEST_CASE("integration: bucket wait_until_ready", "[integration]")
     std::atomic<int> calls{ 0 };
     auto barrier = std::make_shared<std::promise<couchbase::error>>();
     auto future = barrier->get_future();
-    cluster.bucket(integration.ctx.bucket).wait_until_ready(10s, {}, [&calls, barrier](auto err) {
+    cluster.bucket(integration.ctx.bucket).wait_until_ready(60s, {}, [&calls, barrier](auto err) {
       ++calls;
       barrier->set_value(err);
     });


### PR DESCRIPTION
[CXXCBC-992](https://couchbasecloud.atlassian.net/browse/CXXCBC-992)

Two integration cases fail on the valgrind leg because each depends on a wall-clock budget that a process under memcheck cannot meet. Neither reports a valgrind finding; both pass on the compile-time sanitizer legs and against an uninstrumented build.

### `integration: bucket wait_until_ready` / `integration: cluster wait_until_ready`

Every `wait_until_ready` in this file that has to succeed is given ten seconds, and ten seconds is not enough under memcheck. The sections that narrow to `key_value` alone fail just as readily as the one waiting on every deployed service — on #1082's `plain, 1, 2` shard it was the two `key_value` ones:

```
test_integration_wait_until_ready.cxx:108: FAILED:
  REQUIRE_THAT( extract_ec(err.ec()), IsSuccessErrorCode() )
with expansion:
  couchbase.common:14 (unambiguous_timeout (14)) is a success error_code
```

with the KV ping itself cancelled at the deadline:

```
MCBP cancel operation, opaque=8, ec=14 (unambiguous_timeout (14))
```

So the service set is not what decides it — the budget is. And the file already answers what the budget should be: its other two readiness waits (the freshly-created-bucket case and the torn-down-mid-wait case) use **60s**.

Every wait here that asserts success now gets 60s too. `wait_until_ready` returns as soon as the desired state is reached, so the number is a ceiling, not a delay — it costs nothing on a healthy cluster. Left alone: the two 2s waits that *assert* a timeout, and the 10s one that rejects an invalid target without waiting at all.

### `integration: cluster remains usable in a forked child`

The parent kills the child after a fixed six minutes and fails the case. Under memcheck the child needs longer, and it failed at 387 s and 393 s on two separate shards:

```
test_integration_fork.cxx:304: FAILED:
explicitly with message:
  child did not exit within the deadline and was killed after 6 minutes
```

Raised to fifteen minutes. The test's own comment already says this deadline is a backstop against an actual hang rather than a performance assertion, and it had been raised once before for the same reason. A hang is unbounded, so the only real constraint is staying under CTest's per-test timeout — its 1500 s default here.

The file's header already documents *why* the child is slow: `cmake/Testing.cmake` passes `--leak-check=full --show-reachable=yes --num-callers=50`, so at exit memcheck symbolises a 50-frame trace for every one of ~17k still-reachable blocks the child leaves behind via `_Exit()`. The comment at the deadline claimed that cause had been removed by closing the cluster in the child — which the same header explicitly warns against doing, and measured as ineffective. It now states the rule instead of recounting how the number was reached.

### Verification

Both translation units compile clean under the project's warning set (`-Werror -Wall -Wextra -Wconversion -Wold-style-cast …`), `clang-format` clean.

Neither case can now fail on a runner that is merely slow, and both still fail on what they exist to catch: a cluster that never reaches the requested state, a handler invoked more than once, and a child that never exits.


[CXXCBC-992]: https://couchbasecloud.atlassian.net/browse/CXXCBC-992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

### Rebased onto main (2026-08-19), and the fork deadline now has five samples

Rebased past the merges of CXXCBC-984, 987, 988, 989 and 977; no conflict.

The forked-child deadline has since fired **five** times across four pull requests, at **387.45, 387.87, 392.36, 392.60 and 392.86 seconds** against its 360-second limit.

That spread — 5.4 seconds across five independent runs, all landing ~30 s past the limit — is what a deterministic cost slightly over budget looks like. A genuine hang would pin at the deadline plus kill overhead with no workload-dependent variance; an intermittent stall would scatter across tens of seconds. It matches the fixed cost the file's own header documents: memcheck symbolising a 50-frame trace for each of ~17k still-reachable blocks the child leaves via `_Exit()`. The new 15-minute value is 2.3× the worst observation, against observations that vary by 1.4%.

`bucket wait_until_ready` has meanwhile failed on #1080, #1082, #1083 and #1088, and is now the single remaining failure on both of #1088's valgrind shards — so this PR is what unblocks that board.
