### PR TITLE
CXXCBC-1010: wait for every copy before asserting a replica read

### DIFF
--- a/test/test_integration_subdoc.cxx
+++ b/test/test_integration_subdoc.cxx
@@ -21,6 +21,7 @@
 #include "core/operations/document_append.hxx"
 #include "core/operations/document_decrement.hxx"
 #include "core/operations/document_get.hxx"
+#include "core/operations/document_get_all_replicas.hxx"
 #include "core/operations/document_increment.hxx"
 #include "core/operations/document_insert.hxx"
 #include "core/operations/document_lookup_in.hxx"
@@ -35,6 +36,37 @@
 #include <couchbase/codec/tao_json_serializer.hxx>
 #include <couchbase/lookup_in_specs.hxx>
 #include <couchbase/mutate_in_specs.hxx>
+
+#include <algorithm>
+
+// Blocks until every copy of the document answers a full read with the CAS that was written.
+//
+// The precondition the replica cases need, and the one the subdocument fan-out cannot express.
+// lookup_in_all_replicas keeps one entry per node the topology can address, synthesising error
+// fields for a node that answered at the document level, and reports an error only when no node
+// answered at all -- so neither its entry count nor its error code moves while a replica has yet
+// to receive the document. get_all_replicas drops such a node instead, so its count does move, and
+// being a full read it carries a CAS for a body that is not JSON, where every subdocument path
+// fails and there is no successful path to poll on.
+inline void
+wait_until_document_on_every_copy(test::utils::integration_test_guard& integration,
+                                  const couchbase::core::document_id& id,
+                                  couchbase::cas expected_cas)
+{
+  const couchbase::core::operations::get_all_replicas_request req{ id };
+  const auto expected_entries = integration.number_of_replicas() + 1;
+  const auto replicated = test::utils::wait_until([&]() {
+    const auto response = test::utils::execute(integration.cluster, req);
+    if (response.ctx.ec() || response.entries.size() != expected_entries) {
+      return false;
+    }
+    return std::all_of(
+      response.entries.begin(), response.entries.end(), [expected_cas](const auto& entry) {
+        return entry.cas == expected_cas;
+      });
+  });
+  REQUIRE(replicated);
+}
 
 template<typename SubdocumentOperation>
 void
@@ -151,17 +183,8 @@ assert_single_lookup_all_replica_success(test::utils::integration_test_guard& in
   req.specs = couchbase::lookup_in_specs{ spec }.specs();
   INFO(fmt::format(
     "assert_single_lookup_all_replica_success(\"{}\", \"{}\")", id, req.specs[0].path_));
-  // A freshly written document, even one written durably, may not be readable from every
-  // replica the instant the write returns; an all-replica lookup then comes back with fewer
-  // entries (a replica answers not_found). Poll until every replica reports the document
-  // before asserting full coverage, so replication lag does not flake the test.
   const auto expected_entries = integration.number_of_replicas() + 1;
-  couchbase::core::operations::lookup_in_all_replicas_response response;
-  auto replicated = test::utils::wait_until([&]() {
-    response = test::utils::execute(integration.cluster, req);
-    return !response.ctx.ec() && response.entries.size() == expected_entries;
-  });
-  REQUIRE(replicated);
+  const auto response = test::utils::execute(integration.cluster, req);
   REQUIRE_SUCCESS(response.ctx.ec());
   REQUIRE(response.entries.size() == expected_entries);
   auto responses_from_active =
@@ -1465,18 +1488,7 @@ TEST_CASE("integration: subdoc all replica reads", "[integration]")
     inserted_cas = resp.cas;
   }
 
-  {
-    // Wait until the document has replicated to all replica nodes to prevent eventual-consistency
-    // races in subsequent sections
-    couchbase::core::operations::lookup_in_all_replicas_request req{ id };
-    req.specs = couchbase::lookup_in_specs{ couchbase::lookup_in_specs::get("dictkey") }.specs();
-    const auto expected_entries = integration.number_of_replicas() + 1;
-    auto replicated = test::utils::wait_until([&]() {
-      auto response = test::utils::execute(integration.cluster, req);
-      return !response.ctx.ec() && response.entries.size() == expected_entries;
-    });
-    REQUIRE(replicated);
-  }
+  wait_until_document_on_every_copy(integration, id, inserted_cas);
 
   SECTION("dict get")
   {
@@ -1581,6 +1593,7 @@ TEST_CASE("integration: subdoc all replica reads", "[integration]")
       couchbase::core::operations::insert_request req{ non_json_id, non_json_doc };
       auto resp = test::utils::execute(integration.cluster, req);
       REQUIRE_SUCCESS(resp.ctx.ec());
+      wait_until_document_on_every_copy(integration, non_json_id, resp.cas);
     }
 
     SECTION("non json get")
@@ -1803,18 +1816,7 @@ TEST_CASE("integration: subdoc any replica reads", "[integration]")
     inserted_cas = resp.cas;
   }
 
-  {
-    // Wait until the document has replicated to all replica nodes to prevent eventual-consistency
-    // races in subsequent sections
-    couchbase::core::operations::lookup_in_all_replicas_request req{ id };
-    req.specs = couchbase::lookup_in_specs{ couchbase::lookup_in_specs::get("dictkey") }.specs();
-    const auto expected_entries = integration.number_of_replicas() + 1;
-    auto replicated = test::utils::wait_until([&]() {
-      auto response = test::utils::execute(integration.cluster, req);
-      return !response.ctx.ec() && response.entries.size() == expected_entries;
-    });
-    REQUIRE(replicated);
-  }
+  wait_until_document_on_every_copy(integration, id, inserted_cas);
 
   SECTION("dict get")
   {
@@ -1919,6 +1921,7 @@ TEST_CASE("integration: subdoc any replica reads", "[integration]")
       couchbase::core::operations::insert_request req{ non_json_id, non_json_doc };
       auto resp = test::utils::execute(integration.cluster, req);
       REQUIRE_SUCCESS(resp.ctx.ec());
+      wait_until_document_on_every_copy(integration, non_json_id, resp.cas);
     }
 
     SECTION("non json get")


### PR DESCRIPTION
[CXXCBC-1010](https://jira.issues.couchbase.com/browse/CXXCBC-1010)

`integration: subdoc all replica reads` and `integration: subdoc any replica reads` gate their sections on a condition that cannot detect incomplete replication, so a section can assert against a replica that holds nothing.

The gate, in three copies:

```c++
return !response.ctx.ec() && response.entries.size() == expected_entries;
```

Neither half moves while a replica has yet to receive the document. `lookup_in_all_replicas` emplaces one entry per node the topology can address and synthesises error fields for a node that answered at the document level, and it reports an error only when no node answered at all — see the `append_synthetic_error_fields` branch in `core/operations/document_lookup_in_all_replicas.hxx`. So the entry count follows the topology, and the response code is clear as soon as the active succeeds, which the `REQUIRE_SUCCESS` on the preceding insert has already established. The gate passes on its first poll, always.

The comment above one copy states the premise it rests on, and the fan-out does not honour it:

> an all-replica lookup then comes back with fewer entries (a replica answers not_found)

A copy that does not hold the document produces an entry with CAS 0 and a synthesised field status. That is what the sections trip over, in three places: the per-entry CAS check in `assert_single_lookup_all_replica_success`, the per-field status check in `assert_single_lookup_all_replica_error` (which polls for nothing at all), and the CAS comparison in the section that verifies fanout when a path fails.

Each case writes **two** documents, and only the first had a gate of any kind. The second is a non-JSON body, read back through the same all-replica helper — which asserts a per-path failure on every entry, so a copy still receiving it contributes a document-level status instead and the assertion carries the same race.

## The fix

One gate covers every document either case writes, and it waits on a full read rather than a subdocument one. `get_all_replicas` *drops* a node that answered at the document level instead of synthesising fields for it, so its entry count does move while a copy is missing — the premise the old comment stated is true of that fan-out and false of the subdocument one. A full read also carries a CAS for a non-JSON body, where every subdocument path fails and there is no successful path to poll on. Every entry must carry the CAS that was written.

## Measurement

Against a freshly created 3-node Server 8.0.1 cluster with a two-replica bucket, running the two cases 20 times:

| tree | outcome |
|---|---|
| `main` | 19 of 20 runs failed |
| `main` + this change | 20 of 20 passed |

Same cluster, same build directory; only `test/test_integration_subdoc.cxx` differs. The failing assertions were distributed across all four sites above, which is what a replication race looks like rather than a single broken assertion. The whole `integration: subdoc` set — 16 cases — passes with the change.

The observed failures were all on the first document. The second document's race was found by review, not by measurement: its window is much narrower, because by the time a case reaches those sections the earlier ones have already been through the same replication path. The mechanism is the one demonstrated on the first document, in the same helper, and the second document had no gate at all.

## Out of scope

The file is Catch2 and [CXXCBC-964](https://jira.issues.couchbase.com/browse/CXXCBC-964) migrates it; this changes the gate only and converts no assertions.

The section that verifies fanout when a path fails carries a comment claiming that on Server 7.6.0+ a replica returns CAS 0 for a lookup whose path fails, while asserting the opposite. With replication gated it passes on 8.0.1, so the claim does not hold there. It was not re-checked on 7.6.x, and the comment is left alone.


[CXXCBC-1010]: https://jira.issues.couchbase.com/browse/CXXCBC-1010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ




[CXXCBC-964]: https://couchbasecloud.atlassian.net/browse/CXXCBC-964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ