### PR TITLE
CXXCBC-882: Handle Query Error 2120

### DIFF
--- a/core/operations/management/error_utils.cxx
+++ b/core/operations/management/error_utils.cxx
@@ -59,6 +59,7 @@ extract_common_query_error_code(std::uint64_t code, const std::string& message)
 
     case 13014: /* ICode: E_DATASTORE_INSUFFICIENT_CREDENTIALS, IKey:
                    "datastore.couchbase.insufficient_credentials" */
+    case 2120:  /* ICode: E_ADMIN_AUTH, IKey: "admin.clustering.authorize" */
       return errc::common::authentication_failure;
 
     case 5000:

--- a/test/test_integration_connect.cxx
+++ b/test/test_integration_connect.cxx
@@ -291,7 +291,7 @@ TEST_CASE("integration: query after changing to incorrect credentials", "[integr
   session_mgr->close();
   auto resp = test::utils::execute(integration.cluster, req);
 
-  REQUIRE(resp.ctx.ec == couchbase::errc::common::internal_server_failure);
+  REQUIRE(resp.ctx.ec == couchbase::errc::common::authentication_failure);
 }
 
 TEST_CASE("integration: cluster::find_bucket_by_name returns nullptr for unknown bucket",

--- a/test/test_unit_response_parsing.cxx
+++ b/test/test_unit_response_parsing.cxx
@@ -78,6 +78,8 @@ TEST_CASE("unit: map_query_error classifies N1QL error codes", "[unit]")
   REQUIRE(ops::map_query_error(make("fatal", 3000)) == couchbase::errc::common::parsing_failure);
   REQUIRE(ops::map_query_error(make("fatal", 4040)) ==
           couchbase::errc::query::prepared_statement_failure);
+  REQUIRE(ops::map_query_error(make("fatal", 2120)) ==
+          couchbase::errc::common::authentication_failure);
   // Non-success status without an errors block falls back to internal_server_failure.
   REQUIRE(ops::map_query_error(make("fatal", 0)) ==
           couchbase::errc::common::internal_server_failure);

--- a/tools/fit_performer/CMakeLists.txt
+++ b/tools/fit_performer/CMakeLists.txt
@@ -37,7 +37,7 @@ cpmaddpackage(
   GITHUB_REPOSITORY
   "couchbaselabs/fit-protocol"
   GIT_TAG
-  d7fb6ede7ee0f39cc39294b67d5b180674d61449
+  3d5daf4b01a53be0d31bff96353755973401fe51
   DOWNLOAD_ONLY
   YES)
 

--- a/tools/fit_performer/src/service.cxx
+++ b/tools/fit_performer/src/service.cxx
@@ -1570,6 +1570,7 @@ TxnService::performerCapsFetch(grpc::ServerContext* /*context*/,
   response->add_sdk_implementation_caps(protocol::sdk::Caps::WAIT_UNTIL_READY);
   response->add_sdk_implementation_caps(protocol::sdk::Caps::SDK_KV);
   response->add_sdk_implementation_caps(protocol::sdk::Caps::SDK_QUERY);
+  response->add_sdk_implementation_caps(protocol::sdk::Caps::SDK_QUERY_2120);
   response->add_sdk_implementation_caps(protocol::sdk::Caps::SDK_LOOKUP_IN);
   response->add_sdk_implementation_caps(protocol::sdk::Caps::SDK_QUERY_INDEX_MANAGEMENT);
   response->add_sdk_implementation_caps(protocol::sdk::Caps::SDK_BUCKET_MANAGEMENT);


### PR DESCRIPTION

## Changes
* Map query error code 2120, to `authentication_failure`, as per revision 21 of the Error Handling RFC https://github.com/couchbaselabs/sdk-rfcs/commit/18bfefdc82c2b20aa36094c798c4efa731fd4710)
* Declare SDK_QUERY_2120 cap in the performer

## Results
Relevant FIT test passes (`QuerySimulatedErrorCodeTest.handleError2120`)
