### PR TITLE
CXXCBC-1009: release the context before the suite teardown runs

### DIFF
--- a/test/framework/selftest.cxx
+++ b/test/framework/selftest.cxx
@@ -270,6 +270,35 @@ public:
   }
 };
 
+// What the teardown hook is watched with. A hook is a plain function pointer with nowhere to carry
+// state, and the question is whether the context is already gone when one runs, so the two facts
+// live out here.
+std::atomic<bool> backend_alive{ false };
+std::atomic<bool> backend_alive_at_teardown{ false };
+std::atomic<std::size_t> teardowns{ 0 };
+
+// counting_probes, reporting its own lifetime. The context owns the backend, so this destructor is
+// where a real suite closes the connection its probes opened.
+class lifetime_tracking_probes : public counting_probes
+{
+public:
+  lifetime_tracking_probes()
+  {
+    backend_alive = true;
+  }
+  ~lifetime_tracking_probes() override
+  {
+    backend_alive = false;
+  }
+};
+
+void
+record_teardown()
+{
+  ++teardowns;
+  backend_alive_at_teardown = backend_alive.load();
+}
+
 // A file-local requirement: what a translation unit writes when it needs something the built-in
 // vocabulary does not cover. Kept here because "a custom requirement is short" is a claim about
 // the interface, and the only honest way to hold it is to write one.
@@ -657,6 +686,41 @@ one_unanswerable_question_does_not_speak_for_the_others([[maybe_unused]] context
   assert_eq(counters->capability_calls,
             std::size_t{ 1 },
             "and the question that failed is still remembered under its own kind");
+}
+
+void
+the_context_is_released_before_the_suite_teardown_runs([[maybe_unused]] context& ctx)
+{
+  // The hook is where a suite unloads a library it used, so whatever holds a resource of that
+  // library -- the cluster connection the probes opened, above all -- has to be destroyed before it
+  // runs. The other order is a crash at process exit, in the least diagnosable moment of a run.
+  teardowns = 0;
+  backend_alive_at_teardown = true;
+
+  auto owned =
+    std::make_unique<context>(with_cluster(), std::make_unique<lifetime_tracking_probes>());
+  assert_true(backend_alive.load(), "the backend is alive to begin with");
+
+  tear_down(std::move(owned), record_teardown);
+
+  assert_eq(teardowns.load(), std::size_t{ 1 }, "the hook ran");
+  assert_false(backend_alive_at_teardown.load(), "the backend was destroyed before it ran");
+  assert_false(backend_alive.load(), "and stayed destroyed");
+}
+
+void
+a_suite_with_no_teardown_still_releases_its_context([[maybe_unused]] context& ctx)
+{
+  // The path every binary takes today, since nothing registers a hook: the context is released
+  // either way, and a hook that is not there is not called.
+  teardowns = 0;
+  auto owned =
+    std::make_unique<context>(with_cluster(), std::make_unique<lifetime_tracking_probes>());
+
+  tear_down(std::move(owned), nullptr);
+
+  assert_false(backend_alive.load(), "the context was released");
+  assert_eq(teardowns.load(), std::size_t{ 0 }, "and nothing was called in its place");
 }
 
 void
@@ -1473,6 +1537,8 @@ tests() -> test_suite
       { CASE(a_failed_probe_is_not_retried_per_case) },
       { CASE(a_backend_that_cannot_be_opened_is_asked_once) },
       { CASE(one_unanswerable_question_does_not_speak_for_the_others) },
+      { CASE(the_context_is_released_before_the_suite_teardown_runs) },
+      { CASE(a_suite_with_no_teardown_still_releases_its_context) },
       { CASE(a_requirement_that_blocks_fails_its_case_rather_than_the_run), {}, timeout::fast },
       { CASE(a_requirement_that_throws_fails_its_case) },
       { CASE(a_requirement_that_skips_does_not_run_its_case) },

--- a/test/framework/test_framework.hxx
+++ b/test/framework/test_framework.hxx
@@ -176,10 +176,13 @@ struct test_suite {
   std::string name;
   std::vector<test_case> test_cases;
   std::vector<test_case> slow_test_cases{};
-  // Run once after the last case, unless one of them timed out. A timed-out case leaves a worker
-  // detached and possibly still inside the very library the teardown would unload, so test_main.cxx
-  // skips it and leaves through _Exit instead. What test/main.cxx does with OPENSSL_cleanup()
-  // today: a process-wide teardown that belongs to the binary rather than to any case in it.
+  // Run once after the last case and after the context has been released, unless a case timed out.
+  // A timed-out case leaves a worker detached and possibly still inside the very library the
+  // teardown would unload, so test_main.cxx skips it and leaves through _Exit instead. What
+  // test/main.cxx does with OPENSSL_cleanup() today: a process-wide teardown that belongs to the
+  // binary rather than to any case in it. Anything holding a resource of the library it unloads --
+  // the cluster connection the probes opened, above all -- is destroyed with the context first; see
+  // tear_down() in test_runner.hxx.
   void (*teardown)() = nullptr;
 };
 

--- a/test/framework/test_main.cxx
+++ b/test/framework/test_main.cxx
@@ -31,6 +31,7 @@
 #include <cstdlib> // std::_Exit
 #include <exception>
 #include <iostream>
+#include <memory>
 #include <set>
 #include <string>
 #include <string_view>
@@ -75,9 +76,12 @@ main(int argc, char* argv[]) -> int
     return 1;
   }
 
-  context ctx{ std::move(config) };
+  // Owned rather than scoped, because when the run ends decides what may still be alive: the
+  // context has to outlive a detached worker on the timeout path below, and be gone before the
+  // suite's teardown hook on every other one.
+  auto ctx = std::make_unique<context>(std::move(config));
 
-  const auto result = run(suite, filter, ctx, std::cout);
+  const auto result = run(suite, filter, *ctx, std::cout);
 
   // Grouped, because the count alone is what lets a predicate that is permanently false in CI go
   // unnoticed: 37 skipped reads the same whether the environment lacked one thing or everything.
@@ -106,21 +110,18 @@ main(int argc, char* argv[]) -> int
       "Suite \"{}\": {} passed, {} skipped\n", suite.name, result.passed, result.skipped);
   }
 
-  // Skipped after a timeout for the same reason main() leaves through _Exit below: a detached
-  // worker may still be inside the very library the teardown is about to unload.
-  if (suite.teardown != nullptr && result.timed_out == 0) {
-    suite.teardown();
-  }
-
   // A timed-out case leaves its worker detached and still running. Returning from main would run
   // static destructors underneath it -- tearing down spdlog's registry, std::cout and any gRPC
   // channel the body still holds -- which surfaces as a nondeterministic abort at exit, exactly
-  // what the timeout runner exists to prevent. Leave immediately instead. Conditional on purpose:
-  // an unconditional _Exit would also suppress LeakSanitizer's atexit report.
+  // what the timeout runner exists to prevent. Leave immediately instead, destroying nothing and
+  // calling no hook: that worker may still be inside either. Conditional on purpose: an
+  // unconditional _Exit would also suppress LeakSanitizer's atexit report.
   if (result.timed_out > 0) {
     std::cout.flush();
     std::_Exit(exit_code(result));
   }
+
+  tear_down(std::move(ctx), suite.teardown);
 
   return exit_code(result);
 }

--- a/test/framework/test_runner.cxx
+++ b/test/framework/test_runner.cxx
@@ -400,6 +400,17 @@ scale_timeouts(test_suite& suite, double factor)
 }
 
 void
+tear_down(std::unique_ptr<context> ctx, void (*teardown)())
+{
+  // Before the hook, never after: whatever the context holds would otherwise be destroyed against a
+  // library the hook has already unloaded.
+  ctx.reset();
+  if (teardown != nullptr) {
+    teardown();
+  }
+}
+
+void
 scale_timeouts(configuration& config, double factor)
 {
   // The requirement phase is where the cluster is opened, so it is the phase a slow runner is most

--- a/test/framework/test_runner.hxx
+++ b/test/framework/test_runner.hxx
@@ -21,6 +21,7 @@
 
 #include <cstddef>
 #include <map>
+#include <memory>
 #include <optional>
 #include <ostream>
 #include <set>
@@ -55,6 +56,19 @@ struct run_result {
 auto
 run(const test_suite& suite, const std::set<std::string>& filter, context& ctx, std::ostream& out)
   -> run_result;
+
+// Close a run down: release the context, then call the suite's teardown hook if it has one. The
+// order is the whole of it. The context owns the probe backend and, through it, whatever connection
+// the probes opened, while the hook is where a suite unloads a library it used -- the use it
+// documents is the OPENSSL_cleanup() that test/main.cxx performs for the Catch2 suites -- so
+// anything whose destructor calls into such a library has to be gone before the hook runs. The
+// context is taken by value so the caller cannot hold one back, and this lives here rather than
+// inline in main() so a self-test can observe the order.
+//
+// Not for the timeout path: a case that exceeded its budget leaves a worker detached, possibly
+// still inside the context, so main() leaves through _Exit there and destroys nothing.
+void
+tear_down(std::unique_ptr<context> ctx, void (*teardown)());
 
 // Process exit code for a result: any failure => 1; nothing ran but something skipped => 77
 // (the GNU/ctest "skipped" convention); otherwise 0.


### PR DESCRIPTION
Fixes [CXXCBC-1009](https://couchbasecloud.atlassian.net/browse/CXXCBC-1009), found while triaging the suppressed review notes on #1073. #1100 and #1104 have merged, so this now carries a single commit against `main`.

## Why

`main()` calls the suite's teardown hook while the context is still in scope:

```cpp
  context ctx{ std::move(config) };
  const auto result = run(suite, filter, ctx, std::cout);
  ...
  if (suite.teardown != nullptr && result.timed_out == 0) {
    suite.teardown();
  }
  return exit_code(result);          // ctx destroyed here, after the hook
```

The hook is where a suite unloads a library it used — the use its own comment documents is the `OPENSSL_cleanup()` that `test/main.cxx` performs for the Catch2 suites — and the context owns the probe backend, the `integration_test_guard` behind it and whatever cluster connection that guard opened. Those destructors run after the hook, against a library that is no longer there.

Nothing registers a hook yet, so this is latent. It surfaces in the first suite that uses the hook for what it documents, as a nondeterministic crash at process exit — the least diagnosable moment in a run.

## What changed

`tear_down(std::unique_ptr<context>, void (*)())` takes the context by value, releases it, and only then calls the hook, so a caller cannot hold the context back past the point where the hook may unload what it holds. `main()` owns the context through a pointer because both endings have to stay possible: a timed-out case leaves a worker detached and possibly still inside the context, so that path leaves through `_Exit` before reaching the close-down and destroys nothing.

Being a function rather than a sequence inside `main()` is also what makes the order observable at all — the hook is invoked from `main`, where no self-test can reach it.

## Verification

`the_context_is_released_before_the_suite_teardown_runs` drives a backend that reports its own lifetime past a hook that records what it saw. `a_suite_with_no_teardown_still_releases_its_context` covers the path every binary takes today, since nothing registers a hook.

Restoring the old order — leaving the context to be destroyed when the function returns — kills the first of those, run through the CNG tooling's negative control. Deleting the release outright is not a usable mutation: it orphans the parameter and the build fails under `-Werror=unused-parameter` before anything is measured.


[CXXCBC-1009]: https://couchbasecloud.atlassian.net/browse/CXXCBC-1009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
