### PR TITLE
CXXCBC-1005: assert on the message of a thrown exception

### DIFF
--- a/test/framework/selftest.cxx
+++ b/test/framework/selftest.cxx
@@ -79,6 +79,26 @@ body_failed_assertion_inside_assert_throws([[maybe_unused]] context& ctx)
     assert_true(false, "intentional failure from inside a callable");
   });
 }
+void
+body_skip_inside_assert_throws_with([[maybe_unused]] context& ctx)
+{
+  // The substring deliberately matches the skip's own text. Were the skip swallowed, it would also
+  // satisfy the message check, so the case would report passed rather than fail on the substring --
+  // the silent outcome, which is the one worth pinning.
+  assert_throws_with("intentional", []() {
+    skip("intentional skip from inside a callable");
+  });
+}
+void
+body_failed_assertion_inside_assert_throws_with([[maybe_unused]] context& ctx)
+{
+  // The other control-flow type, and the substring matches for the same reason: a nested failure
+  // claimed as the expected exception leaves its own message in `what`, which then satisfies the
+  // check and reports the case passed.
+  assert_throws_with("intentional", []() {
+    assert_true(false, "intentional failure from inside a callable");
+  });
+}
 
 // A backend that answers from fixed values and counts the calls, so the claim that probes are
 // cached can be checked with a number instead of by reading context.cxx.
@@ -311,7 +331,7 @@ message_of(Fn&& fn) -> std::string
 }
 
 void
-body_skip_inside_message_of()
+body_skip_inside_message_of([[maybe_unused]] context& ctx)
 {
   static_cast<void>(message_of([]() {
     skip("intentional skip from inside a callable");
@@ -320,7 +340,7 @@ body_skip_inside_message_of()
   assert_true(false, "the skip did not reach the runner");
 }
 void
-body_throw_inside_message_of()
+body_throw_inside_message_of([[maybe_unused]] context& ctx)
 {
   static_cast<void>(message_of([]() {
     throw std::runtime_error("not an assertion failure");
@@ -898,7 +918,7 @@ assert_throws_rejects_a_callable_that_throws_nothing([[maybe_unused]] context& c
 }
 
 void
-assert_eq_reports_both_values_when_it_can_format_them()
+assert_eq_reports_both_values_when_it_can_format_them([[maybe_unused]] context& ctx)
 {
   const auto message = message_of([]() {
     assert_eq(2 + 2, 5, "arithmetic");
@@ -910,7 +930,7 @@ assert_eq_reports_both_values_when_it_can_format_them()
 }
 
 void
-assert_eq_omits_values_it_cannot_format()
+assert_eq_omits_values_it_cannot_format([[maybe_unused]] context& ctx)
 {
   // The fallback is correct -- there is nothing to print -- but which branch a type takes is a
   // compile-time decision, so without this a change to the condition would silently move every
@@ -924,7 +944,7 @@ assert_eq_omits_values_it_cannot_format()
 }
 
 void
-assert_true_and_assert_false_report_what_was_asked()
+assert_true_and_assert_false_report_what_was_asked([[maybe_unused]] context& ctx)
 {
   assert_true(message_of([]() {
                 assert_true(true);
@@ -956,7 +976,7 @@ assert_true_and_assert_false_report_what_was_asked()
 }
 
 void
-an_assertion_reports_the_location_of_its_call_site()
+an_assertion_reports_the_location_of_its_call_site([[maybe_unused]] context& ctx)
 {
   // Every assertion defaults its source_location at the call site. Lose that -- a helper passing
   // its own location, or the default dropped -- and every failure in the suite names the framework
@@ -976,22 +996,92 @@ an_assertion_reports_the_location_of_its_call_site()
 }
 
 void
-message_of_passes_everything_else_to_the_runner()
+message_of_passes_everything_else_to_the_runner([[maybe_unused]] context& ctx)
 {
   // message_of catches test_assertion_failure and nothing else. A skip is the case that matters:
   // swallowed, it becomes an empty string, the body carries on, and a case that declared it does
   // not apply reports passed. Each body below asserts false after its message_of call, so reaching
   // that line is itself the failure.
   const test_suite skipping_suite{ "inner", { { "s", body_skip_inside_message_of } } };
-  const auto skipped = run_quiet(skipping_suite, {}, false);
+  const auto skipped = run_bare(skipping_suite);
   assert_eq(skipped.skipped, std::size_t{ 1 }, "a skip reaches the runner");
   assert_eq(skipped.passed, std::size_t{ 0 }, "and is not turned into an empty message");
   assert_eq(skipped.failed, std::size_t{ 0 }, "so the line after the call never ran");
 
   const test_suite throwing_suite{ "inner", { { "t", body_throw_inside_message_of } } };
-  const auto threw = run_quiet(throwing_suite, {}, false);
+  const auto threw = run_bare(throwing_suite);
   assert_eq(threw.failed, std::size_t{ 1 }, "an unrelated exception reaches the runner too");
   assert_eq(threw.passed, std::size_t{ 0 }, "and does not read as a satisfied assertion");
+}
+
+void
+assert_throws_with_matches_a_substring_of_the_message([[maybe_unused]] context& ctx)
+{
+  assert_throws_with<std::invalid_argument>("path_invalid", []() {
+    throw std::invalid_argument("the path path_invalid was rejected");
+  });
+  // The type is optional; without it the default accepts anything derived from std::exception,
+  // which is what the Catch2 form being replaced did.
+  assert_throws_with("common flags", []() {
+    throw std::runtime_error("expected the document to have JSON common flags");
+  });
+}
+
+void
+assert_throws_with_reports_both_the_substring_and_the_message([[maybe_unused]] context& ctx)
+{
+  const auto message = message_of([]() {
+    assert_throws_with<std::runtime_error>("wanted", []() {
+      throw std::runtime_error("what it actually said");
+    });
+  });
+  assert_false(message.empty(), "a message that does not contain the substring fails");
+  assert_true(message.find("wanted") != std::string::npos, "the report names what was wanted");
+  assert_true(message.find("what it actually said") != std::string::npos,
+              "and what the exception actually said, which is what decides who is wrong");
+}
+
+void
+assert_throws_with_rejects_a_different_type_and_a_silent_callable([[maybe_unused]] context& ctx)
+{
+  const auto wrong_type = message_of([]() {
+    assert_throws_with<std::logic_error>("anything", []() {
+      throw std::runtime_error("unrelated");
+    });
+  });
+  assert_true(wrong_type.find("a different exception type was thrown") != std::string::npos,
+              "a constrained type still rejects the wrong one, before any message matching");
+
+  const auto nothing = message_of([]() {
+    assert_throws_with("anything", []() {
+    });
+  });
+  assert_true(nothing.find("nothing was thrown") != std::string::npos,
+              "and a callable that throws nothing stays distinct from a wrong message");
+}
+
+void
+a_skip_inside_assert_throws_with_skips_its_case([[maybe_unused]] context& ctx)
+{
+  // The default Exc is std::exception, a base of test_skip_exception, so the control-flow handlers
+  // being matched first is what this depends on rather than a precaution: any other order records
+  // the skip as the expected exception and the case reports passed.
+  const test_suite s{ "inner", { { "s", body_skip_inside_assert_throws_with } } };
+  const auto r = run_bare(s);
+  assert_eq(r.skipped, std::size_t{ 1 }, "the skip reached the runner");
+  assert_eq(r.passed, std::size_t{ 0 }, "and was not counted as the expected exception");
+}
+
+void
+a_failed_assertion_inside_assert_throws_with_fails_its_case([[maybe_unused]] context& ctx)
+{
+  // The same ordering, the other type. A nested failure carries its own location and message, and
+  // being claimed as the expected exception discards both -- then the substring is checked against
+  // the assertion's text instead of an exception's, which is how this reports passed.
+  const test_suite s{ "inner", { { "f", body_failed_assertion_inside_assert_throws_with } } };
+  const auto r = run_bare(s);
+  assert_eq(r.failed, std::size_t{ 1 }, "the nested failure reached the runner");
+  assert_eq(r.passed, std::size_t{ 0 }, "and was not counted as the expected exception");
 }
 
 auto
@@ -1060,6 +1150,16 @@ tests() -> test_suite
         an_assertion_reports_the_location_of_its_call_site },
       { "message_of_passes_everything_else_to_the_runner",
         message_of_passes_everything_else_to_the_runner },
+      { "assert_throws_with_matches_a_substring_of_the_message",
+        assert_throws_with_matches_a_substring_of_the_message },
+      { "assert_throws_with_reports_both_the_substring_and_the_message",
+        assert_throws_with_reports_both_the_substring_and_the_message },
+      { "assert_throws_with_rejects_a_different_type_and_a_silent_callable",
+        assert_throws_with_rejects_a_different_type_and_a_silent_callable },
+      { "a_skip_inside_assert_throws_with_skips_its_case",
+        a_skip_inside_assert_throws_with_skips_its_case },
+      { "a_failed_assertion_inside_assert_throws_with_fails_its_case",
+        a_failed_assertion_inside_assert_throws_with_fails_its_case },
       { "a_scaled_budget_lets_a_case_outlive_its_original_one",
         a_scaled_budget_lets_a_case_outlive_its_original_one,
         {},

--- a/test/framework/test_framework.hxx
+++ b/test/framework/test_framework.hxx
@@ -273,4 +273,48 @@ assert_throws(Fn&& fn,
   }
 }
 
+// Invoke `fn`, require it to throw `Exc`, and require that exception's message to contain
+// `substring`. `Exc` defaults to std::exception because the common use is to assert what went wrong
+// rather than which type carried it; a case that cares about the type names it.
+//
+// The substring leads. A callable is often several lines long, and with it first what is being
+// asserted is only readable after scrolling past the thing doing the asserting.
+//
+// The control-flow types are matched ahead of `Exc` for the reason given on assert_throws above,
+// and here the default makes it load-bearing rather than defensive: `Exc` is a base of both, so any
+// other order would record a skip() from inside the callable as the expected exception.
+template<typename Exc = std::exception, typename Fn>
+inline void
+assert_throws_with(std::string_view substring,
+                   Fn&& fn,
+                   std::string_view message = "expected exception",
+                   source_location loc = source_location::current())
+{
+  std::string what;
+  bool threw_expected = false;
+  try {
+    std::forward<Fn>(fn)();
+  } catch (const test_skip_exception&) {
+    throw;
+  } catch (const test_assertion_failure&) {
+    throw;
+  } catch (const Exc& e) {
+    threw_expected = true;
+    what = e.what();
+  } catch (...) {
+    throw test_assertion_failure(fmt::format(
+      "{}:{}: {} (a different exception type was thrown)", loc.file_name(), loc.line(), message));
+  }
+  if (!threw_expected) {
+    throw test_assertion_failure(
+      fmt::format("{}:{}: {} (nothing was thrown)", loc.file_name(), loc.line(), message));
+  }
+  // Both halves: the substring alone does not tell the reader what the exception actually said, and
+  // that is the thing they need in order to decide whether the code or the expectation is wrong.
+  if (what.find(substring) == std::string_view::npos) {
+    throw test_assertion_failure(fmt::format(
+      R"({}:{}: {} ("{}" is not in "{}"))", loc.file_name(), loc.line(), message, substring, what));
+  }
+}
+
 } // namespace couchbase::test

--- a/test/tools/document_body_generator.cxx
+++ b/test/tools/document_body_generator.cxx
@@ -52,7 +52,7 @@ distinct(const std::vector<std::vector<std::byte>>& bodies) -> std::size_t
 }
 
 void
-random_document_bodies_are_distinct()
+random_document_bodies_are_distinct([[maybe_unused]] context& ctx)
 {
   // The defect this guards: a body generated once and reused makes every
   // document identical, and the storage engine then compresses a block of them
@@ -67,7 +67,7 @@ random_document_bodies_are_distinct()
 }
 
 void
-a_constant_fill_repeats_one_body()
+a_constant_fill_repeats_one_body([[maybe_unused]] context& ctx)
 {
   cbc::document_body_generator generator{
     cbc::body_fill::constant, cbc::body_format::binary, document_size, 0, seed,
@@ -77,7 +77,7 @@ a_constant_fill_repeats_one_body()
 }
 
 void
-a_binary_body_is_exactly_the_requested_size()
+a_binary_body_is_exactly_the_requested_size([[maybe_unused]] context& ctx)
 {
   for (auto fill : { cbc::body_fill::constant, cbc::body_fill::random }) {
     cbc::document_body_generator generator{
@@ -91,7 +91,7 @@ a_binary_body_is_exactly_the_requested_size()
 }
 
 void
-a_random_json_body_parses_and_keeps_its_requested_length()
+a_random_json_body_parses_and_keeps_its_requested_length([[maybe_unused]] context& ctx)
 {
   cbc::document_body_generator generator{
     cbc::body_fill::random, cbc::body_format::json, document_size, 0, seed,
@@ -110,7 +110,7 @@ a_random_json_body_parses_and_keeps_its_requested_length()
 }
 
 void
-a_seed_reproduces_a_dataset_and_a_different_seed_does_not()
+a_seed_reproduces_a_dataset_and_a_different_seed_does_not([[maybe_unused]] context& ctx)
 {
   const auto make = [](std::uint64_t value) {
     cbc::document_body_generator generator{
@@ -127,7 +127,7 @@ a_seed_reproduces_a_dataset_and_a_different_seed_does_not()
 }
 
 void
-a_pool_holds_distinct_bodies_and_cycles_through_them()
+a_pool_holds_distinct_bodies_and_cycles_through_them([[maybe_unused]] context& ctx)
 {
   constexpr std::size_t pooled{ 8 };
 
@@ -145,7 +145,7 @@ a_pool_holds_distinct_bodies_and_cycles_through_them()
 }
 
 void
-a_zero_document_size_yields_the_predefined_document()
+a_zero_document_size_yields_the_predefined_document([[maybe_unused]] context& ctx)
 {
   const auto predefined = couchbase::core::utils::to_binary(R"({"type":"fake_profile"})");
 
@@ -165,22 +165,33 @@ tests() -> test_suite
   return {
     "tools_document_body_generator",
     {
-      { "random_document_bodies_are_distinct", random_document_bodies_are_distinct, timeout::fast },
-      { "a_constant_fill_repeats_one_body", a_constant_fill_repeats_one_body, timeout::instant },
+      { "random_document_bodies_are_distinct",
+        random_document_bodies_are_distinct,
+        {},
+        timeout::fast },
+      { "a_constant_fill_repeats_one_body",
+        a_constant_fill_repeats_one_body,
+        {},
+        timeout::instant },
       { "a_binary_body_is_exactly_the_requested_size",
         a_binary_body_is_exactly_the_requested_size,
+        {},
         timeout::instant },
       { "a_random_json_body_parses_and_keeps_its_requested_length",
         a_random_json_body_parses_and_keeps_its_requested_length,
+        {},
         timeout::instant },
       { "a_seed_reproduces_a_dataset_and_a_different_seed_does_not",
         a_seed_reproduces_a_dataset_and_a_different_seed_does_not,
+        {},
         timeout::instant },
       { "a_pool_holds_distinct_bodies_and_cycles_through_them",
         a_pool_holds_distinct_bodies_and_cycles_through_them,
+        {},
         timeout::instant },
       { "a_zero_document_size_yields_the_predefined_document",
         a_zero_document_size_yields_the_predefined_document,
+        {},
         timeout::instant },
     },
   };


### PR DESCRIPTION
Fixes [CXXCBC-1005](https://couchbasecloud.atlassian.net/browse/CXXCBC-1005).

CXXCBC-1003 (#1097) and CXXCBC-1004 (#1098) have merged, so this now carries a single commit against `main`.

Six Catch2 sites assert on the *message* of a thrown exception and the framework has no equivalent, so those cases cannot be migrated. Converting them to a bare `assert_throws<T>` would keep the type check and silently drop the message check, which is the only thing they verify.

```
test/test_integration_transcoders.cxx:515-518,720   REQUIRE_THROWS_WITH(..., ContainsSubstring(...))
test/test_unit_utils.cxx:46                         CHECK_THROWS_WITH(..., ContainsSubstring(...))
```

**Those six are not converted here, and cannot be.** Both files are Catch2 — 12 and 13 `TEST_CASE`s between them, no framework include, and no Catch2 target links the framework. Reaching them means migrating the files off Catch2 entirely, which is the work of the tickets that own those files; calling `assert_throws_with` from inside a `TEST_CASE` would put two test frameworks in one binary, which is the thing this epic exists to remove. What lands here is the helper they will need, ahead of them, so the conversion when it comes is faithful rather than lossy.

## Shape

```cpp
assert_throws_with<std::system_error>("path_invalid", [&]() {
  resp.content_as<std::uint32_t>("views");
}, "a missing path is reported by name");
```

**The substring is the first argument.** A callable is frequently several lines long, and behind it the thing being asserted is only readable after the thing doing the asserting.

`Exc` defaults to `std::exception`, matching the Catch2 form being replaced, which does not constrain the type at all. A case that cares about the type names it.

A failure prints the substring wanted **and** the message seen. Either alone leaves the reader unable to tell whether the code or the expectation is wrong, which is the question a failing assertion exists to answer.

The control-flow exceptions are matched ahead of `Exc`, as established by CXXCBC-1003 and now on `main`. That ordering is load-bearing here rather than defensive: the default is a base of both `test_skip_exception` and `test_assertion_failure`, so any other order records a `skip()` raised inside the callable as the expected exception — and a substring drawn from the skip's own text would then satisfy the message check and report the case **passed**.

Returning the message from `assert_throws` was considered and rejected: composing `assert_contains(assert_throws<T>(…), …)` adds no name to the vocabulary but reads badly once the callable is more than one line, which is the common case.

## Verification

The cases cover the helper: a substring matching with and without an explicit type, the report naming both halves, a wrong type and a silent callable staying distinct from each other, and both control-flow types — a `skip()` and a failed assertion inside the callable — reaching the runner rather than satisfying the expectation. Each was observed to fail against a one-line break in the helper, through the CNG tooling's negative control:

```
KILLED  throws-with-never-checks-the-substring
KILLED  throws-with-hides-the-message-it-saw
KILLED  throws-with-claims-control-flow-first

7/7 mutations killed
```

The third replaces the `test_skip_exception` handler with one that cannot match, which is what makes the skip fall through to the expected-exception handler. The self-test's substring deliberately matches the skip's own text, so under that mutation the case reports passed rather than failing on the substring — the silent outcome, which is the one worth pinning.


[CXXCBC-1005]: https://couchbasecloud.atlassian.net/browse/CXXCBC-1005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ





