### PR TITLE
CXXCBC-1024: pin the callback queue in every protostellar test

### DIFF
--- a/test/cng/README.md
+++ b/test/cng/README.md
@@ -22,6 +22,30 @@ Getting the cluster-only tests to run means standing up a Couchbase cluster whos
 Gateway is deployed, and pointing the tests at its `couchbase2://` endpoint. The rest of this
 document shows how to do that locally with `cbdinocluster` and `k3d`.
 
+## In-process servers must pin gRPC's callback queue
+
+A case that stands up its own gRPC server creates a `couchbase2://` channel and destroys it when the
+case ends. gRPC serves the C++ callback API from a process-global completion queue whose reference
+count follows the live channels, and destroying the last one shuts that queue down and deletes it
+while its own polling threads are still using it. The process aborts after the case has already
+passed, so `ctest` reports `Subprocess aborted` with no failed assertion:
+
+```
+ref_counted.h:183]  assertion failed: prior > 0
+```
+
+Keeping one channel alive for the whole binary keeps the count above zero and the teardown out of
+the way. So:
+
+- **A class that owns an in-process server derives from `pins_callback_queue`**
+  (`protostellar/callback_queue_keepalive.hxx`). A base subobject is constructed before the derived
+  constructor body, so the queue is pinned before the server is built.
+- **A case that builds a server without such a class calls `pin_callback_queue()` first.**
+
+Either way the file that names `grpc::ServerBuilder` also names one of the two. The race is gRPC's,
+not ours, and is tracked in CXXCBC-1024; pinning keeps it away from tests that exist to cover our
+own transport.
+
 ## Prerequisites
 
 Linux with:

--- a/test/cng/protostellar/callback_queue_keepalive.hxx
+++ b/test/cng/protostellar/callback_queue_keepalive.hxx
@@ -136,4 +136,17 @@ pin_callback_queue()
   static const callback_queue_keepalive keepalive{};
 }
 
+// Base for a holder that stands up an in-process gRPC server. A base subobject is constructed
+// before the derived constructor body runs, so deriving from this pins the queue before the server
+// is built -- the ordering does not depend on where a call is written, or on remembering to write
+// one. Every such holder in these tests derives from it; see test/cng/README.md.
+class pins_callback_queue
+{
+protected:
+  pins_callback_queue()
+  {
+    pin_callback_queue();
+  }
+};
+
 } // namespace couchbase::test

--- a/test/cng/protostellar/component.cxx
+++ b/test/cng/protostellar/component.cxx
@@ -199,16 +199,11 @@ private:
   }
 };
 
-class in_process_server
+class in_process_server : private pins_callback_queue
 {
 public:
   in_process_server()
   {
-    // Pin gRPC's process-global callback completion queue for the lifetime of this binary.
-    // Without it, destroying the last channel between cases drives a teardown that races
-    // gRPC's own polling threads and aborts the process (CXXCBC-919).
-    pin_callback_queue();
-
     grpc::ServerBuilder builder;
     builder.RegisterService(&service_);
     server_ = builder.BuildAndStart();

--- a/test/cng/protostellar/component_kv_operations.cxx
+++ b/test/cng/protostellar/component_kv_operations.cxx
@@ -41,6 +41,8 @@
 
 #include "framework/test_registry.hxx"
 
+#include "callback_queue_keepalive.hxx"
+
 #include "core/cluster_credentials.hxx"
 #include "core/document_id.hxx"
 #include "core/error_context/key_value.hxx"
@@ -429,7 +431,7 @@ private:
 //
 // The pair is deliberately leaked rather than held in a destructible static: letting it be torn
 // down at exit would run exactly the teardown this avoids, at the least debuggable moment there is.
-class in_process_server
+class in_process_server : private pins_callback_queue
 {
 public:
   in_process_server()

--- a/test/cng/protostellar/component_timeouts.cxx
+++ b/test/cng/protostellar/component_timeouts.cxx
@@ -29,6 +29,8 @@
 
 #include "framework/test_registry.hxx"
 
+#include "callback_queue_keepalive.hxx"
+
 #include "core/operations.hxx"
 
 #include "core/cluster.hxx"
@@ -209,6 +211,8 @@ observed_budget_for(Request request) -> std::int64_t
 {
   int port = 0;
   deadline_recording_kv_service service;
+  pin_callback_queue(); // CXXCBC-919: a channel per case cycles gRPC's callback queue
+
   grpc::ServerBuilder builder;
   builder.RegisterService(&service);
   builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);

--- a/test/cng/protostellar/dispatcher.cxx
+++ b/test/cng/protostellar/dispatcher.cxx
@@ -81,17 +81,12 @@ private:
 };
 
 // Owns an in-process gRPC server and hands out channels to it.
-class in_process_server
+class in_process_server : private pins_callback_queue
 {
 public:
   explicit in_process_server(std::chrono::milliseconds delay)
     : service_{ delay }
   {
-    // Pin gRPC's process-global callback completion queue for the lifetime of this binary.
-    // Without it, destroying the last channel between cases drives a teardown that races
-    // gRPC's own polling threads and aborts the process (CXXCBC-919).
-    pin_callback_queue();
-
     grpc::ServerBuilder builder;
     builder.RegisterService(&service_);
     server_ = builder.BuildAndStart();

--- a/test/cng/protostellar/kv_retry.cxx
+++ b/test/cng/protostellar/kv_retry.cxx
@@ -25,6 +25,8 @@
 
 #include "framework/test_registry.hxx"
 
+#include "callback_queue_keepalive.hxx"
+
 #include "core/operations.hxx"
 
 #include "core/cluster.hxx"
@@ -161,6 +163,8 @@ a_retried_kv_operation_stays_within_its_budget([[maybe_unused]] context& ctx)
 {
   int port = 0;
   stalling_kv_service service;
+  pin_callback_queue(); // CXXCBC-919: a channel per case cycles gRPC's callback queue
+
   grpc::ServerBuilder builder;
   builder.RegisterService(&service);
   builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
@@ -255,6 +259,8 @@ an_operation_without_a_timeout_is_bounded_by_the_cluster_default([[maybe_unused]
 {
   int port = 0;
   unavailable_kv_service service;
+  pin_callback_queue();
+
   grpc::ServerBuilder builder;
   builder.RegisterService(&service);
   builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
@@ -332,6 +338,8 @@ a_retried_operation_reports_its_attempts_and_reasons([[maybe_unused]] context& c
 {
   int port = 0;
   flaky_kv_service service{ 2 };
+  pin_callback_queue();
+
   grpc::ServerBuilder builder;
   builder.RegisterService(&service);
   builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
@@ -399,6 +407,8 @@ a_retried_mutation_that_runs_out_of_budget_is_ambiguous([[maybe_unused]] context
 {
   int port = 0;
   unavailable_kv_service service;
+  pin_callback_queue();
+
   grpc::ServerBuilder builder;
   builder.RegisterService(&service);
   builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
@@ -472,6 +482,8 @@ closing_the_cluster_during_a_backoff_still_answers([[maybe_unused]] context& ctx
 {
   int port = 0;
   unavailable_kv_service service;
+  pin_callback_queue();
+
   grpc::ServerBuilder builder;
   builder.RegisterService(&service);
   builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);

--- a/test/cng/protostellar/query_streaming.cxx
+++ b/test/cng/protostellar/query_streaming.cxx
@@ -22,6 +22,8 @@
 
 #include "framework/test_registry.hxx"
 
+#include "callback_queue_keepalive.hxx"
+
 #include "core/cluster_credentials.hxx"
 #include "core/operations/document_analytics.hxx"
 #include "core/operations/document_query.hxx"
@@ -109,7 +111,7 @@ public:
   }
 };
 
-class in_process_query_server
+class in_process_query_server : private pins_callback_queue
 {
 public:
   in_process_query_server()
@@ -385,7 +387,7 @@ public:
   }
 };
 
-class in_process_analytics_server
+class in_process_analytics_server : private pins_callback_queue
 {
 public:
   in_process_analytics_server()

--- a/test/cng/protostellar/retry.cxx
+++ b/test/cng/protostellar/retry.cxx
@@ -28,6 +28,8 @@
 
 #include "framework/test_registry.hxx"
 
+#include "callback_queue_keepalive.hxx"
+
 #include "core/operations.hxx"
 
 #include "core/cluster.hxx"
@@ -116,6 +118,8 @@ non_kv_retry_dispatch_semantics([[maybe_unused]] context& ctx)
 {
   int port = 0;
   retry_query_service service;
+  pin_callback_queue(); // CXXCBC-919: a channel per case cycles gRPC's callback queue
+
   grpc::ServerBuilder builder;
   builder.RegisterService(&service);
   builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
@@ -210,6 +214,8 @@ non_kv_retry_budget_exhaustion([[maybe_unused]] context& ctx)
 {
   int port = 0;
   retry_query_service service;
+  pin_callback_queue();
+
   grpc::ServerBuilder builder;
   builder.RegisterService(&service);
   builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
@@ -292,6 +298,8 @@ closing_the_cluster_during_a_non_kv_backoff_still_answers([[maybe_unused]] conte
 {
   int port = 0;
   retry_query_service service;
+  pin_callback_queue();
+
   grpc::ServerBuilder builder;
   builder.RegisterService(&service);
   builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);
@@ -393,6 +401,8 @@ custom_retry_strategy_rejects_non_kv([[maybe_unused]] context& ctx)
 {
   int port = 0;
   retry_query_service service;
+  pin_callback_queue();
+
   grpc::ServerBuilder builder;
   builder.RegisterService(&service);
   builder.AddListeningPort("127.0.0.1:0", grpc::InsecureServerCredentials(), &port);

--- a/test/cng/protostellar/search_index_admin_component.cxx
+++ b/test/cng/protostellar/search_index_admin_component.cxx
@@ -167,16 +167,11 @@ public:
   }
 };
 
-class in_process_server
+class in_process_server : private pins_callback_queue
 {
 public:
   in_process_server()
   {
-    // Pin gRPC's process-global callback completion queue for the lifetime of this binary, for the
-    // reason component.cxx gives: destroying the last channel between cases otherwise races
-    // gRPC's polling threads and aborts the process (CXXCBC-919).
-    pin_callback_queue();
-
     grpc::ServerBuilder builder;
     builder.RegisterService(&service_);
     server_ = builder.BuildAndStart();

--- a/test/cng/protostellar/streaming.cxx
+++ b/test/cng/protostellar/streaming.cxx
@@ -161,18 +161,12 @@ private:
   service_plan plan_;
 };
 
-class in_process_query_server
+class in_process_query_server : private pins_callback_queue
 {
 public:
   explicit in_process_query_server(service_plan plan = {})
     : service_{ std::move(plan) }
   {
-    // Pin gRPC's process-global callback completion queue for the lifetime of this binary.
-    // Without it, destroying the last channel between cases drives a teardown that races gRPC's
-    // own polling threads and aborts the process (CXXCBC-919). This binary cycles a channel per
-    // case, so it is exactly the shape that trips it.
-    pin_callback_queue();
-
     grpc::ServerBuilder builder;
     builder.RegisterService(&service_);
     server_ = builder.BuildAndStart();


### PR DESCRIPTION
gRPC serves the C++ callback API from a process-global completion queue whose reference count follows the live channels. A test that stands up an in-process server destroys the last channel when the case ends, and that release shuts the queue down and deletes it while gRPC's own polling threads are still using it. The process aborts after the case has passed, so ctest reports `Subprocess aborted` with no failed assertion:

```
"a_durable_mutation_without_a_timeout_gets_the_configured_durable_budget" passed (135.0ms)
Suite "cng_protostellar_component_timeouts": 1 passed, 0 skipped
ref_counted.h:183]  assertion failed: prior > 0
```

No frame of the stack belongs to the SDK or to the test.

CXXCBC-919 added `pin_callback_queue()` to hold one channel for the life of the binary, but the call is easy to omit. Seven classes across these tests hand-roll the same in-process server and three of them never pinned; five binaries had no pin at all, and abort on the cng job of several pull requests and on main.

`pins_callback_queue` is now a base for a class that owns an in-process server. A base subobject is constructed before the derived constructor body, so deriving pins the queue before the server is built and the ordering no longer depends on where a call is written. All seven holders derive from it, and the three files that build servers in free functions call `pin_callback_queue()` there. `test/cng/README.md` records the rule, so a file that names `grpc::ServerBuilder` also names one of the two.

Counting the threads gRPC names `nexting_thread`, the timeouts binary goes from 22 creations to 11 — one queue instead of two, so the teardown between cases is gone rather than less likely.

The race itself is gRPC's and is unchanged. CXXCBC-1024 records the analysis, the remaining exposure for an application that opens and closes clusters in a loop, and what was ruled out — including why leaking a channel is not an option while the CNG suite runs under LSan.

Fixes CXXCBC-1024
