### PR TITLE
CXXCBC-1001: describe the app telemetry metrics for ns_server

### DIFF
--- a/etc/README.md
+++ b/etc/README.md
@@ -1,0 +1,52 @@
+# Metrics metadata
+
+`metrics_metadata.json` describes the application telemetry metrics this client
+reports, in the schema Couchbase Server components use for the same purpose.
+ns_server reads such a file to attach `# TYPE` and `# HELP` to the metrics it
+publishes on `/metrics`; with no file covering the `sdk_` namespace, those
+metrics are published untyped and undocumented.
+
+Metric names, their types and the histogram bucket bounds are fixed by
+[SDK-RFC 84](https://github.com/couchbaselabs/sdk-rfcs/blob/f690b9c46bf562465c10fc5ff5e02d9ec29876ce/rfc/0084-app-service-level-telemetry.md),
+so this file describes the specification rather than this implementation, and is
+the same for every SDK implementing it.
+
+Tracked by [CXXCBC-1001](https://jira.issues.couchbase.com/browse/CXXCBC-1001);
+the server side is [MB-68858](https://jira.issues.couchbase.com/browse/MB-68858).
+
+## Installing
+
+Server components install their file with the `AddMetricsMetadata` macro from
+`tlm`, which validates the JSON, sorts its keys and copies it to
+`$install/etc/couchbase/<component>/metrics_metadata.json`:
+
+    AddMetricsMetadata (JSON etc/metrics_metadata.json COMPONENT sdk)
+
+This client is not part of the server build, so nothing invokes that macro here.
+Which component name the file is installed under, and which repository the
+server build takes it from, are ns_server's decisions and are tracked on
+MB-68858.
+
+## Keeping it in step with the emitter
+
+The key set must equal the metric families `core/app_telemetry_meter.cxx` can
+emit:
+
+    diff <(python3 -c "import json;print('\n'.join(sorted(json.load(open('etc/metrics_metadata.json')))))") \
+         <(grep -oE 'sdk_[a-z_0-9]+' core/app_telemetry_meter.cxx | LC_ALL=C sort -u)
+
+Keys are metric families. A histogram appears once, as
+`sdk_kv_retrieval_duration_milliseconds`, and not under the `_bucket`, `_sum`
+and `_count` series it produces: Prometheus declares `TYPE` and `HELP` once per
+family and the suffixed series inherit them.
+
+`sdk_invalid_metric_total` is absent because ns_server emits it, not the SDK —
+it counts telemetry lines ns_server failed to parse — and describes it in its
+own metadata file.
+
+## Labels
+
+`labels` lists what `/metrics` carries, which is narrower than what the SDK
+sends. `app_telemetry_scraper` keeps `le` and `alt_node` and discards `agent`,
+`node`, `node_uuid` and `bucket`, so metrics that RFC 84 labels per node and
+per bucket reach Prometheus aggregated across both.

--- a/etc/metrics_metadata.json
+++ b/etc/metrics_metadata.json
@@ -1,0 +1,356 @@
+{
+  "sdk_analytics_duration_milliseconds": {
+    "type": "histogram",
+    "unit": "milliseconds",
+    "help": "Latency of Analytics service requests, measured by the client from dispatch to response.",
+    "notes": "Bucket bounds are fixed at 100, 1000, 10000, 30000 and 75000 milliseconds, plus +Inf. Latency is recorded per transmission attempt rather than per application operation, so an operation that is retried contributes one observation per attempt.",
+    "labels": [
+      "le",
+      {
+        "name": "alt_node",
+        "help": "Alternate-address hostname of the node the requests were sent to, present when the client reached the cluster over an alternate address."
+      }
+    ],
+    "added": "8.0.0",
+    "stability": "committed"
+  },
+  "sdk_analytics_r_canceled": {
+    "type": "counter",
+    "help": "Number of Analytics requests that were canceled after being dispatched.",
+    "notes": "A request is canceled when it was dispatched but its outcome can no longer be delivered, most often because the connection was severed. Client shutdown and explicit cancellation by the application also count.",
+    "labels": [
+      {
+        "name": "alt_node",
+        "help": "Alternate-address hostname of the node the requests were sent to, present when the client reached the cluster over an alternate address."
+      }
+    ],
+    "added": "8.0.0",
+    "stability": "committed"
+  },
+  "sdk_analytics_r_timedout": {
+    "type": "counter",
+    "help": "Number of Analytics requests that timed out before a response was received.",
+    "notes": "A response that arrives after the deadline is discarded as an orphan and the request is still counted here.",
+    "labels": [
+      {
+        "name": "alt_node",
+        "help": "Alternate-address hostname of the node the requests were sent to, present when the client reached the cluster over an alternate address."
+      }
+    ],
+    "added": "8.0.0",
+    "stability": "committed"
+  },
+  "sdk_analytics_r_total": {
+    "type": "counter",
+    "help": "Total number of Analytics requests dispatched by the client.",
+    "notes": "Counts requests written to the network, not application operations: each transmission attempt of a retried request is counted separately, and a compound operation such as a read from all replicas is counted once per sub-request. This can exceed the _count of the corresponding latency histogram, because a request whose response never arrives is counted here but contributes no latency observation.",
+    "labels": [
+      {
+        "name": "alt_node",
+        "help": "Alternate-address hostname of the node the requests were sent to, present when the client reached the cluster over an alternate address."
+      }
+    ],
+    "added": "8.0.0",
+    "stability": "committed"
+  },
+  "sdk_eventing_duration_milliseconds": {
+    "type": "histogram",
+    "unit": "milliseconds",
+    "help": "Latency of Eventing service requests, measured by the client from dispatch to response.",
+    "notes": "Bucket bounds are fixed at 100, 1000, 10000, 30000 and 75000 milliseconds, plus +Inf. Latency is recorded per transmission attempt rather than per application operation, so an operation that is retried contributes one observation per attempt.",
+    "labels": [
+      "le",
+      {
+        "name": "alt_node",
+        "help": "Alternate-address hostname of the node the requests were sent to, present when the client reached the cluster over an alternate address."
+      }
+    ],
+    "added": "8.0.0",
+    "stability": "committed"
+  },
+  "sdk_eventing_r_canceled": {
+    "type": "counter",
+    "help": "Number of Eventing requests that were canceled after being dispatched.",
+    "notes": "A request is canceled when it was dispatched but its outcome can no longer be delivered, most often because the connection was severed. Client shutdown and explicit cancellation by the application also count.",
+    "labels": [
+      {
+        "name": "alt_node",
+        "help": "Alternate-address hostname of the node the requests were sent to, present when the client reached the cluster over an alternate address."
+      }
+    ],
+    "added": "8.0.0",
+    "stability": "committed"
+  },
+  "sdk_eventing_r_timedout": {
+    "type": "counter",
+    "help": "Number of Eventing requests that timed out before a response was received.",
+    "notes": "A response that arrives after the deadline is discarded as an orphan and the request is still counted here.",
+    "labels": [
+      {
+        "name": "alt_node",
+        "help": "Alternate-address hostname of the node the requests were sent to, present when the client reached the cluster over an alternate address."
+      }
+    ],
+    "added": "8.0.0",
+    "stability": "committed"
+  },
+  "sdk_eventing_r_total": {
+    "type": "counter",
+    "help": "Total number of Eventing requests dispatched by the client.",
+    "notes": "Counts requests written to the network, not application operations: each transmission attempt of a retried request is counted separately, and a compound operation such as a read from all replicas is counted once per sub-request. This can exceed the _count of the corresponding latency histogram, because a request whose response never arrives is counted here but contributes no latency observation.",
+    "labels": [
+      {
+        "name": "alt_node",
+        "help": "Alternate-address hostname of the node the requests were sent to, present when the client reached the cluster over an alternate address."
+      }
+    ],
+    "added": "8.0.0",
+    "stability": "committed"
+  },
+  "sdk_kv_mutation_durable_duration_milliseconds": {
+    "type": "histogram",
+    "unit": "milliseconds",
+    "help": "Latency of Key-Value mutations that request synchronous replication, measured by the client from dispatch to response.",
+    "notes": "Bucket bounds are fixed at 10, 100, 500, 1000, 2000 and 10000 milliseconds, plus +Inf. Latency is recorded per transmission attempt rather than per application operation, so an operation that is retried contributes one observation per attempt. Key-Value latency is split across three metrics: sdk_kv_mutation_durable_duration_milliseconds for mutations that request synchronous replication, sdk_kv_mutation_nondurable_duration_milliseconds for all other mutations, and sdk_kv_retrieval_duration_milliseconds for everything else.",
+    "labels": [
+      "le",
+      {
+        "name": "alt_node",
+        "help": "Alternate-address hostname of the node the requests were sent to, present when the client reached the cluster over an alternate address."
+      }
+    ],
+    "added": "8.0.0",
+    "stability": "committed"
+  },
+  "sdk_kv_mutation_nondurable_duration_milliseconds": {
+    "type": "histogram",
+    "unit": "milliseconds",
+    "help": "Latency of Key-Value mutations that do not request synchronous replication, measured by the client from dispatch to response.",
+    "notes": "Bucket bounds are fixed at 1, 10, 100, 500, 1000 and 2500 milliseconds, plus +Inf. Latency is recorded per transmission attempt rather than per application operation, so an operation that is retried contributes one observation per attempt. Key-Value latency is split across three metrics: sdk_kv_mutation_durable_duration_milliseconds for mutations that request synchronous replication, sdk_kv_mutation_nondurable_duration_milliseconds for all other mutations, and sdk_kv_retrieval_duration_milliseconds for everything else.",
+    "labels": [
+      "le",
+      {
+        "name": "alt_node",
+        "help": "Alternate-address hostname of the node the requests were sent to, present when the client reached the cluster over an alternate address."
+      }
+    ],
+    "added": "8.0.0",
+    "stability": "committed"
+  },
+  "sdk_kv_r_canceled": {
+    "type": "counter",
+    "help": "Number of Key-Value requests that were canceled after being dispatched.",
+    "notes": "A request is canceled when it was dispatched but its outcome can no longer be delivered, most often because the connection was severed. Client shutdown and explicit cancellation by the application also count.",
+    "labels": [
+      {
+        "name": "alt_node",
+        "help": "Alternate-address hostname of the node the requests were sent to, present when the client reached the cluster over an alternate address."
+      }
+    ],
+    "added": "8.0.0",
+    "stability": "committed"
+  },
+  "sdk_kv_r_timedout": {
+    "type": "counter",
+    "help": "Number of Key-Value requests that timed out before a response was received.",
+    "notes": "A response that arrives after the deadline is discarded as an orphan and the request is still counted here.",
+    "labels": [
+      {
+        "name": "alt_node",
+        "help": "Alternate-address hostname of the node the requests were sent to, present when the client reached the cluster over an alternate address."
+      }
+    ],
+    "added": "8.0.0",
+    "stability": "committed"
+  },
+  "sdk_kv_r_total": {
+    "type": "counter",
+    "help": "Total number of Key-Value requests dispatched by the client.",
+    "notes": "Counts requests written to the network, not application operations: each transmission attempt of a retried request is counted separately, and a compound operation such as a read from all replicas is counted once per sub-request. This can exceed the _count of the corresponding latency histogram, because a request whose response never arrives is counted here but contributes no latency observation.",
+    "labels": [
+      {
+        "name": "alt_node",
+        "help": "Alternate-address hostname of the node the requests were sent to, present when the client reached the cluster over an alternate address."
+      }
+    ],
+    "added": "8.0.0",
+    "stability": "committed"
+  },
+  "sdk_kv_retrieval_duration_milliseconds": {
+    "type": "histogram",
+    "unit": "milliseconds",
+    "help": "Latency of Key-Value requests that do not write data, measured by the client from dispatch to response.",
+    "notes": "Bucket bounds are fixed at 1, 10, 100, 500, 1000 and 2500 milliseconds, plus +Inf. Latency is recorded per transmission attempt rather than per application operation, so an operation that is retried contributes one observation per attempt. Key-Value latency is split across three metrics: sdk_kv_mutation_durable_duration_milliseconds for mutations that request synchronous replication, sdk_kv_mutation_nondurable_duration_milliseconds for all other mutations, and sdk_kv_retrieval_duration_milliseconds for everything else.",
+    "labels": [
+      "le",
+      {
+        "name": "alt_node",
+        "help": "Alternate-address hostname of the node the requests were sent to, present when the client reached the cluster over an alternate address."
+      }
+    ],
+    "added": "8.0.0",
+    "stability": "committed"
+  },
+  "sdk_management_duration_milliseconds": {
+    "type": "histogram",
+    "unit": "milliseconds",
+    "help": "Latency of management service requests, measured by the client from dispatch to response.",
+    "notes": "Bucket bounds are fixed at 100, 1000, 10000, 30000 and 75000 milliseconds, plus +Inf. Latency is recorded per transmission attempt rather than per application operation, so an operation that is retried contributes one observation per attempt.",
+    "labels": [
+      "le",
+      {
+        "name": "alt_node",
+        "help": "Alternate-address hostname of the node the requests were sent to, present when the client reached the cluster over an alternate address."
+      }
+    ],
+    "added": "8.0.0",
+    "stability": "committed"
+  },
+  "sdk_management_r_canceled": {
+    "type": "counter",
+    "help": "Number of management requests that were canceled after being dispatched.",
+    "notes": "A request is canceled when it was dispatched but its outcome can no longer be delivered, most often because the connection was severed. Client shutdown and explicit cancellation by the application also count.",
+    "labels": [
+      {
+        "name": "alt_node",
+        "help": "Alternate-address hostname of the node the requests were sent to, present when the client reached the cluster over an alternate address."
+      }
+    ],
+    "added": "8.0.0",
+    "stability": "committed"
+  },
+  "sdk_management_r_timedout": {
+    "type": "counter",
+    "help": "Number of management requests that timed out before a response was received.",
+    "notes": "A response that arrives after the deadline is discarded as an orphan and the request is still counted here.",
+    "labels": [
+      {
+        "name": "alt_node",
+        "help": "Alternate-address hostname of the node the requests were sent to, present when the client reached the cluster over an alternate address."
+      }
+    ],
+    "added": "8.0.0",
+    "stability": "committed"
+  },
+  "sdk_management_r_total": {
+    "type": "counter",
+    "help": "Total number of management requests dispatched by the client.",
+    "notes": "Counts requests written to the network, not application operations: each transmission attempt of a retried request is counted separately, and a compound operation such as a read from all replicas is counted once per sub-request. This can exceed the _count of the corresponding latency histogram, because a request whose response never arrives is counted here but contributes no latency observation.",
+    "labels": [
+      {
+        "name": "alt_node",
+        "help": "Alternate-address hostname of the node the requests were sent to, present when the client reached the cluster over an alternate address."
+      }
+    ],
+    "added": "8.0.0",
+    "stability": "committed"
+  },
+  "sdk_query_duration_milliseconds": {
+    "type": "histogram",
+    "unit": "milliseconds",
+    "help": "Latency of Query service requests, measured by the client from dispatch to response.",
+    "notes": "Bucket bounds are fixed at 100, 1000, 10000, 30000 and 75000 milliseconds, plus +Inf. Latency is recorded per transmission attempt rather than per application operation, so an operation that is retried contributes one observation per attempt.",
+    "labels": [
+      "le",
+      {
+        "name": "alt_node",
+        "help": "Alternate-address hostname of the node the requests were sent to, present when the client reached the cluster over an alternate address."
+      }
+    ],
+    "added": "8.0.0",
+    "stability": "committed"
+  },
+  "sdk_query_r_canceled": {
+    "type": "counter",
+    "help": "Number of Query requests that were canceled after being dispatched.",
+    "notes": "A request is canceled when it was dispatched but its outcome can no longer be delivered, most often because the connection was severed. Client shutdown and explicit cancellation by the application also count.",
+    "labels": [
+      {
+        "name": "alt_node",
+        "help": "Alternate-address hostname of the node the requests were sent to, present when the client reached the cluster over an alternate address."
+      }
+    ],
+    "added": "8.0.0",
+    "stability": "committed"
+  },
+  "sdk_query_r_timedout": {
+    "type": "counter",
+    "help": "Number of Query requests that timed out before a response was received.",
+    "notes": "A response that arrives after the deadline is discarded as an orphan and the request is still counted here.",
+    "labels": [
+      {
+        "name": "alt_node",
+        "help": "Alternate-address hostname of the node the requests were sent to, present when the client reached the cluster over an alternate address."
+      }
+    ],
+    "added": "8.0.0",
+    "stability": "committed"
+  },
+  "sdk_query_r_total": {
+    "type": "counter",
+    "help": "Total number of Query requests dispatched by the client.",
+    "notes": "Counts requests written to the network, not application operations: each transmission attempt of a retried request is counted separately, and a compound operation such as a read from all replicas is counted once per sub-request. This can exceed the _count of the corresponding latency histogram, because a request whose response never arrives is counted here but contributes no latency observation.",
+    "labels": [
+      {
+        "name": "alt_node",
+        "help": "Alternate-address hostname of the node the requests were sent to, present when the client reached the cluster over an alternate address."
+      }
+    ],
+    "added": "8.0.0",
+    "stability": "committed"
+  },
+  "sdk_search_duration_milliseconds": {
+    "type": "histogram",
+    "unit": "milliseconds",
+    "help": "Latency of Search service requests, measured by the client from dispatch to response.",
+    "notes": "Bucket bounds are fixed at 100, 1000, 10000, 30000 and 75000 milliseconds, plus +Inf. Latency is recorded per transmission attempt rather than per application operation, so an operation that is retried contributes one observation per attempt.",
+    "labels": [
+      "le",
+      {
+        "name": "alt_node",
+        "help": "Alternate-address hostname of the node the requests were sent to, present when the client reached the cluster over an alternate address."
+      }
+    ],
+    "added": "8.0.0",
+    "stability": "committed"
+  },
+  "sdk_search_r_canceled": {
+    "type": "counter",
+    "help": "Number of Search requests that were canceled after being dispatched.",
+    "notes": "A request is canceled when it was dispatched but its outcome can no longer be delivered, most often because the connection was severed. Client shutdown and explicit cancellation by the application also count.",
+    "labels": [
+      {
+        "name": "alt_node",
+        "help": "Alternate-address hostname of the node the requests were sent to, present when the client reached the cluster over an alternate address."
+      }
+    ],
+    "added": "8.0.0",
+    "stability": "committed"
+  },
+  "sdk_search_r_timedout": {
+    "type": "counter",
+    "help": "Number of Search requests that timed out before a response was received.",
+    "notes": "A response that arrives after the deadline is discarded as an orphan and the request is still counted here.",
+    "labels": [
+      {
+        "name": "alt_node",
+        "help": "Alternate-address hostname of the node the requests were sent to, present when the client reached the cluster over an alternate address."
+      }
+    ],
+    "added": "8.0.0",
+    "stability": "committed"
+  },
+  "sdk_search_r_total": {
+    "type": "counter",
+    "help": "Total number of Search requests dispatched by the client.",
+    "notes": "Counts requests written to the network, not application operations: each transmission attempt of a retried request is counted separately, and a compound operation such as a read from all replicas is counted once per sub-request. This can exceed the _count of the corresponding latency histogram, because a request whose response never arrives is counted here but contributes no latency observation.",
+    "labels": [
+      {
+        "name": "alt_node",
+        "help": "Alternate-address hostname of the node the requests were sent to, present when the client reached the cluster over an alternate address."
+      }
+    ],
+    "added": "8.0.0",
+    "stability": "committed"
+  }
+}


### PR DESCRIPTION
Motivation
----------

App telemetry metrics reach the ns_server /metrics endpoint carrying
neither # TYPE nor # HELP. RFC 84 defines neither, and ns_server cannot
supply them for names it did not define: cb_stats_info builds its lookup
from the metrics_metadata.json that each server component installs under
etc/couchbase/<component>, and no component owns the sdk_ namespace.

Names, types and bucket bounds are fixed by RFC 84 and identical in
couchbase-jvm-clients, gocbcore and couchbase-net-client, so the
metadata describes the specification rather than this client. This tree
holds an emitter, so the file can be checked against code.

Modifications
-------------

Add etc/metrics_metadata.json covering the eighteen counters and eight
histograms of RFC 84, in the schema every server component uses: type,
help and added on every entry, unit on the histograms, plus labels,
notes and stability.

Keys are metric families, so a histogram appears once rather than under
the _bucket, _sum and _count series it produces, Prometheus declaring
TYPE and HELP once per family. sdk_invalid_metric_total is absent
because ns_server emits that counter and describes it in its own file.
labels carries what the endpoint publishes rather than what the SDK
sends: app_telemetry_scraper keeps le and alt_node and discards agent,
node, node_uuid and bucket.

Results
-------

Nothing in this build reads the file; the component it installs under
and the repository the server build takes it from are ns_server's to
decide, as are stripping the histogram suffixes before the lookup and
loading a second component's file at all. Those are tracked on
MB-68858.

---

Ticket: [CXXCBC-1001](https://jira.issues.couchbase.com/browse/CXXCBC-1001)


[CXXCBC-1001]: https://couchbasecloud.atlassian.net/browse/CXXCBC-1001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ