### PR TITLE
[Backport] CXXCBC-912: fix use-after-free in the forked child and collateral damage to the parent (#1056)

### DIFF
--- a/core/impl/public_cluster.cxx
+++ b/core/impl/public_cluster.cxx
@@ -65,6 +65,8 @@
 #include <asio/execution_context.hpp>
 #include <asio/post.hpp>
 
+#include <gsl/assert>
+
 #include <functional>
 #include <future>
 #include <memory>
@@ -414,19 +416,110 @@ public:
 
   void notify_fork(fork_event event)
   {
+    // asio requires notify_fork() to run with no thread inside io_context::run():
+    //
+    //   "This function must not be called while any other execution_context
+    //    function, or any function on an I/O object associated with the
+    //    execution_context, is being called in another thread."
+    //                                       -- asio/execution_context.hpp
+    //
+    // That is not a formality for fork_child: epoll_reactor::notify_fork() closes
+    // and recreates epoll_fd_, timer_fd_ and the interrupter, then rewrites every
+    // descriptor registration. Running it against a live reactor makes the IO
+    // thread epoll_wait() on a descriptor another thread is closing, and then
+    // dereference whatever epoll reports as a descriptor_state.
+    //
+    // So the fixup goes in the window where the IO thread is not running: after
+    // the join in fork_prepare, and before the restart that starts the new one.
     if (event == fork_event::prepare) {
+      // Quiesce the transactions cleanup threads BEFORE stopping the io_context.
+      // transactions_cleanup::stop() joins workers that may be blocking on a KV
+      // operation, and only the IO thread can complete those -- so stopping the
+      // io_context first can leave that join waiting forever.
+      if (transactions_) {
+        transactions_->notify_fork(event);
+      }
       io_.stop();
-      io_thread_.join();
+      // Guarded like do_close() below, and for the same reason: close() already
+      // stopped the io_context and joined this thread, so a notify_fork(prepare)
+      // afterwards has nothing left to join -- and join() on a thread that is not
+      // joinable throws std::system_error, out of a void public API.
+      if (io_thread_.joinable()) {
+        io_thread_.join();
+      }
+    }
+
+    // Our own IO thread is gone at this point, checkable in program order
+    // rather than only by a sanitizer: fork_prepare has just joined it, and
+    // fork_child/fork_parent inherit an already-joined one, because prepare runs
+    // before fork() and only the forking thread survives into the child. If a
+    // later change moves the restart back above this line, this fires
+    // immediately instead of turning into an intermittent use-after-free.
+    //
+    // The transactions cleanup threads were stopped above, before io_.stop(), so
+    // by here the only threads this cluster owned are gone.
+    Expects(!io_thread_.joinable());
+
+    if (event == fork_event::prepare) {
+      try {
+        io_.notify_fork(fork_event_to_asio(event));
+      } catch (...) {
+        // Undo everything this prepare did, then report. Returning stopped and threadless
+        // would hang ~cluster_impl, which waits on a completion only the IO thread can
+        // deliver -- the same hazard as the fork_child/fork_parent path below. The fork
+        // must not go ahead, but the cluster stays usable and destructible.
+        //
+        // The io_context comes back first: restarting cleanup spawns workers that issue KV
+        // operations, and only the IO thread completes those. Restoring cleanup matters as
+        // much as restoring the thread -- it was stopped above, and leaving it stopped
+        // would silently disable lost-attempts cleanup for the rest of the process while
+        // this function claimed the cluster was fine.
+        //
+        // Note for the caller: do not try to compensate by calling notify_fork(parent)
+        // after this throws. Prepare has already been undone here, and that call would
+        // find a restarted IO thread and trip the precondition above.
+        io_.restart();
+        io_thread_ = std::thread{ [&io = io_] {
+          io.run();
+        } };
+        if (transactions_) {
+          transactions_->notify_fork(fork_event::parent);
+        }
+        throw;
+      }
     } else {
-      // TODO(SA): close all sockets in fork_event::child
+      // TODO(CXXCBC-913): disown this cluster's sockets here, instead of leaving it to the
+      // reconnect. epoll_reactor::notify_fork(fork_child) below re-registers every
+      // descriptor inherited from the parent into the child's new epoll instance, so
+      // from here until those sockets are closed the child polls file descriptions the
+      // parent is still using. Closing them is at least no longer destructive -- see
+      // stream_impl::close(), which detaches a socket it did not open rather than
+      // shutting it down -- but it happens on the reconnect path, asynchronously, and
+      // only once the replaced impl is destroyed.
       io_.restart();
+      try {
+        io_.notify_fork(fork_event_to_asio(event));
+      } catch (...) {
+        // notify_fork() throws if re-registering a descriptor with the new
+        // epoll instance fails. The io_context is unusable after that (asio says
+        // to destroy it), but destruction itself needs a runner: do_close()
+        // waits on a completion only the IO thread can deliver, so returning
+        // from here stopped and threadless would hang ~cluster_impl instead of
+        // surfacing the failure.
+        io_thread_ = std::thread{ [&io = io_] {
+          io.run();
+        } };
+        throw;
+      }
       io_thread_ = std::thread{ [&io = io_] {
         io.run();
       } };
     }
-    io_.notify_fork(fork_event_to_asio(event));
 
-    if (event != fork_event::child && transactions_) {
+    // prepare was handled above, before the io_context was stopped. The child does
+    // not restart cleanup on this impl: it is about to be replaced, and the
+    // replacement starts its own.
+    if (event == fork_event::parent && transactions_) {
       transactions_->notify_fork(event);
     }
   }
@@ -640,6 +733,16 @@ cluster::connect(const std::string& connection_string,
 auto
 cluster::notify_fork(fork_event event) -> void
 {
+#if defined(_WIN32)
+  // No fork(2) on Windows, so there is nothing to prepare for or recover from.
+  // The function stays part of the API on every platform -- callers, the wrapper
+  // SDKs especially, should not have to compile differently per platform -- but
+  // here it does nothing. Doing the POSIX work instead would stop and restart the
+  // io_context and re-bootstrap the cluster for no reason, and asio's IOCP
+  // backend has no notify_fork to apply either.
+  (void)event;
+  return;
+#else
   if (!impl_) {
     return;
   }
@@ -659,14 +762,24 @@ cluster::notify_fork(fork_event event) -> void
       if (err.ec()) {
         // TODO(SA): we should fall to background reconnect loop similar to Columnar build
         CB_LOG_ERROR("Unable to reconnect instance after fork: {}", err.ec().message());
-        return;
       }
+      // Adopt the new impl either way. Leaving impl_ null on failure turned the
+      // child's next operation into a segfault, because every data-plane method
+      // dereferences impl_ unchecked; an impl that failed to open reports
+      // errc::network::cluster_closed instead, which is what a caller already gets
+      // from a handle it acquired before the fork.
       impl_ = new_impl;
+      // Always fulfill the barrier. Returning early here used to hang this
+      // function forever: `barrier` is still owned by the enclosing scope below,
+      // so the promise is never destroyed and future.get() never sees a
+      // broken_promise either -- a failed post-fork reconnect just wedged the
+      // caller.
       barrier->set_value();
     });
 
     future.get();
   }
+#endif
 }
 
 void

--- a/core/io/streams.cxx
+++ b/core/io/streams.cxx
@@ -23,12 +23,128 @@
 #include <asio/error.hpp>
 #include <asio/ssl.hpp>
 
+#include <cerrno>
+
+#if defined(_WIN32)
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
 namespace couchbase::core::io
 {
+namespace
+{
+auto
+current_process_id() -> long long
+{
+#if defined(_WIN32)
+  return static_cast<long long>(::_getpid());
+#else
+  return static_cast<long long>(::getpid());
+#endif
+}
+
+/**
+ * Release a socket this process inherited across fork(2), without disturbing the
+ * connection the parent is still using.
+ *
+ * Two things differ from the ordinary close path, and both matter:
+ *
+ *  * No shutdown(2). It acts on the open file description, which fork(2) shares,
+ *    so it would send FIN and break the parent's connection. close(2) drops only
+ *    our own descriptor; the peer sees nothing.
+ *  * release() before closing, rather than asio's close(). asio's close() skips
+ *    EPOLL_CTL_DEL on the assumption that closing a descriptor removes its epoll
+ *    registration. Per epoll(7) that happens only once *every* descriptor
+ *    referring to the description is closed -- and the parent still holds one --
+ *    so the registration would outlive the descriptor_state asio recycles, which
+ *    is precisely the stale-pointer shape the reactor faults on. release() emits
+ *    the EPOLL_CTL_DEL explicitly and hands back the raw descriptor to close.
+ *
+ * release() also completes any outstanding asynchronous operations on this socket
+ * with operation_aborted, which is what we want: those reads belong to the parent.
+ */
+// Takes the basic_socket base rather than tcp::socket so the same code serves both
+// the plain socket and a TLS stream's lowest_layer(), whose type is that base.
+void
+detach_inherited_socket(asio::basic_socket<asio::ip::tcp>& socket, asio::error_code& ec)
+{
+  if (!socket.is_open()) {
+    ec = asio::error::bad_descriptor;
+    return;
+  }
+
+  const auto handle = socket.release(ec);
+  if (ec) {
+    // Report it. Do not reach for asio's close() here: that is the very call
+    // whose epoll behaviour makes it unsafe on an inherited descriptor, and the
+    // descriptor goes away when this process exits anyway.
+    return;
+  }
+
+#if defined(_WIN32)
+  // Unreachable: without fork(2) no socket is ever inherited, so the owner pid
+  // always matches and close() never takes this path.
+  (void)handle;
+  ec = asio::error::operation_not_supported;
+#else
+  if (::close(handle) != 0) {
+    ec.assign(errno, asio::error::get_system_category());
+  }
+#endif
+}
+} // namespace
+
+auto
+configure_tls_handshake(asio::ssl::stream<asio::ip::tcp::socket>& stream,
+                        const std::string& hostname) -> std::error_code
+{
+  if (hostname.empty()) {
+    // Fail closed: a TLS client connection must have a hostname to verify the
+    // server's identity against. Returning success here would silently fall back
+    // to CA-only validation -- the CWE-297 problem this function exists to prevent.
+    return asio::error::make_error_code(asio::error::invalid_argument);
+  }
+
+  // Send SNI so that name-based / multi-tenant TLS endpoints present the correct
+  // certificate for this hostname.
+  {
+    // SSL_set_tlsext_host_name() is a macro that expands to an internal C-style
+    // cast to void*, which trips -Wold-style-cast; suppress it locally.
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+    ERR_clear_error();
+    const auto sni_result = SSL_set_tlsext_host_name(stream.native_handle(), hostname.c_str());
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+    if (sni_result != 1) {
+      // Prefer the underlying SSL reason (if any) so failures are diagnosable,
+      // and fall back to a generic error when the SSL error queue is empty.
+      if (const auto reason = ERR_get_error(); reason != 0) {
+        return { static_cast<int>(reason), asio::error::get_ssl_category() };
+      }
+      return asio::error::make_error_code(asio::error::invalid_argument);
+    }
+  }
+
+  // Verify that the presented certificate actually identifies `hostname`
+  // (SAN/CN). asio::ssl::verify_peer on its own only validates the certificate
+  // chain, not the name. In verify_none mode OpenSSL ignores the callback
+  // result, so this has no effect there.
+  std::error_code ec{};
+  stream.set_verify_callback(asio::ssl::host_name_verification(hostname), ec);
+  return ec;
+}
+
 stream_impl::stream_impl(asio::io_context& ctx, bool is_tls)
   : strand_(asio::make_strand(ctx))
   , tls_(is_tls)
   , id_(uuid::to_string(uuid::random()))
+  , owner_pid_(current_process_id())
 {
 }
 
@@ -79,12 +195,20 @@ plain_stream_impl::close(utils::movable_function<void(std::error_code)>&& handle
   if (!stream_) {
     return handler(asio::error::bad_descriptor);
   }
-  return asio::post(strand_, [stream = std::move(stream_), handler = std::move(handler)]() {
-    asio::error_code ec{};
-    stream->shutdown(asio::socket_base::shutdown_both, ec);
-    stream->close(ec);
-    handler(ec);
-  });
+  return asio::post(
+    strand_, [stream = std::move(stream_), owner_pid = owner_pid_, handler = std::move(handler)]() {
+      asio::error_code ec{};
+      // Decide here rather than when this was posted: io_.stop() at fork_prepare
+      // does not drain the queue, so a close queued before the fork runs in the
+      // child once the io_context is restarted, and there the answer differs.
+      if (owner_pid != current_process_id()) {
+        detach_inherited_socket(*stream, ec);
+      } else {
+        stream->shutdown(asio::socket_base::shutdown_both, ec);
+        stream->close(ec);
+      }
+      handler(ec);
+    });
 }
 
 void
@@ -178,12 +302,19 @@ tls_stream_impl::close(utils::movable_function<void(std::error_code)>&& handler)
   if (!stream_) {
     return handler(asio::error::bad_descriptor);
   }
-  return asio::post(strand_, [stream = std::move(stream_), handler = std::move(handler)]() {
-    asio::error_code ec{};
-    stream->lowest_layer().shutdown(asio::socket_base::shutdown_both, ec);
-    stream->lowest_layer().close(ec);
-    handler(ec);
-  });
+  return asio::post(
+    strand_, [stream = std::move(stream_), owner_pid = owner_pid_, handler = std::move(handler)]() {
+      asio::error_code ec{};
+      // See plain_stream_impl::close(): the inheritance test belongs here, not at
+      // post time.
+      if (owner_pid != current_process_id()) {
+        detach_inherited_socket(stream->lowest_layer(), ec);
+      } else {
+        stream->lowest_layer().shutdown(asio::socket_base::shutdown_both, ec);
+        stream->lowest_layer().close(ec);
+      }
+      handler(ec);
+    });
 }
 
 void

--- a/core/io/streams.hxx
+++ b/core/io/streams.hxx
@@ -65,6 +65,12 @@ protected:
   asio::strand<asio::io_context::executor_type> strand_;
   bool tls_;
   std::string id_{};
+  // Identifies the process that opened this socket. close() compares it against
+  // the process running at that moment to tell a socket inherited across fork(2)
+  // apart from one this process opened itself, because an inherited socket must not
+  // be shut down: shutdown(2) acts on the open file description, which fork(2)
+  // shares, so it would tear down a connection the parent is still using.
+  long long owner_pid_;
 
 public:
   stream_impl(asio::io_context& ctx, bool is_tls);

--- a/core/transactions/transactions_cleanup.cxx
+++ b/core/transactions/transactions_cleanup.cxx
@@ -32,7 +32,10 @@
 #include <couchbase/fmt/transaction_keyspace.hxx>
 
 #include <functional>
+#include <future>
+#include <list>
 #include <memory>
+#include <thread>
 #include <utility>
 
 namespace couchbase::core::transactions
@@ -586,10 +589,17 @@ transactions_cleanup::add_collection(const couchbase::transactions::transaction_
     auto it = std::find(collections_.begin(), collections_.end(), keyspace);
     if (it == collections_.end()) {
       collections_.emplace_back(keyspace);
-      // start cleaning right away
-      lost_attempt_cleanup_workers_.emplace_back([this, keyspace = collections_.back()]() {
-        this->clean_collection(keyspace);
-      });
+      // Spawn only while running. stop() takes the worker handles out and joins them, so a
+      // handle appended after that point is one nothing has agreed to join -- and a joinable
+      // std::thread reaching its destructor terminates. Registering the keyspace is still
+      // right: start() spawns a worker for everything in collections_, so cleanup resumes for
+      // it on the next start.
+      if (running_) {
+        // start cleaning right away
+        lost_attempt_cleanup_workers_.emplace_back([this, keyspace = collections_.back()]() {
+          this->clean_collection(keyspace);
+        });
+      }
     }
     lock.unlock();
     CB_ATTEMPT_CLEANUP_LOG_DEBUG("added {} to lost transaction cleanup", keyspace);
@@ -599,8 +609,24 @@ transactions_cleanup::add_collection(const couchbase::transactions::transaction_
 void
 transactions_cleanup::start()
 {
-  running_ =
-    config_.cleanup_config.cleanup_client_attempts || config_.cleanup_config.cleanup_lost_attempts;
+  {
+    const std::unique_lock<std::mutex> lock(mutex_);
+    running_ = config_.cleanup_config.cleanup_client_attempts ||
+               config_.cleanup_config.cleanup_lost_attempts;
+
+    if (config_.cleanup_config.cleanup_lost_attempts) {
+      // Re-spawn a worker for every keyspace still registered from before a previous stop().
+      // add_collection() below cannot do this: it dedupes on collections_, so an
+      // already-registered keyspace is skipped and its lost-attempt cleanup stays dead for the
+      // rest of the process. notify_fork(prepare) calls stop() and notify_fork(parent) calls
+      // start() again, so every fork leaves exactly that state behind unless it's undone here.
+      for (const auto& keyspace : collections_) {
+        lost_attempt_cleanup_workers_.emplace_back([this, keyspace]() {
+          this->clean_collection(keyspace);
+        });
+      }
+    }
+  }
   if (config_.cleanup_config.cleanup_client_attempts) {
     cleanup_thr_ = std::thread([this] {
       attempts_loop();
@@ -628,7 +654,16 @@ transactions_cleanup::stop()
     cleanup_thr_.join();
     CB_ATTEMPT_CLEANUP_LOG_DEBUG("cleanup attempt thread closed");
   }
-  for (auto& t : lost_attempt_cleanup_workers_) {
+  // Take the handles out under mutex_, then join with the lock released: add_collection() and
+  // start() append to this list while holding mutex_, so walking it live would race with them;
+  // and the workers themselves take mutex_ (is_running(), interruptable_wait()), so joining
+  // while still holding it would deadlock.
+  std::list<std::thread> workers;
+  {
+    const std::unique_lock<std::mutex> lock(mutex_);
+    workers.swap(lost_attempt_cleanup_workers_);
+  }
+  for (auto& t : workers) {
     CB_LOST_ATTEMPT_CLEANUP_LOG_DEBUG("shutting down all lost attempt threads...");
     if (t.joinable()) {
       t.join();

--- a/couchbase/cluster.hxx
+++ b/couchbase/cluster.hxx
@@ -97,6 +97,39 @@ public:
   auto operator=(const cluster& other) -> cluster& = default;
   auto operator=(cluster&& other) -> cluster& = default;
 
+  /**
+   * Notify the cluster of a fork-related event, so it can keep its I/O usable
+   * across @c fork().
+   *
+   * Call it three times, in this order: @ref fork_event::prepare in the parent
+   * before forking, then @ref fork_event::child in the child and @ref
+   * fork_event::parent in the parent.
+   *
+   * NOTE: @ref fork_event::child reconnects this cluster on a fresh set of
+   * sockets, because the inherited ones belong to the parent. Any @ref bucket,
+   * @ref scope or @ref collection handle obtained before the fork still refers to
+   * the pre-fork connections, so in the child those handles must be re-acquired
+   * from the cluster -- using a stale one fails with @ref
+   * errc::network::cluster_closed. Handles held in the parent stay valid.
+   *
+   * This function must not be called while operations are in flight on this
+   * cluster from another thread.
+   *
+   * On platforms without @c fork(), Windows in particular, this function does
+   * nothing. It remains callable everywhere so that portable code does not have to
+   * guard the calls, but nothing about the cluster changes.
+   *
+   * @param event the fork-related event that is about to happen, or just happened.
+   *
+   * @throws std::system_error if the I/O backend cannot be carried across the fork.
+   * There is no recovery for this: the cluster's io_context is unusable afterwards
+   * and the only thing left to do with the cluster is destroy it. It is reported
+   * rather than swallowed because a caller that went on using such a cluster would
+   * be operating on a reactor that no longer tracks its sockets.
+   *
+   * @since 1.0.0
+   * @uncommitted
+   */
   void notify_fork(fork_event event);
 
   void close(std::function<void()>&& handler);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,7 @@ integration_test(management_eventing)
 integration_test(management_search_index)
 integration_test(http_session_manager)
 integration_test(node_id)
+integration_test(fork)
 
 unit_test(connection_string)
 unit_test(contains_string)

--- a/test/test_integration_examples.cxx
+++ b/test/test_integration_examples.cxx
@@ -755,7 +755,14 @@ main(int argc, const char* argv[])
     cluster.notify_fork(couchbase::fork_event::child);
 
     fmt::print("CHILD(pid={}): continue after fork()\n", getpid());
-    auto collection = bucket.scope("tenant_agent_00").collection("users");
+
+    // Re-acquire the handles in the child. notify_fork(child) reconnects the
+    // cluster on a fresh set of sockets, so bucket/scope/collection handles
+    // obtained before the fork still refer to the pre-fork connections; using one
+    // here fails with errc::network::cluster_closed. Handles are cheap value
+    // types, so ask the cluster for them again. The parent does not need this --
+    // notify_fork(parent) leaves its connections in place.
+    auto collection = cluster.bucket(bucket_name).scope("tenant_agent_00").collection("users");
 
     {
       fmt::print("CHILD(pid={}): upsert into collection\n", getpid());
@@ -832,28 +839,31 @@ main(int argc, const char* argv[])
       if (WIFCONTINUED(status)) {
         flags.emplace_back("continued");
       }
+      // Each W*() accessor is only defined once its own predicate holds, so each is
+      // reported from inside the matching branch. Unguarded they decode the wrong bits and
+      // invent events: glibc's WSTOPSIG is (status & 0xff00) >> 8, the same bits as the
+      // exit status, so a child that exited with code 3 was reported as "stopsig=3".
       if (WIFSTOPPED(status)) {
-        flags.emplace_back("stopped");
+        flags.emplace_back(fmt::format("stopped, stopsig={}", WSTOPSIG(status)));
       }
       if (WIFEXITED(status)) {
-        flags.emplace_back("exited");
+        flags.emplace_back(fmt::format("exited, exitstatus={}", WEXITSTATUS(status)));
       }
       if (WIFSIGNALED(status)) {
-        flags.emplace_back("signaled");
-      }
-      if (const auto signal = WSTOPSIG(status); signal > 0) {
-        flags.emplace_back(fmt::format("stopsig={}", signal));
-      }
-      if (const auto signal = WTERMSIG(status); signal > 0) {
-        flags.emplace_back(fmt::format("termsig={}", signal));
+        flags.emplace_back(fmt::format("signaled, termsig={}", WTERMSIG(status)));
       }
       return fmt::format("status=0x{:02x} ({})", status, fmt::join(flags, ", "));
     };
-    fmt::print("PARENT(pid={}): Child pid={} returned {}, {}\n",
-               getpid(),
-               child_pid,
-               WEXITSTATUS(status),
-               pretty_status(status));
+    fmt::print(
+      "PARENT(pid={}): Child pid={} returned {}\n", getpid(), child_pid, pretty_status(status));
+
+    // The child does the post-fork half of this example, so its outcome has to
+    // propagate: without this the parent returns 0 even when the child could not
+    // use the cluster at all.
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+      fmt::print("PARENT(pid={}): child pid={} did not exit cleanly\n", getpid(), child_pid);
+      return 1;
+    }
   }
 
   fmt::print("COMMON(pid={}): close cluster\n", getpid());

--- a/test/test_integration_fork.cxx
+++ b/test/test_integration_fork.cxx
@@ -1,0 +1,324 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *   Copyright 2020-Present Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include "test_helper_integration.hxx"
+
+#ifndef _WIN32
+
+#include "utils/logger.hxx"
+
+#include <couchbase/cluster.hxx>
+#include <couchbase/codec/tao_json_serializer.hxx>
+#include <couchbase/error_codes.hxx>
+#include <couchbase/fork_event.hxx>
+
+#include <tao/json/value.hpp>
+
+#include <spdlog/fmt/bundled/format.h>
+
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <chrono>
+// <csignal> rather than <signal.h>: clang-tidy's modernize-deprecated-headers is enabled.
+// kill(2) is POSIX rather than C, but this whole file is already POSIX-only and the build
+// defines _GNU_SOURCE, so the declaration comes through.
+#include <csignal>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <string>
+#include <thread>
+
+// Regression guard for cluster::notify_fork().
+//
+// cluster_impl::notify_fork() used to start the post-fork IO thread and only
+// then call io_context::notify_fork(), which asio forbids. Because close() does
+// not wake a thread already blocked in epoll_wait() -- and the replacement
+// epoll_create1() reuses the same fd number -- the child's IO thread stayed
+// bound to the epoll instance inherited from the parent, and went on
+// dereferencing descriptor_state pointers that are only valid in the parent's
+// address space. Valgrind reported that as three invalid accesses in the child
+// (op_queue.hpp:34 and epoll_reactor.hpp:76, reached from epoll_reactor.ipp).
+//
+// What this test does and does NOT guard, measured rather than assumed:
+//
+//   * It does NOT deterministically detect the ordering bug. Measured against the
+//     unfixed core/impl/public_cluster.cxx it passed 2 of 3 runs, so do not read a
+//     pass here as proof that the reactor is sound. The one failure was the
+//     PARENT's post-fork read, and its cause was a separate defect -- the child
+//     shutting down a descriptor fork() shares -- addressed later in this series.
+//   * The deterministic guard for the ordering itself is the
+//     Expects(!io_thread_.joinable()) precondition in cluster_impl::notify_fork,
+//     which aborts in program order if the restart is ever moved back above the
+//     fixup. Verified: reintroducing the old order makes this test SIGABRT.
+//   * What this test DOES pin down is the post-fork contract for both
+//     processes: the child must be able to use the cluster after
+//     notify_fork(child), the parent must still work after
+//     notify_fork(parent), and a child failure must reach the parent instead of
+//     being swallowed.
+//
+// Unlike "example: using fork() for scaling" this needs no sample bucket, so it
+// runs anywhere the normal integration suite runs.
+
+// Under `ctest --test-action memcheck` this test reports a large defect count (~1700)
+// while every other test in the shard reports none. Measured, so it is not chased again:
+// that number is loss records, not memory errors. With
+// --errors-for-leak-kinds=definite,indirect both processes report 0 errors from 0
+// contexts; the child has 0 definitely-lost and 0 indirectly-lost bytes and no invalid
+// access anywhere. What it does have is ~17k blocks still reachable at exit, because the
+// child leaves through _Exit() (see below), plus a handful of possibly-lost records that
+// are all pthread TLS -- allocate_dtv/_dl_allocate_tls from the IO, resolver, cleanup and
+// ATR-pool threads that existed before the fork and do not exist in the child. That is an
+// unavoidable consequence of fork(2) duplicating the heap but only one thread.
+//
+// The defect the original bug produced looked nothing like this: three *invalid accesses*
+// in the child, at op_queue.hpp:34 and epoll_reactor.hpp:76.
+//
+// This also costs real wall-clock time, which is why the wait for the child below is
+// generous. cmake/Testing.cmake passes --leak-check=full --show-reachable=yes
+// --num-callers=50, so at exit memcheck symbolises a 50-frame trace for every one of those
+// still-reachable blocks. Seen in CI: the child completed its get, then produced no output
+// for the next four minutes while valgrind wrote that report, and an earlier four-minute
+// deadline here killed it and reported a wedge that had not happened.
+//
+// Do not try to fix that by closing the cluster in the child before _Exit(): measured, it
+// takes the child from ~17.0k still-reachable blocks to ~14.4k and the loss-record count
+// actually rises, because the bulk of them are process-wide statics -- logger, TLS library
+// tables, the Catch2 registry, the harness -- that _Exit() skips regardless. The parent
+// reports "0 bytes in use at exit" only because it leaves through a normal return and runs
+// that teardown. Closing in the child buys nothing here and adds a failure mode.
+
+namespace
+{
+// The child is a forked copy of the Catch2 binary. It must leave through
+// _Exit() so it neither runs Catch2's reporter (which would print a second,
+// confusing test summary) nor the static destructors and the test guard's
+// teardown, none of which are valid in a fork child.
+[[noreturn]] void
+leave_child(int status)
+{
+  std::_Exit(status);
+}
+} // namespace
+
+TEST_CASE("integration: cluster remains usable in a forked child", "[integration]")
+{
+  // Capability checks happen in a nested scope so the guard -- which runs its own
+  // IO threads -- is destroyed well before the fork; only the forking thread
+  // survives into the child, so no guard may be live across it.
+  {
+    test::utils::integration_test_guard integration;
+    if (integration.cluster_version().is_mock()) {
+      SKIP("the mock does not support the fork scenario");
+    }
+  }
+
+  // Connection details come from the environment for the same reason: nothing
+  // that owns a thread may straddle the fork.
+  const auto ctx = test::utils::test_context::load_from_environment();
+  test::utils::init_logger();
+
+  // The child inherits this process's stdout buffer; unbuffer it so anything the
+  // child prints before _Exit() is not lost, which is the only diagnostic a
+  // failing run gets beyond the exit code.
+  setbuf(stdout, nullptr);
+
+  auto options = couchbase::cluster_options(ctx.username, ctx.password);
+  // Everything here is 20-30x slower under memcheck, so do not race the
+  // stock timeouts -- this is the same profile the valgrind CI leg selects.
+  options.apply_profile("wan_development");
+
+  auto [connect_err, cluster] = couchbase::cluster::connect(ctx.connection_string, options).get();
+  REQUIRE_SUCCESS(connect_err.ec());
+
+  const auto parent_id = test::utils::uniq_id("fork-parent");
+  const auto child_id = test::utils::uniq_id("fork-child");
+
+  // Do real I/O before forking so the reactor actually has MCBP sockets
+  // registered -- with no registered descriptors the child's reactor has
+  // nothing inherited to trip over and the scenario is not exercised.
+  {
+    auto collection = cluster.bucket(ctx.bucket).default_collection();
+    auto [err, res] = collection.upsert(parent_id, tao::json::value{ { "side", "parent" } }).get();
+    REQUIRE_SUCCESS(err.ec());
+    REQUIRE(!res.cas().empty());
+  }
+
+  cluster.notify_fork(couchbase::fork_event::prepare);
+  const auto child_pid = fork();
+  if (child_pid < 0) {
+    // Hand the cluster back a runnable io_context before failing. After
+    // notify_fork(prepare) it is stopped with no IO thread, and ~cluster_impl waits
+    // on a completion only that thread can deliver -- so bailing out here without
+    // notify_fork(parent) would hang this process on teardown rather than report a
+    // failed fork, and take the rest of the suite's run with it.
+    const auto fork_errno = errno;
+    cluster.notify_fork(couchbase::fork_event::parent);
+    FAIL("fork() failed: " << std::strerror(fork_errno));
+  }
+
+  if (child_pid == 0) {
+    // No exception may escape into Catch2 from here. This process is a fork of the
+    // test binary, so unwinding out of the child would run Catch2's reporter and the
+    // static destructors -- exactly what leave_child() exists to avoid. And
+    // notify_fork(child) is a throwing call: asio reports a failure to re-register a
+    // descriptor with the child's new epoll instance as an exception.
+    try {
+      cluster.notify_fork(couchbase::fork_event::child);
+
+      // Handles acquired before the fork refer to the connections
+      // notify_fork(child) replaces, so re-acquire from the cluster.
+      auto collection = cluster.bucket(ctx.bucket).default_collection();
+
+      auto [upsert_err, upsert_res] =
+        collection.upsert(child_id, tao::json::value{ { "side", "child" } }).get();
+      if (upsert_err.ec() || upsert_res.cas().empty()) {
+        // Only the exit code crosses back to the parent, so say why here or a red
+        // run carries no reason at all.
+        fmt::print("CHILD(pid={}): upsert failed: {}\n", getpid(), upsert_err.ec().message());
+        leave_child(1);
+      }
+
+      auto [get_err, get_res] = collection.get(child_id).get();
+      if (get_err.ec()) {
+        fmt::print("CHILD(pid={}): get failed: {}\n", getpid(), get_err.ec().message());
+        leave_child(2);
+      }
+      if (get_res.content_as<tao::json::value>()["side"].get_string() != "child") {
+        leave_child(3);
+      }
+    } catch (const std::exception& e) {
+      fmt::print("CHILD(pid={}): threw: {}\n", getpid(), e.what());
+      leave_child(4);
+    } catch (...) {
+      fmt::print("CHILD(pid={}): threw an unknown exception\n", getpid());
+      leave_child(4);
+    }
+    leave_child(0);
+  }
+
+  // The parent must still work on its own connections after the fork. This is the
+  // check that catches a child which tore down a descriptor the parent shares, so it
+  // has to stay a hard requirement -- but a timeout is not that symptom, it just
+  // means the cluster was slow, which under a sanitizer or a loaded CI box it
+  // will sometimes be. So retry on a timeout and stop immediately on anything else:
+  // errc::network::cluster_closed or a connection reset is the interesting outcome
+  // and must not be retried away.
+  //
+  // NOTHING from here to the reap below may throw out of this TEST_CASE, because the
+  // waitpid() is the only thing guaranteeing the child does not outlive the test. Three
+  // things here can throw: a Catch2 assertion, notify_fork(parent) (documented to throw
+  // when the I/O backend cannot be carried across the fork), and tao's JSON decode on a
+  // malformed or wrongly-typed body. The last one is not hypothetical here -- a child that
+  // stole bytes from this connection would produce exactly a mangled body, so the decode
+  // is likeliest to throw precisely when the defect under test is present, which is the
+  // worst moment to lose the diagnostic and leak the child. So this section only records;
+  // every check happens after the reap.
+  std::string parent_side_error{};
+  couchbase::error parent_read_err{};
+  bool parent_read_succeeded{ false };
+  bool parent_read_own_document{ false };
+  try {
+    cluster.notify_fork(couchbase::fork_event::parent);
+
+    auto collection = cluster.bucket(ctx.bucket).default_collection();
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::minutes{ 2 };
+    do {
+      auto [err, res] = collection.get(parent_id).get();
+      parent_read_err = err;
+      if (!err.ec()) {
+        parent_read_succeeded = true;
+        parent_read_own_document =
+          res.content_as<tao::json::value>()["side"].get_string() == "parent";
+        break;
+      }
+      if (err.ec() != couchbase::errc::common::unambiguous_timeout &&
+          err.ec() != couchbase::errc::common::ambiguous_timeout) {
+        break;
+      }
+    } while (std::chrono::steady_clock::now() < deadline);
+  } catch (const std::exception& e) {
+    parent_side_error = e.what();
+  } catch (...) {
+    parent_side_error = "unknown exception";
+  }
+
+  // Bounded wait, then kill. A wedged child is precisely the failure mode this area is
+  // about -- a post-fork reconnect that never completes -- and a blocking waitpid() would
+  // hand that case to CTest's own timeout: the shard spends its budget and reports
+  // "timeout" with nothing to read. Polling turns it into a fast, named failure, and the
+  // SIGKILL makes sure the wedged child is gone rather than left running for the rest of
+  // the suite. EINTR keeps the poll going; anything else is a real waitpid() failure.
+  //
+  // The budget only has to be short enough to beat CTest's own timeout, and long enough
+  // never to fire on a child that is merely slow. The first version used four minutes,
+  // reasoning about the wan_development bootstrap timeout, and it fired in CI on a child
+  // that had already succeeded -- the real cost was valgrind's exit-time leak report, not
+  // anything the child was waiting for. That cause is removed above by closing the cluster
+  // before _Exit(); this stays as a backstop against an actual hang, with enough headroom
+  // that a loaded sanitizer box does not trip it.
+  constexpr int child_deadline_minutes{ 6 };
+  int status{};
+  pid_t reaped{ -1 };
+  const auto child_deadline =
+    std::chrono::steady_clock::now() + std::chrono::minutes{ child_deadline_minutes };
+  do {
+    reaped = waitpid(child_pid, &status, WNOHANG);
+    if (reaped == child_pid || (reaped < 0 && errno != EINTR)) {
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds{ 100 });
+  } while (std::chrono::steady_clock::now() < child_deadline);
+
+  const auto child_wedged = reaped != child_pid;
+  if (child_wedged) {
+    kill(child_pid, SIGKILL);
+    while ((reaped = waitpid(child_pid, &status, 0)) < 0 && errno == EINTR) {
+      // reap the killed child so it cannot outlive this test
+    }
+  }
+
+  if (child_wedged) {
+    // Deliberately does not claim a cause. The first time this fired, the child had already
+    // completed every operation and was sitting in valgrind's exit-time leak report; saying
+    // "wedged in the post-fork reconnect" would have sent the reader in the wrong direction.
+    // Check the child's own output above before concluding anything.
+    FAIL("child did not exit within the deadline and was killed after "
+         << child_deadline_minutes << " minutes; see the child's output above for how far it got");
+  }
+  if (!parent_side_error.empty()) {
+    FAIL("parent threw after the fork: " << parent_side_error);
+  }
+  if (!parent_read_succeeded) {
+    FAIL(
+      "parent could not read its own document after the fork: " << parent_read_err.ec().message());
+  }
+  REQUIRE(parent_read_own_document);
+  REQUIRE(reaped == child_pid);
+  REQUIRE(WIFEXITED(status));
+  // 1 = upsert failed (this is what a dropped/replaced impl looks like:
+  // errc::network::cluster_closed), 2 = get failed, 3 = wrong content,
+  // 4 = something in the child threw.
+  REQUIRE(WEXITSTATUS(status) == 0);
+
+  cluster.close().get();
+}
+
+#endif // _WIN32


### PR DESCRIPTION
Backport of #1056

The transactions cleanup needed some adjustments to resolve conflicts (as we are missing some txn cleanup changes in this branch), everything else got backported cleanly.