### PR TITLE
CXXCBC-920: give every generated document its own body

### DIFF
--- a/cmake/TestFramework.cmake
+++ b/cmake/TestFramework.cmake
@@ -181,3 +181,6 @@ endfunction()
 # inner suites here assert on absolute millisecond budgets, which valgrind would blow with no
 # multiplier able to reach them.
 couchbase_add_test(framework/selftest LABEL cng)
+
+# unit, because it is pure computation over the tools helper and needs no server.
+couchbase_add_test(tools/document_body_generator LABEL unit LINK_CLIENT)

--- a/docs/cbc-pillowfight.md
+++ b/docs/cbc-pillowfight.md
@@ -27,12 +27,69 @@ Run simple workload generator that sends GET/UPSERT requests with optional N1QL 
 <dt>`--number-of-worker-threads=INTEGER`</dt><dd>Number of the IO threads. [default: `1`]</dd>
 <dt>`--operation-ratio=TEXT`</dt><dd>The ratio of the operations to generate in form "G:R:D:I:Q", where letters represent ratio of the operations in whole numbers: Get, Replace, Delete, Insert and Query respectively. (e.g. "5:0:0:1:0" would do on average 5 gets for every insert). [default: `1:1:0:0:0`]</dd>
 <dt>`--query-statement=STRING`</dt><dd>The N1QL query statement to use (`{bucket_name}`, `{scope_name}` and `{collection_name}` will be substituted). [default: <code>SELECT COUNT(*) FROM \`{bucket_name}\` WHERE type = "fake_profile"</code>]</dd>
-<dt>`--incompressible-body`</dt><dd>Use random characters to fill generated document value (by default uses 'x' to fill the body).</dd>
 <dt>`--document-body-size=INTEGER`</dt><dd>Size of the body (if zero, it will use predefined document). [default: `0`]</dd>
+<dt>`--document-body-fill=MODE`</dt><dd>How to fill a generated document body (allowed values: `constant`, `random`). `constant` repeats a single character; `random` draws every document from a seeded pseudo-random generator. Only `random` gives each document distinct bytes. [default: `constant`]</dd>
+<dt>`--document-body-format=FORMAT`</dt><dd>Format of a generated document (allowed values: `json`, `binary`). `json` wraps the body in a JSON object and restricts it to a JSON-safe alphabet; `binary` stores the body as opaque bytes of exactly `--document-body-size`. [default: `json`]</dd>
+<dt>`--document-body-pool-size=INTEGER`</dt><dd>Pre-generate this many bytes of document bodies per worker thread and cycle through them, instead of generating a fresh body for every document. Measured in bytes, with a floor of 1 MiB. [default: `0`]</dd>
+<dt>`--document-body-seed=INTEGER`</dt><dd>Seed for `--document-body-fill=random`, so that a dataset can be reproduced. Each worker thread offsets it by its index. Without it the generator is seeded from the system entropy source.</dd>
 <dt>`--number-of-keys-to-populate=INTEGER`</dt><dd>Preload keys before running workload, so that the worker will not generate new keys afterwards. [default: `1000`]</dd>
 <dt>`--operations-limit=INTEGER`</dt><dd>Stop and exit after the number of the operations reaches this limit. (zero for running indefinitely) [default: `0`]</dd>
 </dl>
 
+
+### LOADING INCOMPRESSIBLE DOCUMENTS
+
+Sizing a dataset to a target disk footprint needs documents that do not compress, so that the
+bytes written follow from the number of documents. Two compressors stand in the way, and they
+work at different scopes.
+
+Per document, the SDK and the Key/Value service compress with snappy, keeping the compressed form
+only when it is smaller by a configured margin — `--compression-minimum-ratio` here,
+`min_compression_ratio` on the server. Random bytes never clear that bar.
+
+Per data block, the storage engine compresses several documents together, with `lz4` by default.
+This is the one that matters: a body reused across documents is stored once and back-referenced
+for the rest of the block, so a load of a million identical documents occupies a fraction of
+their combined size no matter how random that single body looks. `--document-body-fill=random`
+gives every document its own bytes.
+
+Measured over the generator's own output, compressed in 4096-byte blocks:
+
+| `--document-body-fill` / `--document-body-format` | lz4 | snappy | zstd |
+|---|---|---|---|
+| `constant` / `json` | 67.79x | 18.29x | 80.72x |
+| `random` / `json` | 1.00x | 1.00x | 1.33x |
+| `random` / `binary` | 1.00x | 1.00x | 1.00x |
+
+A JSON body has to stay inside a JSON string, so it is drawn from a 62-character alphabet. That is
+invisible to `lz4` and `snappy`, neither of which entropy-codes, but not to `zstd`, which
+`magma_data_compression_algo` can be set to. Binary bodies are drawn from the full byte range and
+hold at 1.00x whichever algorithm is configured.
+
+To load 100 million documents of exactly 1024 bytes:
+
+```
+cbc pillowfight --bucket-name default \
+    --document-body-size 1024 \
+    --document-body-fill random \
+    --document-body-format binary \
+    --number-of-keys-to-populate 100000000 \
+    --operations-limit 1
+```
+
+`--operations-limit 1` ends the workload phase at the first completed batch, so the run is the
+load and little else. `--document-body-format=binary` makes `--document-body-size` the exact size
+of the stored document; under `json` the body is wrapped in an object and the document is larger
+than the value given. Binary documents are opaque to the Query service, so `--operation-ratio`
+should not ask for queries alongside it.
+
+`--document-body-pool-size` bounds the work spent per document by pre-generating bodies and
+cycling them. It is rarely worth setting: generating a fresh body costs a fraction of a
+microsecond, far less than the operation carrying it. When it is set, it is measured in **bytes**,
+not documents, because what has to be defeated is the compressor's look-back distance — a distance
+in bytes, which a document count does not describe. A pool smaller than that distance puts the
+same body into one block twice and the documents compress again, silently and by a large factor.
+That is why the option refuses a pool below 1 MiB rather than warning about it.
 
 ### LOGGER OPTIONS
 

--- a/test/tools/document_body_generator.cxx
+++ b/test/tools/document_body_generator.cxx
@@ -1,0 +1,188 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "test/framework/test_framework.hxx"
+
+#include "core/utils/json.hxx"
+#include "tools/document_body_generator.hxx"
+
+#include <cstddef>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace couchbase::test
+{
+namespace
+{
+constexpr std::size_t document_size{ 256 };
+constexpr std::size_t sample{ 500 };
+constexpr std::uint64_t seed{ 1234 };
+
+auto
+collect(cbc::document_body_generator& generator, std::size_t count)
+  -> std::vector<std::vector<std::byte>>
+{
+  std::vector<std::vector<std::byte>> bodies;
+  bodies.reserve(count);
+  for (std::size_t i = 0; i < count; ++i) {
+    bodies.push_back(generator.next());
+  }
+  return bodies;
+}
+
+auto
+distinct(const std::vector<std::vector<std::byte>>& bodies) -> std::size_t
+{
+  return std::set<std::vector<std::byte>>{ bodies.begin(), bodies.end() }.size();
+}
+
+void
+random_document_bodies_are_distinct()
+{
+  // The defect this guards: a body generated once and reused makes every
+  // document identical, and the storage engine then compresses a block of them
+  // to a fraction of its size however random a single body looks.
+  for (auto format : { cbc::body_format::json, cbc::body_format::binary }) {
+    cbc::document_body_generator generator{
+      cbc::body_fill::random, format, document_size, 0, seed,
+    };
+
+    assert_eq(distinct(collect(generator, sample)), sample, "bodies repeated within one worker");
+  }
+}
+
+void
+a_constant_fill_repeats_one_body()
+{
+  cbc::document_body_generator generator{
+    cbc::body_fill::constant, cbc::body_format::binary, document_size, 0, seed,
+  };
+
+  assert_eq(distinct(collect(generator, sample)), std::size_t{ 1 });
+}
+
+void
+a_binary_body_is_exactly_the_requested_size()
+{
+  for (auto fill : { cbc::body_fill::constant, cbc::body_fill::random }) {
+    cbc::document_body_generator generator{
+      fill, cbc::body_format::binary, document_size, 0, seed,
+    };
+
+    for (const auto& body : collect(generator, 16)) {
+      assert_eq(body.size(), document_size);
+    }
+  }
+}
+
+void
+a_random_json_body_parses_and_keeps_its_requested_length()
+{
+  cbc::document_body_generator generator{
+    cbc::body_fill::random, cbc::body_format::json, document_size, 0, seed,
+  };
+
+  for (const auto& body : collect(generator, 16)) {
+    auto parsed = couchbase::core::utils::json::parse_binary(body);
+    assert_eq(parsed["size"].get_unsigned(), static_cast<std::uint64_t>(document_size));
+    const auto& text = parsed["text"].get_string();
+    assert_eq(text.size(), document_size);
+    assert_eq(
+      text.find_first_not_of("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"),
+      std::string::npos,
+      "a JSON body carried a character outside the JSON-safe alphabet");
+  }
+}
+
+void
+a_seed_reproduces_a_dataset_and_a_different_seed_does_not()
+{
+  const auto make = [](std::uint64_t value) {
+    cbc::document_body_generator generator{
+      cbc::body_fill::random, cbc::body_format::binary, document_size, 0, value,
+    };
+    return collect(generator, 32);
+  };
+
+  assert_true(make(7) == make(7), "the same seed produced a different sequence");
+
+  // Worker threads offset a shared seed by their index, so neighbouring seeds
+  // are the case that must not collide.
+  assert_false(make(7) == make(8), "neighbouring seeds produced the same sequence");
+}
+
+void
+a_pool_holds_distinct_bodies_and_cycles_through_them()
+{
+  constexpr std::size_t pooled{ 8 };
+
+  cbc::document_body_generator generator{
+    cbc::body_fill::random, cbc::body_format::binary, document_size, document_size * pooled, seed,
+  };
+  assert_eq(generator.pooled_documents(), pooled);
+
+  const auto first = collect(generator, pooled);
+  assert_eq(distinct(first), pooled, "the pool holds duplicate bodies");
+
+  // Cycled, not sampled: a pool drawn from at random repeats bodies inside a
+  // single storage block long before it is exhausted.
+  assert_true(collect(generator, pooled) == first, "the pool did not cycle in order");
+}
+
+void
+a_zero_document_size_yields_the_predefined_document()
+{
+  const auto predefined = couchbase::core::utils::to_binary(R"({"type":"fake_profile"})");
+
+  cbc::document_body_generator generator{
+    cbc::body_fill::random, cbc::body_format::json, 0, 0, seed, predefined,
+  };
+
+  for (const auto& body : collect(generator, 4)) {
+    assert_true(body == predefined, "a zero size did not yield the predefined document");
+  }
+}
+} // namespace
+
+auto
+tests() -> test_suite
+{
+  return {
+    "tools_document_body_generator",
+    {
+      { "random_document_bodies_are_distinct", random_document_bodies_are_distinct, timeout::fast },
+      { "a_constant_fill_repeats_one_body", a_constant_fill_repeats_one_body, timeout::instant },
+      { "a_binary_body_is_exactly_the_requested_size",
+        a_binary_body_is_exactly_the_requested_size,
+        timeout::instant },
+      { "a_random_json_body_parses_and_keeps_its_requested_length",
+        a_random_json_body_parses_and_keeps_its_requested_length,
+        timeout::instant },
+      { "a_seed_reproduces_a_dataset_and_a_different_seed_does_not",
+        a_seed_reproduces_a_dataset_and_a_different_seed_does_not,
+        timeout::instant },
+      { "a_pool_holds_distinct_bodies_and_cycles_through_them",
+        a_pool_holds_distinct_bodies_and_cycles_through_them,
+        timeout::instant },
+      { "a_zero_document_size_yields_the_predefined_document",
+        a_zero_document_size_yields_the_predefined_document,
+        timeout::instant },
+    },
+  };
+}
+} // namespace couchbase::test

--- a/tools/document_body_generator.hxx
+++ b/tools/document_body_generator.hxx
@@ -1,0 +1,232 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2026-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#pragma once
+
+#include "core/utils/binary.hxx"
+#include "core/utils/json.hxx"
+
+#include <tao/json.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <random>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace cbc
+{
+enum class body_fill : std::uint8_t {
+  constant, // every document repeats one filler character
+  random,   // a seeded Mersenne Twister
+};
+
+enum class body_format : std::uint8_t {
+  json,   // a JSON object, so the body is restricted to a JSON-safe alphabet
+  binary, // opaque bytes of exactly the requested size
+};
+
+inline auto
+parse_body_fill(const std::string& name) -> body_fill
+{
+  if (name == "random") {
+    return body_fill::random;
+  }
+  return body_fill::constant;
+}
+
+inline auto
+parse_body_format(const std::string& name) -> body_format
+{
+  if (name == "binary") {
+    return body_format::binary;
+  }
+  return body_format::json;
+}
+
+/**
+ * Source of document bodies for one worker thread.
+ *
+ * A random fill has to give every document distinct bytes. The storage engine
+ * compresses a whole data block at once, so a body reused across documents is
+ * stored once and back-referenced for the rest of the block: a bucket loaded
+ * that way reports several times the compression its documents earn
+ * individually, and its disk footprint stops following from the number of
+ * documents written.
+ */
+class document_body_generator
+{
+public:
+  /**
+   * @param predefined used for every document when @p document_size is zero
+   */
+  document_body_generator(body_fill fill,
+                          body_format format,
+                          std::size_t document_size,
+                          std::size_t pool_size,
+                          std::uint64_t seed,
+                          std::vector<std::byte> predefined = {})
+    : fill_{ fill }
+    , format_{ format }
+    , document_size_{ document_size }
+    , generator_{ seed }
+  {
+    if (document_size_ == 0) {
+      pool_.push_back(std::move(predefined));
+      return;
+    }
+    if (fill_ == body_fill::constant) {
+      pool_.push_back(render(std::string(document_size_, constant_filler)));
+      return;
+    }
+    for (std::size_t generated = 0; generated + document_size_ <= pool_size;
+         generated += document_size_) {
+      pool_.push_back(generate());
+    }
+  }
+
+  /**
+   * The next body. It stays valid until the following call.
+   */
+  [[nodiscard]] auto next() -> const std::vector<std::byte>&
+  {
+    if (pool_.empty()) {
+      current_ = generate();
+      return current_;
+    }
+    const auto& body = pool_[cursor_];
+    cursor_ = (cursor_ + 1) % pool_.size();
+    return body;
+  }
+
+  /**
+   * How many distinct bodies this generator cycles through, or zero when it
+   * generates a fresh one for every document.
+   */
+  [[nodiscard]] auto pooled_documents() const -> std::size_t
+  {
+    return pool_.size();
+  }
+
+  [[nodiscard]] auto binary() const -> bool
+  {
+    return format_ == body_format::binary;
+  }
+
+private:
+  static constexpr char constant_filler{ 'x' };
+  static constexpr std::size_t entropy_buffer_size{ 64 * 1024 };
+  static constexpr std::string_view alphabet{
+    "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+  };
+
+  [[nodiscard]] auto generate() -> std::vector<std::byte>
+  {
+    if (format_ == body_format::binary) {
+      std::vector<std::byte> body(document_size_);
+      fill(body.data(), body.size());
+      return body;
+    }
+    return render(random_text());
+  }
+
+  [[nodiscard]] auto render(std::string text) const -> std::vector<std::byte>
+  {
+    if (format_ == body_format::binary) {
+      return couchbase::core::utils::to_binary(text);
+    }
+    return couchbase::core::utils::json::generate_binary({
+      { "size", document_size_ },
+      { "text", std::move(text) },
+    });
+  }
+
+  [[nodiscard]] auto random_text() -> std::string
+  {
+    // The largest multiple of the alphabet size that fits in a byte. Folding the
+    // whole byte range onto the alphabet would over-represent its first eight
+    // symbols.
+    static constexpr std::uint8_t unbiased_limit{ 248 };
+    static_assert(unbiased_limit % alphabet.size() == 0);
+
+    std::string text(document_size_, constant_filler);
+    for (auto& symbol : text) {
+      std::uint8_t byte{ 0 };
+      do {
+        byte = next_byte();
+      } while (byte >= unbiased_limit);
+      symbol = alphabet[byte % alphabet.size()];
+    }
+    return text;
+  }
+
+  [[nodiscard]] auto next_byte() -> std::uint8_t
+  {
+    if (entropy_cursor_ == entropy_.size()) {
+      refill();
+    }
+    return static_cast<std::uint8_t>(entropy_[entropy_cursor_++]);
+  }
+
+  /**
+   * Copy @p size random bytes out of the buffer, refilling it as it runs dry, so
+   * that the generator is stepped in bulk rather than once per byte consumed.
+   */
+  void fill(std::byte* out, std::size_t size)
+  {
+    while (size > 0) {
+      if (entropy_cursor_ == entropy_.size()) {
+        refill();
+      }
+      const auto chunk = std::min(size, entropy_.size() - entropy_cursor_);
+      std::memcpy(out, entropy_.data() + entropy_cursor_, chunk);
+      entropy_cursor_ += chunk;
+      out += chunk;
+      size -= chunk;
+    }
+  }
+
+  void refill()
+  {
+    std::size_t offset{ 0 };
+    for (; offset + sizeof(std::uint64_t) <= entropy_.size(); offset += sizeof(std::uint64_t)) {
+      const auto word = generator_();
+      std::memcpy(entropy_.data() + offset, &word, sizeof(word));
+    }
+    if (offset < entropy_.size()) {
+      const auto word = generator_();
+      std::memcpy(entropy_.data() + offset, &word, entropy_.size() - offset);
+    }
+    entropy_cursor_ = 0;
+  }
+
+  body_fill fill_;
+  body_format format_;
+  std::size_t document_size_;
+  std::mt19937_64 generator_;
+
+  std::vector<std::vector<std::byte>> pool_{};
+  std::size_t cursor_{ 0 };
+  std::vector<std::byte> current_{};
+
+  std::vector<std::byte> entropy_ = std::vector<std::byte>(entropy_buffer_size);
+  std::size_t entropy_cursor_{ entropy_buffer_size };
+};
+} // namespace cbc

--- a/tools/pillowfight.cxx
+++ b/tools/pillowfight.cxx
@@ -17,6 +17,8 @@
 
 #include "pillowfight.hxx"
 
+#include "document_body_generator.hxx"
+
 #include "core/utils/json.hxx"
 #include "utils.hxx"
 
@@ -39,10 +41,13 @@
 #include <couchbase/fmt/error.hxx>
 
 #include <csignal>
+#include <cstring>
 #include <deque>
 #include <memory>
 #include <numeric>
 #include <random>
+#include <stdexcept>
+#include <string_view>
 #include <thread>
 
 namespace cbc
@@ -155,6 +160,23 @@ constexpr const char* default_query_statement{
 };
 constexpr operation_weights default_operation_ratio{};
 constexpr std::size_t default_document_body_size{ 0 };
+constexpr const char* default_document_body_fill{ "constant" };
+constexpr const char* default_document_body_format{ "json" };
+constexpr std::size_t default_document_body_pool_size{ 0 };
+
+/*
+ * A pool smaller than the storage compressor's look-back distance puts the same
+ * body into one data block twice, which is the duplication a random fill exists
+ * to remove. Measured over a cycled pool of distinct bodies, snappy stops
+ * matching once the pool exceeds 16 KiB and lz4 once it exceeds 64 KiB; magma
+ * takes its algorithm from magma_data_compression_algo, which is dynamic and
+ * accepts zstd, and zstd still matches across roughly a megabyte.
+ */
+constexpr std::size_t minimum_document_body_pool_size{ 1024 * 1024 };
+constexpr std::size_t minimum_pooled_documents{ 2 };
+
+const std::vector<std::string> allowed_document_body_fills{ "constant", "random" };
+const std::vector<std::string> allowed_document_body_formats{ "json", "binary" };
 constexpr std::size_t default_operations_limit{ 0 };
 constexpr std::size_t default_operation_batch_size{ 100 };
 constexpr std::chrono::milliseconds default_batch_wait{ 0 };
@@ -293,16 +315,28 @@ uniq_id(const std::string& prefix) -> std::string
 }
 
 auto
-random_text(std::size_t length) -> std::string
+upsert_document(const couchbase::collection& collection,
+                const std::string& document_id,
+                const std::vector<std::byte>& body,
+                bool binary) -> std::future<std::pair<couchbase::error, couchbase::mutation_result>>
 {
-  std::string alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-  static thread_local std::mt19937_64 gen{ std::random_device()() };
-  std::uniform_int_distribution<std::size_t> dis(0, alphabet.size() - 1);
-  std::string text(length, '-');
-  for (std::size_t i = 0; i < length; ++i) {
-    text[i] = alphabet[dis(gen)];
+  if (binary) {
+    return collection.upsert<couchbase::codec::raw_binary_transcoder>(document_id, body);
   }
-  return text;
+  return collection.upsert<raw_json_transcoder>(document_id, body);
+}
+
+auto
+replace_document(const couchbase::collection& collection,
+                 const std::string& document_id,
+                 const std::vector<std::byte>& body,
+                 bool binary)
+  -> std::future<std::pair<couchbase::error, couchbase::mutation_result>>
+{
+  if (binary) {
+    return collection.replace<couchbase::codec::raw_binary_transcoder>(document_id, body);
+  }
+  return collection.replace<raw_json_transcoder>(document_id, body);
 }
 
 class pillowfight_app : public CLI::App
@@ -319,10 +353,33 @@ public:
                document_body_size_,
                "Size of the body (if zero, it will use predefined document).")
       ->default_val(default_document_body_size);
-    add_flag("--incompressible-body",
-             incompressible_body_,
-             "Use random characters to fill generated document value (by default uses 'x' to fill "
-             "the body).");
+    add_option("--document-body-fill",
+               document_body_fill_,
+               "How to fill a generated document body: \"constant\" repeats a single character, "
+               "\"random\" draws every document from a seeded pseudo-random generator. Only "
+               "\"random\" gives each document distinct bytes, which is what stops a loaded "
+               "bucket from compressing.")
+      ->default_val(default_document_body_fill)
+      ->transform(CLI::IsMember(allowed_document_body_fills));
+    add_option("--document-body-format",
+               document_body_format_,
+               "Format of a generated document: \"json\" wraps the body in a JSON object and "
+               "restricts it to a JSON-safe alphabet, \"binary\" stores the body as opaque bytes "
+               "of exactly --document-body-size.")
+      ->default_val(default_document_body_format)
+      ->transform(CLI::IsMember(allowed_document_body_formats));
+    add_option("--document-body-pool-size",
+               document_body_pool_size_,
+               "Pre-generate this many bytes of document bodies per worker thread and cycle "
+               "through them, instead of generating a fresh body for every document (zero). A "
+               "pool has to be larger than the storage compressor's look-back distance or its "
+               "documents compress again, so it is measured in bytes and not in documents.")
+      ->default_val(default_document_body_pool_size);
+    add_option("--document-body-seed",
+               document_body_seed_,
+               "Seed for --document-body-fill=random, so that a dataset can be reproduced. Each "
+               "worker thread offsets it by its index. Without it the generator is seeded from "
+               "the system entropy source.");
     add_option("--number-of-io-threads", number_of_io_threads_, "Number of the IO threads.")
       ->default_val(default_number_of_io_threads);
     add_option("--number-of-keys-to-populate",
@@ -362,13 +419,14 @@ public:
 
     add_common_options(this, common_options_);
     allow_extras(true);
+
+    parse_complete_callback([this]() {
+      validate_options();
+    });
   }
 
   [[nodiscard]] auto execute() const -> int
   {
-    if (operation_batch_size_ == 0) {
-      throw CLI::ValidationError("--operation-batch-size cannot be zero");
-    }
     apply_logger_options(common_options_.logger);
 
     const auto cluster_options = build_cluster_options(common_options_);
@@ -399,11 +457,15 @@ public:
                "| Version: {}\n"
                "| Connection String: {}\n"
                "| Ratio: {} (Get:Replace:Delete:Insert:Query)\n"
-               "| Batch size: {}\n",
+               "| Batch size: {}\n"
+               "| Document body: {} {}, {}\n",
                couchbase::core::meta::sdk_semver(),
                connection_string,
                operation_generator::parse(operation_ratio_string_).to_string(),
-               operation_batch_size_);
+               operation_batch_size_,
+               document_body_fill_,
+               document_body_format_,
+               describe_document_body_size());
 
     auto [connect_err, cluster] =
       couchbase::cluster::connect(connection_string, cluster_options).get();
@@ -429,8 +491,8 @@ public:
     std::vector<std::thread> worker_pool{};
     worker_pool.reserve(number_of_worker_threads_);
     for (std::size_t i = 0; i < number_of_worker_threads_; ++i) {
-      worker_pool.emplace_back([this, cluster = cluster, &keys = known_keys[i]]() {
-        worker(cluster, keys);
+      worker_pool.emplace_back([this, cluster = cluster, &keys = known_keys[i], i]() {
+        worker(cluster, keys, i);
       });
     }
     for (auto& thread : worker_pool) {
@@ -482,21 +544,90 @@ public:
     return 0;
   }
 
-  [[nodiscard]] auto generate_document_body() const -> std::vector<std::byte>
+private:
+  void validate_options() const
   {
-    if (document_body_size_ > 0) {
-      return couchbase::core::utils::json::generate_binary({
-        { "size", document_body_size_ },
-        { "text",
-          incompressible_body_ ? random_text(document_body_size_)
-                               : std::string(document_body_size_, 'x') },
-      });
+    if (operation_batch_size_ == 0) {
+      throw CLI::ValidationError("--operation-batch-size cannot be zero");
     }
-    return couchbase::core::utils::to_binary(default_json_doc);
+
+    const auto fill = parse_body_fill(document_body_fill_);
+
+    if (fill != body_fill::constant && document_body_size_ == 0) {
+      throw CLI::ValidationError("--document-body-fill=" + document_body_fill_ +
+                                 " requires a non-zero --document-body-size; without a size the "
+                                 "predefined document is used and nothing is generated");
+    }
+    if (parse_body_format(document_body_format_) == body_format::binary &&
+        document_body_size_ == 0) {
+      throw CLI::ValidationError("--document-body-format=binary requires a non-zero "
+                                 "--document-body-size, because the predefined document is JSON");
+    }
+    if (document_body_pool_size_ == 0) {
+      return;
+    }
+    if (fill == body_fill::constant) {
+      throw CLI::ValidationError("--document-body-pool-size applies only to "
+                                 "--document-body-fill=random, which generates a body per "
+                                 "document; a constant fill has only one body to pool");
+    }
+    // Refused rather than warned about: an undersized pool fails silently, by
+    // producing exactly the compressible dataset the caller asked to avoid.
+    if (document_body_pool_size_ < minimum_document_body_pool_size) {
+      throw CLI::ValidationError(
+        fmt::format("--document-body-pool-size must be at least {} bytes, or the pooled bodies "
+                    "repeat within one storage block and compress; {} was given",
+                    minimum_document_body_pool_size,
+                    document_body_pool_size_));
+    }
+    if (document_body_pool_size_ / document_body_size_ < minimum_pooled_documents) {
+      throw CLI::ValidationError(
+        fmt::format("--document-body-pool-size of {} bytes holds fewer than {} documents of {} "
+                    "bytes; raise the pool or lower --document-body-size",
+                    document_body_pool_size_,
+                    minimum_pooled_documents,
+                    document_body_size_));
+    }
   }
 
-private:
-  void worker(couchbase::cluster connected_cluster, std::vector<std::string>& known_keys) const
+  [[nodiscard]] auto describe_document_body_size() const -> std::string
+  {
+    if (document_body_size_ == 0) {
+      return "predefined document";
+    }
+    if (document_body_pool_size_ == 0) {
+      return fmt::format("{} bytes, generated per document", document_body_size_);
+    }
+    return fmt::format(
+      "{} bytes, cycling a {}-byte pool per worker", document_body_size_, document_body_pool_size_);
+  }
+
+  [[nodiscard]] auto make_body_generator(std::size_t worker_index) const -> document_body_generator
+  {
+    return { parse_body_fill(document_body_fill_),
+             parse_body_format(document_body_format_),
+             document_body_size_,
+             document_body_pool_size_,
+             seed_for_worker(worker_index),
+             couchbase::core::utils::to_binary(default_json_doc) };
+  }
+
+  /**
+   * Worker threads must not share a seed. Sharing one makes every thread emit
+   * the same sequence of bodies, and documents that differ only by which thread
+   * wrote them still meet in the same storage block.
+   */
+  [[nodiscard]] auto seed_for_worker(std::size_t worker_index) const -> std::uint64_t
+  {
+    if (count("--document-body-seed") > 0) {
+      return document_body_seed_ + worker_index;
+    }
+    return std::random_device{}();
+  }
+
+  void worker(couchbase::cluster connected_cluster,
+              std::vector<std::string>& known_keys,
+              std::size_t worker_index) const
   {
     auto cluster = std::move(connected_cluster);
 
@@ -505,7 +636,7 @@ private:
 
     auto collection = cluster.bucket(bucket_name_).scope(scope_name_).collection(collection_name_);
 
-    std::vector<std::byte> json_doc = generate_document_body();
+    auto body = make_body_generator(worker_index);
     auto query_statement{ fmt::format(query_statement_, fmt::arg("bucket_name", bucket_name_)) };
 
     bool stopping{ false };
@@ -531,16 +662,18 @@ private:
             futures.emplace_back(std::chrono::system_clock::now(), collection.get(document_id));
             break;
           case operation::cmd_replace:
-            futures.emplace_back(std::chrono::system_clock::now(),
-                                 collection.replace<raw_json_transcoder>(document_id, json_doc));
+            futures.emplace_back(
+              std::chrono::system_clock::now(),
+              replace_document(collection, document_id, body.next(), body.binary()));
             break;
           case operation::cmd_delete:
             futures.emplace_back(std::chrono::system_clock::now(), collection.remove(document_id));
             break;
           case operation::cmd_insert:
             known_keys.push_back(document_id);
-            futures.emplace_back(std::chrono::system_clock::now(),
-                                 collection.replace<raw_json_transcoder>(document_id, json_doc));
+            futures.emplace_back(
+              std::chrono::system_clock::now(),
+              replace_document(collection, document_id, body.next(), body.binary()));
             break;
           case operation::cmd_query:
             futures.emplace_back(std::chrono::system_clock::now(),
@@ -591,7 +724,6 @@ private:
 
     auto collection = cluster.bucket(bucket_name_).scope(scope_name_).collection(collection_name_);
 
-    const auto json_doc = generate_document_body();
     const auto start_time = std::chrono::system_clock::now();
 
     constexpr std::size_t minimum_batch_size{ 10 };
@@ -599,6 +731,7 @@ private:
     std::size_t retried_keys{ 0 };
     for (std::size_t i = 0; i < number_of_worker_threads_; ++i) {
       auto keys_left = number_of_keys_to_populate_;
+      auto body = make_body_generator(i);
 
       while (keys_left > 0) {
         fmt::print(stderr,
@@ -617,8 +750,8 @@ private:
         futures.reserve(batch_size);
         for (std::size_t k = 0; k < batch_size; ++k) {
           const std::string document_id = uniq_id("id");
-          futures.emplace_back(document_id,
-                               collection.upsert<raw_json_transcoder>(document_id, json_doc));
+          futures.emplace_back(
+            document_id, upsert_document(collection, document_id, body.next(), body.binary()));
         }
 
         for (auto&& [document_id, future] : futures) {
@@ -657,7 +790,10 @@ private:
   std::size_t number_of_keys_to_populate_{};
   std::string operation_ratio_string_{ default_operation_ratio.to_string() };
   std::string query_statement_;
-  bool incompressible_body_{};
+  std::string document_body_fill_{ default_document_body_fill };
+  std::string document_body_format_{ default_document_body_format };
+  std::size_t document_body_pool_size_{ default_document_body_pool_size };
+  std::uint64_t document_body_seed_{ 0 };
   std::size_t document_body_size_{};
   std::size_t operations_limit_{};
 };

--- a/tools/pillowfight.cxx
+++ b/tools/pillowfight.cxx
@@ -327,6 +327,18 @@ upsert_document(const couchbase::collection& collection,
 }
 
 auto
+insert_document(const couchbase::collection& collection,
+                const std::string& document_id,
+                const std::vector<std::byte>& body,
+                bool binary) -> std::future<std::pair<couchbase::error, couchbase::mutation_result>>
+{
+  if (binary) {
+    return collection.insert<couchbase::codec::raw_binary_transcoder>(document_id, body);
+  }
+  return collection.insert<raw_json_transcoder>(document_id, body);
+}
+
+auto
 replace_document(const couchbase::collection& collection,
                  const std::string& document_id,
                  const std::vector<std::byte>& body,
@@ -673,7 +685,7 @@ private:
             known_keys.push_back(document_id);
             futures.emplace_back(
               std::chrono::system_clock::now(),
-              replace_document(collection, document_id, body.next(), body.binary()));
+              insert_document(collection, document_id, body.next(), body.binary()));
             break;
           case operation::cmd_query:
             futures.emplace_back(std::chrono::system_clock::now(),


### PR DESCRIPTION
Motivation
----------
--incompressible-body did not produce incompressible documents. It filled one body per worker thread, and one for the whole populate phase, so every document written carried identical bytes. Magma compresses a whole 4096-byte data block with lz4, which stores one copy of a repeated body and back-references the rest, so the flag measured 3.82x block compression where distinct bodies measure 1.00x. The alphabet it drew from was beside the point: neither lz4 nor snappy entropy-codes, and snappy already declined these bodies individually -- 1024 bytes in, 1029 out, against a min_compression_ratio of 1.2.

A load whose footprint does not follow from the number of documents cannot be used to size a dataset, which is what the option was for.

Modifications
-------------
document_body_generator produces a fresh body per document. --document-body-fill selects a constant character or a seeded Mersenne Twister; --document-body-format selects a JSON object, restricted to a JSON-safe alphabet, or opaque bytes stored through the raw binary transcoder. Under binary, --document-body-size is the exact size of the stored document rather than the size of a field inside it, and the body is drawn from the full byte range, so it stays incompressible under zstd as well. A JSON body's alphabet costs 1.33x there, and nothing under the configured default.

--document-body-pool-size pre-generates bodies and cycles them. It is measured in bytes because what it has to exceed is the compressor's look-back distance, not a document count: that threshold held at 16 KiB for snappy and 64 KiB for lz4 across document sizes from 256 B to 4 KiB, and zstd needs about 1 MiB. A pool below 1 MiB is refused rather than warned about, because its failure mode is to silently restore the defect above. The pool is cycled and not sampled, since sampling repeats bodies within a block by birthday collision.

Worker threads offset a shared --document-body-seed by their index. Threads sharing a seed emit the same sequence, and documents differing only by their writer still meet in one block.

The generator draws from the standard library rather than a cryptographic source. Over 4 MiB of blocks the two are indistinguishable to lz4, snappy and zstd alike, and the standard library one can be seeded, so a dataset is reproducible.

Option validation moves to a parse-complete callback. A ValidationError is a ParseError, so raised there it reaches the usage handler and exits 105; raised from execute() it was an ordinary exception, which a debug build deliberately does not catch, so a rejected combination aborted instead of reporting itself. The pre-existing --operation-batch-size check moves with it.

--incompressible-body is removed rather than aliased. It was a flag whose documented behaviour it did not implement, and an alias would leave two overlapping options.

Results
-------
Measured over the generator's own output in 4096-byte blocks, a random fill holds at 1.00x under lz4 and snappy in both formats, and under zstd for binary.

test/tools/document_body_generator covers distinctness in both formats, exact binary sizing, JSON validity, seed reproducibility across neighbouring seeds, pool cycling, and the predefined-document path; restoring either defect fails it. It is written against the test framework rather than Catch2, and is the first suite outside that framework's own selftest to use it.

The change has not been run against a live bucket.

---

**CXXCBC-920: insert the documents the insert operation generates**

Motivation
----------
The insert arm of --operation-ratio calls replace against a document id it has just generated, so every operation it weights fails with document_not_found. Weighting inserts produces errors and no documents.

Modifications
-------------
The arm calls insert. Its sibling helpers upsert_document and replace_document gain insert_document alongside them, so the transcoder choice stays in one place for all three.

The id is still recorded before the operation completes, so a failed insert leaves an id in the worker's key list that was never written. Correcting that needs the completion handler to know which id it carried, and the batch loop erases the operation's type before it gets there; it is left alone rather than reshaped here.

Results
-------
An insert-weighted ratio writes documents rather than accumulating document_not_found. No regression test accompanies this: the operation arms dispatch inside worker(), which needs a live cluster, and the tools have no integration harness to hang one on.

---

Ticket: [CXXCBC-920](https://jira.issues.couchbase.com/browse/CXXCBC-920)


[CXXCBC-920]: https://couchbasecloud.atlassian.net/browse/CXXCBC-920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ