### PR TITLE
CXXCBC-1002: report app telemetry latency sums in milliseconds

### DIFF
--- a/core/app_telemetry_meter.cxx
+++ b/core/app_telemetry_meter.cxx
@@ -233,7 +233,7 @@ struct http_histogram {
       fmt::format_to(output, "{}_bucket{{le=\"30000\",{}}} {}\n", name, lbuf, le_30s.load());
       fmt::format_to(output, "{}_bucket{{le=\"75000\",{}}} {}\n", name, lbuf, le_75s.load());
       fmt::format_to(output, "{}_bucket{{le=\"+Inf\",{}}} {}\n", name, lbuf, inf.load());
-      fmt::format_to(output, "{}_sum{{{}}} {}\n", name, lbuf, sum.load() / 1000);
+      fmt::format_to(output, "{}_sum{{{}}} {}\n", name, lbuf, sum.load());
       fmt::format_to(output, "{}_count{{{}}} {}\n", name, lbuf, count.load());
     }
   }

--- a/test/test_unit_app_telemetry_meter.cxx
+++ b/test/test_unit_app_telemetry_meter.cxx
@@ -17,12 +17,45 @@
 
 #include "core/app_telemetry_meter.hxx"
 
+#include <chrono>
 #include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <sstream>
+#include <string>
 #include <vector>
 
 using couchbase::core::app_telemetry_counter;
+using couchbase::core::app_telemetry_latency;
 using couchbase::core::app_telemetry_meter;
 using couchbase::core::app_telemetry_recorder_cache;
+
+namespace
+{
+auto
+generate_report_text(app_telemetry_meter& meter) -> std::string
+{
+  std::vector<std::byte> buffer{};
+  meter.generate_report(buffer);
+  return { reinterpret_cast<const char*>(buffer.data()), buffer.size() };
+}
+
+/**
+ * Value of the named series in a report, e.g. "sdk_query_duration_milliseconds_sum". Matches at the
+ * start of a line so that a series name which is a suffix of another cannot be picked up.
+ */
+auto
+series_value(const std::string& report, const std::string& series) -> std::optional<std::uint64_t>
+{
+  std::istringstream lines{ report };
+  for (std::string line; std::getline(lines, line);) {
+    if (line.rfind(series + "{", 0) == 0) {
+      return std::stoull(line.substr(line.find("} ") + 2));
+    }
+  }
+  return {};
+}
+} // namespace
 
 TEST_CASE("unit: app_telemetry_recorder_cache resolves once and stays valid within a generation",
           "[unit]")
@@ -80,4 +113,50 @@ TEST_CASE("unit: app_telemetry_recorder_cache re-resolves when the key changes",
 
   // Switching back re-resolves again (the single slot now holds node-2's recorder).
   REQUIRE(cache.value_recorder(meter, "node-1", "bucket-1") != node2);
+}
+
+TEST_CASE("unit: app_telemetry_meter reports histogram sums in milliseconds", "[unit]")
+{
+  struct sample {
+    app_telemetry_latency latency;
+    const char* metric;
+    std::uint64_t millis;
+  };
+
+  // One observation per histogram, each a distinct duration so that a sample routed to the wrong
+  // family shows up in both series checked below. 250ms and 1500ms straddle a second: reporting the
+  // sum in seconds would give 0 and 1.
+  const std::vector<sample> samples{
+    { app_telemetry_latency::kv_retrieval, "sdk_kv_retrieval_duration_milliseconds", 3 },
+    { app_telemetry_latency::kv_mutation_nondurable,
+      "sdk_kv_mutation_nondurable_duration_milliseconds",
+      7 },
+    { app_telemetry_latency::kv_mutation_durable,
+      "sdk_kv_mutation_durable_duration_milliseconds",
+      40 },
+    { app_telemetry_latency::query, "sdk_query_duration_milliseconds", 1500 },
+    { app_telemetry_latency::search, "sdk_search_duration_milliseconds", 250 },
+    { app_telemetry_latency::analytics, "sdk_analytics_duration_milliseconds", 30000 },
+    { app_telemetry_latency::management, "sdk_management_duration_milliseconds", 120 },
+    { app_telemetry_latency::eventing, "sdk_eventing_duration_milliseconds", 900 },
+  };
+
+  app_telemetry_meter meter;
+  const auto recorder = meter.value_recorder("node-1", "bucket-1");
+  for (const auto& s : samples) {
+    recorder->record_latency(s.latency, std::chrono::milliseconds{ s.millis });
+  }
+
+  const auto report = generate_report_text(meter);
+
+  for (const auto& s : samples) {
+    const std::string metric{ s.metric };
+    CAPTURE(metric);
+    const auto sum = series_value(report, metric + "_sum");
+    const auto count = series_value(report, metric + "_count");
+    REQUIRE(sum.has_value());
+    REQUIRE(count.has_value());
+    REQUIRE(*sum == s.millis);
+    REQUIRE(*count == std::uint64_t{ 1 });
+  }
 }


### PR DESCRIPTION
Motivation
----------

http_histogram::generate_to divides the accumulated sum by 1000 before
emitting it, while sum accumulates std::chrono::milliseconds and the
bucket bounds written alongside it are milliseconds. RFC 84 requires the
sum in milliseconds. The two KV histogram types in the same file emit it
undivided.

Five families are affected: sdk_query_duration_milliseconds and its
search, analytics, management and eventing counterparts. _sum over
_count is how a Prometheus histogram's mean is read, so for those
services it understates latency by three orders of magnitude. The sum is
one accumulator divided once at emission, so a report whose total is
under a second reports zero.

couchbase-jvm-clients, gocbcore and couchbase-net-client all emit
milliseconds, which leaves this client the only source of the
discrepancy: an aggregate spanning SDKs is skewed by whatever share of
the traffic it carries.

Modifications
-------------

Emit the sum undivided, matching the KV histograms and the bucket bounds
beside it.

Cover all eight histograms with a unit test that records one observation
of a known duration against each and reads _sum and _count back out of
a generated report. Two of the durations straddle a second, so a sum in
seconds surfaces as 0 and 1 rather than 250 and 1500, and _count pins
each observation to the family it was recorded against, so a routing
change cannot pass by cancelling out.

Results
-------

The five HTTP-service families report _sum in the unit their name and
their metadata declare. A mean computed from them server-side changes by
a factor of a thousand, so a dashboard or alert threshold derived from
the previous values needs revisiting; whether anything downstream
compensates for them has not been established.

---

Ticket: [CXXCBC-1002](https://jira.issues.couchbase.com/browse/CXXCBC-1002)


[CXXCBC-1002]: https://couchbasecloud.atlassian.net/browse/CXXCBC-1002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ