### PR TITLE
CXXCBC-997: bound the time a dependency install can hang

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ jobs:
       # BoringSSL's x86/x64 assembly is assembled with nasm; the ARM64 leg
       # builds with OPENSSL_NO_ASM and therefore does not need it.
       - name: Install dependencies
+        timeout-minutes: 20
         if: matrix.os != 'windows-11-arm'
         run: |
           choco install --no-progress nasm

--- a/.github/workflows/columnar.yml
+++ b/.github/workflows/columnar.yml
@@ -21,6 +21,7 @@ jobs:
 
     steps:
       - name: Install build environment
+        timeout-minutes: 20
         run: |
           sudo apt-get update -y
           sudo apt-get install -y libssl-dev cmake curl wget gnupg2 libcurl4-openssl-dev libprotobuf-dev libgrpc-dev libgrpc++-dev protobuf-compiler-grpc gdb

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           fetch-depth: 2
       - name: Install dependencies
+        timeout-minutes: 20
         run: |
           sudo apt-get update -y
           sudo apt-get install -y wget gnupg2 git
@@ -46,6 +47,7 @@ jobs:
         with:
           submodules: recursive
       - name: Install dependencies
+        timeout-minutes: 20
         run: |
           sudo apt-get update -y
           sudo apt-get install -y libssl-dev cmake curl wget gnupg2 libcurl4-openssl-dev libprotobuf-dev libgrpc-dev libgrpc++-dev gdb protobuf-compiler protobuf-compiler-grpc
@@ -73,6 +75,7 @@ jobs:
         with:
           submodules: recursive
       - name: Install dependencies
+        timeout-minutes: 20
         run: |
           sudo apt-get update -y
           sudo apt-get install -y libssl-dev cmake curl wget gnupg2 cppcheck libcurl4-openssl-dev libprotobuf-dev libgrpc-dev libgrpc++-dev gdb protobuf-compiler protobuf-compiler-grpc
@@ -95,6 +98,7 @@ jobs:
           # Need history back to the PR base so the diff-based run can find it.
           fetch-depth: 0
       - name: Install dependencies
+        timeout-minutes: 20
         run: |
           sudo apt-get update -y
           sudo apt-get install -y libssl-dev cmake curl wget gnupg2 libcurl4-openssl-dev libprotobuf-dev libgrpc-dev libgrpc++-dev gdb protobuf-compiler protobuf-compiler-grpc

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Install dependencies
+        timeout-minutes: 20
         run: |
           sudo apt-get update -y
           sudo apt-get install -y libssl-dev cmake curl wget gnupg2 libcurl4-openssl-dev libprotobuf-dev libgrpc-dev libgrpc++-dev protobuf-compiler-grpc gdb valgrind
@@ -86,6 +87,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Install dependencies
+        timeout-minutes: 20
         run: |
           sudo apt-get update -y
           sudo apt-get install -y libssl-dev cmake curl wget gnupg2 libcurl4-openssl-dev libprotobuf-dev libgrpc-dev libgrpc++-dev protobuf-compiler-grpc gdb valgrind
@@ -163,6 +165,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Install dependencies
+        timeout-minutes: 20
         run: |
           sudo apt-get update -y
           sudo apt-get install -y libssl-dev cmake curl wget gnupg2 libcurl4-openssl-dev libprotobuf-dev libgrpc-dev libgrpc++-dev protobuf-compiler-grpc gdb valgrind

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Install dependencies
+        timeout-minutes: 20
         run: |
           sudo apt-get update -y
           sudo apt-get install -y libssl-dev cmake gcc g++ curl libcurl4-openssl-dev libprotobuf-dev libgrpc-dev libgrpc++-dev gdb protobuf-compiler protobuf-compiler-grpc
@@ -59,6 +60,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Install dependencies
+        timeout-minutes: 20
         run: |
           sudo apt-get update -y
           # libgrpc++-dev/libprotobuf-dev pull in the gRPC runtime needed to *run* the gRPC-linked
@@ -137,6 +139,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Install dependencies
+        timeout-minutes: 20
         run: |
           sudo apt-get update -y
           # libgrpc++-dev/libprotobuf-dev pull in the gRPC runtime needed to *run* the gRPC-linked
@@ -186,6 +189,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Install dependencies
+        timeout-minutes: 20
         run: |
           sudo apt-get update -y
           sudo apt-get install -y libssl-dev cmake gcc g++ curl gdb libprotobuf-dev libgrpc-dev libgrpc++-dev


### PR DESCRIPTION
Motivation
----------

Nothing bounds the dependency install steps, so when a package mirror
stops responding the step holds its runner until the job's own
360-minute ceiling expires. On 2026-08-19 six jobs across three
workflows died that way: one spent 150 minutes in Install dependencies
before being cancelled, and the rest consumed 306 to 360 minutes each.
Their logs run to a couple of hundred lines and contain no compilation
at all, each stopping at an apt-get update line against
azure.archive.ubuntu.com and producing nothing after it.

The cost is not only the runner. In sanitizers.yml and tests.yml the
unit and integration jobs declare needs: build, so one hung install in
the build matrix blocks every downstream job, including shards that do
not depend on the leg that hung. A job that ends at the ceiling with no
compiler output also reads exactly like a genuine build failure in the
run summary, so each one costs a reader a log to dismiss.

Modifications
-------------

Give every step that runs apt-get, choco install or brew install a
twenty-minute bound: thirteen steps across build.yml, columnar.yml,
linters.yml, sanitizers.yml and tests.yml. A healthy install of these
package sets takes two to four minutes, so the bound sits about five
times above the observed cost and will not fire on a mirror that is slow
but working.

Results
-------

A stalled mirror now fails the step in twenty minutes instead of
occupying a runner for six hours, and it fails against the step whose
name says what stalled. Nothing else changes: the bound is per step, so
a workflow whose install succeeds behaves exactly as before.