### PR TITLE
CXXCBC-995: flush the test framework's output as it is written

### DIFF
--- a/test/framework/framework_selftest.cxx
+++ b/test/framework/framework_selftest.cxx
@@ -24,6 +24,7 @@
 
 #include <chrono>
 #include <cstddef>
+#include <ios>
 #include <set>
 #include <sstream>
 #include <thread>
@@ -128,6 +129,20 @@ env_gating_skips_cluster_only_without_a_cluster()
 }
 
 void
+case_output_is_flushed_as_it_is_written()
+{
+  // ctest gives these binaries a pipe for stdout, where the stream is block-buffered, and a case
+  // that aborts the process discards whatever is still buffered -- so the log names neither the
+  // aborting case nor any that passed before it. The cases that crash are the ones whose output is
+  // most needed, so the runner must not leave its stream block-buffered.
+  std::ostringstream sink;
+  const test_suite s{ "inner", { { "p", body_pass } } };
+  static_cast<void>(run(s, {}, false, sink));
+  assert_true((sink.flags() & std::ios::unitbuf) != 0,
+              "the runner flushes its stream after every write");
+}
+
+void
 filter_selects_cases_by_name()
 {
   const test_suite s{ "inner", { { "a", body_pass }, { "b", body_pass } } };
@@ -202,6 +217,7 @@ tests() -> test_suite
       { "runner_detects_a_timeout", runner_detects_a_timeout, timeout::fast },
       { "env_gating_skips_cluster_only_without_a_cluster",
         env_gating_skips_cluster_only_without_a_cluster },
+      { "case_output_is_flushed_as_it_is_written", case_output_is_flushed_as_it_is_written },
       { "filter_selects_cases_by_name", filter_selects_cases_by_name },
       { "a_failing_case_does_not_suppress_later_cases",
         a_failing_case_does_not_suppress_later_cases },

--- a/test/framework/test_runner.cxx
+++ b/test/framework/test_runner.cxx
@@ -22,6 +22,7 @@
 #include <cstdlib>
 #include <exception>
 #include <future>
+#include <ostream>
 #include <thread>
 
 #include <spdlog/fmt/fmt.h>
@@ -91,6 +92,12 @@ run(const test_suite& suite,
     bool real_cluster,
     std::ostream& out) -> run_result
 {
+  // Flush each line as it is written. ctest runs these binaries with stdout on a pipe, where the
+  // stream is block-buffered, and a case that aborts the process discards the whole buffer: the log
+  // then shows neither the case that was running nor any that had already passed, only ctest's
+  // "Subprocess aborted". The cases that crash are exactly the ones whose output is needed.
+  out << std::unitbuf;
+
   run_result result;
   // Names the filter asked for that actually exist, so an unmatched name can be reported below.
   std::set<std::string> matched;


### PR DESCRIPTION
A test binary built on `test/framework/` that crashes produces **no output at all**: the log says neither which case was running nor which cases had already passed.

ctest gives these binaries a pipe for stdout, where the stream is block-buffered. The runner writes into that buffer and nothing flushes it until the process exits normally, so a case that aborts or segfaults takes the whole buffer with it. What survives is only what the crashing library wrote to stderr, which is unbuffered.

The cases that crash are exactly the ones whose output is most needed, so the diagnostic goes missing precisely when it matters. A sweep of 510 `tests.yml` and `sanitizers.yml` runs found thirteen crashes, none of them naming the case that crashed:

| binary | jobs | all that was logged |
|---|---|---|
| `cng_live_observability_test` | 91911067349, 91927035615, 92012817578, 92034360739, 92068803041, 92109193143, 92174261193 | nothing — no case name, no stack, only ctest's `***Exception: SegFault` |
| `cng_streaming_test` | 92228534741, 92365850937, 92389593358 | `pure virtual method called` |
| `cng_live_search_index_admin_test` | 96143344909 | one gRPC assertion line |
| `cng_dispatcher_test` | 90692609954 | one gRPC assertion line |
| `cng_live_kv_test` | 93522122017 | one gRPC assertion line |

### Change

Leave the stream the runner writes through unit-buffered, so each line reaches the pipe as it is written. The cost is one flush per line against suites that print tens of lines.

A selftest case holds the property, so removing the flush fails rather than silently restoring the blind spot.

Registering one ctest entry per case (CXXCBC-947) recovers the case name from the ctest side for the suites already migrated — job 95934926255 shows that working. This is the complementary half: it also keeps the output of the cases that *passed*, and it covers the suites that still register one entry per binary.

### Verification

A case was temporarily made to `std::abort()` and the binary run with stdout on a pipe, as ctest runs it.

Before — reproducing the CI blind spot exactly:

```
$ ./cng_ping_diagnostics_test 2>/dev/null | cat
--- (exit 134) ---
```

After:

```
$ ./cng_ping_diagnostics_test 2>/dev/null | cat
Running "ping_and_diagnostics_are_feature_not_available_over_couchbase2" (budget: 30000.0ms)...
--- (exit 134) ---
```

The deliberate abort was then reverted. The new selftest case fails without the flush and passes with it, and `ctest --label-regex 'cng|unit'` is 424/424 with the commit in isolation.

This does not fix any of the crashes above; it makes the next one diagnosable. CXXCBC-996 tracks the gRPC callback-queue aborts, which currently cannot be attributed to a case at all.
