### PR TITLE
CXXCBC-1008: remember a refused connection for every probe kind

### DIFF
--- a/test/framework/cluster_probes.cxx
+++ b/test/framework/cluster_probes.cxx
@@ -150,16 +150,27 @@ public:
 
 private:
   // The guard opens the connection in its constructor, so it is built on the first probe and not
-  // before. Anything it throws -- a refused connection, a management endpoint that answered with
-  // an error -- becomes probe_failure, which the runner reports as undetermined and therefore as a
-  // failed case. An unreachable cluster must not read as an inapplicable one.
+  // before. Anything either step throws -- a refused connection, a management endpoint that
+  // answered with an error -- becomes probe_failure, which the runner reports as undetermined and
+  // therefore as a failed case. An unreachable cluster must not read as an inapplicable one.
+  //
+  // The two steps are told apart in what they throw. A constructor that failed reports
+  // probe_backend_unavailable, which the context remembers for every probe kind: there is no
+  // second endpoint to try, and its answer caches are per kind, so a suite asking two different
+  // things would otherwise wait out the same connection attempt once for each. A probe that threw
+  // on an open connection is that one question failing and stays a plain probe_failure.
   template<typename Fn>
   auto guarded(Fn&& fn) -> decltype(fn(std::declval<utils::integration_test_guard&>()))
   {
-    try {
-      if (!guard_) {
+    if (!guard_) {
+      try {
         guard_ = std::make_unique<utils::integration_test_guard>();
+      } catch (const std::exception& e) {
+        throw probe_backend_unavailable(
+          fmt::format("the cluster could not be reached: {}", e.what()));
       }
+    }
+    try {
       return std::forward<Fn>(fn)(*guard_);
     } catch (const std::system_error& e) {
       throw probe_failure(fmt::format("the cluster could not answer: {}", e.what()));

--- a/test/framework/context.cxx
+++ b/test/framework/context.cxx
@@ -39,6 +39,10 @@ public:
     if (!value_.has_value() && failure_.empty()) {
       try {
         value_ = std::forward<Fn>(compute)();
+      } catch (const probe_backend_unavailable&) {
+        // Not remembered here: it says nothing about this question, and a memory keyed to one probe
+        // kind is the wrong place for a connection that was never made. The caller keeps it.
+        throw;
       } catch (const probe_failure& e) {
         failure_ = e.what();
       }
@@ -120,6 +124,29 @@ struct context::impl {
   std::map<std::string, cached<bool>, std::less<>> services{};
   std::map<std::string, cached<bool>, std::less<>> capabilities{};
 
+  // The message from the first probe that reported the backend could not be opened. Every probe
+  // after it reports the same thing without asking again: the caches above are per probe kind,
+  // which is the right memory for a question this cluster cannot answer and the wrong one for a
+  // connection that was refused, so without a slot covering all of them a suite asking two
+  // different things waits out the same connection attempt twice.
+  std::string unavailable{};
+
+  // Every probe goes through here, so the two memories stay distinct in one place rather than in
+  // each accessor.
+  template<typename T, typename Fn>
+  auto ask(cached<T>& answer, Fn&& compute) -> T
+  {
+    if (!unavailable.empty()) {
+      throw probe_backend_unavailable(unavailable);
+    }
+    try {
+      return answer.get(std::forward<Fn>(compute));
+    } catch (const probe_backend_unavailable& e) {
+      unavailable = e.what();
+      throw;
+    }
+  }
+
   auto probes() -> probe_backend&
   {
     if (backend == nullptr) {
@@ -164,7 +191,7 @@ auto
 context::server_version() -> couchbase::test::server_version
 {
   const std::lock_guard<std::mutex> guard{ impl_->mutex };
-  return impl_->version.get([this]() {
+  return impl_->ask(impl_->version, [this]() {
     return impl_->probes().server_version();
   });
 }
@@ -173,7 +200,7 @@ auto
 context::has_service(const std::string& name) -> bool
 {
   const std::lock_guard<std::mutex> guard{ impl_->mutex };
-  return impl_->services[name].get([this, &name]() {
+  return impl_->ask(impl_->services[name], [this, &name]() {
     return impl_->probes().has_service(name);
   });
 }
@@ -182,7 +209,7 @@ auto
 context::has_bucket_capability(const std::string& capability) -> bool
 {
   const std::lock_guard<std::mutex> guard{ impl_->mutex };
-  return impl_->capabilities[capability].get([this, &capability]() {
+  return impl_->ask(impl_->capabilities[capability], [this, &capability]() {
     return impl_->probes().has_bucket_capability(capability);
   });
 }
@@ -191,7 +218,7 @@ auto
 context::number_of_replicas() -> std::size_t
 {
   const std::lock_guard<std::mutex> guard{ impl_->mutex };
-  return impl_->replicas.get([this]() {
+  return impl_->ask(impl_->replicas, [this]() {
     return impl_->probes().number_of_replicas();
   });
 }
@@ -200,7 +227,7 @@ auto
 context::number_of_nodes() -> std::size_t
 {
   const std::lock_guard<std::mutex> guard{ impl_->mutex };
-  return impl_->nodes.get([this]() {
+  return impl_->ask(impl_->nodes, [this]() {
     return impl_->probes().number_of_nodes();
   });
 }
@@ -209,7 +236,7 @@ auto
 context::server_groups() -> std::vector<std::string>
 {
   const std::lock_guard<std::mutex> guard{ impl_->mutex };
-  return impl_->groups.get([this]() {
+  return impl_->ask(impl_->groups, [this]() {
     return impl_->probes().server_groups();
   });
 }
@@ -218,7 +245,7 @@ auto
 context::storage_backend() -> std::string
 {
   const std::lock_guard<std::mutex> guard{ impl_->mutex };
-  return impl_->storage.get([this]() {
+  return impl_->ask(impl_->storage, [this]() {
     return impl_->probes().storage_backend();
   });
 }

--- a/test/framework/context.hxx
+++ b/test/framework/context.hxx
@@ -53,6 +53,17 @@ private:
   std::string message_;
 };
 
+// Thrown by a probe whose backend could not be opened at all, as against one the cluster could not
+// answer. Every probe in the process shares that outcome: the connection lives in the backend, so
+// an endpoint that refused one refuses the next, and the answer caches are keyed per probe kind. A
+// backend that opened and then could not answer one question throws plain probe_failure, or that
+// one question would speak for the rest.
+class probe_backend_unavailable : public probe_failure
+{
+public:
+  using probe_failure::probe_failure;
+};
+
 enum class server_edition : std::uint8_t {
   unknown,
   enterprise,
@@ -181,7 +192,8 @@ public:
   [[nodiscard]] auto env(const std::string& name) const -> std::optional<std::string>;
 
   // Probes. Each is cached for the lifetime of the process -- a binary with 300 cases must not
-  // open 300 connections -- and each throws probe_failure when it cannot answer.
+  // open 300 connections -- and each throws probe_failure when it cannot answer. A backend that
+  // reports it could not be opened is asked nothing further, by any of them.
   [[nodiscard]] auto server_version() -> couchbase::test::server_version;
   [[nodiscard]] auto has_service(const std::string& name) -> bool;
   [[nodiscard]] auto has_bucket_capability(const std::string& capability) -> bool;

--- a/test/framework/selftest.cxx
+++ b/test/framework/selftest.cxx
@@ -210,6 +210,66 @@ public:
   }
 };
 
+// A backend that cannot be opened at all, standing in for an endpoint that refuses the connection
+// rather than one that answers a question badly. Counting every probe is the point: the connection
+// behind them is attempted once for the process, and a count is the only way to hold that claim to
+// account.
+class unopenable_probes : public probe_backend
+{
+public:
+  std::size_t calls{ 0 };
+
+  [[nodiscard]] auto server_version() -> couchbase::test::server_version override
+  {
+    refuse();
+  }
+  [[nodiscard]] auto has_service(const std::string& /* name */) -> bool override
+  {
+    refuse();
+  }
+  [[nodiscard]] auto has_bucket_capability(const std::string& /* capability */) -> bool override
+  {
+    refuse();
+  }
+  [[nodiscard]] auto number_of_replicas() -> std::size_t override
+  {
+    refuse();
+  }
+  [[nodiscard]] auto number_of_nodes() -> std::size_t override
+  {
+    refuse();
+  }
+  [[nodiscard]] auto server_groups() -> std::vector<std::string> override
+  {
+    refuse();
+  }
+  [[nodiscard]] auto storage_backend() -> std::string override
+  {
+    refuse();
+  }
+
+private:
+  [[noreturn]] void refuse()
+  {
+    ++calls;
+    throw probe_backend_unavailable("connection refused");
+  }
+};
+
+// The other side of that distinction: a backend that opened and answers everything except one
+// question, which is what a cluster looks like when a single management endpoint is unhappy.
+class one_broken_probe : public counting_probes
+{
+public:
+  std::size_t capability_calls{ 0 };
+
+  [[nodiscard]] auto has_bucket_capability(const std::string& /* capability */) -> bool override
+  {
+    ++capability_calls;
+    throw probe_failure("the bucket could not be described");
+  }
+};
+
 // A file-local requirement: what a translation unit writes when it needs something the built-in
 // vocabulary does not cover. Kept here because "a custom requirement is short" is a claim about
 // the interface, and the only honest way to hold it is to write one.
@@ -541,6 +601,62 @@ a_failed_probe_is_not_retried_per_case([[maybe_unused]] context& ctx)
   const auto r = run_quiet(s, {}, probed);
   assert_eq(r.failed, std::size_t{ 3 }, "each case fails on its own account");
   assert_eq(counters->calls, std::size_t{ 1 }, "but the cluster was asked exactly once");
+}
+
+void
+a_backend_that_cannot_be_opened_is_asked_once([[maybe_unused]] context& ctx)
+{
+  // Answers are cached per probe kind, so a refused connection remembered only there costs one
+  // attempt per kind: three questions, three waits on an endpoint that will not accept any of them.
+  auto probes = std::make_unique<unopenable_probes>();
+  auto* counters = probes.get();
+  context probed{ with_cluster(), std::move(probes) };
+
+  const test_suite s{ "inner",
+                      { { "version", body_pass, { needs::cluster_version(v7_0) } },
+                        { "service", body_pass, { needs::service("kv") } },
+                        { "replicas", body_pass, { needs::replicas(1) } } } };
+  std::ostringstream sink;
+  const auto r = run(s, {}, probed, sink);
+  assert_eq(r.failed, std::size_t{ 3 }, "each case fails on its own account");
+  assert_eq(r.skipped, std::size_t{ 0 }, "and none of them is a skip");
+  assert_eq(counters->calls, std::size_t{ 1 }, "the backend was asked once, not once per kind");
+
+  // Asking once must not cost the other two their reason: what the one attempt found is what every
+  // case reports.
+  const auto report = sink.str();
+  std::size_t mentions = 0;
+  for (auto at = report.find("connection refused"); at != std::string::npos;
+       at = report.find("connection refused", at + 1)) {
+    ++mentions;
+  }
+  assert_eq(mentions, std::size_t{ 3 }, "and every case still says why it failed");
+}
+
+void
+one_unanswerable_question_does_not_speak_for_the_others([[maybe_unused]] context& ctx)
+{
+  // The failure that must not spread. A backend that opened and could not answer one question is
+  // not an unreachable cluster, and treating it as one turns a single missing answer into a binary
+  // of failures.
+  auto probes = std::make_unique<one_broken_probe>();
+  auto* counters = probes.get();
+  context probed{ with_cluster(), std::move(probes) };
+
+  const test_suite s{
+    "inner",
+    { { "capability", body_pass, { needs::bucket_capability("durableWrite") } },
+      { "version", body_pass, { needs::cluster_version(v7_0) } },
+      { "capability_again", body_pass, { needs::bucket_capability("durableWrite") } } },
+  };
+  const auto r = run_quiet(s, {}, probed);
+  assert_eq(r.failed, std::size_t{ 2 }, "both cases asking the broken question fail");
+  assert_eq(r.passed, std::size_t{ 1 }, "and the one asking something else still runs");
+  assert_eq(
+    counters->version_calls, std::size_t{ 1 }, "the version was asked for after the failure");
+  assert_eq(counters->capability_calls,
+            std::size_t{ 1 },
+            "and the question that failed is still remembered under its own kind");
 }
 
 void
@@ -1312,6 +1428,8 @@ tests() -> test_suite
       { CASE(probes_are_cached_across_every_case_in_the_binary) },
       { CASE(one_probe_answers_every_caller_that_arrives_at_once) },
       { CASE(a_failed_probe_is_not_retried_per_case) },
+      { CASE(a_backend_that_cannot_be_opened_is_asked_once) },
+      { CASE(one_unanswerable_question_does_not_speak_for_the_others) },
       { CASE(a_requirement_that_blocks_fails_its_case_rather_than_the_run), {}, timeout::fast },
       { CASE(a_requirement_that_throws_fails_its_case) },
       { CASE(a_requirement_that_skips_does_not_run_its_case) },


### PR DESCRIPTION
Fixes [CXXCBC-1008](https://couchbasecloud.atlassian.net/browse/CXXCBC-1008), found while triaging the suppressed review notes on #1073. Carries a single commit against `main`.

## Why

`cluster_probes::guarded()` builds `test::utils::integration_test_guard` on the first probe. When the constructor throws — a refused connection, a management endpoint that never answers — `guard_` stays null and the failure becomes `probe_failure`. The context caches that, but its caches are keyed per probe kind:

```cpp
cached<couchbase::test::server_version> version{};
std::map<std::string, cached<bool>, std::less<>> services{};
```

So a case whose first unsatisfied requirement asks a *different* question builds another guard and waits out the same refusal. One bootstrap timeout against a closed port is **10.0 s**, measured as the whole runtime of `framework_cluster_probes_selftest` pointed at `couchbase://127.0.0.1:11999`; before this change that is the price of each distinct probe kind a binary reaches, and each attempt is bounded only by the phase it runs in — `requirement_budget`, 60 s by default, for a requirement.

The comment above `guarded()` claimed one connection attempt per binary. That held only for repeats of the same probe kind.

**What it costs today, stated plainly:** every migrated case gates on `needs::real_cluster()`, which reads the configuration and probes nothing, and the four cases of `framework_cluster_probes_selftest` all reach `needs::service("kv")` first — so the one binary that does probe asks a single kind and pays one timeout either way. This is what stage 2 walks into, as migrated cases start gating on services, versions and capabilities the way the Catch2 suites they come from do.

## What changed

A backend that could not be opened at all reports `probe_backend_unavailable`, and the context keeps that message in one slot every probe consults before asking anything.

The distinction it draws is the load-bearing part. A probe that threw on an *open* connection — a bucket that cannot be described, say — is one question failing rather than a cluster that cannot be reached, so it stays a plain `probe_failure` cached under its own kind. The per-kind cache lets the new type through untouched instead of storing it, because storing it is exactly what flattens both facts into one string.

## Verification

`a_backend_that_cannot_be_opened_is_asked_once` drives three cases asking three different kinds through the runner, and asserts one call to the backend and one reason per case — a shared memory must not cost the other two their message. `one_unanswerable_question_does_not_speak_for_the_others` asserts the other half: the cases whose question cannot be answered fail, the one asking something else runs, and the failed question is still remembered under its own kind rather than re-asked.

Three mutations, run through the CNG tooling's negative control, all killed: dropping the shared slot, letting the per-kind cache swallow the new type, and widening the slot to every `probe_failure`.

Against the real backend, `framework_cluster_probes_selftest` still fails every case with the message the one attempt produced when pointed at the closed port, and still passes against a live four-node cluster.


[CXXCBC-1008]: https://couchbasecloud.atlassian.net/browse/CXXCBC-1008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ