### PR TITLE
CXXCBC-994: report the close, not the error a retry would replace

### DIFF
--- a/core/cluster.cxx
+++ b/core/cluster.cxx
@@ -1124,56 +1124,74 @@ public:
       *request,
       [self = shared_from_this(), request, handler = std::forward<Handler>(handler), deadline](
         auto response) mutable {
-        if (!self->stopped_) {
-          if (auto reason = protostellar::retry_reason_for(protostellar_response_ec(response.ctx));
-              reason.has_value()) {
-            auto strategy = request->retries.strategy()
-                              ? request->retries.strategy()
-                              : self->origin_.options().default_retry_strategy_;
-            if (strategy) {
-              const auto action = strategy->retry_after(request->retries, reason.value());
-              // The wait is capped at the deadline rather than the retry being refused for landing
-              // past it. Refusing would end the operation early on the last attempt's transport
-              // error -- temporary_failure for an unreachable gateway -- while the caller's budget
-              // was still running, so the same condition that times out over the classic transport
-              // would report a different code here. Capping lets the operation use its whole budget
-              // and end on the deadline: the attempt scheduled at it gets a non-positive remainder
-              // above, which the component answers as a timeout carrying the accumulated attempts
-              // and reasons. That is terminal, so the loop cannot spin on it -- retry_reason_for
-              // does not classify a timeout as retryable. Both other implementations of this loop
-              // cap the same way (io/retry_orchestrator.hxx cap_duration, and Java's
-              // RetryOrchestratorProtostellar.capDuration).
-              const auto when =
-                std::min(std::chrono::steady_clock::now() + action.duration(), deadline);
-              if (action.need_to_retry()) {
-                // Recorded before the re-issue, so the next attempt carries the accumulated count
-                // and the error context it builds reports the retries that preceded it.
-                request->retries.record_retry_attempt(reason.value());
-                auto timer = std::make_shared<asio::steady_timer>(self->ctx_);
-                timer->expires_at(when);
-                timer->async_wait([self,
-                                   request,
-                                   handler = std::move(handler),
-                                   deadline,
-                                   response = std::move(response),
-                                   timer](const std::error_code& timer_ec) mutable {
-                  if (timer_ec) {
-                    // Timer cancelled: deliver the last retryable response rather than dropping
-                    // the caller's completion, which would hang it.
-                    handler(std::move(response));
-                    return;
-                  }
-                  // A cluster closed during the backoff is answered by dispatch_protostellar,
-                  // which re-reads the component under the lock and reports cluster_closed. The
-                  // last retryable response would instead report a temporary failure, which reads
-                  // as "retry later" for a cluster that is gone.
-                  self->dispatch_protostellar(std::move(request), std::move(handler), deadline);
-                });
-                return;
+        if (auto reason = protostellar::retry_reason_for(protostellar_response_ec(response.ctx));
+            reason.has_value()) {
+          auto strategy = request->retries.strategy()
+                            ? request->retries.strategy()
+                            : self->origin_.options().default_retry_strategy_;
+          if (strategy) {
+            const auto action = strategy->retry_after(request->retries, reason.value());
+            // The wait is capped at the deadline rather than the retry being refused for landing
+            // past it. Refusing would end the operation early on the last attempt's transport
+            // error -- temporary_failure for an unreachable gateway -- while the caller's budget
+            // was still running, so the same condition that times out over the classic transport
+            // would report a different code here. Capping lets the operation use its whole budget
+            // and end on the deadline: the attempt scheduled at it gets a non-positive remainder
+            // above, which the component answers as a timeout carrying the accumulated attempts
+            // and reasons. That is terminal, so the loop cannot spin on it -- retry_reason_for
+            // does not classify a timeout as retryable. Both other implementations of this loop
+            // cap the same way (io/retry_orchestrator.hxx cap_duration, and Java's
+            // RetryOrchestratorProtostellar.capDuration).
+            const auto when =
+              std::min(std::chrono::steady_clock::now() + action.duration(), deadline);
+            if (action.need_to_retry()) {
+              if (self->stopped_) {
+                // A retry was due and will not happen: close() latches stopped_ before it clears
+                // the component, so this completion arrived after the close. The transport error
+                // the next attempt would have replaced is not the caller's answer -- reporting it
+                // says "try again" about a cluster that is gone -- so report the close, as the
+                // re-entry below does once the component is cleared. Gating on a due retry keeps a
+                // terminal response out of this: request_canceled in particular carries the
+                // CXXCBC-909 rule that the statement must not be replayed.
+                return handler(request->make_response(
+                  make_key_value_error_context(errc::network::cluster_closed,
+                                               request->id,
+                                               request->retries.retry_attempts(),
+                                               request->retries.retry_reasons()),
+                  typename Request::encoded_response_type{}));
               }
+              // Recorded before the re-issue, so the next attempt carries the accumulated count
+              // and the error context it builds reports the retries that preceded it.
+              request->retries.record_retry_attempt(reason.value());
+              auto timer = std::make_shared<asio::steady_timer>(self->ctx_);
+              timer->expires_at(when);
+              timer->async_wait([self,
+                                 request,
+                                 handler = std::move(handler),
+                                 deadline,
+                                 response = std::move(response),
+                                 timer](const std::error_code& timer_ec) mutable {
+                if (timer_ec) {
+                  // Timer cancelled: deliver the last retryable response rather than dropping
+                  // the caller's completion, which would hang it.
+                  handler(std::move(response));
+                  return;
+                }
+                // A cluster closed during the backoff is answered by dispatch_protostellar,
+                // which re-reads the component under the lock and reports cluster_closed. The
+                // last retryable response would instead report a temporary failure, which reads
+                // as "retry later" for a cluster that is gone.
+                self->dispatch_protostellar(std::move(request), std::move(handler), deadline);
+              });
+              return;
             }
           }
         }
+        // A declined retry reports the transport error even when the cluster is closing: the
+        // strategy, not the close, is what ended the operation, and the caller gets the answer a
+        // close-free run would have given. The close is reported only where it is the more specific
+        // answer -- above, where a retry was due and will not happen, and at the top of this
+        // function, where no attempt was made and there is no transport error to report.
         handler(std::move(response));
       });
   }
@@ -1250,13 +1268,22 @@ public:
        handler = std::forward<Handler>(handler),
        retries,
        deadline](auto response) mutable {
-        if (!self->stopped_ && retries->strategy()) {
-          if (auto reason = protostellar::retry_reason_for(protostellar_response_ec(response.ctx));
-              reason.has_value()) {
+        if (auto reason = protostellar::retry_reason_for(protostellar_response_ec(response.ctx));
+            reason.has_value()) {
+          if (retries->strategy()) {
             const auto action = retries->strategy()->retry_after(*retries, reason.value());
             const auto when =
               std::min(std::chrono::steady_clock::now() + action.duration(), deadline);
             if (action.need_to_retry()) {
+              if (self->stopped_) {
+                // See dispatch_protostellar(): a retry the close will not let happen reports the
+                // close, not the error the next attempt would have replaced.
+                auto closed = request_ptr->make_response({ errc::network::cluster_closed },
+                                                         typename Request::encoded_response_type{});
+                closed.ctx.retry_attempts = retries->retry_attempts();
+                closed.ctx.retry_reasons = retries->retry_reasons();
+                return handler(std::move(closed));
+              }
               retries->record_retry_attempt(reason.value());
               auto timer = std::make_shared<asio::steady_timer>(self->ctx_);
               timer->expires_at(when);
@@ -1288,6 +1315,8 @@ public:
             }
           }
         }
+        // As in dispatch_protostellar(): a declined retry reports the transport error, because the
+        // strategy rather than the close is what ended the operation.
         response.ctx.retry_attempts = retries->retry_attempts();
         response.ctx.retry_reasons = retries->retry_reasons();
         handler(std::move(response));

--- a/test/cng/protostellar/kv_retry.cxx
+++ b/test/cng/protostellar/kv_retry.cxx
@@ -456,12 +456,15 @@ a_retried_mutation_that_runs_out_of_budget_is_ambiguous()
                 terminal_ec.message());
 }
 
-// Closing the cluster while an operation sits in its backoff must still answer the caller. The
-// re-entry does not touch protostellar_ directly -- it re-reads through the locked accessor, which
-// returns an empty pointer once close() has run, and answers cluster_closed. Two properties are
-// pinned here: that the completion is delivered and not dropped, whichever side of the close the
-// timer lands on, and that the answer is cluster_closed rather than the last retryable response,
-// which would tell the caller to try again against a cluster that is gone.
+// Closing the cluster while an operation sits in its backoff must still answer the caller. Two
+// properties are pinned here: that the completion is delivered and not dropped, whichever side of
+// the close the attempt lands on, and that the answer is terminal rather than the last retryable
+// response, which would tell the caller to try again against a cluster that is gone.
+//
+// Both sides are reachable. close() latches stopped_ on the caller's thread but only posts the
+// teardown that clears the component, so the re-entry from the timer answers cluster_closed once
+// that has run, while a completion processed after the latch is answered by the retry loop itself.
+// A call the close's own drain cancelled answers request_canceled, which is terminal too.
 //
 // The bounded wait is what keeps a dropped completion a failing assertion rather than a hung suite.
 void
@@ -535,11 +538,14 @@ closing_the_cluster_during_a_backoff_still_answers()
   assert_true(reached_the_service,
               "the first attempt reached the service, so a backoff was entered");
   assert_true(arrived, "closing the cluster mid-backoff still answers the caller");
-  // Not merely "an answer arrived": the last retryable response would report temporary_failure,
-  // which tells a caller to try again against a cluster that is gone. Asserting the code is what
-  // makes this case able to see which of the two it got.
-  assert_true(answer_ec == errc::network::cluster_closed,
-              "closing mid-backoff answers cluster_closed, got: " + answer_ec.message());
+  // Not merely "an answer arrived". Two codes are correct and both are terminal: cluster_closed
+  // when the close was observed before the next attempt went out, and request_canceled when the
+  // close's own drain cancelled the call already in flight. temporary_failure is the one that must
+  // never arrive -- it tells a caller to try again against a cluster that is gone -- so naming the
+  // accepted pair is what lets this case see which of the three it got.
+  assert_true(answer_ec == errc::network::cluster_closed ||
+                answer_ec == errc::common::request_canceled,
+              "closing mid-backoff answers terminally, got: " + answer_ec.message());
 }
 
 } // namespace

--- a/test/cng/protostellar/retry.cxx
+++ b/test/cng/protostellar/retry.cxx
@@ -267,16 +267,21 @@ non_kv_retry_budget_exhaustion()
 }
 
 // Closing the cluster while a non-KV operation sits in its backoff must answer the caller, and must
-// answer cluster_closed rather than the last retryable response -- a temporary_failure tells a
-// caller to try again against a cluster that is gone. The KV path pins the same property in
-// kv_retry.cxx; this is the non-KV half, and it is the only observer of the retry state carried
-// onto that answer.
+// not answer with the retryable transport error the next attempt would have replaced -- a
+// temporary_failure tells a caller to try again against a cluster that is gone. The KV path pins
+// the same property in kv_retry.cxx; this is the non-KV half, and it is the only observer of the
+// retry state carried onto that answer.
 //
 // "always-fail" answers UNAVAILABLE forever, so the loop cannot end on its own and any close before
-// the deadline lands inside a backoff. Determinism comes from close() clearing the component before
-// it reports completion: once the close future returns, the pending timer is guaranteed to re-enter
-// with no component. The bounded wait for the first attempt is what keeps a dropped completion a
-// failing assertion rather than a hung suite.
+// the deadline lands inside a backoff. Two orderings are reachable and the case accepts either,
+// because close() latches stopped_ on the caller's thread but only posts the teardown that clears
+// the component: the attempt's completion can be processed before the close, in which case the
+// timer re-enters, finds no component and answers cluster_closed, or after it, in which case the
+// retry loop answers the close itself. Where the close's own drain cancelled a call already in
+// flight the answer is request_canceled, terminal and equally not an invitation to retry.
+//
+// The wait for a second attempt is what establishes that a retry was recorded, and the bounded wait
+// for the answer is what keeps a dropped completion a failing assertion rather than a hung suite.
 void
 closing_the_cluster_during_a_non_kv_backoff_still_answers()
 {
@@ -318,14 +323,16 @@ closing_the_cluster_during_a_non_kv_backoff_still_answers()
     done.set_value(std::move(r));
   });
 
-  // Wait for the first attempt to have failed, so the operation is provably in a backoff when the
-  // cluster closes rather than still connecting.
-  const auto first_attempt_by = std::chrono::steady_clock::now() + 5s;
-  while (service.always_fail_calls.load() < 1 &&
-         std::chrono::steady_clock::now() < first_attempt_by) {
+  // Wait for a SECOND attempt to reach the service. One call proves only that the service was
+  // reached, which is a server-side fact: the client may not have processed that failure yet, so
+  // nothing has been recorded and the assertion on retry_attempts below has no ground. A second
+  // call cannot happen until the first failure came back and the retry loop acted on it, so it is
+  // the earliest point at which a retry attempt is known to be recorded.
+  const auto retried_by = std::chrono::steady_clock::now() + 5s;
+  while (service.always_fail_calls.load() < 2 && std::chrono::steady_clock::now() < retried_by) {
     std::this_thread::sleep_for(5ms);
   }
-  const auto reached_the_service = service.always_fail_calls.load() >= 1;
+  const auto retried = service.always_fail_calls.load() >= 2;
 
   std::promise<void> closed;
   cluster.close([&closed]() {
@@ -345,17 +352,21 @@ closing_the_cluster_during_a_non_kv_backoff_still_answers()
   server->Wait();
 
   assert_false(static_cast<bool>(open_ec), "open(couchbase2://) succeeds");
-  assert_true(reached_the_service,
-              "the first attempt reached the service, so a backoff was entered");
+  assert_true(retried, "a second attempt reached the service, so a retry was recorded");
   assert_true(arrived, "closing the cluster mid-backoff still answers the caller");
-  assert_true(res.ctx.ec == couchbase::errc::network::cluster_closed,
-              "closing mid-backoff answers cluster_closed, got: " + res.ctx.ec.message());
-  // The retry state is carried onto the cluster_closed answer rather than dropped: an operation
-  // that retried before the close must not be reported as never retried.
+  // Two answers are correct and both are terminal: cluster_closed when the close was observed
+  // before the next attempt went out, and request_canceled when the close's own drain cancelled the
+  // call already in flight. The one that must never arrive is temporary_failure -- it tells the
+  // caller to try again against a cluster that is gone, and it is what this case exists to exclude.
+  assert_true(res.ctx.ec == couchbase::errc::network::cluster_closed ||
+                res.ctx.ec == couchbase::errc::common::request_canceled,
+              "closing mid-backoff answers terminally, got: " + res.ctx.ec.message());
+  // The retry state is carried onto that answer rather than dropped: an operation that retried
+  // before the close must not be reported as never retried.
   assert_true(res.ctx.retry_attempts > 0,
-              "the cluster_closed answer still reports the attempts that preceded the close");
+              "the answer still reports the attempts that preceded the close");
   assert_true(res.ctx.retry_reasons.count(couchbase::retry_reason::service_not_available) > 0,
-              "the cluster_closed answer still reports service_not_available");
+              "the answer still reports service_not_available");
 }
 
 class fail_fast_retry_strategy final : public couchbase::retry_strategy


### PR DESCRIPTION
Closing a cluster while a `couchbase2://` operation is in flight can answer the caller with `errc::common::temporary_failure` instead of `errc::network::cluster_closed`. `temporary_failure` reads as "busy, try again", so a caller — or a wrapper SDK built on this one — is told to retry against a cluster that is gone.

Both couchbase2 retry loops are affected: `dispatch_protostellar()` for key/value, and `execute_protostellar_http()` for query, analytics, search, view and management.

### Mechanism

`cluster_impl::close()` latches `stopped_` synchronously on the caller's thread and only then *posts* the teardown that clears `protostellar_`. An attempt already in flight fails as the channel goes, and its completion is posted to the `io_context`. By the time that completion runs `stopped_` is set, so the retry decision is skipped — and the fall-through hands the caller the raw transport error.

Each loop carries a comment stating the opposite contract, that a cluster closed during a backoff is answered by the re-entry reporting `cluster_closed`. That holds only when the completion arrives *before* the flag is latched, and which side it lands on is a race.

Instrumenting the two candidate delivery points shows it directly. A failing run:

```
PROBE HTTP-RESP     stopped=1 ec=temporary_failure (7)
PROBE HTTP-PASSTHRU stopped=1 ec=temporary_failure (7)
```

and a passing one, where the completion beat the close and the timer re-entry answered:

```
PROBE HTTP-RESP         stopped=0 ec=temporary_failure (7)
PROBE HTTP-ENTRY-CLOSED stopped=1
```

### Scope of the rewrite

Only a response the loop was going to replace is re-reported as the close; a terminal response is the operation's own answer.

That distinction is load-bearing for `request_canceled`. `core/protostellar/component.cxx` manufactures it from any retryable status once a stream has delivered anything (CXXCBC-909), to record that the statement began executing and must not be replayed. Keying the rewrite on the error code would erase that signal and could let a mutation be applied twice, so it is keyed on the response being retryable instead.

`request_canceled` therefore remains a correct answer when the close's own `cancel_and_drain()` cancelled an in-flight call. It is terminal and does not invite a retry, which is the property that matters. The two cases now name the accepted pair and so still exclude `temporary_failure` — CI has produced both codes at these assertions.

### Test changes

The non-KV case waited on a server-side counter (`always_fail_calls >= 1`), which proves only that the service was reached. The client may not have processed that failure yet, so nothing has been recorded and the case's own `retry_attempts > 0` assertion has no ground. It now waits for a *second* attempt, which cannot happen until the client acted on the first failure.

The gate is deliberately not tightened further. Pinning the ordering — e.g. signalling from the backoff calculator the test installs — would make the case pass without the core change, and so blind to the defect it just caught. Leaving both orderings reachable is what keeps it a regression test.

### Verification

Against an in-process gateway, Debug, gRPC 1.48.4, system protobuf 3.19.6:

| | without the `cluster.cxx` change | with it |
|---|---|---|
| non-KV close case | **13 / 200 fail** | 0 / 300 |
| KV close case | 0 / 200 | 0 / 300 |

Both cases then held a further 250 runs each with the commit in isolation. `ctest --label-regex 'cng|unit'` is 424/424.

The KV loop's fix is not locally reproducible at this rate — that case installs a 300 ms backoff, which makes the window very small here — but CI has hit it on both codes, so the same change is applied to both loops.

Both edits sit inside the `COUCHBASE_CXX_CLIENT_BUILD_COUCHBASE2` guard, so the classic transport is untouched.
