### PR TITLE
CXXCBC-1006: print error codes when an assertion on them fails

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -191,7 +191,7 @@ The failure message already prints the operands — that is what `operand_printe
 
 ### Printing a type in a failure message
 
-`assert_eq` and `assert_ne` show both operands for any type with an `operand_printer`. Integers, `bool`, `char`, floating point, the string types and enums are built in; `framework/errors.hxx` adds `std::error_code` and `couchbase::error`. A type with none is not an error — the assertion still fires, it just omits the values. To teach the framework a type, specialise it next to the test that needs it:
+`assert_eq` and `assert_ne` show both operands for any type with an `operand_printer`. Integers, `bool`, `char`, floating point, the string types, enums and `std::error_code` are built in. `couchbase::error` is not one of them: `framework/errors.hxx` overloads the two assertions for it instead, because a printer for it would be visible only in the translation units that include that header, and the same comparison would then have two definitions in one binary. A type with no printer is not an error — the assertion still fires, it just omits the values. To teach the framework a type, specialise it in the translation unit that needs it, for the same reason:
 
 ```cpp
 template<>

--- a/test/cng/protostellar/retry.cxx
+++ b/test/cng/protostellar/retry.cxx
@@ -50,6 +50,7 @@
 #include <atomic>
 #include <future>
 #include <string>
+#include <system_error>
 #include <thread>
 
 namespace couchbase::test
@@ -256,8 +257,12 @@ non_kv_retry_budget_exhaustion([[maybe_unused]] context& ctx)
   server->Wait();
 
   assert_false(static_cast<bool>(open_ec), "open(couchbase2://) succeeds");
-  assert_true(res.ctx.ec == couchbase::errc::common::unambiguous_timeout,
-              "always-failing query fails with unambiguous_timeout when budget is exhausted");
+  // assert_eq rather than assert_true on a comparison: both operands are std::error_code so the
+  // failure names the code that came back. This case has failed intermittently under TSan, and the
+  // boolean form left nothing in the log to diagnose it with.
+  assert_eq(res.ctx.ec,
+            std::error_code{ couchbase::errc::common::unambiguous_timeout },
+            "always-failing query fails with unambiguous_timeout when budget is exhausted");
   assert_true(service.always_fail_calls.load() > 1,
               "multiple attempts occurred before budget exhaustion");
   assert_true(res.ctx.retry_attempts > 0,

--- a/test/framework/errors.hxx
+++ b/test/framework/errors.hxx
@@ -32,19 +32,18 @@
 #include <couchbase/error.hxx>
 
 #include <string>
+#include <string_view>
 #include <system_error>
 
 namespace couchbase::test
 {
 
+// One spelling for an error code, shared with the one assert_eq prints, so a failure and a message
+// built by hand cannot describe the same code differently.
 [[nodiscard]] inline auto
 describe(const std::error_code& ec) -> std::string
 {
-  if (!ec) {
-    return "success";
-  }
-  return std::string{ ec.category().name() } + ':' + std::to_string(ec.value()) + " (" +
-         ec.message() + ")";
+  return operand_printer<std::error_code>::to_text(ec);
 }
 
 [[nodiscard]] inline auto
@@ -63,26 +62,43 @@ describe(const couchbase::error& error) -> std::string
   return result;
 }
 
-// So assert_eq and assert_ne on error values print operands rather than nothing. A class template
-// specialisation is found at the point of instantiation, so it works from a header included after
-// test_framework.hxx -- which a free function overload would not.
-template<>
-struct operand_printer<std::error_code> {
-  static constexpr bool available = true;
-  [[nodiscard]] static auto to_text(const std::error_code& ec) -> std::string
-  {
-    return describe(ec);
+// So assert_eq and assert_ne on a couchbase::error print operands rather than nothing.
+//
+// Overloads, not an operand_printer specialisation. The template is declared in
+// test_framework.hxx, which every test includes, while this header is included only where a test
+// asserts on an error -- so a specialisation here is visible in some translation units of a binary
+// and not others, and assert_eq<couchbase::error, ...> then has two definitions in one program.
+// That is the same hazard that keeps the std::error_code printer in test_framework.hxx, and it
+// applies to every type this header could add: `couchbase::error` reaches a test through
+// <couchbase/error.hxx>, with its own operator==, whether or not this header came with it.
+//
+// An overload is resolved by ordinary lookup at the call, so a case body finds it however late this
+// header is included. What it would not reach is a dependent call from a template defined above
+// the include, because argument-dependent lookup from couchbase::error searches namespace
+// couchbase and not couchbase::test. No test compares errors from a template.
+inline void
+assert_eq(const couchbase::error& actual,
+          const couchbase::error& expected,
+          std::string_view message = "expected equal",
+          source_location loc = source_location::current())
+{
+  if (!(actual == expected)) {
+    throw test_assertion_failure(detail::at(loc, message) + " (actual: " + describe(actual) +
+                                 ", expected: " + describe(expected) + ")");
   }
-};
+}
 
-template<>
-struct operand_printer<couchbase::error> {
-  static constexpr bool available = true;
-  [[nodiscard]] static auto to_text(const couchbase::error& error) -> std::string
-  {
-    return describe(error);
+inline void
+assert_ne(const couchbase::error& actual,
+          const couchbase::error& unexpected,
+          std::string_view message = "expected different",
+          source_location loc = source_location::current())
+{
+  if (actual == unexpected) {
+    throw test_assertion_failure(detail::at(loc, message) + " (both are: " + describe(actual) +
+                                 ")");
   }
-};
+}
 
 inline void
 assert_success(const std::error_code& ec,

--- a/test/framework/errors_selftest.cxx
+++ b/test/framework/errors_selftest.cxx
@@ -114,8 +114,9 @@ assert_error_distinguishes_one_failure_from_another([[maybe_unused]] context& ct
 void
 error_codes_render_as_operands([[maybe_unused]] context& ctx)
 {
-  // assert_eq prints operands only for types with an operand_printer. Without the specialisations
-  // in errors.hxx, a mismatch between two error codes would say "expected equal" and nothing else.
+  // assert_eq prints operands only for types with an operand_printer, and std::error_code has one
+  // in test_framework.hxx; without it a mismatch between two error codes would say "expected
+  // equal" and nothing else.
   const auto message = message_of([]() {
     assert_eq(make_error_code(couchbase::errc::common::unambiguous_timeout),
               make_error_code(couchbase::errc::common::request_canceled));
@@ -124,10 +125,26 @@ error_codes_render_as_operands([[maybe_unused]] context& ctx)
   assert_contains(message, "request_canceled", "and so does the expected one");
 
   assert_true(operand_printer<std::error_code>::available, "error codes are printable");
-  assert_true(operand_printer<couchbase::error>::available, "and so are errors");
   assert_eq(operand_printer<std::error_code>::to_text(std::error_code{}),
             std::string{ "success" },
             "a default error code renders as success");
+
+  // couchbase::error takes the overloads this header adds rather than a printer, so what is worth
+  // pinning is that a mismatch between two of them still names both. The overload has to be picked
+  // over the template, which is the part a printer used to do.
+  const auto errors = message_of([]() {
+    assert_eq(couchbase::error{ make_error_code(couchbase::errc::common::unambiguous_timeout) },
+              couchbase::error{ make_error_code(couchbase::errc::key_value::document_not_found) });
+  });
+  assert_contains(errors, "unambiguous_timeout", "the error it saw renders");
+  assert_contains(errors, "document_not_found", "and so does the one it expected");
+
+  const auto same = message_of([]() {
+    const couchbase::error error{ make_error_code(couchbase::errc::common::request_canceled) };
+    assert_ne(error, error, "the two are the same error");
+  });
+  assert_contains(same, "both are:", "and assert_ne names the value they share");
+  assert_contains(same, "request_canceled", "by rendering it");
 }
 } // namespace
 

--- a/test/framework/selftest.cxx
+++ b/test/framework/selftest.cxx
@@ -842,6 +842,49 @@ a_scaled_budget_lets_a_case_outlive_its_original_one([[maybe_unused]] context& c
 }
 
 void
+an_error_code_assertion_names_the_code_it_saw([[maybe_unused]] context& ctx)
+{
+  const auto message_of = [](auto&& fn) -> std::string {
+    try {
+      fn();
+    } catch (const test_assertion_failure& e) {
+      return e.what();
+    }
+    return {};
+  };
+
+  // Without a printer for std::error_code, assert_eq takes its value-free branch and reports no
+  // more than assert_true on the same comparison would: the expectation, and nothing about what
+  // came back. A failure in CI is then undiagnosable without reproducing it.
+  const auto mismatch = message_of([]() {
+    assert_eq(std::make_error_code(std::errc::timed_out),
+              std::make_error_code(std::errc::permission_denied),
+              "the operation timed out");
+  });
+  assert_contains(mismatch, "actual:", "the failure prints the code it saw");
+  // The value inside the delimiters the printer puts around it, never bare. The message opens with
+  // a location, and a line number contains the value on any platform where the two coincide --
+  // errc::timed_out is 60 on macOS, which "selftest.cxx:860" satisfies whatever the printer did.
+  assert_contains(mismatch,
+                  ":" + std::to_string(static_cast<int>(std::errc::timed_out)) + " (",
+                  "including its value");
+  assert_contains(mismatch, "expected:", "and the one it wanted");
+
+  // The category is part of the identity: the same number means different things in different
+  // categories, so a report carrying only the value points at the wrong table.
+  assert_contains(mismatch,
+                  std::make_error_code(std::errc::timed_out).category().name(),
+                  "and the category the value belongs to");
+
+  // A success prints as a word rather than as "generic:0", which reads as a code that was returned.
+  // Through the printer directly: errors.hxx would pull in the public SDK header, and this binary
+  // links no client library.
+  assert_eq(operand_printer<std::error_code>::to_text(std::error_code{}),
+            std::string{ "success" },
+            "a clear code says so");
+}
+
+void
 the_added_assertions_report_what_they_saw([[maybe_unused]] context& ctx)
 {
   const auto message_of = [](auto&& fn) -> std::string {
@@ -1348,6 +1391,7 @@ tests() -> test_suite
       { CASE(a_failure_names_the_file_and_line_it_came_from) },
       { CASE(operands_render_without_a_formatting_library) },
       { CASE(a_type_with_no_printer_still_fails_its_assertion) },
+      { CASE(an_error_code_assertion_names_the_code_it_saw) },
       { CASE(the_added_assertions_report_what_they_saw) },
       { CASE(the_configuration_reads_the_environment_it_documents) },
     },

--- a/test/framework/test_framework.hxx
+++ b/test/framework/test_framework.hxx
@@ -36,6 +36,7 @@
 #include <exception>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -329,6 +330,22 @@ struct operand_printer<std::string> {
   [[nodiscard]] static auto to_text(const std::string& value) -> std::string
   {
     return detail::quoted(value);
+  }
+};
+
+template<>
+struct operand_printer<std::error_code> {
+  static constexpr bool available = true;
+  // category:value (message). The category matters: two codes with the same value mean different
+  // things in different categories, and a failure that prints only the number sends the reader to
+  // look one up in the wrong table. errors.hxx renders through this so there is one spelling.
+  [[nodiscard]] static auto to_text(const std::error_code& value) -> std::string
+  {
+    if (!value) {
+      return "success";
+    }
+    return std::string{ value.category().name() } + ':' + std::to_string(value.value()) + " (" +
+           value.message() + ")";
   }
 };
 


### PR DESCRIPTION
Fixes [CXXCBC-1006](https://couchbasecloud.atlassian.net/browse/CXXCBC-1006).

Stage 1 of [CXXCBC-945](https://couchbasecloud.atlassian.net/browse/CXXCBC-945) has merged — CXXCBC-946 (#1070), CXXCBC-947 (#1071), CXXCBC-948 (#1072), CXXCBC-949 (#1073), CXXCBC-950 (#1074) and CXXCBC-975 (#1075) — so this now carries a single commit against `main`, and is the last of the line.

## Why

An assertion comparing two error codes printed neither. A `unit (tsan)` leg reported:

```
"non_kv_retry_budget_exhaustion" FAILED: test/cng/protostellar/retry.cxx:259:
  always-failing query fails with unambiguous_timeout when budget is exhausted
```

No other test failed, the run carried no ThreadSanitizer report, and the case ran for 0.14 s. What `res.ctx.ec` actually held is not recoverable from that log, so an intermittent failure could not be diagnosed without reproducing it.

`test/cng` holds 181 `assert_true(x == y)` comparisons, 46 of them on an error code. Every one is undiagnosable when it fails.

## The printer existed, in the wrong header

`operand_printer<std::error_code>` was already defined — in `errors.hxx`. Only some translation units include that header, and a class template specialisation visible in some but not others gives `assert_eq<std::error_code, …>` more than one definition across the program. `retry.cxx` is one of the units without it, so converting its assertion in place would have printed nothing.

It moves to `test_framework.hxx`, beside the assertions it serves, where it needs only `<system_error>` and is visible wherever `assert_eq` is. `errors.hxx` gives `couchbase::error` `assert_eq` and `assert_ne` overloads instead of a printer. That type reaches a test through `<couchbase/error.hxx>`, with its own `operator==`, so a printer in a header only some translation units include would recreate exactly the divergence above — while an overload cannot diverge: a unit without the header resolves to the template, which prints no operands, in that unit and every other alike. `describe()` now renders codes through the printer rather than keeping a second spelling of the same text.

The failing assertion becomes `assert_eq`. Both operands are `std::error_code`: a raw `errc` enum has no printer, and `assert_eq` prints values only when it can render **both**.

## Verification

A mismatch now reads:

```
the operation timed out (actual: generic:110 (Connection timed out), expected: generic:13 (Permission denied))
```

That was produced by a program including `test_framework.hxx` and nothing else, which is what establishes the printer is no longer conditional on `errors.hxx`.

`an_error_code_assertion_names_the_code_it_saw` covers the value, the category — the same number means different things in different categories, so a report carrying only the value points at the wrong table — and that a clear code prints as `success` rather than `generic:0`. Setting the specialisation's `available` to `false` kills it, run through the CNG tooling's negative control.

The other 45 sites convert with the files they live in; this changes only the one that exposed the gap.


[CXXCBC-1006]: https://couchbasecloud.atlassian.net/browse/CXXCBC-1006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ




[CXXCBC-945]: https://couchbasecloud.atlassian.net/browse/CXXCBC-945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
