### PR TITLE
Update meta for 1.3.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ endif()
 
 project(
   couchbase_cxx_client
-  VERSION "1.3.2"
+  VERSION "1.3.3"
   LANGUAGES CXX C)
 message(
   STATUS

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ CPMAddPackage(
   NAME
   couchbase_cxx_client
   GIT_TAG
-  1.3.2
+  1.3.3
   VERSION
-  1.3.2
+  1.3.3
   GITHUB_REPOSITORY
   "couchbase/couchbase-cxx-client"
   OPTIONS


### PR DESCRIPTION
Binary compatible with 1.3.0, 1.3.1 and 1.3.2. No public type or signature changed.

Bug Fixes
---------

* CXXCBC-839: **Configuration Push Scope** -- A cluster-level (bucket-less) configuration push advanced a bucket-bound session's revision floor, so the map-carrying configuration that followed was discarded as old. The session kept routing on a stale map: Not-My-VBucket loops and timeouts during failover and rebalance. A configuration is now accepted only when its bucket scope matches the session's.

* CXXCBC-841: **Bucket Management on Couchbase Server 8.1** -- `bucket_update` built its form-encoded body from `&`-prefixed fragments, and since every field is optional the body began with `&`, which Server 8.1 rejects. Both `bucket_update` and `bucket_create` now compose the body through the form encoder.

* CXXCBC-912: **fork() Safety** -- The child started its I/O thread before applying the asio fork fixup, so it kept using the parent's epoll registrations and faulted on descriptor state that exists only in the parent's address space. The fixup is now applied while no thread is inside `run()`. Closing a socket inherited across the fork no longer calls `shutdown(2)`, which acts on the shared open file description and tore down the connection the parent was still using. A failed post-fork reconnect crashed or hung the child's next operation; it now reports `errc::network::cluster_closed`. Forking no longer risks a deadlock in transactions cleanup, and lost-attempts cleanup keeps running afterwards instead of staying dead for the rest of the process. Handles obtained before the fork must be re-acquired in the child. On Windows the call is a no-op.

* CXXCBC-864: **Transaction Thread-Safety** -- A KV operation read the attempt mode before registering in the wait group, so a concurrent query could switch to query mode and issue `BEGIN WORK` in the gap. The operation stayed on the KV path and staged a mutation `BEGIN WORK` had missed, orphaning a client ATR and losing the mutation at commit. The mode is now read after the operation is counted. An operation racing commit or rollback surfaced an `UNKNOWN` cause; where the outcome is not yet known it now reports `CONCURRENT_OPERATIONS_DETECTED_ON_SAME_DOCUMENT`. A data race on the internal query-mode reset is closed, and a query-mode `insert` or `replace` whose query returns no rows now fails the transaction instead of reading past the end of the result.