### PR TITLE
CXXCBC-993: fail the cluster check when the cluster is not balanced

### DIFF
--- a/bin/check-cluster
+++ b/bin/check-cluster
@@ -16,7 +16,7 @@
 
 HOST=${HOST:-localhost}
 USERNAME=${USERNAME:-Administrator}
-PASSWORD=${PASSWOWRD:-password}
+PASSWORD=${PASSWORD:-password}
 
 CREDS="${USERNAME}:${PASSWORD}"
 
@@ -28,4 +28,39 @@ curl -sS -w "\n" -u${CREDS} http://${HOST}:8091/pools
 curl -sS -w "\n" -u${CREDS} http://${HOST}:8091/pools/default
 curl -sS -w "\n" -u${CREDS} http://${HOST}:8091/pools/default/buckets/default
 curl -sS -w "\n" -u${CREDS} http://${HOST}:8091/pools/default/b/default
+
+set +x
+
+# A cluster whose rebalance failed answers every request above and is still unusable: the
+# services the rebalance would have activated cannot serve, so every analytics, search and
+# eventing test fails with service_not_available half an hour into the run, with nothing
+# pointing back at setup. Refuse to hand such a cluster to the suite.
+#
+# servicesNeedRebalance names the services that cannot serve, which is the harm itself. It is
+# the only field here that discriminates: `balanced` is false on a healthy 7.1.6 cluster whose
+# rebalance succeeded, and counters.rebalance_fail is cumulative and stays set after a
+# successful retry. A server that does not report servicesNeedRebalance at all -- 7.1.6 does
+# not -- reads as an empty list and passes, so this fails only on stated evidence. A rebalance
+# still in progress is not a failure, so wait for it.
+deadline=$((SECONDS + 300))
+while :
+do
+    pools_default=$(curl -sS -u"${CREDS}" "http://${HOST}:8091/pools/default" || true)
+    unbalanced=$(jq -c '.servicesNeedRebalance // []' <<<"${pools_default}" 2>/dev/null || echo '[]')
+    if [ "${unbalanced}" = "[]" ]
+    then
+        break
+    fi
+    if [ "$(jq -r '.rebalanceStatus // "none"' <<<"${pools_default}")" != "running" ]
+    then
+        echo "cluster needs a rebalance that is not running: ${unbalanced}"
+        exit 1
+    fi
+    if [ "${SECONDS}" -ge "${deadline}" ]
+    then
+        echo "rebalance did not complete within 5 minutes: ${unbalanced}"
+        exit 1
+    fi
+    sleep 5
+done
 


### PR DESCRIPTION
[CXXCBC-993](https://couchbasecloud.atlassian.net/browse/CXXCBC-993)

`bin/check-cluster` cannot fail on a bad cluster. It runs four `curl` calls and prints the bodies, so the CI step named "Check couchbase" only catches a cluster that will not answer HTTP at all.

A cluster whose rebalance failed answers all four perfectly well and is still unusable — the services the rebalance would have activated cannot serve. `integration (lsan, 8.0.0, tls)` on #1083 is the case. All three nodes joined and the definition requested `[kv,n1ql,index]`, `[kv,fts]` and `[kv,cbas,eventing]`, but the step's *own printed output* contains:

```json
"counters":{"rebalance_fail":1,"rebalance_start":1}
"servicesNeedRebalance":[{"code":"service_not_balanced","description":"Service needs rebalance.","services":["index","fts","cbas","eventing"]}]
```

It passed. Twenty-five minutes later the suite reported **34 failed tests out of 241**, all 62 failing assertions carrying `service_not_available (4)`, and zero leak records — which reads as a regression in the analytics, search and eventing paths rather than as a cluster that was never finished.

### Fix

The script rejects a cluster that reports a service needing a rebalance while no rebalance is running:

```bash
deadline=$((SECONDS + 300))
while :
do
    pools_default=$(curl -sS -u"${CREDS}" "http://${HOST}:8091/pools/default" || true)
    unbalanced=$(jq -c '.servicesNeedRebalance // []' <<<"${pools_default}" 2>/dev/null || echo '[]')
    if [ "${unbalanced}" = "[]" ]
    then
        break
    fi
    if [ "$(jq -r '.rebalanceStatus // "none"' <<<"${pools_default}")" != "running" ]
    then
        echo "cluster needs a rebalance that is not running: ${unbalanced}"
        exit 1
    fi
    ...
```

**`servicesNeedRebalance` is the only field here that discriminates**, and it names the harm itself — the services that cannot serve.

The first revision of this PR gated on `balanced == false` instead, and CI showed why that is wrong. A **healthy 7.1.6** cluster reports:

| | 7.1.6, healthy | 8.0.0, broken (#1083) |
|---|---|---|
| `balanced` | `false` | `false` |
| `counters` | `rebalance_success: 1` | `rebalance_fail: 1` |
| `servicesNeedRebalance` | field **absent** → `[]` | `[{services:[index,fts,cbas,eventing]}]` |
| nodes | all 3, correct services | all 3, correct services |

So `balanced: false` is not evidence of anything — it is false on a cluster whose rebalance *succeeded*. `counters.rebalance_fail` is no better: it is cumulative and stays set after a successful retry.

A server that does not report `servicesNeedRebalance` at all — 7.1.6 does not — reads as `[]` and passes, so the check fails only on stated evidence. A rebalance in progress is not a failure, so it waits, capped at five minutes.

Unrelated but in the same file: `PASSWORD=${PASSWOWRD:-password}` read a misspelled variable, so a caller-supplied password was silently discarded. CI passes only `HOST`, so nothing changes there, but the script could not be pointed at a cluster with other credentials.

### Verification

`bash -n` clean. The decision logic was exercised against **both real recorded `/pools/default` bodies** — the healthy 7.1.6 one the first revision wrongly rejected, and the broken 8.0.0 one from #1083 — plus synthetic cases:

| input | outcome |
|---|---|
| healthy 7.1.6 (rejected by the first revision) | **passes** |
| broken 8.0.0 from #1083 | **fails**, listing `["index","fts","cbas","eventing"]` |
| `servicesNeedRebalance` non-empty, `rebalanceStatus: running` | waits |
| field absent (mock, 7.1.6) | passes |
| unparseable body (e.g. a 401 page) | passes |

So the failure that cost #1083 twenty-five minutes would have stopped that job in seconds, and no healthy cluster in the matrix is turned away.


[CXXCBC-993]: https://couchbasecloud.atlassian.net/browse/CXXCBC-993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

### Rebased onto main (2026-08-19), and the corrected gate is verified across the matrix

Rebased past the merges of CXXCBC-984, 987, 988, 989 and 977; no conflict.

Before the rebase, the corrected gate passed **all 20 integration legs**: six server versions (7.0.5, 7.1.6, 7.2.9, 7.6.10, 8.0.0, 8.0.1-4792) × integration and transaction, plus asan, lsan, tsan and ubsan in both plain and TLS. Every one of those ran `bin/check-cluster` with this change and was accepted — including **7.1.6**, the version whose healthy-but-`balanced: false` cluster the first revision wrongly rejected.

A second independent confirmation also arrived, from a PR that does not carry this change: `integration (asan, 8.0.0, plain)` on #1078 failed 21 tests with zero sanitizer findings, on a cluster reporting

```json
"counters":{"rebalance_fail":1,"rebalance_start":1}
"servicesNeedRebalance":[{"services":["kv","fts","cbas","eventing"]}]
```

Note `kv` in that list, which the #1083 occurrence did not have — hence the wider blast radius there (16 × `service_not_available`, 5 × `durability_impossible`, 1 × `ambiguous_timeout`, since unplaced replicas make a majority-durable write genuinely impossible). The gate rejects that recorded body too, so this would have stopped that job at setup rather than after a full suite run.
