### PR TITLE
CXXCBC-1015: register the generator where the append survives

### DIFF
--- a/cmake/TestFramework.cmake
+++ b/cmake/TestFramework.cmake
@@ -257,9 +257,6 @@ endfunction()
 # multiplier able to reach them.
 couchbase_add_test(framework/selftest LABEL cng)
 
-# unit, because it is pure computation over the tools helper and needs no server.
-couchbase_add_test(tools/document_body_generator LABEL unit LINK_CLIENT)
-
 # What assert_success prints. It needs couchbase::error, and therefore the client library, but no
 # server: every value it asserts on is constructed by hand. cng for the same reason as above.
 couchbase_add_test(framework/errors_selftest LABEL cng LINK_CLIENT)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,11 @@
 # because it is no longer a Catch2 file.
 couchbase_add_test(unit/core/config_profiles LABEL unit LINK_CLIENT)
 
+# Registered here rather than in cmake/TestFramework.cmake beside the framework's own self-tests:
+# only a call from this file reaches build_unit_tests. It is pure computation over the tools helper
+# and needs no server, so unit is the label, and unit is a label with an aggregate.
+couchbase_add_test(tools/document_body_generator LABEL unit LINK_CLIENT)
+
 integration_test(connect)
 integration_test(crud)
 integration_test(query)


### PR DESCRIPTION
Fixes [CXXCBC-1015](https://couchbasecloud.atlassian.net/browse/CXXCBC-1015). One registration moved, no behaviour change to any case.

`cmake/TestFramework.cmake:261` registered `tools/document_body_generator` with `LABEL unit`. `couchbase_add_test()` appends the target to the `COUCHBASE_UNIT_TESTS` global property that `build_unit_tests` depends on, but `cmake/Testing.cmake` blanks that property and is included after `cmake/TestFramework.cmake` (`CMakeLists.txt:717`, then `:721`), so the append was discarded. The comment at `cmake/TestFramework.cmake:221` says so, immediately above the code doing the appending.

The two ways of selecting the unit suite therefore disagreed. The target was absent from `build_unit_tests`, so it was never built and never wrote its discovery file, and the shim registered `tools_document_body_generator_NOT_BUILT` in its place, carrying the `unit` label. Building the aggregate and then filtering with `ctest --label-regex unit` selected a case whose binary did not exist.

The two framework self-tests a few lines away are unaffected: they carry `LABEL cng`, and `cng` has no aggregate.

No GitHub Actions job has caught this because none builds the aggregate. `bin/build-tests:123` sets `--target build_${CB_TEST_SUITE}_tests` only when `CB_TEST_SUITE` is set, and no workflow sets it, so the build at `tests.yml:42` falls through to the default target, where every registered target is present. The path that does reach it is supported and available today: `CB_TEST_SUITE=unit ./bin/build-tests` followed by `bin/run-unit-tests` fails on the placeholder. The first job to take that path is the `workflow_dispatch`-only big-endian one added by #1108, which builds `--target build_unit_tests` and then runs `ctest --label-regex unit`. That PR and this one can land in either order.

One intended behaviour change: `cmake/TestFramework.cmake` is read when either `COUCHBASE_CXX_CLIENT_BUILD_TESTS` or `COUCHBASE_CXX_CLIENT_BUILD_CNG_TESTS` is on, while `test/CMakeLists.txt` is reached only through `cmake/Testing.cmake`, which needs the former. A CNG-only configure therefore no longer registers this case, which matches its label. No CI leg configures CNG-only; `bin/build-tests` always passes `-DCOUCHBASE_CXX_CLIENT_BUILD_TESTS=ON`.

## Verification

CI cannot tell the two sides of this change apart: every job builds the default target, where the target is present either way. What distinguishes them is the generate step. With the move, `CMakeFiles/Makefile2` carries the edge that was missing:

```
CMakeFiles/build_unit_tests.dir/all: test/CMakeFiles/tools_document_body_generator.dir/all
```

so the aggregate builds the generator and it writes its discovery file. No `_NOT_BUILT` placeholder is left under the label, and `ctest --label-regex unit` is 396/396, the seven real generator cases among them.


[CXXCBC-1015]: https://couchbasecloud.atlassian.net/browse/CXXCBC-1015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ