### PR TITLE
CXXCBC-1003: catch the framework's own exceptions first

### DIFF
--- a/test/framework/selftest.cxx
+++ b/test/framework/selftest.cxx
@@ -31,6 +31,7 @@
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <utility>
 
 namespace couchbase::test
 {
@@ -58,6 +59,24 @@ body_sleep()
   std::this_thread::sleep_for(std::chrono::milliseconds{ 200 });
 }
 
+// assert_throws asked for a base of the framework's own control-flow types. Both bodies exist to be
+// run through the runner rather than called directly: what is under test is the outcome the runner
+// reports, and a case body cannot observe its own verdict.
+void
+body_skip_inside_assert_throws()
+{
+  assert_throws<std::exception>([]() {
+    skip("intentional skip from inside a callable");
+  });
+}
+void
+body_failed_assertion_inside_assert_throws()
+{
+  assert_throws<std::exception>([]() {
+    assert_true(false, "intentional failure from inside a callable");
+  });
+}
+
 // A sink for the runner's progress output so the self-test stays quiet.
 auto
 run_quiet(const test_suite& suite, const std::set<std::string>& filter, bool real_cluster)
@@ -65,6 +84,21 @@ run_quiet(const test_suite& suite, const std::set<std::string>& filter, bool rea
 {
   std::ostringstream sink;
   return run(suite, filter, real_cluster, sink);
+}
+
+// The message an assertion produced, or empty if it did not fail. assert_throws cannot be used to
+// observe a test_assertion_failure: naming that type as the expected one leaves its own handler
+// unreachable, so the framework's own tests catch it directly.
+template<typename Fn>
+auto
+message_of(Fn&& fn) -> std::string
+{
+  try {
+    std::forward<Fn>(fn)();
+  } catch (const test_assertion_failure& e) {
+    return e.what();
+  }
+  return {};
 }
 
 // ── the self-test cases ──────────────────────────────────────────────────────
@@ -298,6 +332,74 @@ a_scaled_budget_lets_a_case_outlive_its_original_one()
 
 } // namespace
 
+void
+a_skip_inside_assert_throws_skips_its_case()
+{
+  // std::exception is a base of test_skip_exception, so an expected-exception handler matched ahead
+  // of the control-flow ones claims the skip. The body still runs to completion; what is lost is
+  // the skip itself -- assert_throws returns normally, nothing propagates, and the runner counts
+  // the case as passed. A case that declared it does not apply then reads as one that verified
+  // something.
+  //
+  // This guards it twice over. Under the default build the wrong order does not compile at all,
+  // because instantiating assert_throws<std::exception> leaves a handler unreachable and
+  // -Wexceptions is an error; with those warnings demoted it builds, and the counts below catch it.
+  const test_suite s{ "inner", { { "s", body_skip_inside_assert_throws } } };
+  const auto r = run_quiet(s, {}, false);
+  assert_eq(r.skipped, std::size_t{ 1 }, "the skip reached the runner");
+  assert_eq(r.passed, std::size_t{ 0 }, "and was not counted as the expected exception");
+  assert_eq(r.failed, std::size_t{ 0 }, "a skip is not a failure either");
+}
+
+void
+a_failed_assertion_inside_assert_throws_fails_its_case()
+{
+  // Same ordering, the other control-flow type. A nested failure carries its own location and
+  // message, and being counted as the expected exception discards both.
+  const test_suite s{ "inner", { { "s", body_failed_assertion_inside_assert_throws } } };
+  const auto r = run_quiet(s, {}, false);
+  assert_eq(r.failed, std::size_t{ 1 }, "the nested failure reached the runner");
+  assert_eq(r.passed, std::size_t{ 0 }, "and did not satisfy the expectation");
+}
+
+void
+assert_throws_accepts_a_base_of_the_thrown_type()
+{
+  // The legitimate use of a base type, which the ordering above must not have cost: asking for
+  // std::exception and getting something derived from it is a match.
+  assert_throws<std::exception>([]() {
+    throw std::invalid_argument("derived from std::exception");
+  });
+  assert_throws<std::logic_error>([]() {
+    throw std::invalid_argument("derived from std::logic_error");
+  });
+}
+
+void
+assert_throws_rejects_an_unrelated_type_and_says_so()
+{
+  const auto message = message_of([]() {
+    assert_throws<std::logic_error>([]() {
+      throw std::runtime_error("unrelated");
+    });
+  });
+  assert_false(message.empty(), "an unrelated type is not accepted");
+  assert_true(message.find("a different exception type was thrown") != std::string::npos,
+              "and the report says the type was wrong rather than that nothing was thrown");
+}
+
+void
+assert_throws_rejects_a_callable_that_throws_nothing()
+{
+  const auto message = message_of([]() {
+    assert_throws<std::exception>([]() {
+    });
+  });
+  assert_false(message.empty(), "a callable that throws nothing fails the assertion");
+  assert_true(message.find("nothing was thrown") != std::string::npos,
+              "and is distinguished from having thrown the wrong type");
+}
+
 auto
 tests() -> test_suite
 {
@@ -324,6 +426,15 @@ tests() -> test_suite
       { "timeout_multiplier_defaults_to_one_and_rejects_anything_but_a_number",
         timeout_multiplier_defaults_to_one_and_rejects_anything_but_a_number },
       { "scale_timeouts_multiplies_every_budget", scale_timeouts_multiplies_every_budget },
+      { "a_skip_inside_assert_throws_skips_its_case", a_skip_inside_assert_throws_skips_its_case },
+      { "a_failed_assertion_inside_assert_throws_fails_its_case",
+        a_failed_assertion_inside_assert_throws_fails_its_case },
+      { "assert_throws_accepts_a_base_of_the_thrown_type",
+        assert_throws_accepts_a_base_of_the_thrown_type },
+      { "assert_throws_rejects_an_unrelated_type_and_says_so",
+        assert_throws_rejects_an_unrelated_type_and_says_so },
+      { "assert_throws_rejects_a_callable_that_throws_nothing",
+        assert_throws_rejects_a_callable_that_throws_nothing },
       { "a_scaled_budget_lets_a_case_outlive_its_original_one",
         a_scaled_budget_lets_a_case_outlive_its_original_one,
         timeout::fast },

--- a/test/framework/test_framework.hxx
+++ b/test/framework/test_framework.hxx
@@ -272,14 +272,26 @@ assert_throws(Fn&& fn,
               source_location loc = source_location::current())
 {
   bool threw_expected = false;
+  // The two control-flow types are matched ahead of `Exc`, and the order is the whole point:
+  // handlers are tried in order and both derive from std::exception, so with `Exc` naming any base
+  // of them -- std::exception itself, most obviously -- the expected-exception handler would claim
+  // them and the case would report passed. A swallowed skip is the failure this framework exists to
+  // make impossible: the case is counted as having verified something it had just declared it could
+  // not, and nothing in the report says otherwise.
+  //
+  // Neither type is assertable here as a consequence: a case that wants to observe a skip or a
+  // failure drives run() and asserts on the run_result, the way the self-tests do. Naming one as
+  // `Exc` leaves its handler below unreachable, which is a hard error in this project's default
+  // build: -Wexceptions under -Werror (cmake/CompilerWarnings.cmake). So the wrong order is caught
+  // at compile time here and only misreports where those warnings are not fatal.
   try {
     std::forward<Fn>(fn)();
+  } catch (const test_skip_exception&) {
+    throw; // skip() states that the case does not apply, whatever type was asked for
+  } catch (const test_assertion_failure&) {
+    throw; // a nested failure carries its own location and message; neither survives being counted
   } catch (const Exc&) {
     threw_expected = true;
-  } catch (const test_skip_exception&) {
-    throw; // a skip() inside the callable must reach the runner, not be reported as a wrong type
-  } catch (const test_assertion_failure&) {
-    throw; // ditto for a nested assertion failure, which carries its own location and message
   } catch (...) {
     throw test_assertion_failure(fmt::format(
       "{}:{}: {} (a different exception type was thrown)", loc.file_name(), loc.line(), message));


### PR DESCRIPTION
Fixes [CXXCBC-1003](https://couchbasecloud.atlassian.net/browse/CXXCBC-1003).

`assert_throws` matched the requested type ahead of `test_skip_exception` and `test_assertion_failure`, both of which derive from `std::exception`. Handlers are tried in order, so naming any base of them as the expected type left those two unreachable — and the comments on them stated a guarantee the ordering did not deliver.

It manifests two ways. `cmake/CompilerWarnings.cmake` defaults `WARNINGS_AS_ERRORS` to `TRUE`, so in the normal build and in CI it is the first:

- **An ordinary assertion does not compile.** Instantiating `assert_throws<std::exception>` gives `error: exception of type 'couchbase::test::test_skip_exception' will be caught by earlier handler [-Werror=exceptions]`. Asking whether a callable throws *some* `std::exception` cannot be written.
- **Where those warnings are not fatal, the case reports passed.** Built with `-DWARNINGS_AS_ERRORS=OFF` the same code compiles with four warnings, and a `skip()` raised inside the callable is claimed by the expected-exception handler: the runner counts `skipped` 0 and the case passes. A nested assertion failure goes the same way, discarding the location and message it carried.

The control-flow handlers now precede `Exc`. Neither type is assertable through `assert_throws` as a consequence — a case that wants to observe a skip drives `run()` and asserts on the `run_result`, as the self-tests do.

No current caller is affected: all five call sites request `std::invalid_argument`. The function is unchanged since it was promoted out of the CNG tree, so this is not a regression in any open pull request; it was found while reviewing #1073 and is out of scope there.

## Verification

Self-test cases now cover `assert_throws`, which nothing exercised before.

Two are the regression guards, and they bite at both levels. Reinstating the old ordering makes `test/framework/selftest.cxx` fail to build under the default warning settings; with warnings demoted it builds and the two cases fail on the runner's counts:

```
a_skip_inside_assert_throws_skips_its_case              FAILED: the skip reached the runner (actual: 0, expected: 1)
a_failed_assertion_inside_assert_throws_fails_its_case  FAILED: the nested failure reached the runner (actual: 0, expected: 1)
```

The other three pin what the reordering must not have cost: a base of the thrown type is still accepted, an unrelated type is still reported as the wrong type rather than as nothing thrown, and a callable that throws nothing stays distinct from both.

The self-test is green with the fix under `WARNINGS_AS_ERRORS=ON`, which is the configuration the defect made unbuildable. `test_unit_config_profiles` is the only `assert_throws` caller outside the framework, and it passes unchanged.


[CXXCBC-1003]: https://couchbasecloud.atlassian.net/browse/CXXCBC-1003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
